### PR TITLE
Add Crow and GLM dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,12 @@
 cmake_minimum_required(VERSION 3.10)
 project(SEPEngine)
 
-include_directories(${CMAKE_SOURCE_DIR}/include
-                    ${CMAKE_SOURCE_DIR}/third_party)
+include_directories(
+    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/third_party
+    ${CMAKE_SOURCE_DIR}/third_party/nlohmann
+    ${CMAKE_SOURCE_DIR}/third_party/crow/include
+)
 add_subdirectory(src/api)
 add_subdirectory(src/audio)
 add_subdirectory(src/blender)
@@ -21,4 +25,3 @@ target_link_libraries(sep_engine
                       sep_audio
                       sep_blender
                       sep_compat)
-include_directories(${CMAKE_SOURCE_DIR}/third_party/nlohmann)

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -11,6 +11,7 @@ sudo apt-get install -y \
     libspdlog-dev \
     libfmt-dev \
     libglm-dev \
+    libasio-dev \
     libcurl4-openssl-dev \
     liblz4-dev \
     libzstd-dev \


### PR DESCRIPTION
## Summary
- include Crow headers in CMake build
- install `libasio-dev` alongside glm and other libs

## Testing
- `cmake /workspace/sep`
- `make -j4` *(fails: invalid application of ‘sizeof’ to incomplete type ‘sep::pattern::PatternProcessor’)*

------
https://chatgpt.com/codex/tasks/task_e_6859624a65bc832a98f63ae868f9c759