### PR TITLE
Remove random sources from quantum code

### DIFF
--- a/include/quantum/quantum_rng.h
+++ b/include/quantum/quantum_rng.h
@@ -1,0 +1,37 @@
+#ifndef SEP_QUANTUM_QUANTUM_RNG_H
+#define SEP_QUANTUM_QUANTUM_RNG_H
+
+#include <cstdint>
+#include <cmath>
+
+namespace sep::quantum {
+
+class QuantumRNG {
+public:
+    explicit QuantumRNG(uint32_t seed = 0x12345678u) : state_(seed) {}
+
+    float uniform() {
+        state_ ^= state_ << 13;
+        state_ ^= state_ >> 17;
+        state_ ^= state_ << 5;
+        return static_cast<float>(state_ & 0xFFFFFFu) / static_cast<float>(0xFFFFFFu);
+    }
+
+    uint32_t uniform(uint32_t max) {
+        return static_cast<uint32_t>(uniform() * static_cast<float>(max));
+    }
+
+    float gaussian(float mean, float stddev) {
+        float u1 = uniform();
+        float u2 = uniform();
+        float z = std::sqrt(-2.0f * std::log(u1 + 1e-6f)) * std::cos(2.0f * M_PI * u2);
+        return mean + z * stddev;
+    }
+
+private:
+    uint32_t state_;
+};
+
+} // namespace sep::quantum
+
+#endif // SEP_QUANTUM_QUANTUM_RNG_H

--- a/src/quantum/evolution.cpp
+++ b/src/quantum/evolution.cpp
@@ -1,10 +1,9 @@
 #include "quantum/evolution.h"
 #include "quantum/processor.h"
 #include <glm/glm.hpp>
-#include <glm/gtc/random.hpp>
+#include "quantum/quantum_rng.h"
 #include <algorithm>
 #include <numeric>
-#include <random>
 #include <stdexcept>
 #include <chrono>
 #include <atomic>
