### PR TITLE
Add tbb dep & crow includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ project(SEPEngine)
 
 include_directories(${CMAKE_SOURCE_DIR}/include
                     ${CMAKE_SOURCE_DIR}/third_party)
+include_directories(${CMAKE_SOURCE_DIR}/third_party/crow/include)
 add_subdirectory(src/api)
 add_subdirectory(src/audio)
 add_subdirectory(src/blender)

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -11,6 +11,7 @@ sudo apt-get install -y \
     libspdlog-dev \
     libfmt-dev \
     libglm-dev \
+    libtbb-dev \
     libcurl4-openssl-dev \
     liblz4-dev \
     libzstd-dev \


### PR DESCRIPTION
## Summary
- ensure tbb dev package is installed in dependency script
- include crow headers during build via CMake

## Testing
- `cmake ..`
- `make -j$(nproc)` *(fails: missing CUDA symbols and incomplete types)*

------
https://chatgpt.com/codex/tasks/task_e_6859624a65bc832a98f63ae868f9c759