### PR TITLE
Fix build configs and header definitions

### DIFF
--- a/include/api/crow_adapter.h
+++ b/include/api/crow_adapter.h
@@ -39,7 +39,7 @@ class CrowRequestAdapter : public HttpRequest {
 public:
   explicit CrowRequestAdapter(::crow::request &req);
   std::string url() const override;
-  const std::string &method() const override;
+  std::string method() const override;
   std::string body() const override;
 
  private:

--- a/include/api/lock_free_rate_limiter.h
+++ b/include/api/lock_free_rate_limiter.h
@@ -5,7 +5,12 @@
 #include <atomic>
 #include <chrono>
 #include <memory>
-#include <tbb/concurrent_hash_map.h>
+#ifdef SEP_USE_TBB
+#  include <tbb/concurrent_hash_map.h>
+#else
+#  include <unordered_map>
+#  include <mutex>
+#endif
 #include <thread>
 
 namespace sep::api {
@@ -122,10 +127,16 @@ private:
       PriorityConfig{5.0f}  // CRITICAL
   };
 
-  // Client management using TBB concurrent hash map
+  // Client management container
+#ifdef SEP_USE_TBB
   using ClientMap =
       tbb::concurrent_hash_map<std::string, std::unique_ptr<ClientData>>;
   ClientMap clients_;
+#else
+  using ClientMap = std::unordered_map<std::string, std::unique_ptr<ClientData>>;
+  ClientMap clients_;
+  mutable std::mutex clients_mutex_;
+#endif
 
   // Background cleanup
   std::unique_ptr<BackgroundCleanup> background_cleanup_;

--- a/include/api/ollama_client.h
+++ b/include/api/ollama_client.h
@@ -1,0 +1,4 @@
+#pragma once
+
+#include "api/client.h"
+

--- a/include/api/server.h
+++ b/include/api/server.h
@@ -26,9 +26,11 @@ template <typename... Middlewares>
 class Crow;
 }  // namespace crow
 
