### PR TITLE
Introduce GPU context and unify memory tier

### DIFF
--- a/include/memory/memory_tier.hpp
+++ b/include/memory/memory_tier.hpp
@@ -15,13 +15,6 @@
 
 namespace sep {
 
-// Memory tier enum - for pattern storage
-enum class MemoryTierEnum {
-    STM = 0,  // Short-term memory
-    MTM = 1,  // Medium-term memory
-    LTM = 2   // Long-term memory
-};
-
 namespace memory {
 
 // Memory tier types

--- a/include/quantum/gpu_context.h
+++ b/include/quantum/gpu_context.h
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace sep::quantum {
+
+struct GPUContext {
+    int device_id{0};
+    // Additional GPU-related fields can be added here
+};
+
+} // namespace sep::quantum

--- a/include/quantum/pattern_processor.h
+++ b/include/quantum/pattern_processor.h
@@ -4,6 +4,7 @@
 #include "quantum/types.h"
 #include "core/types.h"
 #include "memory/memory_tier.hpp"
+#include "quantum/gpu_context.h"
 #include <vector>
 #include <memory>
 #include <string>
@@ -11,7 +12,6 @@
 namespace sep::quantum {
 
 // Forward declarations
-class GPUContext;
 namespace core { class SystemHooks; }
 
 // Constants for pattern processing

--- a/include/quantum/processor.h
+++ b/include/quantum/processor.h
@@ -3,12 +3,11 @@
 
 #include "types.h"
 #include "core/common.h"
+#include "quantum/gpu_context.h"
 #include <memory>
 #include <vector>
 
 namespace sep::quantum {
-
-class GPUContext;
 namespace core { class SystemHooks; }
 
 class ProcessorImpl;

--- a/include/quantum/quantum_pattern_processor.h
+++ b/include/quantum/quantum_pattern_processor.h
@@ -6,6 +6,7 @@
 #include "quantum/pattern_evolution.h"
 #include "quantum/quantum_processor.h"
 #include "quantum/types.h"
+#include "quantum/gpu_context.h"
 #include <string>
 #include <vector>
 

--- a/include/quantum/quantum_processor.h
+++ b/include/quantum/quantum_processor.h
@@ -2,15 +2,26 @@
 
 // Compatibility header - redirects to new unified processor
 #include "quantum/processor.h"
+#include <stdexcept>
+#include <glm/vec3.hpp>
+#include <memory>
 
 namespace sep::quantum {
+
+class QuantumProcessorError : public std::runtime_error {
+public:
+    explicit QuantumProcessorError(const std::string& message);
+};
+
+class QBSAProcessor;
+class QuantumProcessorImpl;
 
 // Forward compatibility - QuantumProcessor is now just Processor
 // This allows existing code to continue working
 class QuantumProcessor : public Processor {
 public:
     using Processor::Processor;
-    
+
     // Legacy Config type mapping
     struct Config {
         size_t max_qubits = 16;
@@ -21,6 +32,28 @@ public:
         // Convert to new ProcessingConfig
         operator ProcessingConfig() const;
     };
+
+    QuantumProcessor() = default;
+    explicit QuantumProcessor(const Config& config);
+    ~QuantumProcessor();
+
+    float calculateCoherence(const glm::vec3& a, const glm::vec3& b);
+    float calculateStability(float coherence, float historical_stability,
+                             float generation_count, float access_frequency);
+    bool processPattern(const glm::vec3& data, size_t id);
+    bool updatePattern(size_t id, const glm::vec3& data);
+    void removePattern(size_t id);
+    bool isStable(float coherence) const;
+    bool isCollapsed(float coherence) const;
+    bool isQuantum(float coherence) const;
+    void updateConfig(const Config& new_config);
+
+private:
+    Config config_{};
+    std::unique_ptr<QBSAProcessor> qbsa_processor_;
+    std::unique_ptr<QuantumProcessorImpl> impl_;
 };
+
+std::unique_ptr<QuantumProcessor> createQuantumProcessor(const QuantumProcessor::Config& config);
 
 } // namespace sep::quantum

--- a/include/quantum/quantum_processor_qfh.h
+++ b/include/quantum/quantum_processor_qfh.h
@@ -4,6 +4,7 @@
 #include "memory/types.h"
 #include "quantum/qbsa.h"
 #include "quantum/qfh.h"
+#include "quantum/types.h"
 #include <cstdint>
 #include <glm/glm.hpp>
 #include <memory>

--- a/include/quantum/types.h
+++ b/include/quantum/types.h
@@ -5,13 +5,17 @@
 #include <vector>
 #include <string>
 
-namespace sep::quantum {
+namespace sep {
 
 enum class MemoryTierEnum {
     STM,
     MTM,
     LTM
 };
+
+} // namespace sep
+
+namespace sep::quantum {
 
 enum class RelationshipType {
     ENTANGLEMENT,

--- a/src/quantum/quantum_processor.cpp
+++ b/src/quantum/quantum_processor.cpp
@@ -56,31 +56,10 @@ private:
 
 QuantumProcessor::~QuantumProcessor() = default;
 
-// QuantumProcessor public interface implementation
-
-QuantumProcessor::QuantumProcessor(const Config& config) : config_(config) {
-    validateConfig(config);
-    initializeProcessor();
-    qbsa_processor_ = createQFHBasedQBSAProcessor();
-}
-
-void QuantumProcessor::validateConfig(const Config& config) {
-    if (config.coherence_threshold < 0.0f || config.coherence_threshold > 1.0f) {
-        return;
-    }
-    if (config.stability_threshold < 0.0f || config.stability_threshold > 1.0f) {
-        return;
-    }
-    if (config.minimum_coherence < 0.0f || config.minimum_coherence > 1.0f) {
-        return;
-    }
-    if (config.demotion_threshold < 0.0f || config.demotion_threshold > 1.0f) {
-        return;
-    }
-}
-
-void QuantumProcessor::initializeProcessor() {
+QuantumProcessor::QuantumProcessor(const Config& config)
+    : Processor(static_cast<ProcessingConfig>(config)), config_(config) {
     impl_ = std::make_unique<QuantumProcessorImpl>();
+    qbsa_processor_ = createQFHBasedQBSAProcessor({});
 }
 
 float QuantumProcessor::calculateCoherence(const glm::vec3& pattern_a, const glm::vec3& pattern_b) {
@@ -137,22 +116,21 @@ void QuantumProcessor::removePattern(size_t pattern_id) {
 }
 
 bool QuantumProcessor::isStable(float coherence) const {
-    return coherence >= config_.stability_threshold;
+    return coherence >= config_.measurement_threshold;
 }
 
 bool QuantumProcessor::isCollapsed(float coherence) const {
-    return coherence < config_.minimum_coherence;
+    return coherence < config_.decoherence_rate;
 }
 
 bool QuantumProcessor::isQuantum(float coherence) const {
-    return coherence >= config_.minimum_coherence &&
-           coherence < config_.coherence_threshold;
+    return coherence >= config_.decoherence_rate &&
+           coherence < config_.measurement_threshold;
 }
 
 void QuantumProcessor::updateConfig(const Config& new_config) {
-    validateConfig(new_config);
     config_ = new_config;
-    initializeProcessor();
+    impl_ = std::make_unique<QuantumProcessorImpl>();
 }
 
 // Factory functions
@@ -161,12 +139,12 @@ std::unique_ptr<QuantumProcessor> createQuantumProcessor(
     return std::make_unique<QuantumProcessor>(config);
 }
 
-ProcessingConfig QuantumProcessor::Config::operator ProcessingConfig() const {
+QuantumProcessor::Config::operator ProcessingConfig() const {
     ProcessingConfig pc;
-    pc.max_qubits = max_qubits;
-    pc.decoherence_rate = decoherence_rate;
-    pc.measurement_threshold = measurement_threshold;
-    pc.enable_gpu = enable_gpu;
+    pc.max_patterns = max_qubits;
+    pc.mutation_rate = decoherence_rate;
+    pc.ltm_coherence_threshold = measurement_threshold;
+    pc.enable_cuda = enable_gpu;
     return pc;
 }
 } // namespace sep::quantum

--- a/src/quantum/quantum_processor_qfh.cpp
+++ b/src/quantum/quantum_processor_qfh.cpp
@@ -8,13 +8,13 @@ const QFHResult& QuantumProcessorQFH::getLastQFHResult() const {
     return lastQFHResult();
 }
 
-MemoryTierEnum QuantumProcessorQFH::determineMemoryTier(float coherence, float stability,
+sep::MemoryTierEnum QuantumProcessorQFH::determineMemoryTier(float coherence, float stability,
                                                         uint32_t generation_count) const {
     if (coherence >= 0.9f && stability >= 0.85f && generation_count >= 100)
-        return MemoryTierEnum::LTM;
+        return sep::MemoryTierEnum::LTM;
     if (coherence >= 0.7f && generation_count >= 5)
-        return MemoryTierEnum::MTM;
-    return MemoryTierEnum::STM;
+        return sep::MemoryTierEnum::MTM;
+    return sep::MemoryTierEnum::STM;
 }
 
 }  // namespace sep::quantum


### PR DESCRIPTION
## Summary
- add minimal GPUContext definition for quantum
- centralize MemoryTierEnum in quantum/types
- expose QuantumProcessorError and update QuantumProcessor class
- use updated MemoryTierEnum in QFH processor

## Testing
- `cmake --build build` *(fails: evolution.cpp missing impl_)*

------
https://chatgpt.com/codex/tasks/task_e_68593749e6d8832a8e4d51fcc5d5737d