### PR TITLE
Document audio pipeline and refactor PipeWire stubs

### DIFF
--- a/docs/audio.md
+++ b/docs/audio.md
@@ -1,47 +1,17 @@
-# Audio Module Overview
+# Audio Pipeline and Cleanup Tasks
 
-This document describes the remaining files under `src/audio` and `include/audio` after removing generated artefacts. It also explains how the audio interfaces integrate with the rest of the engine.
+This document summarises the real-time audio path and the repository cleanup performed for the module.
 
-## Clean Up Results
+## Pipeline Overview
 
-All `cmake_install.cmake` files were deleted from the repository. The `src/audio` directory now contains only the source files needed to build the optional audio library:
+1. **Capture** – `PipeWireCapture` opens a `pw_thread_loop` and pulls samples from the default source.
+2. **Frame Queue** – `AudioPipeline` groups samples into fixed-size frames.
+3. **Window & FFT** – each frame receives a Hann window before a simplified FFT.
+4. **Feature Extraction** – fundamental frequency, spectral centroid and spectral flux are computed.
+5. **Pattern Output** – results are normalised into `glm::vec3` vectors and optionally queued for other modules.
 
-```
-src/audio/
-  CMakeLists.txt        - build rules for the `sep_audio` library
-  README.md             - documentation for the module
-  config.cpp            - global configuration and coherence helpers
-  pipeline.cpp          - implementation of `AudioPipeline`
-  pipewire_capture.cpp  - implementation of `PipeWireCapture`
-```
+Implementation files live under `src/audio/` and the public headers in `include/audio/` now contain only declarations.  Any stub logic originally inside headers was moved to `.cpp` sources.
 
-The public headers remain under `include/audio`:
+## Cleanup Tasks
 
-```
-include/audio/
-  capture.h             - `AudioCapture` interface and factory helper
-  config.h              - `AudioPipelineConfig` and coherence utilities
-  pipeline.h            - declarations for `AudioPipeline`
-  pipewire_capture.h    - `PipeWireCapture` class
-  pipewire_includes.h   - conditional PipeWire wrapper/stubs
-  types.h               - common structs and enums
-  README.md             - API overview
-```
-
-`pipewire_capture.cpp` and `pipeline.cpp` include their corresponding headers for all declarations. No extra inline implementations exist outside the headers except for the small stubs in `pipewire_includes.h` which allow compilation without the PipeWire library.
-
-## Integration Points
-
-`include/core/engine.h` forward declares `AudioCapture` and `Engine` owns a `std::unique_ptr` to an instance created via `AudioCapture::create()`. During `Engine::init()` the capture object is initialised and optionally started when the engine runs. Processed pattern vectors produced by `AudioPipeline` can then be consumed by other modules such as `src/pattern` or `src/memory`.
-
-
-## Capture Pipeline Design
-
-PipeWireCapture initializes a `pw_thread_loop` and forwards raw float samples to a callback. `AudioPipeline` collects those samples into fixed-size frames, applies a Hann window, runs a small FFT and extracts fundamental frequency, spectral centroid and spectral flux. The results are normalized into `glm::vec3` pattern vectors and optionally queued for other modules.
-
-Generated build files (for example `cmake_install.cmake`) should not be committed. A scan of this repository found none.
-
-## File Status
-
-No obsolete headers or stub sources were found. `capture.h` is still required as the abstract interface used by `PipeWireCapture` and referenced by the core engine. The only stub code resides in `pipewire_includes.h` to handle the absence of PipeWire headers.
-
+Generated build artefacts such as `cmake_install.cmake` were removed across the repository.  See `docs/build_cleanup.md` for the commands used to search for these files.  The previously referenced `src/audio/cmake_install.cmake` is no longer present.

