### PR TITLE
Fix includes and add stub context types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,8 @@ cmake_minimum_required(VERSION 3.10)
 project(SEPEngine)
 
 include_directories(${CMAKE_SOURCE_DIR}/include
-                    ${CMAKE_SOURCE_DIR}/third_party)
+                    ${CMAKE_SOURCE_DIR}/third_party
+                    ${CMAKE_SOURCE_DIR}/third_party/crow/include)
 add_subdirectory(src/api)
 add_subdirectory(src/audio)
 add_subdirectory(src/blender)

--- a/include/blender/bridge.h
+++ b/include/blender/bridge.h
@@ -13,6 +13,8 @@
 #include "blender/gpu_context.h"
 #include "blender/pattern_common.h"
 #include "pattern/data.hpp"
+#include "quantum/pattern_processor.h"
+#include "blender/config.h"
 
 #include "blender/types.h"
 #include "core/types.h"
@@ -21,7 +23,6 @@
 
 namespace sep {
 namespace pattern {
-using ::sep::SEPResult;
 
 struct PatternLimits {
     static constexpr size_t MAX_PATTERNS = 10000;

--- a/include/compat/cuda_impl.h
+++ b/include/compat/cuda_impl.h
@@ -433,5 +433,12 @@ inline cudaError_t cudaMemcpyAsync(void* dst, const void* src, size_t count, cud
 }
 }  // namespace cuda_stub_constants
 
+#if !SEP_CUDA_AVAILABLE
+using cuda_stub_constants::cudaEvent_t;
+using cuda_stub_constants::cudaStream_t;
+using cuda_stub_constants::cudaMemcpyKind;
+using cuda_stub_constants::cudaDeviceProp;
+#endif
+
 #endif  // !SEP_CUDA_AVAILABLE
 #endif  // SEP_CUDA_IMPL_H

--- a/include/context/processor.h
+++ b/include/context/processor.h
@@ -1,0 +1,53 @@
+#pragma once
+#include "context/types.h"
+#include <memory>
+
+namespace sep::context {
+
+struct ProcessResult {
+    bool success{false};
+    ::sep::shim::vector<CheckResult> value;
+};
+
+struct ValidationResult {
+    bool valid{false};
+    sep::shim::string error;
+};
+
+struct EmbeddingResult {
+    bool success{false};
+    ::sep::shim::vector<float> value;
+};
+
+struct SimilarityResult {
+    bool success{false};
+    float value{0.0f};
+};
+
+struct BlendResult {
+    bool success{false};
+    Context value;
+};
+
+struct ProcessorMetrics {
+    size_t processed{0};
+};
+
+struct ProcessOptions {};
+
+class Processor {
+public:
+    virtual ~Processor() = default;
+    virtual ProcessResult processBatch(const Batch& batch) = 0;
+    virtual ProcessResult processContext(const Context& context) = 0;
+    virtual ValidationResult validateContext(const Context& context) = 0;
+    virtual EmbeddingResult extractEmbeddings(const Context& context) = 0;
+    virtual SimilarityResult calculateSimilarity(const Context& a, const Context& b) = 0;
+    virtual BlendResult blendContexts(const ::sep::shim::vector<Context>& contexts,
+                                     const ::sep::shim::vector<float>& weights) = 0;
+    virtual ProcessorMetrics getMetrics() const = 0;
+};
+
+std::unique_ptr<Processor> createProcessor(const ProcessOptions& options = ProcessOptions());
+
+} // namespace sep::context

--- a/include/context/types.h
+++ b/include/context/types.h
@@ -1,0 +1,30 @@
+#pragma once
+#include <nlohmann/json.hpp>
+#include "compat/shim.h"
+#include <vector>
+#include <string>
+
+namespace sep::context {
+
+struct CheckResult {
+    enum class Status { STABLE = 0, INVALID };
+    Status status{Status::STABLE};
+    float score{0.0f};
+    sep::shim::string error;
+};
+
+struct Context {
+    sep::shim::string type;
+    nlohmann::json content;
+    std::vector<nlohmann::json> relationships;
+    ::sep::shim::vector<sep::shim::string> tags;
+    nlohmann::json metadata;
+    nlohmann::json processorResult;
+};
+
+struct Batch {
+    std::string layer;
+    ::sep::shim::vector<Context> contexts;
+};
+
+} // namespace sep::context

--- a/include/core/types.h
+++ b/include/core/types.h
@@ -229,6 +229,14 @@ inline void from_json(const nlohmann::json& j, APIConfig& c)
 
 }  // namespace config
 
+enum class PatternStateEnum {
+    UNINITIALIZED = 0,
+    INITIALIZING,
+    ACTIVE,
+    STOPPED,
+    ERROR
+};
+
 enum class StreamFlags { Default = 0, NonBlocking = 1 };
 }  // namespace sep
 

--- a/src/api/bridge.cpp
+++ b/src/api/bridge.cpp
@@ -1,6 +1,7 @@
 #define BUILDING_SEP_BRIDGE
 #include "api/bridge.h"
 #include "api/bridge.hpp"
+#include "api/types.h"
 
 
 #include <mutex>

--- a/src/api/bridge_c.cpp
+++ b/src/api/bridge_c.cpp
@@ -1,7 +1,7 @@
 #define BUILDING_SEP_BRIDGE
 #include "api/bridge.h"
 #include "api/bridge.hpp"
-#include "bridge_internal.hpp"
+#include "api/bridge_internal.hpp"
 #include "config/manager.h"
 #include <nlohmann/json.hpp>
 #include <cstdio>

--- a/src/audio/pipeline.cpp
+++ b/src/audio/pipeline.cpp
@@ -82,7 +82,7 @@ void AudioPipeline::applyHannWindow(std::vector<float>& samples) {
     for (size_t i = 0; i < samples.size(); ++i) {
         float angle = 2.0f * glm::pi<float>() * static_cast<float>(i) /
                       static_cast<float>(samples.size());
-        float window = 0.5f * (1.0f - std::cosf(angle));
+        float window = 0.5f * (1.0f - std::cos(angle));
         samples[i] *= window;
     }
 }


### PR DESCRIPTION
## Summary
- add Crow includes for build
- update CUDA stubs with aliases
- replace `std::cosf` usage
- add missing Quantum/Blender headers
- provide minimal `context` type stubs

## Testing
- `cmake ..`
- `make -j$(nproc)` *(fails: undefined types and missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_685966716bbc832a88f8d7f75184be81