### PR TITLE
Fix Crow RTTI and add external libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.10)
 project(SEPEngine)
 
+# Use compile definition globally for Crow without RTTI
+add_compile_definitions(CROW_DISABLE_RTTI=1)
+
 include(FetchContent)
 
 # Add our fixed Crow headers directory BEFORE other include directories
@@ -38,10 +41,17 @@ add_subdirectory(src/compat)
 add_subdirectory(src/core)
 add_subdirectory(src/memory)
 add_subdirectory(src/quantum)
+
+# External dependencies
+find_package(CURL REQUIRED)
+find_library(HIREDIS_LIBRARIES hiredis)
+find_package(CUDAToolkit)
 add_executable(sep_engine src/main.cpp)
 target_include_directories(sep_engine
     PUBLIC
         ${CMAKE_SOURCE_DIR}/include
+        ${CURL_INCLUDE_DIRS}
+        ${CUDAToolkit_INCLUDE_DIRS}
 )
 
 target_link_libraries(sep_engine
@@ -51,4 +61,7 @@ target_link_libraries(sep_engine
     sep_quantum
     sep_audio
     sep_blender
-    sep_compat)
+    sep_compat
+    ${CURL_LIBRARIES}
+    ${HIREDIS_LIBRARIES}
+    ${CUDAToolkit_LIBRARIES})

--- a/include/api/crow_adapter.h
+++ b/include/api/crow_adapter.h
@@ -8,8 +8,7 @@
 
 #pragma once
 
-// Define CROW_DISABLE_RTTI first since we're using with CUDA
-#define CROW_DISABLE_RTTI 1
+// CROW_DISABLE_RTTI is defined globally via CMake. No need to define it here.
 
 // Forward declarations - use class instead of struct to match crow's definitions
 namespace crow {

--- a/include/api/crow_request.h
+++ b/include/api/crow_request.h
@@ -14,7 +14,7 @@ namespace sep::api {
 class CrowRequest : public IRequest
 {
 public:
-    CrowRequest(const ::crow::request& req) : req_(req)
+    CrowRequest(const ::crow::request& req) : req_(req), body_(req.body)
     {
         // In Crow, headers might not be directly accessible as a member
         // So we'll populate our headers from individual header values
@@ -38,7 +38,7 @@ public:
     
     const std::string& body() const override
     {
-        return req_.body;
+        return body_;
     }
 
     const std::unordered_map<std::string, std::string>& headers() const override
@@ -63,6 +63,7 @@ public:
 
 private:
     const ::crow::request& req_;
+    std::string body_;
     std::unordered_map<std::string, std::string> headers_;
 };
 

--- a/src/api/crow_adapter.cpp
+++ b/src/api/crow_adapter.cpp
@@ -6,8 +6,7 @@
  * SEP Engine API via HTTP endpoints using the Crow web framework.
  */
 
-// Define CROW_DISABLE_RTTI first since we're using with CUDA
-#define CROW_DISABLE_RTTI 1
+// CROW_DISABLE_RTTI is defined globally via CMake.
 
 // First include our fixed isolation headers to avoid conflicts
 #include "crow/crow_isolation.h"

--- a/src/memory/manager.cpp
+++ b/src/memory/manager.cpp
@@ -1,7 +1,6 @@
 #include "memory/manager.h"
 
-// Define CROW_DISABLE_RTTI to use isolation headers
-#define CROW_DISABLE_RTTI
+// CROW_DISABLE_RTTI is defined globally via CMake.
 #include <spdlog/sinks/rotating_file_sink.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/spdlog.h>


### PR DESCRIPTION
## Summary
- define `CROW_DISABLE_RTTI` globally
- clean up redundant macro definitions in API and memory code
- copy request body in `CrowRequest` to avoid lifetime issues
- link against CURL/Hiredis/CUDA as documented

## Testing
- `./build.sh test` *(fails: undefined references during linking)*

------
https://chatgpt.com/codex/tasks/task_e_685aaaf9cd8c832a9ad576ff885e6ae5