@@ -14,7 +13,7 @@ namespace sep::quantum {
 class EvolutionEngine::EvolutionEngineImpl {
 public:
     explicit EvolutionEngineImpl(Processor* processor)
-        : processor_(processor), generation_number_(0), random_engine_(std::random_device{}()) {
+        : processor_(processor), generation_number_(0), rng_() {
         if (!processor) {
             throw std::invalid_argument("Processor cannot be null");
         }
@@ -50,7 +49,7 @@ public:
                 auto parent1 = processor_->getPattern(parent_ids[0]);
                 auto parent2 = processor_->getPattern(parent_ids[1]);
                 auto child = crossover(parent1, parent2);
-                if (uniform_real_distribution_(random_engine_) < processor_->getConfig().mutation_rate) {
+                if (rng_.uniform() < processor_->getConfig().mutation_rate) {
                     child = mutate(child);
                 }
                 processor_->addPattern(child);
@@ -87,7 +86,7 @@ public:
         child.last_accessed = child.timestamp;
         child.last_modified = child.timestamp;
 
-        float alpha = uniform_real_distribution_(random_engine_);
+        float alpha = rng_.uniform();
         auto& state1 = parent1.quantum_state;
         auto& state2 = parent2.quantum_state;
         auto& child_state = child.quantum_state;
@@ -115,12 +114,12 @@ public:
         auto& state = mutated.quantum_state;
         float sigma = processor_->getConfig().mutation_rate;
 
-        state.coherence = glm::clamp(state.coherence + glm::gaussRand(0.0f, sigma), 0.0f, 1.0f);
-        state.stability = glm::clamp(state.stability + glm::gaussRand(0.0f, sigma * 0.5f), 0.0f, 1.0f);
-        state.entropy = glm::clamp(state.entropy + glm::gaussRand(0.0f, sigma * 2.0f), 0.0f, 1.0f);
+        state.coherence = glm::clamp(state.coherence + rng_.gaussian(0.0f, sigma), 0.0f, 1.0f);
+        state.stability = glm::clamp(state.stability + rng_.gaussian(0.0f, sigma * 0.5f), 0.0f, 1.0f);
+        state.entropy = glm::clamp(state.entropy + rng_.gaussian(0.0f, sigma * 2.0f), 0.0f, 1.0f);
 
-        mutated.position += glm::vec4(glm::gaussRand(0.0f, sigma), glm::gaussRand(0.0f, sigma),
-                                      glm::gaussRand(0.0f, sigma), 0.0f);
+        mutated.position += glm::vec4(rng_.gaussian(0.0f, sigma), rng_.gaussian(0.0f, sigma),
+                                      rng_.gaussian(0.0f, sigma), 0.0f);
 
         state.mutation_count++;
         return mutated;
@@ -148,12 +147,12 @@ public:
         if (patterns.empty()) return {};
 
         std::vector<std::string> winners;
-        std::uniform_int_distribution<size_t> dist(0, patterns.size() - 1);
+        size_t range = patterns.size();
 
         for (size_t w = 0; w < num_winners; ++w) {
             std::vector<std::pair<std::string, float>> tournament;
             for (size_t i = 0; i < tournament_size; ++i) {
-                size_t idx = dist(random_engine_);
+                size_t idx = rng_.uniform(range);
                 tournament.push_back({patterns[idx].id, calculateFitness(patterns[idx])});
             }
             auto winner = std::max_element(tournament.begin(), tournament.end(),
@@ -176,10 +175,8 @@ public:
         }
 
         std::vector<std::string> selected;
-        std::uniform_real_distribution<float> dist(0.0f, total_fitness);
-
         for (size_t i = 0; i < count; ++i) {
-            float value = dist(random_engine_);
+            float value = rng_.uniform() * total_fitness;
             float cumulative = 0.0f;
             for (size_t j = 0; j < patterns.size(); ++j) {
                 cumulative += fitness_values[j];
@@ -278,8 +275,7 @@ private:
     size_t generation_number_;
     EvolutionStats current_stats_;
     std::vector<EvolutionStats> stats_history_;
-    std::mt19937 random_engine_;
-    std::uniform_real_distribution<float> uniform_real_distribution_{0.0f, 1.0f};
+    QuantumRNG rng_;
 };
 
 EvolutionEngine::EvolutionEngine(Processor* processor) : impl_(std::make_unique<EvolutionEngineImpl>(processor)) {}
@@ -306,26 +302,25 @@ namespace evolution {
 Pattern gaussianMutation(const Pattern& pattern, float sigma) {
     Pattern mutated = pattern;
     auto& state = mutated.quantum_state;
-    state.coherence = glm::clamp(state.coherence + glm::gaussRand(0.0f, sigma), 0.0f, 1.0f);
-    state.stability = glm::clamp(state.stability + glm::gaussRand(0.0f, sigma * 0.5f), 0.0f, 1.0f);
-    state.entropy = glm::clamp(state.entropy + glm::gaussRand(0.0f, sigma * 2.0f), 0.0f, 1.0f);
-    mutated.position += glm::vec4(glm::gaussRand(0.0f, sigma), glm::gaussRand(0.0f, sigma),
-                                  glm::gaussRand(0.0f, sigma), 0.0f);
+    QuantumRNG rng;
+    state.coherence = glm::clamp(state.coherence + rng.gaussian(0.0f, sigma), 0.0f, 1.0f);
+    state.stability = glm::clamp(state.stability + rng.gaussian(0.0f, sigma * 0.5f), 0.0f, 1.0f);
+    state.entropy = glm::clamp(state.entropy + rng.gaussian(0.0f, sigma * 2.0f), 0.0f, 1.0f);
+    mutated.position += glm::vec4(rng.gaussian(0.0f, sigma), rng.gaussian(0.0f, sigma),
+                                  rng.gaussian(0.0f, sigma), 0.0f);
     state.mutation_count++;
     return mutated;
 }
 
 Pattern uniformMutation(const Pattern& pattern, float rate) {
     Pattern mutated = pattern;
-    std::random_device rd;
-    std::mt19937 gen(rd());
-    std::uniform_real_distribution<float> dist(0.0f, 1.0f);
+    QuantumRNG rng;
     auto& state = mutated.quantum_state;
-    if (dist(gen) < rate) state.coherence = dist(gen);
-    if (dist(gen) < rate) state.stability = dist(gen);
-    if (dist(gen) < rate) state.entropy = dist(gen);
+    if (rng.uniform() < rate) state.coherence = rng.uniform();
+    if (rng.uniform() < rate) state.stability = rng.uniform();
+    if (rng.uniform() < rate) state.entropy = rng.uniform();
     for (int i = 0; i < 3; ++i) {
-        if (dist(gen) < rate) mutated.position[i] = dist(gen) * 2.0f - 1.0f;
+        if (rng.uniform() < rate) mutated.position[i] = rng.uniform() * 2.0f - 1.0f;
     }
     state.mutation_count++;
     return mutated;
@@ -353,18 +348,16 @@ float complexityFitness(const Pattern& pattern) {
 
 std::vector<Pattern> createRandomPopulation(size_t size) {
     std::vector<Pattern> population;
-    std::random_device rd;
-    std::mt19937 gen(rd());
-    std::uniform_real_distribution<float> dist(0.0f, 1.0f);
+    QuantumRNG rng;
     for (size_t i = 0; i < size; ++i) {
         Pattern pattern;
         pattern.id = "rand_" + std::to_string(i);
         auto& state = pattern.quantum_state;
-        state.coherence = dist(gen);
-        state.stability = dist(gen);
-        state.entropy = dist(gen);
-        pattern.position = glm::vec4(dist(gen) * 2.0f - 1.0f, dist(gen) * 2.0f - 1.0f,
-                                     dist(gen) * 2.0f - 1.0f, 1.0f);
+        state.coherence = rng.uniform();
+        state.stability = rng.uniform();
+        state.entropy = rng.uniform();
+        pattern.position = glm::vec4(rng.uniform() * 2.0f - 1.0f, rng.uniform() * 2.0f - 1.0f,
+                                     rng.uniform() * 2.0f - 1.0f, 1.0f);
         population.push_back(pattern);
     }
     return population;

--- a/src/quantum/processor.cpp
+++ b/src/quantum/processor.cpp
@@ -1,7 +1,7 @@
 #include "quantum/processor.h"
 #include "quantum/types.h"
 #include <glm/glm.hpp>
-#include <glm/gtc/random.hpp>
+#include "quantum/quantum_rng.h"
 #include <mutex>
 #include <unordered_map>
 #include <chrono>
@@ -13,7 +13,7 @@ namespace sep::quantum {
 class ProcessorImpl {
 public:
     explicit ProcessorImpl(const ProcessingConfig& config)
-        : config_(config), initialized_(false), gpu_context_(nullptr), hooks_(nullptr) {}
+        : config_(config), initialized_(false), gpu_context_(nullptr), hooks_(nullptr), rng_() {}
 
     SEPResult init(GPUContext* gpu_context) {
         std::lock_guard<std::mutex> lock(mutex_);
@@ -282,10 +282,10 @@ private:
     }
 
     void mutateQuantumState(QuantumState& state) {
-        state.coherence = glm::clamp(state.coherence + glm::gaussRand(0.0f, config_.mutation_rate), 0.0f, 1.0f);
-        state.stability = glm::clamp(state.stability + glm::gaussRand(0.0f, config_.mutation_rate * 0.5f), 0.0f, 1.0f);
-        state.entropy = glm::clamp(state.entropy + glm::gaussRand(0.0f, config_.mutation_rate * 2.0f), 0.0f, 1.0f);
-        state.mutation_rate *= (1.0f + glm::gaussRand(0.0f, 0.1f));
+        state.coherence = glm::clamp(state.coherence + rng_.gaussian(0.0f, config_.mutation_rate), 0.0f, 1.0f);
+        state.stability = glm::clamp(state.stability + rng_.gaussian(0.0f, config_.mutation_rate * 0.5f), 0.0f, 1.0f);
+        state.entropy = glm::clamp(state.entropy + rng_.gaussian(0.0f, config_.mutation_rate * 2.0f), 0.0f, 1.0f);
+        state.mutation_rate *= (1.0f + rng_.gaussian(0.0f, 0.1f));
         state.mutation_count++;
     }
 
@@ -335,6 +335,7 @@ private:
     bool initialized_;
     GPUContext* gpu_context_;
     core::SystemHooks* hooks_;
+    QuantumRNG rng_;
 };
 
 Processor::Processor(const ProcessingConfig& config) : impl_(std::make_unique<ProcessorImpl>(config)) {}


### PR DESCRIPTION
## Summary
- replace GLM random utilities with a lightweight RNG
- remove use of `<random>` throughout the quantum engine

## Testing
- `cmake .. -DSEP_BUILD_TESTS=ON` *(fails: `crow/http_request.h` not found)*
- `make -j$(nproc)` *(fails: missing dependencies like `glm` and CUDA headers)*

------
https://chatgpt.com/codex/tasks/task_e_6859603052d8832a9e2a2d4327c3a10a