### PR TITLE
Add memory tier aggregate metric

### DIFF
--- a/_sep/testbed/test.cpp
+++ b/_sep/testbed/test.cpp
@@ -1,11 +1,15 @@
 #include "compat/shim.h"
 #include "api/json_helpers.h"
+#include "memory/memory_tier_manager.hpp"
 #include <iostream>
 
 int main() {
     sep::shim::string s("hello");
     s += " world";
     auto j = sep::api::parse_json("{\"a\":1}");
-    std::cout << s.c_str() << ' ' << j["a"] << std::endl;
+    sep::memory::MemoryTierManager mgr;
+    mgr.allocate(128, sep::memory::TierType::STM);
+    std::cout << s.c_str() << ' ' << j["a"]
+              << " total=" << mgr.getTotalAllocated() << std::endl;
     return 0;
 }

--- a/include/memory/memory_tier_manager.hpp
+++ b/include/memory/memory_tier_manager.hpp
@@ -84,6 +84,9 @@ public:
     void optimizeBlocks();
     void optimizeTiers();
 
+    // Aggregate metrics
+    std::size_t getTotalAllocated() const;
+
     // Access tier objects
     MemoryTier& getSTM();
     MemoryTier& getMTM();

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -68,6 +68,13 @@ float MemoryTierManager::getTierFragmentation(sep::memory::TierType tier) const 
     return t ? t->calculateFragmentation() : 0.0f;
 }
 
+std::size_t MemoryTierManager::getTotalAllocated() const {
+    std::size_t used_stm = config_.stm_size - stm_->getFreeSpace();
+    std::size_t used_mtm = config_.mtm_size - mtm_->getFreeSpace();
+    std::size_t used_ltm = config_.ltm_size - ltm_->getFreeSpace();
+    return used_stm + used_mtm + used_ltm;
+}
+
 void MemoryTierManager::updateBlockMetrics(MemoryBlock* block, float coherence, float stability,
                                            std::uint32_t generation, float context_score) {
     if (!block)

--- a/tests/memory/memory_manager_test.cpp
+++ b/tests/memory/memory_manager_test.cpp
@@ -48,3 +48,16 @@ TEST(MemoryManager, MultipleAllocations) {
     EXPECT_EQ(mgr.getTierUtilization(sep::memory::TierType::MTM), 0.0f);
     EXPECT_EQ(mgr.getTierUtilization(sep::memory::TierType::LTM), 0.0f);
 }
+
+TEST(MemoryManager, TotalAllocatedMemory) {
+    MemoryTierManager mgr;
+    EXPECT_EQ(mgr.getTotalAllocated(), 0u);
+    MemoryBlock* a = mgr.allocate(64, sep::memory::TierType::STM);
+    MemoryBlock* b = mgr.allocate(128, sep::memory::TierType::MTM);
+    ASSERT_NE(a, nullptr);
+    ASSERT_NE(b, nullptr);
+    EXPECT_GT(mgr.getTotalAllocated(), 0u);
+    mgr.deallocate(a);
+    mgr.deallocate(b);
+    EXPECT_EQ(mgr.getTotalAllocated(), 0u);
+}


### PR DESCRIPTION
## Summary
- add `getTotalAllocated` to `MemoryTierManager`
- expose metric in testbed example
- test aggregated allocation in unit tests

## Testing
- `./build.sh test --cc=/usr/bin/gcc --cxx=/usr/bin/g++` *(fails: Configuring incomplete, errors occurred)*

------
https://chatgpt.com/codex/tasks/task_e_685a9aaf35f4832a968dbdaaa4b25e4b