### PR TITLE
Refactor API headers and docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,16 @@
-# API Module Review
+# API Module Overview
 
-This document summarizes the state of the files under `src/api` and `include/api`.
+The API layer is split into a public header tree under `include/api` and
+matching implementations in `src/api`.  Each header exposes declarations only
+so other modules can depend on the API without pulling in implementation
+details.  Previous helper sources like `connection_manager.cpp` have been
+removed, leaving `connection_manager.h` as an interface used solely by tests.
+
+Generated build files (`cmake_install.cmake`, `CMakeFiles/` directories, etc.)
+were removed from version control to keep the repository clean.
+
+The following table lists the remaining headers and their corresponding
+implementations:
 
 ## Public interface headers
 

--- a/include/api/server.h
+++ b/include/api/server.h
@@ -99,8 +99,8 @@ class SEPApiServer : public Server {
   void updateConfig(const ::sep::config::APIConfig &new_config);
 
   // Server interface implementation
-  std::mutex &getMetricsMutex() override { return metrics_mutex_; }
-  ServerMetrics &getModifiableMetrics() override { return server_metrics_; }
+  std::mutex &getMetricsMutex() override;
+  ServerMetrics &getModifiableMetrics() override;
   std::unique_ptr<HttpResponse> makeJsonResponse(int code,
                                                            const std::string &message) override;
   std::string handleError(const std::string &message, int code) override;

--- a/src/api/server.cpp
+++ b/src/api/server.cpp
@@ -57,6 +57,14 @@ SEPApiServer::~SEPApiServer() {
   instance_ = nullptr;
 }
 
+std::mutex &SEPApiServer::getMetricsMutex() {
+  return metrics_mutex_;
+}
+
+ServerMetrics &SEPApiServer::getModifiableMetrics() {
+  return server_metrics_;
+}
+
 bool SEPApiServer::start() {
   if (running_) {
     logger_->warn("Server is already running");


### PR DESCRIPTION
## Summary
- convert `SEPApiServer` accessors to out-of-line definitions
- clarify API design and cleanups in docs

## Testing
- `cmake ..` *(fails: missing dependencies)*
- `make -j$(nproc)` *(fails: missing headers)*

------
https://chatgpt.com/codex/tasks/task_e_685911d65388832ab9784d70c8bfe03f