### PR TITLE
Integrate PatternData definitions

### DIFF
--- a/include/blender/bridge.h
+++ b/include/blender/bridge.h
@@ -12,6 +12,7 @@
 #include "blender/compat/blender_types.h"
 #include "blender/gpu_context.h"
 #include "blender/pattern_common.h"
+#include "pattern/data.hpp"
 
 #include "blender/types.h"
 #include "core/types.h"

--- a/include/blender/mesh_handler.h
+++ b/include/blender/mesh_handler.h
@@ -6,6 +6,7 @@
 
 #include "blender/compat/blender_types.h"
 #include "blender/pattern_common.h"
+#include "pattern/data.hpp"
 
 #include "blender/types.h"
 #include "core/common.h"  // for sep::SEPResult

--- a/include/blender/pattern_bridge.h
+++ b/include/blender/pattern_bridge.h
@@ -7,8 +7,8 @@
 #include "blender/base_types.h"
 #include "blender/compat/blender_types.h"  // If still needed
 #include "blender/gpu_context.h"           // For GPUContext
-#include "blender/pattern_common.h"
-  // For ObjectState (assuming)
+#include "blender/pattern_common.h"  // For ObjectState (assuming)
+#include "pattern/data.hpp"
 #include "core/types.h"
 #include "blender/pattern_observer.h"   // For PatternObserver
 #include "blender/types.h"              // For Object, SEPResult, etc.

--- a/include/blender/pattern_visualization_pipeline.h
+++ b/include/blender/pattern_visualization_pipeline.h
@@ -3,6 +3,7 @@
 #include "blender/mesh_handler.h"
 #include "blender/gpu_context.h"
 #include "blender/pattern_common.h"
+#include "pattern/data.hpp"
 #include "compat/shim.h"
 #include <array>
 

--- a/include/compat/kernels.cuh
+++ b/include/compat/kernels.cuh
@@ -19,6 +19,7 @@
 // Other project headers
 #include "compat/constants.h"
 #include "quantum/types.h"
+#include "pattern/data.hpp"
 
 #ifndef __CUDACC__
 #include "compat/cuda_impl.h"

--- a/include/memory/memory_tier_manager.hpp
+++ b/include/memory/memory_tier_manager.hpp
@@ -15,6 +15,7 @@
 #include "compat/shim.h"
 #include "quantum/relationship.h"
 #include "quantum/types.h"
+#include "pattern/data.hpp"
 
 // Standard library includes
 #include <cstddef>
@@ -91,11 +92,6 @@ public:
     void rebuildLookup();
 
     // Pattern management
