### PR TITLE
Implement missing functions

### DIFF
--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -94,6 +94,23 @@ void MemoryTierManager::updateBlockMetrics(MemoryBlock* block, float coherence, 
     }
 }
 
+void MemoryTierManager::rebuildLookup() {
+    lookup_map_.clear();
+
+    auto rebuild = [this](MemoryTier* tier) {
+        if (!tier) return;
+        for (auto& blk : tier->getBlocks()) {
+            if (blk.allocated) {
+                lookup_map_[blk.ptr] = const_cast<MemoryBlock*>(&blk);
+            }
+        }
+    };
+
+    rebuild(stm_.get());
+    rebuild(mtm_.get());
+    rebuild(ltm_.get());
+}
+
 void MemoryTierManager::defragmentTier(sep::memory::TierType tier) {
     if (MemoryTier* t = getTier(tier))
         t->defragment();

--- a/src/quantum/pattern_processor.cpp
+++ b/src/quantum/pattern_processor.cpp
@@ -108,3 +108,48 @@ std::unique_ptr<PatternQuantumProcessor> createPatternQuantumProcessor(
 }
 
 } // namespace sep::quantum
+
+namespace sep::pattern {
+
+PatternProcessor::PatternProcessor(Implementation impl) : implementation_(impl) {}
+
+SEPResult PatternProcessor::init(quantum::GPUContext* ctx) {
+    (void)ctx;
+    return SEPResult::SUCCESS;
+}
+
+void PatternProcessor::evolvePatterns() {
+    for (auto& p : patterns_) {
+        ++p.generation;
+    }
+}
+
+PatternData PatternProcessor::mutatePattern(const PatternData& parent) {
+    PatternData child = parent;
+    child.generation = parent.generation + 1;
+    child.id = parent.id + "_child";
+    return child;
+}
+
+SEPResult PatternProcessor::addPattern(const PatternData& pattern) {
+    patterns_.push_back(pattern);
+    return SEPResult::SUCCESS;
+}
+
+const std::vector<PatternData>& PatternProcessor::getPatterns() const { return patterns_; }
+
+CPUPatternProcessor::CPUPatternProcessor() : PatternProcessor(Implementation::CPU), patterns_(patterns_) {}
+
+SEPResult CPUPatternProcessor::init(quantum::GPUContext* ctx) { return PatternProcessor::init(ctx); }
+
+void CPUPatternProcessor::evolvePatterns() {
+    for (auto& p : patterns_) {
+        p = mutatePattern(p);
+    }
+}
+
+PatternData CPUPatternProcessor::mutatePattern(const PatternData& parent) {
+    return PatternProcessor::mutatePattern(parent);
+}
+
+} // namespace sep::pattern


### PR DESCRIPTION
## Summary
- fix linking issues by implementing `rebuildLookup` in MemoryTierManager
- provide simple PatternProcessor and CPUPatternProcessor implementations

## Testing
- `cmake ..` *(fails: Specify CUDA_TOOLKIT_ROOT_DIR)*
- `g++ test.cpp -I../../include -std=c++17 -o testbed_app` *(fails: ‘STM’ is not a member of ‘sep::memory::TierType’)*

------
https://chatgpt.com/codex/tasks/task_e_685ab58b878c832a986bf9b35bf33617