### PR TITLE
Fix header search paths in CMake targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,12 +17,17 @@ add_subdirectory(src/core)
 add_subdirectory(src/memory)
 add_subdirectory(src/quantum)
 add_executable(sep_engine src/main.cpp)
+target_include_directories(sep_engine
+    PUBLIC
+        ${CMAKE_SOURCE_DIR}/include
+)
+
 target_link_libraries(sep_engine
-                      sep_core
-                      sep_api
-                      sep_context
-                      sep_memory
-                      sep_quantum
-                      sep_audio
-                      sep_blender
-                      sep_compat)
+    sep_core
+    sep_api
+    sep_context
+    sep_memory
+    sep_quantum
+    sep_audio
+    sep_blender
+    sep_compat)

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -1,1 +1,6 @@
 add_library(sep_api STATIC auth_middleware.cpp bridge.cpp bridge_c.cpp client.cpp crow_adapter.cpp crow_error.cpp curl_http_client.cpp js_integration.cpp lock_free_rate_limiter.cpp ollama_client.cpp rate_limit_middleware.cpp sep_engine.cpp server.cpp)
+
+target_include_directories(sep_api
+    PUBLIC
+        ${CMAKE_SOURCE_DIR}/include
+)

--- a/src/audio/CMakeLists.txt
+++ b/src/audio/CMakeLists.txt
@@ -1,1 +1,6 @@
 add_library(sep_audio STATIC config.cpp pipeline.cpp pipewire_capture.cpp pipewire_stubs.cpp)
+
+target_include_directories(sep_audio
+    PUBLIC
+        ${CMAKE_SOURCE_DIR}/include
+)

--- a/src/blender/CMakeLists.txt
+++ b/src/blender/CMakeLists.txt
@@ -1,2 +1,6 @@
 add_library(sep_blender STATIC api.cpp blender_integration.cpp compression_utils.cpp compression.cpp gpu_context.cpp mesh_handler.cpp pattern_visualization_pipeline.cpp)
-include_directories(${CMAKE_SOURCE_DIR}/include)
+
+target_include_directories(sep_blender
+    PUBLIC
+        ${CMAKE_SOURCE_DIR}/include
+)

--- a/src/compat/CMakeLists.txt
+++ b/src/compat/CMakeLists.txt
@@ -1,1 +1,6 @@
 add_library(sep_compat STATIC core/stream.cpp core/core.cu raii.cpp)
+
+target_include_directories(sep_compat
+    PUBLIC
+        ${CMAKE_SOURCE_DIR}/include
+)

--- a/src/context/CMakeLists.txt
+++ b/src/context/CMakeLists.txt
@@ -1,1 +1,6 @@
 add_library(sep_context STATIC processor.cpp relationship.cpp)
+
+target_include_directories(sep_context
+    PUBLIC
+        ${CMAKE_SOURCE_DIR}/include
+)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,1 +1,6 @@
 add_library(sep_core STATIC allocation_metrics.cpp dag_graph.cpp engine.cpp error_handler.cpp manager.cpp metrics_collector.cpp prometheus_exporter.cpp tracing.cpp)
+
+target_include_directories(sep_core
+    PUBLIC
+        ${CMAKE_SOURCE_DIR}/include
+)

--- a/src/memory/CMakeLists.txt
+++ b/src/memory/CMakeLists.txt
@@ -1,1 +1,6 @@
 add_library(sep_memory STATIC memory_tier.cpp memory_tier_manager.cpp manager.cpp redis_manager.cpp)
+
+target_include_directories(sep_memory
+    PUBLIC
+        ${CMAKE_SOURCE_DIR}/include
+)

--- a/src/quantum/CMakeLists.txt
+++ b/src/quantum/CMakeLists.txt
@@ -1,1 +1,6 @@
 add_library(sep_quantum STATIC qbsa.cpp qbsa_qfh.cpp qfh.cpp quantum_processor.cpp quantum_processor_qfh.cpp quantum_processor_qfh_common.cpp evolution.cpp processor.cpp types_serialization.cpp pattern_processor.cpp)
+
+target_include_directories(sep_quantum
+    PUBLIC
+        ${CMAKE_SOURCE_DIR}/include
+)


### PR DESCRIPTION
## Summary
- expose the project include directory for each library target
- ensure the top level executable also has include paths

## Testing
- `cmake .. -DCMAKE_EXPORT_COMPILE_COMMANDS=ON`
- `make -j$(nproc)` *(fails: glm/glm.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6859917b489c832a9e75de1654d96190