### PR TITLE
Fix core library linking

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -4,3 +4,9 @@ target_include_directories(sep_core
     PUBLIC
         ${CMAKE_SOURCE_DIR}/include
 )
+
+# Link against the compat library so that CUDA wrappers
+# and other compatibility utilities are available when
+# building the core library. This resolves linker errors
+# for symbols defined in the compat module (e.g. CudaCore).
+target_link_libraries(sep_core PUBLIC sep_compat)


### PR DESCRIPTION
## Summary
- link `sep_core` with `sep_compat` so CUDA wrapper symbols resolve

## Testing
- `cmake ..`
- `make -j4` *(fails: cuda_runtime.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_685ad3e56248832a912fca1ec5d7ac2e