### PR TITLE
Fix macro redefinition and link libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,15 @@
 cmake_minimum_required(VERSION 3.10)
 project(SEPEngine)
 
+# Ensure RTTI is disabled consistently across all targets when building with
+# the Crow isolation headers.
+add_compile_definitions(CROW_DISABLE_RTTI=1)
+
+# Locate external dependencies required by the engine
+find_package(CURL QUIET)
+find_package(Hiredis QUIET)
+find_package(CUDAToolkit QUIET)
+
 include(FetchContent)
 
 # Add our fixed Crow headers directory BEFORE other include directories
@@ -51,4 +60,7 @@ target_link_libraries(sep_engine
     sep_quantum
     sep_audio
     sep_blender
-    sep_compat)
+    sep_compat
+    ${CURL_LIBRARIES}
+    ${HIREDIS_LIBRARIES}
+    ${CUDAToolkit_LIBRARIES})

--- a/include/api/crow_adapter.h
+++ b/include/api/crow_adapter.h
@@ -8,8 +8,10 @@
 
 #pragma once
 
-// Define CROW_DISABLE_RTTI first since we're using with CUDA
+// Define CROW_DISABLE_RTTI only if not provided by the build system
+#ifndef CROW_DISABLE_RTTI
 #define CROW_DISABLE_RTTI 1
+#endif
 
 // Forward declarations - use class instead of struct to match crow's definitions
 namespace crow {

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -4,3 +4,6 @@ target_include_directories(sep_api
     PUBLIC
         ${CMAKE_SOURCE_DIR}/include
 )
+
+# Link external dependencies when available
+target_link_libraries(sep_api PRIVATE ${CURL_LIBRARIES} ${HIREDIS_LIBRARIES})

--- a/src/memory/manager.cpp
+++ b/src/memory/manager.cpp
@@ -1,7 +1,9 @@
 #include "memory/manager.h"
 
-// Define CROW_DISABLE_RTTI to use isolation headers
+// Ensure CROW_DISABLE_RTTI is defined when building without RTTI support
+#ifndef CROW_DISABLE_RTTI
 #define CROW_DISABLE_RTTI
+#endif
 #include <spdlog/sinks/rotating_file_sink.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/spdlog.h>


### PR DESCRIPTION
## Summary
- avoid redefinition warnings for `CROW_DISABLE_RTTI`
- link `sep_api` and the main executable against external dependencies
- set `CROW_DISABLE_RTTI` at the CMake level and attempt to find optional libs

## Testing
- `cmake -B build -S .`
- `cmake --build build -j4` *(fails: undefined reference to fmt and cuda symbols)*

------
https://chatgpt.com/codex/tasks/task_e_685aaaf9cd8c832a9ad576ff885e6ae5