### PR TITLE
Fix missing types for CUDA stub and pattern state

### DIFF
--- a/include/compat/cuda_impl.h
+++ b/include/compat/cuda_impl.h
@@ -433,5 +433,9 @@ inline cudaError_t cudaMemcpyAsync(void* dst, const void* src, size_t count, cud
 }
 }  // namespace cuda_stub_constants
 
+using cuda_stub_constants::cudaEvent_t;
+using cuda_stub_constants::cudaStream_t;
+using cuda_stub_constants::cudaMemcpyKind;
+
 #endif  // !SEP_CUDA_AVAILABLE
 #endif  // SEP_CUDA_IMPL_H

--- a/include/core/types.h
+++ b/include/core/types.h
@@ -229,6 +229,11 @@ inline void from_json(const nlohmann::json& j, APIConfig& c)
 
 }  // namespace config
 
+enum class PatternStateEnum {
+    UNINITIALIZED,
+    INITIALIZING
+};
+
 enum class StreamFlags { Default = 0, NonBlocking = 1 };
 }  // namespace sep
 


### PR DESCRIPTION
## Summary
- add `PatternStateEnum` enum to unify pattern state references
- expose CUDA stub types `cudaEvent_t`, `cudaStream_t` and `cudaMemcpyKind`

Compilation still fails due to missing third party headers (crow and glm).

## Testing
- `cmake ..`
- `make -j$(nproc)` *(fails: fatal error: crow/http_request.h: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_685966716bbc832a88f8d7f75184be81