### PR TITLE
Fix declarations for MemoryTierManager

### DIFF
--- a/include/memory/memory_tier_manager.hpp
+++ b/include/memory/memory_tier_manager.hpp
@@ -12,9 +12,9 @@
 #include "core/dag_graph.h"
 #include "memory/memory_tier.hpp"
 #include "memory/types.h"
+#include "quantum/types.h"
 #include "compat/shim.h"
 #include "quantum/relationship.h"
-#include "quantum/types.h"
 
 // Standard library includes
 #include <cstddef>
@@ -28,6 +28,11 @@
 #include <glm/vec3.hpp>
 
 namespace sep {
+namespace pattern {
+struct PatternData;
+struct PatternConfig;
+}
+
 namespace core {
 class SystemHooks;
 }
@@ -91,11 +96,6 @@ public:
     void rebuildLookup();
 
     // Pattern management
-    // Forward declare pattern namespace types to avoid compilation errors
-    namespace sep { namespace pattern {
-        struct PatternData;
-        struct PatternConfig;
-    }}
 
     SEPResult launch_pattern_processing(sep::pattern::PatternData* patterns,
                                       sep::pattern::PatternData* results,

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -213,15 +213,15 @@ void MemoryTierManager::pruneWeakRelationships() {
 
 void MemoryTierManager::calculateRelationshipCoherence() {}
 void MemoryTierManager::loadLTMFromPersistence() {}
-void MemoryTierManager::storeLTMToPersistence(const Pattern&) {}
+void MemoryTierManager::storeLTMToPersistence(const quantum::Pattern&) {}
 
-Pattern* MemoryTierManager::findPattern(std::size_t id) {
+quantum::Pattern* MemoryTierManager::findPattern(std::size_t id) {
     auto it = pattern_registry_.find(id);
     if (it == pattern_registry_.end()) {
         return nullptr;
     }
     const sep::pattern::PatternData* data = it->second.get();
-    Pattern* pattern = new Pattern();
+    quantum::Pattern* pattern = new quantum::Pattern();
     pattern->id = data->id;
     const float values[] = {data->attributes.x, data->attributes.y, data->attributes.z, data->attributes.w};
     pattern->data.assign(values, values + 4);
@@ -232,13 +232,13 @@ Pattern* MemoryTierManager::findPattern(std::size_t id) {
     return pattern;
 }
 
-const Pattern* MemoryTierManager::findPattern(std::size_t id) const {
+const quantum::Pattern* MemoryTierManager::findPattern(std::size_t id) const {
     auto it = pattern_registry_.find(id);
     if (it == pattern_registry_.end()) {
         return nullptr;
     }
     const sep::pattern::PatternData* data = it->second.get();
-    Pattern* pattern = new Pattern();
+    quantum::Pattern* pattern = new quantum::Pattern();
     pattern->id = data->id;
     const float values[] = {data->attributes.x, data->attributes.y, data->attributes.z, data->attributes.w};
     pattern->data.assign(values, values + 4);


### PR DESCRIPTION
## Summary
- add forward declarations for pattern types at namespace scope
- deduplicate quantum includes
- adjust pattern-related method signatures to use quantum::Pattern

## Testing
- `g++ -std=c++17 -Iinclude -Ithird_party -c src/memory/memory_tier_manager.cpp -o /tmp/mtm.o` *(fails: cuda types not found)*

------
https://chatgpt.com/codex/tasks/task_e_68593748a104832a84a15b9aa1cc1eec