### PR TITLE
Fix build includes and type defs

### DIFF
--- a/include/api/client.h
+++ b/include/api/client.h
@@ -4,6 +4,7 @@
 #include "api/types.h"
 #include "curl/curl.h"
 #include "core/common.h"
+#include "ollama/types.h"
 
 #include <chrono>
 #include <nlohmann/json.hpp>

--- a/include/api/crow_adapter.h
+++ b/include/api/crow_adapter.h
@@ -39,7 +39,7 @@ class CrowRequestAdapter : public HttpRequest {
 public:
   explicit CrowRequestAdapter(::crow::request &req);
   std::string url() const override;
-  const std::string &method() const override;
+  std::string method() const override;
   std::string body() const override;
 
  private:

--- a/include/api/lock_free_rate_limiter.h
+++ b/include/api/lock_free_rate_limiter.h
@@ -5,7 +5,13 @@
 #include <atomic>
 #include <chrono>
 #include <memory>
-#include <tbb/concurrent_hash_map.h>
+#if __has_include(<tbb/concurrent_hash_map.h>)
+#  include <tbb/concurrent_hash_map.h>
+#  define SEP_HAS_TBB 1
+#else
+#  include <unordered_map>
+#  define SEP_HAS_TBB 0
+#endif
 #include <thread>
 
 namespace sep::api {
@@ -122,9 +128,14 @@ private:
       PriorityConfig{5.0f}  // CRITICAL
   };
 
-  // Client management using TBB concurrent hash map
+  // Client management using concurrent hash map when TBB is available
+#if SEP_HAS_TBB
   using ClientMap =
       tbb::concurrent_hash_map<std::string, std::unique_ptr<ClientData>>;
+#else
+  using ClientMap =
+      std::unordered_map<std::string, std::unique_ptr<ClientData>>;
+#endif
   ClientMap clients_;
 
   // Background cleanup

--- a/include/api/ollama_client.h
+++ b/include/api/ollama_client.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "api/client.h"
+
+// This header simply exposes the OllamaClient definition from client.h

--- a/include/api/server.h
+++ b/include/api/server.h
@@ -8,6 +8,7 @@
 #include "api/rate_limit_middleware.h"
 #include "api/types.h"
 #include "api/auth_middleware.h"
+#include "api/ollama_client.h"
 #include <atomic>
 #include <memory>
 #include <mutex>

--- a/include/api/types.h
+++ b/include/api/types.h
@@ -1,8 +1,11 @@
 #pragma once
 
-#include <string>
+#include <atomic>
+#include <chrono>
 #include <map>
+#include <string>
 #include <vector>
+#include <nlohmann/json.hpp>
 
 namespace sep::api {
 
@@ -22,9 +25,7 @@ public:
     virtual std::string method() const = 0;
     virtual std::string body() const = 0;
 
-    virtual std::string getHeader(const std::string& name) const {
-        return "";
-    }
+    virtual std::string getHeader(const std::string& name) const { return ""; }
 };
 
 class HttpResponse {
@@ -38,15 +39,25 @@ public:
     virtual void end() = 0;
 
     virtual void setHeader(const std::string& name, const std::string& value) {
-        (void)name; (void)value;
+        (void)name;
+        (void)value;
     }
 };
 
+// Basic health metrics used by the HTTP client
 struct HealthMetrics {
-    bool healthy = true;
-    std::string status = "ok";
-    int64_t uptime_ms = 0;
-    std::map<std::string, double> metrics;
+    std::atomic<size_t> totalRequests{0};
+    std::atomic<size_t> successfulRequests{0};
+    std::atomic<size_t> failedRequests{0};
+    std::atomic<size_t> timeoutRequests{0};
+    std::atomic<size_t> rateLimitedCount{0};
+    std::atomic<double> averageResponseTime{0.0};
+    std::chrono::steady_clock::time_point lastRequestTime;
+    std::chrono::steady_clock::time_point startTime;
+    std::chrono::milliseconds lastResponseTime{0};
+    std::chrono::system_clock::time_point lastSuccessTime;
+    std::chrono::system_clock::time_point lastErrorTime;
+    int lastErrorCode{0};
 };
 
 struct RateLimitConfig {
@@ -58,5 +69,55 @@ struct AuthConfig {
     bool enabled = false;
     std::vector<std::string> tokens;
 };
+
+// Error codes returned by API operations
+enum class ErrorCode {
+    Success = 0,
+    InvalidArgument,
+    InvalidParameter,
+    InvalidOperation,
+    ResourceNotFound,
+    OutOfMemory,
+    InvalidState,
+    SystemError,
+    CudaError,
+    ProcessingError,
+    ApiError,
+    GeneralError,
+    BufferTooSmall,
+    Unknown
+};
+
+// Request priority for rate limiting
+enum class Priority { LOW = 0, NORMAL = 1, HIGH = 2, CRITICAL = 3 };
+
+struct APIRequest {
+    std::string method;
+    std::string url;
+    std::string body;
+    std::map<std::string, std::string> headers;
+    Priority priority = Priority::NORMAL;
+    std::chrono::milliseconds timeout{5000};
+    std::string requestId;
+};
+
+struct APIResponse {
+    int statusCode = 0;
+    std::string body;
+    std::map<std::string, std::string> headers;
+    std::chrono::milliseconds responseTime{0};
+    std::string requestId;
+    bool success = false;
+    struct Error {
+        ErrorCode code{ErrorCode::Success};
+        std::string message;
+    } error;
+};
+
+// Utility helpers for API responses
+nlohmann::json make_error_response(ErrorCode code, const std::string& message);
+bool validate_fields(const nlohmann::json& data,
+                     const std::vector<std::string>& fields,
+                     nlohmann::json& error);
 
 } // namespace sep::api

--- a/include/core/types.h
+++ b/include/core/types.h
@@ -9,6 +9,7 @@
 // Project headers (must come before std headers for proper isolation)
 #include "compat/cuda.h"
 #include "api/types.h"
+#include "ollama/types.h"
 
 // Standard C headers
 #include <cstddef>

--- a/include/ollama/types.h
+++ b/include/ollama/types.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace sep::ollama {
+
+struct OllamaConfig {
+    std::string host{"http://127.0.0.1:11434"};
+    std::string model{"llama2"};
+};
+
+struct GenerateRequest {
+    std::string model;
+    std::string prompt;
+    std::string system;
+    bool stream{false};
+};
+
+struct GenerateResponse {
+    std::string response;
+    bool done{false};
+    std::string model;
+};
+
+struct EmbeddingRequest {
+    std::string model;
+    std::string prompt;
+};
+
+struct EmbeddingResponse {
+    std::vector<float> embedding;
+};
+
+} // namespace sep::ollama

--- a/src/api/crow_adapter.cpp
+++ b/src/api/crow_adapter.cpp
@@ -39,7 +39,7 @@ CrowRequestAdapter::CrowRequestAdapter(::crow::request &req) : req_(req) {
 
 std::string CrowRequestAdapter::url() const { return std::string(req_.url); }
 
-const std::string& CrowRequestAdapter::method() const { return method_str_; }
+std::string CrowRequestAdapter::method() const { return method_str_; }
 
 std::string CrowRequestAdapter::body() const { return std::string(req_.body); }
 

--- a/src/api/server.cpp
+++ b/src/api/server.cpp
@@ -2,7 +2,8 @@
 #include "api/ollama_client.h"
 #include "api/json_helpers.h"
 #include <spdlog/spdlog.h>
-#include "crow/crow.h"
+#include "crow/app.h"
+#include "crow/middlewares/cors.h"
 
 #include <chrono>
 #include <csignal>

--- a/src/core/manager.cpp
+++ b/src/core/manager.cpp
@@ -96,7 +96,7 @@ public:
 
       // Support both --key=value and --key value
       sep::shim::string value;
-      auto pos = arg.find("=");
+      auto pos = arg.find('=');
       if (pos != sep::shim::string::npos) {
         // Extract substring after '='
         std::string arg_str = arg.c_str();


### PR DESCRIPTION
## Summary
- add comprehensive API type definitions and Ollama types
- include OllamaClient definition in server and client
- handle optional TBB dependency for the lock-free rate limiter
- replace char* find call
- adjust Crow adapter to match interface
- use crow/app.h include

## Testing
- `./build.sh build` *(fails: request for member 'reserve' in 'buffers', 'asio' not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a9e5c8634832a90c2b1bda2fb0bc6