### PR TITLE
Fix partial CUDA build setup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.10)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
-project(SEPEngine LANGUAGES CXX) # Explicitly enable CUDA language
+project(SEPEngine LANGUAGES CXX CUDA)
 
 # Ensure RTTI is disabled consistently across all targets when building with
 # the Crow isolation headers.
@@ -12,7 +12,6 @@ include(${CMAKE_SOURCE_DIR}/cmake/CustomCUDA.cmake)
 
 # Locate external dependencies required by the engine
 find_package(CURL QUIET)
-find_package(Hiredis QUIET)
 find_package(CUDAToolkit QUIET)
 
 include(FetchContent)
@@ -31,7 +30,15 @@ find_package(CURL REQUIRED)
 # so fall back to a simple find_library/find_path approach.
 find_library(HIREDIS_LIBRARIES NAMES hiredis)
 find_path(HIREDIS_INCLUDE_DIR hiredis/hiredis.h)
-find_package(CUDA REQUIRED)
+
+if(CUDAToolkit_FOUND)
+    set(SEP_CUDA_AVAILABLE 1)
+else()
+    set(SEP_CUDA_AVAILABLE 0)
+    message(WARNING "CUDA toolkit not found, building without CUDA support")
+endif()
+
+add_compile_definitions(SEP_CUDA_AVAILABLE=${SEP_CUDA_AVAILABLE})
 
 # Add our fixed Crow headers directory BEFORE other include directories
 # This ensures our fixed headers are used instead of the problematic ones

--- a/include/compat/core.h
+++ b/include/compat/core.h
@@ -10,6 +10,7 @@
 
 #include "compat/memory.h"
 #include "compat/stream.h"
+#include "compat/cuda_defs.h"
 
 namespace sep::cuda {
 

--- a/src/compat/raii.cpp
+++ b/src/compat/raii.cpp
@@ -133,7 +133,7 @@ EventRAII::EventRAII() {
     // the real CUDA runtime or the stub implementation. Casting through
     // the stub-specific type is unnecessary and breaks when the stub is
     // absent, so simply pass the address of the underlying handle.
-    cudaError_t err = cudaEventCreate(reinterpret_cast<void**>(&event_));
+    cudaError_t err = cudaEventCreate(&event_);
     if (err != cudaSuccess) {
         event_ = nullptr;
         if (debugAllocEnabled()) {


### PR DESCRIPTION
## Summary
- project uses CUDA so enable language
- make CUDA optional and expose `SEP_CUDA_AVAILABLE`
- include CUDA defs in compat core header
- fix CUDA event creation logic in RAII wrapper

## Testing
- `cmake ..`
- `make -j$(nproc)` *(fails: undefined fields in pattern_kernels.cu and event.cu)*

------
https://chatgpt.com/codex/tasks/task_e_685ab58b878c832a986bf9b35bf33617