### PR TITLE
Add basic stubs to unblock compilation

### DIFF
--- a/include/core/types.h
+++ b/include/core/types.h
@@ -19,6 +19,7 @@
 #include <nlohmann/json.hpp>
 #include <string>
 #include <vector>
+#include <vector>
 
 namespace sep {
 namespace config {
@@ -228,6 +229,15 @@ inline void from_json(const nlohmann::json& j, APIConfig& c)
 }
 
 }  // namespace config
+
+struct PinState {
+    std::uint64_t id{0};
+    std::uint32_t value{0};
+
+    bool operator==(const PinState& other) const {
+        return id == other.id && value == other.value;
+    }
+};
 
 enum class PatternStateEnum {
     UNINITIALIZED = 0,

--- a/include/quantum/processor.h
+++ b/include/quantum/processor.h
@@ -8,6 +8,7 @@
 #include "core/types.h"
 #include "quantum/gpu_context.h"
 #include "quantum/data.hpp"
+#include "quantum/resource_predictor.h" // provides Context and CheckResult
 #include <memory>
 #include <vector>
 #include <string>
@@ -110,6 +111,25 @@ public:
     SEPResult addRelationship(const std::string& pattern_id1, const std::string& pattern_id2,
                               float strength, RelationshipType type);
     float calculateCoherence(const std::string& pattern_id1, const std::string& pattern_id2) const;
+
+    struct ProcessResult {
+        bool success{true};
+        std::vector<context::CheckResult> value{};
+        shim::string error_message{};
+
+        static ProcessResult ok(std::vector<context::CheckResult> v = {}) {
+            return {true, std::move(v), {}};
+        }
+
+        static ProcessResult fail(const std::string& err) {
+            ProcessResult r;
+            r.success = false;
+            r.error_message = shim::string(err.c_str());
+            return r;
+        }
+    };
+
+    ProcessResult processContext(const context::Context& context);
 
     std::string getStatus() const;
     ProcessingConfig getConfig() const;

--- a/src/blender/blender_integration.cpp
+++ b/src/blender/blender_integration.cpp
@@ -44,10 +44,6 @@ std::shared_ptr<BlenderBridge> BlenderBridge::create()
     return std::shared_ptr<BlenderBridge>(new (std::nothrow) BlenderBridge());
 }
 
-static bool isValidConfig(const PatternConfig& cfg)
-{
-    return cfg.max_patterns > 0 && cfg.batch_size > 0;
-}
 
 sep::SEPResult BlenderBridge::init(sep::GPUContext* ctx)
 {
@@ -92,8 +88,8 @@ sep::SEPResult BlenderBridge::registerObject(Object* obj, const PatternConfig& c
         return sep::SEPResult::INVALID_ARGUMENT;
     }
 
-    // Validate configuration
-    if (!isValidConfig(config))
+    // Validate configuration using shared helper
+    if (!sep::pattern::isValidConfig(config))
     {
         return sep::SEPResult::INVALID_ARGUMENT;
     }

--- a/src/quantum/processor.cpp
+++ b/src/quantum/processor.cpp
@@ -380,6 +380,11 @@ std::string Processor::getStatus() const { return impl_->getStatus(); }
 ProcessingConfig Processor::getConfig() const { return impl_->getConfig(); }
 void Processor::updateConfig(const ProcessingConfig& config) { impl_->updateConfig(config); }
 
+Processor::ProcessResult Processor::processContext(const context::Context& /*context*/) {
+    // Stub implementation for API compatibility
+    return ProcessResult::ok();
+}
+
 std::unique_ptr<Processor> createProcessor(const ProcessingConfig& config) {
     return std::make_unique<Processor>(config);
 }


### PR DESCRIPTION
## Summary
- fix redundant isValidConfig definition
- add PinState struct in core/types
- introduce Processor::ProcessResult and processContext stub

Compilation still fails due to numerous missing types and methods, but initial headers compile further.

## Testing
- `cmake ..`
- `make -j$(nproc)` *(fails: operator! not defined in Engine::init, PinState, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685a5153a7b8832ab5b0ea0b87545494