### PR TITLE
Add missing Ollama types and fix manager arg parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ boost/
 tbb/
 temp/
 ollama/
+!include/ollama/
 
 #.vscode/
 .idea/

--- a/include/api/client.h
+++ b/include/api/client.h
@@ -2,6 +2,7 @@
 #define SEP_API_CLIENT_H
 
 #include "api/types.h"
+#include "ollama/types.h"
 #include "curl/curl.h"
 #include "core/common.h"
 

--- a/include/api/ollama_client.h
+++ b/include/api/ollama_client.h
@@ -1,0 +1,2 @@
+#pragma once
+#include "api/client.h"

--- a/include/api/types.h
+++ b/include/api/types.h
@@ -1,8 +1,11 @@
 #pragma once
 
-#include <string>
+#include <atomic>
+#include <chrono>
 #include <map>
+#include <string>
 #include <vector>
+#include <nlohmann/json.hpp>
 
 namespace sep::api {
 
@@ -22,9 +25,7 @@ public:
     virtual std::string method() const = 0;
     virtual std::string body() const = 0;
 
-    virtual std::string getHeader(const std::string& name) const {
-        return "";
-    }
+    virtual std::string getHeader(const std::string& name) const { return ""; }
 };
 
 class HttpResponse {
@@ -38,15 +39,70 @@ public:
     virtual void end() = 0;
 
     virtual void setHeader(const std::string& name, const std::string& value) {
-        (void)name; (void)value;
+        (void)name;
+        (void)value;
     }
 };
 
+enum class Status { OK = 0, ERROR = 1 };
+
+enum class Priority { LOW = 0, NORMAL = 1, HIGH = 2, CRITICAL = 3 };
+
+enum HttpMethod { HTTP_GET, HTTP_POST, HTTP_PUT, HTTP_DELETE, HTTP_PATCH, HTTP_OPTIONS, HTTP_HEAD };
+
+enum class ErrorCode {
+    Success = 0,
+    InvalidArgument,
+    InvalidParameter,
+    InvalidOperation,
+    ResourceNotFound,
+    OutOfMemory,
+    InvalidState,
+    SystemError,
+    CudaError,
+    ProcessingError,
+    ApiError,
+    GeneralError,
+    BufferTooSmall,
+    Unknown
+};
+
+struct APIRequest {
+    std::string method;
+    std::string url;
+    std::string body;
+    std::map<std::string, std::string> headers;
+    Priority priority{Priority::NORMAL};
+    std::chrono::milliseconds timeout{5000};
+    std::string requestId;
+};
+
+struct APIResponse {
+    int statusCode{0};
+    std::string body;
+    std::map<std::string, std::string> headers;
+    std::chrono::milliseconds responseTime{0};
+    std::string requestId;
+    bool success{false};
+    struct Error {
+        ErrorCode code{ErrorCode::Success};
+        std::string message;
+    } error;
+};
+
 struct HealthMetrics {
-    bool healthy = true;
-    std::string status = "ok";
-    int64_t uptime_ms = 0;
-    std::map<std::string, double> metrics;
+    std::atomic<size_t> totalRequests{0};
+    std::atomic<size_t> successfulRequests{0};
+    std::atomic<size_t> failedRequests{0};
+    std::atomic<size_t> timeoutRequests{0};
+    std::atomic<size_t> rateLimitedCount{0};
+    std::atomic<double> averageResponseTime{0.0};
+    std::chrono::steady_clock::time_point lastRequestTime;
+    std::chrono::steady_clock::time_point startTime;
+    std::chrono::milliseconds lastResponseTime{0};
+    std::chrono::system_clock::time_point lastSuccessTime;
+    std::chrono::system_clock::time_point lastErrorTime;
+    int lastErrorCode{0};
 };
 
 struct RateLimitConfig {
@@ -58,5 +114,10 @@ struct AuthConfig {
     bool enabled = false;
     std::vector<std::string> tokens;
 };
+
+nlohmann::json make_error_response(ErrorCode code, const std::string& message);
+bool validate_fields(const nlohmann::json& data,
+                     const std::vector<std::string>& fields,
+                     nlohmann::json& error);
 
 } // namespace sep::api

--- a/include/core/types.h
+++ b/include/core/types.h
@@ -9,6 +9,7 @@
 // Project headers (must come before std headers for proper isolation)
 #include "compat/cuda.h"
 #include "api/types.h"
+#include "ollama/types.h"
 
 // Standard C headers
 #include <cstddef>

--- a/include/ollama/types.h
+++ b/include/ollama/types.h
@@ -1,0 +1,43 @@
+#pragma once
+#include <string>
+#include <vector>
+
+namespace sep::ollama {
+
+struct GPUConfig {
+    bool enabled{false};
+    float memory_fraction{0.0f};
+};
+
+struct OllamaConfig {
+    bool enabled{false};
+    std::string host{"http://127.0.0.1:11434"};
+    std::string model{"llama2"};
+    std::size_t batch_size{1};
+    std::size_t context_window{512};
+    GPUConfig gpu{};
+};
+
+struct GenerateRequest {
+    std::string model;
+    std::string prompt;
+    std::string system;
+    bool stream{false};
+};
+
+struct GenerateResponse {
+    std::string response;
+    bool done{false};
+    std::string model;
+};
+
+struct EmbeddingRequest {
+    std::string model;
+    std::string prompt;
+};
+
+struct EmbeddingResponse {
+    std::vector<float> embedding;
+};
+
+} // namespace sep::ollama

--- a/src/api/ollama_client.cpp
+++ b/src/api/ollama_client.cpp
@@ -1,4 +1,4 @@
-#include "api/client.h"
+#include "api/ollama_client.h"
 #include "api/types.h"
 
 #include <chrono>

--- a/src/core/manager.cpp
+++ b/src/core/manager.cpp
@@ -96,7 +96,7 @@ public:
 
       // Support both --key=value and --key value
       sep::shim::string value;
-      auto pos = arg.find("=");
+      auto pos = arg.find('=');
       if (pos != sep::shim::string::npos) {
         // Extract substring after '='
         std::string arg_str = arg.c_str();


### PR DESCRIPTION
## Summary
- add missing `ollama` client and message types
- expose API enums and request/response structures
- include new headers across project
- fix command line parsing in core manager

## Testing
- `./build.sh build` *(fails: conflicting return type in include/api/crow_adapter.h)*

------
https://chatgpt.com/codex/tasks/task_e_685a9e5c8634832a90c2b1bda2fb0bc6