-    // Forward declare pattern namespace types to avoid compilation errors
-    namespace sep { namespace pattern {
-        struct PatternData;
-        struct PatternConfig;
-    }}
 
     SEPResult launch_pattern_processing(sep::pattern::PatternData* patterns,
                                       sep::pattern::PatternData* results,

--- a/include/pattern/data.hpp
+++ b/include/pattern/data.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "compat/shim.h"
+#include "quantum/types.h"
+#include <glm/glm.hpp>
+#include <vector>
+
+namespace sep {
+namespace pattern {
+
+struct PatternData {
+    shim::string id;
+    int generation{0};
+    glm::vec4 position{0.0f};
+    glm::vec4 velocity{0.0f};
+    glm::vec4 attributes{0.0f};
+    float coherence{0.0f};
+    float stability{0.0f};
+    float entropy{0.0f};
+    float mutation_rate{0.0f};
+    std::uint32_t mutation_count{0};
+    quantum::MemoryTierEnum memory_tier{quantum::MemoryTierEnum::STM};
+    std::vector<quantum::PatternRelationship> relationships;
+};
+
+struct PatternConfig {
+    float update_threshold{0.1f};
+    bool enable_mutations{true};
+    std::size_t max_patterns{1000};
+    std::size_t batch_size{64};
+};
+
+enum class SEPResult {
+    SUCCESS = 0,
+    INVALID_ARGUMENT = -1,
+    ALLOCATION_FAILED = -2,
+    PROCESSING_ERROR = -3
+};
+
+} // namespace pattern
+} // namespace sep
+

--- a/include/quantum/pattern_evolution.h
+++ b/include/quantum/pattern_evolution.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "quantum/types.h"
+#include "pattern/data.hpp"
 #include <nlohmann/json.hpp>
 #include <vector>
 #include <string>
@@ -11,21 +12,21 @@ namespace mcp {
 
 class PatternEvolution {
 public:
-    static Pattern::PatternData evolvePattern(const nlohmann::json& config,
+    static sep::pattern::PatternData evolvePattern(const nlohmann::json& config,
                                          const std::string& patternId = "");
 
-    static std::vector<Pattern::PatternData> getPatterns(const nlohmann::json& args = {});
+    static std::vector<sep::pattern::PatternData> getPatterns(const nlohmann::json& args = {});
 
-    static SEPResult processPatterns(const std::vector<Pattern::PatternData>& input,
-                                          const ::sep::Pattern::PatternConfig& config,
-                                          std::vector<Pattern::PatternData>& output);
+    static SEPResult processPatterns(const std::vector<sep::pattern::PatternData>& input,
+                                          const sep::pattern::PatternConfig& config,
+                                          std::vector<sep::pattern::PatternData>& output);
 
-    static float calculateRelationshipStrength(const Pattern::PatternData& pattern1,
-                                               const Pattern::PatternData& pattern2);
+    static float calculateRelationshipStrength(const sep::pattern::PatternData& pattern1,
+                                               const sep::pattern::PatternData& pattern2);
 
-    static nlohmann::json toJson(const Pattern::PatternData& pattern);
+    static nlohmann::json toJson(const sep::pattern::PatternData& pattern);
 
-    static Pattern::PatternData fromJson(const nlohmann::json& j);
+    static sep::pattern::PatternData fromJson(const nlohmann::json& j);
 };
 
 } // namespace mcp

--- a/include/quantum/quantum_pattern_processor.h
+++ b/include/quantum/quantum_pattern_processor.h
@@ -6,6 +6,7 @@
 #include "quantum/pattern_evolution.h"
 #include "quantum/quantum_processor.h"
 #include "quantum/types.h"
+#include "pattern/data.hpp"
 #include <string>
 #include <vector>
 

--- a/src/compat/pattern_kernels.cu
+++ b/src/compat/pattern_kernels.cu
@@ -3,6 +3,7 @@
 
 #include "compat/cuda_unified_fix.h"
 #include "quantum/types.h"
+#include "pattern/data.hpp"
 
 #include "compat/cuda_helpers.h"
 #ifdef __CUDACC__

--- a/src/context/processor.cpp
+++ b/src/context/processor.cpp
@@ -4,6 +4,7 @@
 #include "quantum/relationship.h"
 #include "quantum/pattern_processor.h"
 #include "core/types.h"
+#include "pattern/data.hpp"
 
 #include "memory/memory_tier_manager.hpp"
 #include "compat/math_common.h"

--- a/src/quantum/pattern_evolution.cpp
+++ b/src/quantum/pattern_evolution.cpp
@@ -1,6 +1,7 @@
 
 #include "quantum/pattern_evolution.h"
 #include "quantum/types.h"
+#include "pattern/data.hpp"
 #include <nlohmann/json.hpp>
 #include "compat/shim.h"
 #include "core/types.h"

--- a/src/quantum/quantum_pattern_processor.cpp
+++ b/src/quantum/quantum_pattern_processor.cpp
@@ -1,4 +1,5 @@
 #include "quantum/quantum_pattern_processor.h"
+#include "pattern/data.hpp"
 
 namespace sep {
 namespace pattern {


### PR DESCRIPTION
## Summary
- define `PatternData`, `PatternConfig`, and local `SEPResult`
- include the new header across CPU/GPU sources
- remove obsolete forward declarations

## Testing
- `cmake ..`
- `cmake --build .` *(fails: missing ProcessingConfig members and other compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_68593746edf0832ab6f30b9c4d00ebdb