### PR TITLE
Fix compile errors from build log

### DIFF
--- a/include/compat/cuda_common.h
+++ b/include/compat/cuda_common.h
@@ -15,7 +15,10 @@ namespace sep::cuda {
 #if SEP_CUDA_AVAILABLE
 void logCudaError(const char* operation, cudaError_t error);
 #else
-void logCudaError(const char* operation, cuda_stub_constants::cudaError_t error);
+// The stub implementation reuses sep::cuda::cudaError_t directly rather than
+// relying on the internal cuda_stub_constants namespace.  This avoids build
+// failures when the stub constants header does not provide a matching type.
+void logCudaError(const char* operation, cudaError_t error);
 #endif
 }  // namespace sep::cuda
 

--- a/include/quantum/evolution.h
+++ b/include/quantum/evolution.h
@@ -3,6 +3,7 @@
 
 #include "quantum/types.h"
 #include <vector>
+#include <memory>
 
 namespace sep::quantum {
 

--- a/src/blender/gpu_context.cpp
+++ b/src/blender/gpu_context.cpp
@@ -2,13 +2,11 @@
 
 namespace sep {
 
-// Implementation of the GPUBufferDeleter operator()
-void GPUBufferDeleter::operator()(GPUBuffer* buffer) const noexcept {
-    if (ctx && buffer) {
-        ctx->deleteBuffer(buffer);
-    }
-}
-
-// That's it! The GPUContext methods are already implemented inline in the header.
+// This translation unit intentionally remains empty. All methods of GPUContext
+// and its helper types are defined inline in the header to allow the minimal
+// stub implementation to be header-only. Keeping this file ensures that the
+// build system can still reference a source for the component without
+// generating duplicate symbol definitions when the header is included in
+// multiple translation units.
 
 }  // namespace sep

--- a/src/core/dag_graph.cpp
+++ b/src/core/dag_graph.cpp
@@ -70,7 +70,9 @@ void DagGraph::removeNode(uint64_t id)
 
 bool DagGraph::hasNode(uint64_t id) const
 {
-    return nodes_.contains(id);
+    // `std::unordered_map::contains` is only available in C++20. Use a
+    // find-based check for broader compiler support.
+    return nodes_.find(id) != nodes_.end();
 }
 
 }  // namespace dag

--- a/src/quantum/evolution.cpp
+++ b/src/quantum/evolution.cpp
@@ -5,6 +5,8 @@
 #include <algorithm>
 #include <numeric>
 #include <random>
+#include <atomic>
+#include <chrono>
 
 namespace sep::quantum {
 

--- a/src/quantum/processor.cpp
+++ b/src/quantum/processor.cpp
@@ -1,6 +1,7 @@
 #include "quantum/processor.h"
 #include "quantum/types.h"
 #include <glm/glm.hpp>
+#include <glm/gtc/random.hpp>
 #include <mutex>
 #include <unordered_map>
 #include <chrono>


### PR DESCRIPTION
## Summary
- clean up CUDA compatibility error type
- include `<memory>` in evolution header
- remove duplicate GPU buffer deleter implementation
- use `find` rather than C++20 `contains`
- include missing headers in quantum sources
- include glm random utilities

## Testing
- `cmake .. -DSEP_BUILD_TESTS=ON`
- `make -j$(nproc)` *(fails: glm/glm.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685953582bf8832a9b2a4e528bf6dceb