-namespace sep::api {
-
+namespace sep::ollama {
 class OllamaClient;
+}
+
+namespace sep::api {
 class CrowRequest;
 
 
@@ -212,7 +214,7 @@ class SEPApiServer : public Server {
   mutable std::mutex metrics_mutex_;
 
   // Clients
-  std::unique_ptr<OllamaClient> ollama_client_;
+  std::unique_ptr<sep::ollama::OllamaClient> ollama_client_;
 };
 
 }  // namespace sep::api

--- a/include/api/types.h
+++ b/include/api/types.h
@@ -1,18 +1,41 @@
 #pragma once
 
 #include <string>
+#include <atomic>
+#include <chrono>
 #include <map>
 #include <vector>
+#include <nlohmann/json.hpp>
 
 namespace sep::api {
 
 constexpr int HTTP_OK = 200;
 constexpr int HTTP_CREATED = 201;
+constexpr int HTTP_ACCEPTED = 202;
+constexpr int HTTP_NO_CONTENT = 204;
 constexpr int HTTP_BAD_REQUEST = 400;
 constexpr int HTTP_UNAUTHORIZED = 401;
+constexpr int HTTP_FORBIDDEN = 403;
 constexpr int HTTP_NOT_FOUND = 404;
+constexpr int HTTP_METHOD_NOT_ALLOWED = 405;
+constexpr int HTTP_CONFLICT = 409;
 constexpr int HTTP_INTERNAL_ERROR = 500;
+constexpr int HTTP_NOT_IMPLEMENTED = 501;
 constexpr int HTTP_SERVICE_UNAVAILABLE = 503;
+constexpr int HTTP_TOO_MANY_REQUESTS = 429;
+
+enum class Status { OK = 0, ERROR = 1 };
+enum class Priority { LOW = 0, NORMAL = 1, HIGH = 2, CRITICAL = 3 };
+
+enum HttpMethod {
+    HTTP_GET,
+    HTTP_POST,
+    HTTP_PUT,
+    HTTP_DELETE,
+    HTTP_PATCH,
+    HTTP_OPTIONS,
+    HTTP_HEAD
+};
 
 class HttpRequest {
 public:
@@ -42,11 +65,59 @@ public:
     }
 };
 
+enum class ErrorCode {
+    Success = 0,
+    InvalidArgument,
+    InvalidParameter,
+    InvalidOperation,
+    ResourceNotFound,
+    OutOfMemory,
+    InvalidState,
+    SystemError,
+    CudaError,
+    ProcessingError,
+    ApiError,
+    GeneralError,
+    BufferTooSmall,
+    Unknown
+};
+
+struct APIRequest {
+    std::string method;
+    std::string url;
+    std::string body;
+    std::map<std::string, std::string> headers;
+    Priority priority = Priority::NORMAL;
+    std::chrono::milliseconds timeout{5000};
+    std::string requestId;
+};
+
+struct APIResponse {
+    int statusCode = 0;
+    std::string body;
+    std::map<std::string, std::string> headers;
+    std::chrono::milliseconds responseTime{0};
+    std::string requestId;
+    bool success = false;
+    struct Error {
+        ErrorCode code{ErrorCode::Success};
+        std::string message;
+    } error;
+};
+
 struct HealthMetrics {
-    bool healthy = true;
-    std::string status = "ok";
-    int64_t uptime_ms = 0;
-    std::map<std::string, double> metrics;
+    std::atomic<size_t> totalRequests{0};
+    std::atomic<size_t> successfulRequests{0};
+    std::atomic<size_t> failedRequests{0};
+    std::atomic<size_t> timeoutRequests{0};
+    std::atomic<size_t> rateLimitedCount{0};
+    std::atomic<double> averageResponseTime{0.0};
+    std::chrono::steady_clock::time_point lastRequestTime;
+    std::chrono::steady_clock::time_point startTime;
+    std::chrono::milliseconds lastResponseTime{0};
+    std::chrono::system_clock::time_point lastSuccessTime;
+    std::chrono::system_clock::time_point lastErrorTime;
+    int lastErrorCode{0};
 };
 
 struct RateLimitConfig {
@@ -60,3 +131,34 @@ struct AuthConfig {
 };
 
 } // namespace sep::api
+
+namespace sep::ollama {
+
+struct OllamaConfig {
+    std::string host{"http://127.0.0.1:11434"};
+    std::string model{"llama2"};
+};
+
+struct GenerateRequest {
+    std::string model;
+    std::string prompt;
+    std::string system;
+    bool stream{false};
+};
+
+struct GenerateResponse {
+    std::string response;
+    bool done{false};
+    std::string model;
+};
+
+struct EmbeddingRequest {
+    std::string model;
+    std::string prompt;
+};
+
+struct EmbeddingResponse {
+    std::vector<float> embedding;
+};
+
+}  // namespace sep::ollama

--- a/src/api/crow_adapter.cpp
+++ b/src/api/crow_adapter.cpp
@@ -39,7 +39,7 @@ CrowRequestAdapter::CrowRequestAdapter(::crow::request &req) : req_(req) {
 
 std::string CrowRequestAdapter::url() const { return std::string(req_.url); }
 
-const std::string& CrowRequestAdapter::method() const { return method_str_; }
+std::string CrowRequestAdapter::method() const { return method_str_; }
 
 std::string CrowRequestAdapter::body() const { return std::string(req_.body); }
 

--- a/src/api/lock_free_rate_limiter.cpp
+++ b/src/api/lock_free_rate_limiter.cpp
@@ -34,13 +34,22 @@ bool LockFreeRateLimiter::checkRateLimit(const IRequest &req) {
   const auto priority = getPriorityFromRequest(req);
 
   // Get or create client data
+#ifdef SEP_USE_TBB
   ClientMap::accessor accessor;
-  // clients_.insert(accessor, key) returns true if a new element was inserted.
-  // If true, accessor->second is a default-constructed unique_ptr (i.e., nullptr).
   if (clients_.insert(accessor, client_id)) {
     accessor->second = std::make_unique<ClientData>();
   }
   return tryInsertRequest(*(accessor->second), priority, now);
+#else
+  std::unique_lock<std::mutex> lock(clients_mutex_);
+  auto &ptr = clients_[client_id];
+  if (!ptr) {
+    ptr = std::make_unique<ClientData>();
+  }
+  ClientData &ref = *ptr;
+  lock.unlock();
+  return tryInsertRequest(ref, priority, now);
+#endif
 }
 
 bool LockFreeRateLimiter::tryInsertRequest(
@@ -118,9 +127,16 @@ void LockFreeRateLimiter::removeExpiredEntries(
 
 void LockFreeRateLimiter::cleanup(std::chrono::steady_clock::time_point now) {
   // Cleanup is now handled by background thread
+#ifdef SEP_USE_TBB
   for (auto it = clients_.begin(); it != clients_.end(); ++it) {
     removeExpiredEntries(*it->second, now);
   }
+#else
+  std::lock_guard<std::mutex> lock(clients_mutex_);
+  for (auto &pair : clients_) {
+    removeExpiredEntries(*pair.second, now);
+  }
+#endif
 }
 
 std::string LockFreeRateLimiter::getErrorResponse(const std::string &message,
@@ -145,15 +161,25 @@ void LockFreeRateLimiter::setPriorityQuota(Priority priority,
 
 unsigned int
 LockFreeRateLimiter::GetRequestCount(const std::string &client_id) const {
+#ifdef SEP_USE_TBB
   ClientMap::const_accessor acc;
   if (clients_.find(acc, client_id)) {
     return acc->second->request_count.load(std::memory_order_acquire);
   }
   return 0;
+#else
+  std::lock_guard<std::mutex> lock(clients_mutex_);
+  auto it = clients_.find(client_id);
+  if (it != clients_.end()) {
+    return it->second->request_count.load(std::memory_order_acquire);
+  }
+  return 0;
+#endif
 }
 
 unsigned int LockFreeRateLimiter::GetWindowSize(const std::string &client_id,
                                                 Priority priority) const {
+#ifdef SEP_USE_TBB
   ClientMap::const_accessor acc;
   if (clients_.find(acc, client_id)) {
     const auto &window = acc->second->window;
@@ -175,6 +201,27 @@ unsigned int LockFreeRateLimiter::GetWindowSize(const std::string &client_id,
     return count;
   }
   return 0;
+#else
+  std::lock_guard<std::mutex> lock(clients_mutex_);
+  auto it = clients_.find(client_id);
+  if (it != clients_.end()) {
+    const auto &window = it->second->window;
+    size_t count = 0;
+    const size_t head = window.head.load(std::memory_order_acquire);
+    const size_t tail = window.tail.load(std::memory_order_acquire);
+    size_t current = head;
+    while (current != tail) {
+      const auto &entry = window.entries[current];
+      if (entry.priority.load(std::memory_order_acquire) ==
+          static_cast<uint8_t>(priority)) {
+        count += entry.count.load(std::memory_order_acquire);
+      }
+      current = (current + 1) % WINDOW_SIZE;
+    }
+    return count;
+  }
+  return 0;
+#endif
 }
 
 unsigned int LockFreeRateLimiter::getAdjustedLimit(Priority priority) const {

--- a/src/api/server.cpp
+++ b/src/api/server.cpp
@@ -2,7 +2,7 @@
 #include "api/ollama_client.h"
 #include "api/json_helpers.h"
 #include <spdlog/spdlog.h>
-#include "crow/crow.h"
+#include "crow/crow_isolation.h"
 
 #include <chrono>
 #include <csignal>
@@ -47,10 +47,8 @@ SEPApiServer::SEPApiServer(const ::sep::config::APIConfig& config)
     // Initialize logger
     setup_logging();
 
-    // Initialize clients if needed
-    if (config_.ollama.enabled) {
-        ollama_client_ = std::make_unique<OllamaClient>(config_.ollama);
-    }
+    // Initialize Ollama client
+    ollama_client_ = std::make_unique<sep::ollama::OllamaClient>(config_.ollama);
 }
 
 SEPApiServer::~SEPApiServer() {
@@ -127,7 +125,7 @@ std::unique_ptr<HttpResponse> SEPApiServer::makeJsonResponse(int code, const std
     void setBody(const std::string& body) override { body_ = body; }
     void end() override {}
     int getCode() const override { return code_; }
-    const std::string& getBody() const override { return body_; }
+    std::string getBody() const override { return body_; }
 
    private:
     int code_;
@@ -308,7 +306,7 @@ void SEPApiServer::setup_routes() {
 
   // Health check endpoint
   app_->route_dynamic("/api/v1/health")
-      .methods(::crow::HTTPMethod::Get)([this, &engine](const ::crow::request& req) {
+      .methods(::crow::HTTPMethod::GET)([this, &engine](const ::crow::request& req) {
     auto start_time = std::chrono::steady_clock::now();
 
     #if SEP_HAS_EXCEPTIONS
@@ -338,7 +336,7 @@ void SEPApiServer::setup_routes() {
 
   // Process patterns endpoint
   app_->route_dynamic("/api/v1/pattern/evolve")
-      .methods(::crow::HTTPMethod::Post)([this, &engine](const ::crow::request& req) {
+      .methods(::crow::HTTPMethod::POST)([this, &engine](const ::crow::request& req) {
         auto start_time = std::chrono::steady_clock::now();
 
 #if SEP_HAS_EXCEPTIONS
@@ -384,7 +382,7 @@ void SEPApiServer::setup_routes() {
 
   // Process batch endpoint
   app_->route_dynamic("/api/v1/memory/query")
-      .methods(::crow::HTTPMethod::Post)([this, &engine](const ::crow::request& req) {
+      .methods(::crow::HTTPMethod::POST)([this, &engine](const ::crow::request& req) {
         auto start_time = std::chrono::steady_clock::now();
 
 #if SEP_HAS_EXCEPTIONS
@@ -427,7 +425,7 @@ void SEPApiServer::setup_routes() {
 
   // Pattern history endpoint
   app_->route_dynamic("/api/v1/patterns/history")
-      .methods(::crow::HTTPMethod::Post)([this, &engine](const ::crow::request& req) {
+      .methods(::crow::HTTPMethod::POST)([this, &engine](const ::crow::request& req) {
         auto start_time = std::chrono::steady_clock::now();
 
 #if SEP_HAS_EXCEPTIONS
@@ -470,7 +468,7 @@ void SEPApiServer::setup_routes() {
 
   // Validate contexts endpoint
   app_->route_dynamic("/api/v1/context/process")
-      .methods(::crow::HTTPMethod::Post)([this, &engine](const ::crow::request& req) {
+      .methods(::crow::HTTPMethod::POST)([this, &engine](const ::crow::request& req) {
         auto start_time = std::chrono::steady_clock::now();
 
 #if SEP_HAS_EXCEPTIONS
@@ -513,7 +511,7 @@ void SEPApiServer::setup_routes() {
 
   // Extract embeddings endpoint
   app_->route_dynamic("/api/v1/embeddings/extract")
-      .methods(::crow::HTTPMethod::Post)([this, &engine](const ::crow::request& req) {
+      .methods(::crow::HTTPMethod::POST)([this, &engine](const ::crow::request& req) {
         auto start_time = std::chrono::steady_clock::now();
 
 #if SEP_HAS_EXCEPTIONS
@@ -556,7 +554,7 @@ void SEPApiServer::setup_routes() {
 
   // Analyze patterns endpoint
   app_->route_dynamic("/api/v1/pattern/analyze")
-      .methods(::crow::HTTPMethod::Post)([this, &engine](const ::crow::request& req) {
+      .methods(::crow::HTTPMethod::POST)([this, &engine](const ::crow::request& req) {
         auto start_time = std::chrono::steady_clock::now();
 
 #if SEP_HAS_EXCEPTIONS
@@ -599,7 +597,7 @@ void SEPApiServer::setup_routes() {
 
   // Context relationships endpoint
   app_->route_dynamic("/api/v1/context/relationships")
-      .methods(::crow::HTTPMethod::Post)([this, &engine](const ::crow::request& req) {
+      .methods(::crow::HTTPMethod::POST)([this, &engine](const ::crow::request& req) {
         auto start_time = std::chrono::steady_clock::now();
 
 #if SEP_HAS_EXCEPTIONS
@@ -642,7 +640,7 @@ void SEPApiServer::setup_routes() {
 
   // Memory metrics endpoint
   app_->route_dynamic("/api/v1/metrics/memory")
-      .methods(::crow::HTTPMethod::Get)([this, &engine](const ::crow::request& req) {
+      .methods(::crow::HTTPMethod::GET)([this, &engine](const ::crow::request& req) {
         auto start_time = std::chrono::steady_clock::now();
 
 #if SEP_HAS_EXCEPTIONS
@@ -748,7 +746,7 @@ void SEPApiServer::initClients() {
   try {
 #endif
     // Initialize Ollama client if configured
-    ollama_client_ = std::make_unique<OllamaClient>(config_.ollama);
+    ollama_client_ = std::make_unique<sep::ollama::OllamaClient>(config_.ollama);
     logger_->info("Ollama client initialized");
 #if SEP_HAS_EXCEPTIONS
   } catch (const std::exception& e) {

--- a/src/core/manager.cpp
+++ b/src/core/manager.cpp
@@ -96,7 +96,7 @@ public:
 
       // Support both --key=value and --key value
       sep::shim::string value;
-      auto pos = arg.find("=");
+      auto pos = arg.find('=');
       if (pos != sep::shim::string::npos) {
         // Extract substring after '='
         std::string arg_str = arg.c_str();


### PR DESCRIPTION
## Summary
- restore API type definitions including `ErrorCode`, `Priority`, request/response structs
- provide fallback implementation for `LockFreeRateLimiter` when TBB isn't available
- adjust Crow adapter signatures and server client initialization
- add missing `ollama_client` header
- fix minor build issues in manager and server

## Testing
- `./build.sh build` *(fails: undefined reference errors)*

------
https://chatgpt.com/codex/tasks/task_e_685a9e5c8634832a90c2b1bda2fb0bc6