### PR TITLE
Integrate external dependencies and fix Crow RTTI macro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,18 @@ project(SEPEngine)
 
 include(FetchContent)
 
+# Disable RTTI in Crow globally
+add_compile_definitions(CROW_DISABLE_RTTI=1)
+
+# Locate external dependencies
+find_package(CURL REQUIRED)
+find_library(HIREDIS_LIBRARIES hiredis)
+find_path(HIREDIS_INCLUDE_DIR hiredis/hiredis.h)
+find_package(CUDAToolkit QUIET)
+if(CUDAToolkit_FOUND)
+  set(SEP_CUDA_LIB CUDA::cudart)
+endif()
+
 # Add our fixed Crow headers directory BEFORE other include directories
 # This ensures our fixed headers are used instead of the problematic ones
 include_directories(BEFORE
@@ -43,6 +55,9 @@ target_include_directories(sep_engine
     PUBLIC
         ${CMAKE_SOURCE_DIR}/include
 )
+if(HIREDIS_INCLUDE_DIR)
+    target_include_directories(sep_engine PUBLIC ${HIREDIS_INCLUDE_DIR})
+endif()
 
 target_link_libraries(sep_engine
     sep_core
@@ -51,4 +66,10 @@ target_link_libraries(sep_engine
     sep_quantum
     sep_audio
     sep_blender
-    sep_compat)
+    sep_compat
+    CURL::libcurl
+    ${SEP_CUDA_LIB}
+)
+if(HIREDIS_LIBRARIES)
+    target_link_libraries(sep_engine PRIVATE ${HIREDIS_LIBRARIES})
+endif()

--- a/include/api/crow_adapter.h
+++ b/include/api/crow_adapter.h
@@ -8,8 +8,6 @@
 
 #pragma once
 
-// Define CROW_DISABLE_RTTI first since we're using with CUDA
-#define CROW_DISABLE_RTTI 1
 
 // Forward declarations - use class instead of struct to match crow's definitions
 namespace crow {

--- a/src/api/crow_adapter.cpp
+++ b/src/api/crow_adapter.cpp
@@ -6,9 +6,6 @@
  * SEP Engine API via HTTP endpoints using the Crow web framework.
  */
 
-// Define CROW_DISABLE_RTTI first since we're using with CUDA
-#define CROW_DISABLE_RTTI 1
-
 // First include our fixed isolation headers to avoid conflicts
 #include "crow/crow_isolation.h"
 #include "crow/common.h"

--- a/src/memory/manager.cpp
+++ b/src/memory/manager.cpp
@@ -1,7 +1,5 @@
 #include "memory/manager.h"
 
-// Define CROW_DISABLE_RTTI to use isolation headers
-#define CROW_DISABLE_RTTI
 #include <spdlog/sinks/rotating_file_sink.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/spdlog.h>


### PR DESCRIPTION
## Summary
- find Curl, Hiredis and CUDA toolkit in the main `CMakeLists.txt`
- link these libraries to `sep_engine` when available
- define `CROW_DISABLE_RTTI` globally via CMake instead of per file
- remove duplicate `CROW_DISABLE_RTTI` defines from sources

## Testing
- `cmake -B build -S .`
- `cmake --build build -j $(nproc)` *(fails: undefined references)*

------
https://chatgpt.com/codex/tasks/task_e_685aaaf9cd8c832a9ad576ff885e6ae5