### PR TITLE
Link external libs and unify Crow RTTI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,22 @@ project(SEPEngine)
 
 include(FetchContent)
 
+# Use C++17 across all targets
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Define Crow compile-time configuration globally to avoid
+# redundant macro definitions in individual compilation units
+add_compile_definitions(CROW_DISABLE_RTTI=1)
+
+# Locate external dependencies required for the final executable
+find_package(CURL REQUIRED)
+# Hiredis doesn't ship a CMake package file in many distributions,
+# so fall back to a simple find_library/find_path approach.
+find_library(HIREDIS_LIBRARIES NAMES hiredis)
+find_path(HIREDIS_INCLUDE_DIR hiredis/hiredis.h)
+find_package(CUDA REQUIRED)
+
 # Add our fixed Crow headers directory BEFORE other include directories
 # This ensures our fixed headers are used instead of the problematic ones
 include_directories(BEFORE
@@ -44,6 +60,10 @@ target_include_directories(sep_engine
         ${CMAKE_SOURCE_DIR}/include
 )
 
+if(HIREDIS_INCLUDE_DIR)
+    target_include_directories(sep_engine PRIVATE ${HIREDIS_INCLUDE_DIR})
+endif()
+
 target_link_libraries(sep_engine
     sep_core
     sep_api
@@ -51,4 +71,10 @@ target_link_libraries(sep_engine
     sep_quantum
     sep_audio
     sep_blender
-    sep_compat)
+    sep_compat
+    ${CURL_LIBRARIES}
+    ${CUDA_LIBRARIES})
+
+if(HIREDIS_LIBRARIES)
+    target_link_libraries(sep_engine PRIVATE ${HIREDIS_LIBRARIES})
+endif()

--- a/include/api/crow_adapter.h
+++ b/include/api/crow_adapter.h
@@ -8,8 +8,7 @@
 
 #pragma once
 
-// Define CROW_DISABLE_RTTI first since we're using with CUDA
-#define CROW_DISABLE_RTTI 1
+// CROW_DISABLE_RTTI is defined globally via CMake
 
 // Forward declarations - use class instead of struct to match crow's definitions
 namespace crow {

--- a/src/api/crow_adapter.cpp
+++ b/src/api/crow_adapter.cpp
@@ -6,8 +6,7 @@
  * SEP Engine API via HTTP endpoints using the Crow web framework.
  */
 
-// Define CROW_DISABLE_RTTI first since we're using with CUDA
-#define CROW_DISABLE_RTTI 1
+// CROW_DISABLE_RTTI is defined globally via CMake
 
 // First include our fixed isolation headers to avoid conflicts
 #include "crow/crow_isolation.h"

--- a/src/memory/manager.cpp
+++ b/src/memory/manager.cpp
@@ -1,7 +1,6 @@
 #include "memory/manager.h"
 
-// Define CROW_DISABLE_RTTI to use isolation headers
-#define CROW_DISABLE_RTTI
+// CROW_DISABLE_RTTI is defined globally via CMake
 #include <spdlog/sinks/rotating_file_sink.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/spdlog.h>


### PR DESCRIPTION
## Summary
- configure global compile definitions for Crow
- require cURL, CUDA and search for hiredis
- link external libs to `sep_engine`
- drop redundant `CROW_DISABLE_RTTI` defines
- use C++17 across the project

## Testing
- `cmake ..` *(fails: Specify CUDA_TOOLKIT_ROOT_DIR)*

------
https://chatgpt.com/codex/tasks/task_e_685aaaf9cd8c832a9ad576ff885e6ae5