### PR TITLE
Fix missing pattern processor and rebuild lookup

### DIFF
--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -119,6 +119,22 @@ MemoryTier& MemoryTierManager::getLTM() {
     return *ltm_;
 }
 
+void MemoryTierManager::rebuildLookup()
+{
+    lookup_map_.clear();
+    auto rebuild = [this](MemoryTier* t) {
+        if (!t)
+            return;
+        for (const auto& blk : t->getBlocks()) {
+            if (blk.allocated)
+                lookup_map_[blk.ptr] = const_cast<MemoryBlock*>(&blk);
+        }
+    };
+    rebuild(stm_.get());
+    rebuild(mtm_.get());
+    rebuild(ltm_.get());
+}
+
 SEPResult MemoryTierManager::promoteBlock(MemoryBlock* block, MemoryBlock*& out_block) {
     if (!block)
         return SEPResult::INVALID_ARGUMENT;

--- a/src/quantum/CMakeLists.txt
+++ b/src/quantum/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(sep_quantum STATIC qbsa.cpp qbsa_qfh.cpp qfh.cpp quantum_processor.cpp quantum_processor_qfh.cpp quantum_processor_qfh_common.cpp evolution.cpp processor.cpp types_serialization.cpp pattern_processor.cpp)
+add_library(sep_quantum STATIC qbsa.cpp qbsa_qfh.cpp qfh.cpp quantum_processor.cpp quantum_processor_qfh.cpp quantum_processor_qfh_common.cpp evolution.cpp processor.cpp types_serialization.cpp pattern_processor.cpp pattern_processor_interface.cpp)
 
 target_include_directories(sep_quantum
     PUBLIC

--- a/src/quantum/pattern_processor_interface.cpp
+++ b/src/quantum/pattern_processor_interface.cpp
@@ -1,0 +1,61 @@
+#include "quantum/processor.h"
+
+namespace sep::pattern {
+
+PatternProcessor::PatternProcessor(Implementation impl)
+    : implementation_(impl) {}
+
+SEPResult PatternProcessor::init(quantum::GPUContext* ctx)
+{
+    (void)ctx;
+    return SEPResult::SUCCESS;
+}
+
+void PatternProcessor::evolvePatterns()
+{
+    // Simple example evolution: increment generation
+    for (auto& p : patterns_)
+        ++p.generation;
+}
+
+PatternData PatternProcessor::mutatePattern(const PatternData& parent)
+{
+    PatternData child = parent;
+    child.id = parent.id + "_child";
+    ++child.generation;
+    return child;
+}
+
+SEPResult PatternProcessor::addPattern(const PatternData& pattern)
+{
+    patterns_.push_back(pattern);
+    return SEPResult::SUCCESS;
+}
+
+const std::vector<PatternData>& PatternProcessor::getPatterns() const
+{
+    return patterns_;
+}
+
+CPUPatternProcessor::CPUPatternProcessor()
+    : PatternProcessor(Implementation::CPU), patterns_(PatternProcessor::patterns_)
+{
+}
+
+SEPResult CPUPatternProcessor::init(quantum::GPUContext* ctx)
+{
+    return PatternProcessor::init(ctx);
+}
+
+void CPUPatternProcessor::evolvePatterns()
+{
+    PatternProcessor::evolvePatterns();
+}
+
+PatternData CPUPatternProcessor::mutatePattern(const PatternData& parent)
+{
+    return PatternProcessor::mutatePattern(parent);
+}
+
+} // namespace sep::pattern
+


### PR DESCRIPTION
## Summary
- implement simple PatternProcessor/CPUPatternProcessor interface
- update quantum library build files
- rebuild memory lookup table when blocks move

## Testing
- `./build.sh` *(fails: Specify CUDA_TOOLKIT_ROOT_DIR)*

------
https://chatgpt.com/codex/tasks/task_e_685ab58b878c832a986bf9b35bf33617