### PR TITLE
Fix audio test vector usage

### DIFF
--- a/include/compat/shim.h
+++ b/include/compat/shim.h
@@ -508,6 +508,11 @@ namespace shim {
       size_ += count;
     }
   };
+
+  template<typename T>
+  inline std::vector<T> to_std_vector(const vector<T>& v) {
+    return std::vector<T>(v.begin(), v.end());
+  }
   
   template<typename K, typename V, typename... Args>
   class map {

--- a/tests/audio/features_test.cpp
+++ b/tests/audio/features_test.cpp
@@ -2,6 +2,7 @@
 #include "audio/pipeline.h"
 #include "compat/shim.h"
 #include <cmath>
+#include <vector>
 
 using namespace sep::audio;
 
@@ -10,7 +11,8 @@ TEST(AudioPipelineTestbed, ExtractsFundamentalFrequency){
     const float freq=1000.0f;
     for(int i=0;i<2048;i++){
         float sample = std::sinf(2.0f*M_PI*freq*(float)i/48000.0f);
-        pipeline.processAudioFrame(sep::shim::vector<float>{sample});
+        sep::shim::vector<float> frame{sample};
+        pipeline.processAudioFrame(sep::shim::to_std_vector(frame));
     }
     auto patterns = pipeline.getPatterns();
     ASSERT_FALSE(patterns.empty());


### PR DESCRIPTION
## Summary
- add helper to convert shim::vector to std::vector
- update audio feature test to use shim::vector with conversion

## Testing
- `cmake --build .` *(fails: no declaration matches in quantum_processor.cpp)*
- `ctest --output-on-failure` *(no tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_6859374bb994832ab15c2198be89bf98