### PR TITLE
Fix compat build includes

### DIFF
--- a/src/compat/CMakeLists.txt
+++ b/src/compat/CMakeLists.txt
@@ -1,1 +1,12 @@
 add_library(sep_compat STATIC core/stream.cpp core/core.cu raii.cpp)
+
+# Explicitly expose the project's include directories to this target. This
+# avoids issues where tools (linters, IDEs) fail to resolve headers such as
+# "compat/raii.h" when they don't pick up the global include directories.
+target_include_directories(sep_compat PUBLIC
+    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/third_party
+    ${CMAKE_SOURCE_DIR}/third_party/crow/include
+    ${CMAKE_SOURCE_DIR}/third_party/glm
+    ${CMAKE_SOURCE_DIR}/third_party/tbb
+)


### PR DESCRIPTION
## Summary
- expose include dirs in `src/compat/CMakeLists.txt` so RAII headers are found

## Testing
- `cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON`
- `cmake --build build` *(fails: crow/http_request.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6859917b489c832a9e75de1654d96190