--- a/include/audio/pipewire_includes.h
+++ b/include/audio/pipewire_includes.h
@@ -123,106 +123,36 @@ typedef enum pw_stream_flags {
 #define SPA_POD_BUILDER_INIT(buffer, size) \
     {}
 
-// Define stubs for the functions
+// Stub function declarations
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-inline void pw_init(void* argc, void* argv) {
-    (void)argc;
-    (void)argv;
-}
-inline void pw_deinit(void) {}
+void pw_init(void* argc, void* argv);
+void pw_deinit(void);
 
-inline const char* pw_stream_state_as_string(enum pw_stream_state state) {
-    (void)state;
-    return "pipewire-not-available";
-}
+const char* pw_stream_state_as_string(enum pw_stream_state state);
 
-inline pw_properties* pw_properties_new(const char* key, const char* value, ...) {
-    (void)key;
-    (void)value;
-    return NULL;
-}
-
-inline pw_thread_loop* pw_thread_loop_new(const char* name, const void* props) {
-    (void)name;
-    (void)props;
-    return NULL;
-}
-
-inline pw_loop* pw_thread_loop_get_loop(pw_thread_loop* loop) {
-    (void)loop;
-    return NULL;
-}
-
-inline pw_context* pw_context_new(pw_loop* main_loop, pw_properties* props, size_t user_data_size) {
-    (void)main_loop;
-    (void)props;
-    (void)user_data_size;
-    return NULL;
-}
-
-inline pw_core* pw_context_connect(pw_context* context, pw_properties* props, size_t user_data_size) {
-    (void)context;
-    (void)props;
-    (void)user_data_size;
-    return NULL;
-}
-
-inline pw_stream* pw_stream_new(pw_core* core, const char* name, pw_properties* props) {
-    (void)core;
-    (void)name;
-    (void)props;
-    return NULL;
-}
-
-inline int pw_stream_connect(pw_stream* stream, enum pw_direction direction, uint32_t target_id,
-                     enum pw_stream_flags flags, const struct spa_pod** params, uint32_t n_params) {
-    (void)stream;
-    (void)direction;
-    (void)target_id;
-    (void)flags;
-    (void)params;
-    (void)n_params;
-    return -1;
-}
-
-inline void pw_stream_destroy(pw_stream* stream) { (void)stream; }
-inline void pw_core_disconnect(pw_core* core) { (void)core; }
-inline void pw_context_destroy(pw_context* context) { (void)context; }
-inline void pw_thread_loop_destroy(pw_thread_loop* loop) { (void)loop; }
-inline int pw_thread_loop_start(pw_thread_loop* loop) { (void)loop; return -1; }
-inline void pw_thread_loop_stop(pw_thread_loop* loop) { (void)loop; }
-
-inline int pw_stream_add_listener(pw_stream* stream, spa_hook* listener,
-                         const void* events, void* data) {
-    (void)stream;
-    (void)listener;
-    (void)events;
-    (void)data;
-    return -1;
-}
-
-inline void spa_hook_remove(spa_hook* hook) { (void)hook; }
-
-inline pw_buffer* pw_stream_dequeue_buffer(pw_stream* stream) {
-    (void)stream;
-    return NULL;
-}
-
-inline int pw_stream_queue_buffer(pw_stream* stream, pw_buffer* buffer) {
-    (void)stream;
-    (void)buffer;
-    return -1;
-}
-
-inline spa_pod* spa_format_audio_raw_build(spa_pod_builder* builder, uint32_t id, const void* info) {
-    (void)builder;
-    (void)id;
-    (void)info;
-    return NULL;
-}
+pw_properties* pw_properties_new(const char* key, const char* value, ...);
+pw_thread_loop* pw_thread_loop_new(const char* name, const void* props);
+pw_loop* pw_thread_loop_get_loop(pw_thread_loop* loop);
+pw_context* pw_context_new(pw_loop* main_loop, pw_properties* props, size_t user_data_size);
+pw_core* pw_context_connect(pw_context* context, pw_properties* props, size_t user_data_size);
+pw_stream* pw_stream_new(pw_core* core, const char* name, pw_properties* props);
+int pw_stream_connect(pw_stream* stream, enum pw_direction direction, uint32_t target_id,
+                      enum pw_stream_flags flags, const struct spa_pod** params, uint32_t n_params);
+void pw_stream_destroy(pw_stream* stream);
+void pw_core_disconnect(pw_core* core);
+void pw_context_destroy(pw_context* context);
+void pw_thread_loop_destroy(pw_thread_loop* loop);
+int  pw_thread_loop_start(pw_thread_loop* loop);
+void pw_thread_loop_stop(pw_thread_loop* loop);
+int  pw_stream_add_listener(pw_stream* stream, spa_hook* listener,
+                            const void* events, void* data);
+void spa_hook_remove(spa_hook* hook);
+pw_buffer* pw_stream_dequeue_buffer(pw_stream* stream);
+int pw_stream_queue_buffer(pw_stream* stream, pw_buffer* buffer);
+spa_pod* spa_format_audio_raw_build(spa_pod_builder* builder, uint32_t id, const void* info);
 
 // Macros for PipeWire keys
 #define PW_KEY_CONFIG_NAME "pipewire.config.name"

--- a/src/audio/CMakeLists.txt
+++ b/src/audio/CMakeLists.txt
@@ -1,1 +1,1 @@
-add_library(sep_audio STATIC config.cpp pipeline.cpp pipewire_capture.cpp)
+add_library(sep_audio STATIC config.cpp pipeline.cpp pipewire_capture.cpp pipewire_stubs.cpp)

--- a/src/audio/pipewire_stubs.cpp
+++ b/src/audio/pipewire_stubs.cpp
@@ -1,0 +1,68 @@
+#include "audio/pipewire_includes.h"
+
+#if !SEP_HAS_PIPEWIRE
+extern "C" {
+void pw_init(void* argc, void* argv) { (void)argc; (void)argv; }
+void pw_deinit(void) {}
+
+const char* pw_stream_state_as_string(enum pw_stream_state state) {
+    (void)state;
+    return "pipewire-not-available";
+}
+
+pw_properties* pw_properties_new(const char* key, const char* value, ...) {
+    (void)key; (void)value; return nullptr;
+}
+
+pw_thread_loop* pw_thread_loop_new(const char* name, const void* props) {
+    (void)name; (void)props; return nullptr;
+}
+
+pw_loop* pw_thread_loop_get_loop(pw_thread_loop* loop) {
+    (void)loop; return nullptr;
+}
+
+pw_context* pw_context_new(pw_loop* main_loop, pw_properties* props, size_t user_data_size) {
+    (void)main_loop; (void)props; (void)user_data_size; return nullptr;
+}
+
+pw_core* pw_context_connect(pw_context* context, pw_properties* props, size_t user_data_size) {
+    (void)context; (void)props; (void)user_data_size; return nullptr;
+}
+
+pw_stream* pw_stream_new(pw_core* core, const char* name, pw_properties* props) {
+    (void)core; (void)name; (void)props; return nullptr;
+}
+
+int pw_stream_connect(pw_stream* stream, enum pw_direction direction, uint32_t target_id,
+                      enum pw_stream_flags flags, const struct spa_pod** params, uint32_t n_params) {
+    (void)stream; (void)direction; (void)target_id; (void)flags; (void)params; (void)n_params; return -1;
+}
+
+void pw_stream_destroy(pw_stream* stream) { (void)stream; }
+void pw_core_disconnect(pw_core* core) { (void)core; }
+void pw_context_destroy(pw_context* context) { (void)context; }
+void pw_thread_loop_destroy(pw_thread_loop* loop) { (void)loop; }
+int  pw_thread_loop_start(pw_thread_loop* loop) { (void)loop; return -1; }
+void pw_thread_loop_stop(pw_thread_loop* loop) { (void)loop; }
+
+int pw_stream_add_listener(pw_stream* stream, spa_hook* listener,
+                           const void* events, void* data) {
+    (void)stream; (void)listener; (void)events; (void)data; return -1;
+}
+
+void spa_hook_remove(spa_hook* hook) { (void)hook; }
+
+pw_buffer* pw_stream_dequeue_buffer(pw_stream* stream) {
+    (void)stream; return nullptr;
+}
+
+int pw_stream_queue_buffer(pw_stream* stream, pw_buffer* buffer) {
+    (void)stream; (void)buffer; return -1;
+}
+
+spa_pod* spa_format_audio_raw_build(spa_pod_builder* builder, uint32_t id, const void* info) {
+    (void)builder; (void)id; (void)info; return nullptr;
+}
+} // extern "C"
+#endif // !SEP_HAS_PIPEWIRE


### PR DESCRIPTION
## Summary
- explain the audio pipeline and clean-up steps in `docs/audio.md`
- move stub PipeWire functions from header to `pipewire_stubs.cpp`
- expose stub prototypes only in `pipewire_includes.h`
- add new stub source to the audio CMake target

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: glm not found)*

------
https://chatgpt.com/codex/tasks/task_e_68591435d748832aaec53babd03b330c