### PR TITLE
Move DAG graph to core

### DIFF
--- a/docs/quantum.md
+++ b/docs/quantum.md
@@ -30,6 +30,12 @@ interfaces stabilize they could be merged with `quantum_processor.cpp` to reduce
 duplication. The existing DAG utilities mentioned in the `README` may also be
 consolidated with context management to avoid multiple lineage trackers.
 
+## DAG Utility Relocation
+
+`dag_graph.h` and its implementation were moved out of the `quantum` module. The
+header now lives in `include/core` and is built from `src/core/dag_graph.cpp`.
+This centralizes the DAG structures for use by memory and context code.
+
 ## Integration with Pattern Processing
 
 After cleanup the quantum processors expose minimal headers and integrate

--- a/include/memory/memory_tier_manager.hpp
+++ b/include/memory/memory_tier_manager.hpp
@@ -9,7 +9,7 @@
 
 // Project includes
 #include "core/common.h"
-#include "quantum/dag_graph.h"
+#include "core/dag_graph.h"
 #include "memory/memory_tier.h"
 #include "memory/types.h"
 #include "compat/shim.h"

--- a/src/core/dag_graph.cpp
+++ b/src/core/dag_graph.cpp
@@ -1,4 +1,4 @@
-#include "quantum/dag_graph.h"
+#include "core/dag_graph.h"
 #include <algorithm>
 #include <vector>
 

--- a/src/quantum/README.md
+++ b/src/quantum/README.md
@@ -52,6 +52,6 @@ This directory hosts the experimental quantum-inspired components. Key implement
 
 Additional files such as `qbsa_qfh.cpp` and `quantum_processor_qfh_common.cpp` explore combining QBSA with QFH techniques. These experimental helpers may be merged into the core processor once stabilized.
 
-`dag_graph.h` currently lives in this module and implements a small DAG structure used by patterns. Consider folding this into `src/dag` or integrating directly with context/relationship code for a single source of truth.
+`dag_graph.h` has been moved to `include/core` with its implementation in `src/core/dag_graph.cpp`. The DAG utilities can now be shared across modules and may later integrate with the context relationship code for a single source of truth.
 
 


### PR DESCRIPTION
## Summary
- centralize `dag_graph` utility in core
- update includes and docs to new path
- describe DAG changes in `docs/quantum.md`

## Testing
- `cmake -S . -B build`
- `cmake --build build -j $(nproc)` *(fails: cuda/math_common.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_685911dfe6e0832ab0fc857da43b5f1a