### PR TITLE
Fix CUDA build paths and compile .cu files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,10 @@ include_directories(BEFORE
 )
 
 include_directories(
+  ${CMAKE_SOURCE_DIR}/include/compat
+)
+
+include_directories(
   ${CMAKE_SOURCE_DIR}/third_party
   ${CMAKE_SOURCE_DIR}/third_party/glm
   ${CMAKE_SOURCE_DIR}/third_party/tbb

--- a/src/compat/CMakeLists.txt
+++ b/src/compat/CMakeLists.txt
@@ -14,14 +14,16 @@ add_library(sep_compat STATIC
     utils.cu
 )
 
-# Comment out CUDA configuration
+# Ensure the CUDA source files are treated correctly
 set_source_files_properties(
-     core/core.cu
-     cuda_api.cu
-     event.cu
-     pattern_kernels.cu
-     quantum_kernels.cu
-     utils.cu
+    core/core.cu
+    cuda_api.cu
+    event.cu
+    pattern_kernels.cu
+    quantum_kernels.cu
+    utils.cu
+    PROPERTIES
+        LANGUAGE CUDA
 )
 
 # Add include directories needed by compat library sources


### PR DESCRIPTION
## Summary
- add missing compat include directory so stub CUDA headers are found
- mark CUDA sources so CMake compiles them using CUDA

## Testing
- `./build.sh build sep_engine` *(fails: Condensed Error Summary)*

------
https://chatgpt.com/codex/tasks/task_e_685ad3e56248832a912fca1ec5d7ac2e