### PR TITLE
Implement tier metrics utilities

### DIFF
--- a/include/memory/memory_tier_manager.hpp
+++ b/include/memory/memory_tier_manager.hpp
@@ -80,6 +80,8 @@ public:
     MemoryTier* getTier(sep::memory::TierType tier);
     float getTierUtilization(sep::memory::TierType tier) const;
     float getTierFragmentation(sep::memory::TierType tier) const;
+    float getTotalUtilization() const;
+    float getTotalFragmentation() const;
     void defragmentTier(sep::memory::TierType tier);
     void optimizeBlocks();
     void optimizeTiers();

--- a/src/memory/memory_tier.cpp
+++ b/src/memory/memory_tier.cpp
@@ -196,6 +196,7 @@ SEPResult MemoryTier::defragment() {
             mgr.updateBlockMetrics(&blk, blk.coherence, blk.stability, blk.generation, 1.0f);
         }
     }
+    mgr.rebuildLookup();
 
     if (logger) {
         LOG_INFO(logger, "Tier {} fragmentation now {:.2f}", static_cast<int>(config_.type), calculateFragmentation());

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -68,6 +68,38 @@ float MemoryTierManager::getTierFragmentation(sep::memory::TierType tier) const 
     return t ? t->calculateFragmentation() : 0.0f;
 }
 
+float MemoryTierManager::getTotalUtilization() const {
+    float total = 0.0f;
+    total += getTierUtilization(sep::memory::TierType::STM);
+    total += getTierUtilization(sep::memory::TierType::MTM);
+    total += getTierUtilization(sep::memory::TierType::LTM);
+    return total / 3.0f;
+}
+
+float MemoryTierManager::getTotalFragmentation() const {
+    float total = 0.0f;
+    total += getTierFragmentation(sep::memory::TierType::STM);
+    total += getTierFragmentation(sep::memory::TierType::MTM);
+    total += getTierFragmentation(sep::memory::TierType::LTM);
+    return total / 3.0f;
+}
+
+void MemoryTierManager::rebuildLookup() {
+    lookup_map_.clear();
+    auto add_blocks = [&](MemoryTier* tier) {
+        if (!tier) return;
+        const auto& blocks = tier->getBlocks();
+        for (const auto& blk : blocks) {
+            if (blk.allocated) {
+                lookup_map_[blk.ptr] = const_cast<MemoryBlock*>(&blk);
+            }
+        }
+    };
+    add_blocks(stm_.get());
+    add_blocks(mtm_.get());
+    add_blocks(ltm_.get());
+}
+
 void MemoryTierManager::updateBlockMetrics(MemoryBlock* block, float coherence, float stability,
                                            std::uint32_t generation, float context_score) {
     if (!block)

--- a/tests/memory/memory_tier_manager_test.cpp
+++ b/tests/memory/memory_tier_manager_test.cpp
@@ -160,3 +160,22 @@ TEST(MemoryTierManagerTest, AutoDefragmentationThreshold) {
     mgr.deallocate(b2);
 }
 
+TEST(MemoryTierManagerTest, TotalMetrics) {
+    MemoryTierManager mgr;
+    MemoryBlock* a = mgr.allocate(128, sep::memory::TierType::STM);
+    MemoryBlock* b = mgr.allocate(128, sep::memory::TierType::MTM);
+    MemoryBlock* c = mgr.allocate(128, sep::memory::TierType::LTM);
+
+    float util = mgr.getTotalUtilization();
+    EXPECT_GT(util, 0.0f);
+    EXPECT_LT(util, 1.0f);
+
+    mgr.deallocate(a);
+    mgr.deallocate(b);
+    mgr.deallocate(c);
+
+    float frag = mgr.getTotalFragmentation();
+    EXPECT_GE(frag, 0.0f);
+    EXPECT_LE(frag, 1.0f);
+}
+


### PR DESCRIPTION
## Summary
- expose total utilization/fragmentation helpers
- keep lookup map in sync with memory blocks
- call `rebuildLookup` after defragmentation
- test overall metric helpers

## Testing
- `cmake .. -DSEP_BUILD_TESTS=ON` *(fails: include/crow directory missing)*
- `ctest --output-on-failure` *(fails: no tests found due to build failure)*

------
https://chatgpt.com/codex/tasks/task_e_685a9aaf35f4832a968dbdaaa4b25e4b