### PR TITLE
Consolidate metrics utilities

### DIFF
--- a/docs/core.md
+++ b/docs/core.md
@@ -95,3 +95,10 @@ No legacy or duplicate implementations were found during the audit.
 - Update tests referencing `src/core/system_hooks.h` to include the installed header path.
 - Continue consolidating metrics utilities under the `sep::metrics` namespace to reduce boilerplate.
 
+## Unified Metrics Module
+
+Runtime counters, tracing helpers and the new `MetricsCollector` implementation now
+reside in the shared `sep::metrics` namespace.  Source files live under `src/core`
+with public headers in `include/core`.  Each component registers with the
+`PrometheusExporter` so tools can scrape a single consolidated endpoint.
+

--- a/include/core/allocation_metrics.h
+++ b/include/core/allocation_metrics.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "metrics/prometheus_exporter.h"
+#include "core/prometheus_exporter.h"
 
 namespace sep::metrics {
 

--- a/include/core/metrics_collector.h
+++ b/include/core/metrics_collector.h
@@ -8,8 +8,7 @@
 #include "compat/shim.h"
 #include <string>
 
-namespace sep {
-namespace core {
+namespace sep::metrics {
 
 // Forward declaration for PIMPL pattern
 struct DetailedMetrics {
@@ -104,5 +103,4 @@ private:
     SystemMetrics system_metrics_;
 };
 
-} // namespace core
-} // namespace sep
+} // namespace sep::metrics

--- a/include/memory/manager.h
+++ b/include/memory/manager.h
@@ -8,7 +8,7 @@
 #include <string>
 
 #include "memory/types.h"
-#include "metrics/tracing.h"
+#include "core/tracing.h"
 
 // Handle ASIO/Crow includes based on RTTI availability
 #ifndef CROW_DISABLE_RTTI

--- a/src/context/processor.cpp
+++ b/src/context/processor.cpp
@@ -45,7 +45,7 @@
 #include "quantum/pattern_evolution.h"
 #include "quantum/types.h"
 #include "memory/manager.h"
-#include "metrics/allocation_metrics.h"
+#include "core/allocation_metrics.h"
 
 namespace sep::context {
 

--- a/src/core/allocation_metrics.cpp
+++ b/src/core/allocation_metrics.cpp
@@ -1,4 +1,4 @@
-#include "metrics/allocation_metrics.h"
+#include "core/allocation_metrics.h"
 
 namespace sep::metrics {
 

--- a/src/core/metrics_collector.cpp
+++ b/src/core/metrics_collector.cpp
@@ -23,8 +23,7 @@
 using namespace sep::shim::chrono_literals;
 using namespace sep::cuda;
 
-namespace sep {
-namespace core {
+namespace sep::metrics {
 
 class MetricsCollector::Impl {
  public:
@@ -342,5 +341,4 @@ void MetricsCollector::resetOperation(const std::string& operation_name) {
     performance_metrics_.erase(key);
 }
 
-}  // namespace core
-}  // namespace sep
+}  // namespace sep::metrics

--- a/src/core/prometheus_exporter.cpp
+++ b/src/core/prometheus_exporter.cpp
@@ -1,4 +1,4 @@
-#include "metrics/prometheus_exporter.h"
+#include "core/prometheus_exporter.h"
 
 #include <sstream>
 

--- a/src/core/tracing.cpp
+++ b/src/core/tracing.cpp
@@ -1,4 +1,4 @@
-#include "metrics/tracing.h"
+#include "core/tracing.h"
 
 #include <iostream>
 #include <memory>

--- a/src/memory/memory_tier.cpp
+++ b/src/memory/memory_tier.cpp
@@ -30,7 +30,7 @@
 #include "memory/logger.hpp"
 #include "memory/manager.h"
 #include "memory/memory_tier_manager.hpp"
-#include "metrics/allocation_metrics.h"
+#include "core/allocation_metrics.h"
 
 namespace sep::memory {
 

--- a/tests/blender/mocks/mock_trace_span.cpp
+++ b/tests/blender/mocks/mock_trace_span.cpp
@@ -7,7 +7,7 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored 
 
-#include "metrics/tracing.h"
+#include "core/tracing.h"
 #include <iostream>
 #include <string>
 #include <chrono>

--- a/tests/context/allocation_metric_exposed_test.cpp
+++ b/tests/context/allocation_metric_exposed_test.cpp
@@ -1,6 +1,6 @@
 #include "context/processor.h"
 #include "context/types.h"
-#include "metrics/allocation_metrics.h"
+#include "core/allocation_metrics.h"
 #include <gtest/gtest.h>
 #include <vector>
 

--- a/tests/core/metrics_collector_test.cpp
+++ b/tests/core/metrics_collector_test.cpp
@@ -4,7 +4,7 @@
 #include <thread>
 
 namespace sep {
-namespace core {
+namespace metrics {
 namespace test {
 
 class MetricsCollectorTest : public ::testing::Test {
@@ -94,5 +94,5 @@ TEST_F(MetricsCollectorTest, StopCollectionTest) {
 }
 
 } // namespace test
-} // namespace core
+} // namespace metrics
 } // namespace sep


### PR DESCRIPTION
## Summary
- remove old `metrics/` header references
- move `MetricsCollector` into `sep::metrics`
- update tests for new namespace
- document unified metrics module

## Testing
- `cmake ..`
- `make -j$(nproc)` *(fails: cuda/crow headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_685911de66e4832ab9edd2233a22f540