### PR TITLE
Fix build for environments without CUDA

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ find_package(CROW QUIET)
 find_package(TBB QUIET)
 find_package(glm QUIET)
 find_package(fmt QUIET)
+find_package(spdlog QUIET)
 
 include(FetchContent)
 
@@ -101,13 +102,15 @@ target_include_directories(sep_engine
 )
 
 target_link_libraries(sep_engine
-    sep_core
     sep_api
     sep_memory
     sep_quantum
+    sep_core
     sep_audio
     sep_blender
     sep_compat
     ${CURL_LIBRARIES}
     ${CUDA_LIBRARIES}
+    fmt::fmt
+    spdlog::spdlog
 )

--- a/cmake/CustomCUDA.cmake
+++ b/cmake/CustomCUDA.cmake
@@ -23,9 +23,17 @@ set(CUDA_LIBRARY_DIRS
     CACHE STRING "CUDA library directories"
 )
 
-# Add CUDA library directories and include directories globally
-link_directories(${CUDA_LIBRARY_DIRS})
-include_directories(SYSTEM ${CUDA_INCLUDE_DIRS})
+# Check if the expected CUDA library path exists; if not, disable CUDA support.
+if(NOT EXISTS "${CUDA_PATH}/lib64")
+    message(WARNING "CUDA path ${CUDA_PATH} not found; disabling CUDA support")
+    set(CUDAToolkit_FOUND OFF CACHE BOOL "CUDA toolkit found" FORCE)
+    set(CUDA_LIBRARIES "" CACHE STRING "CUDA libraries" FORCE)
+    set(CUDA_LIBRARY_DIRS "" CACHE STRING "CUDA library directories" FORCE)
+else()
+    # Add CUDA library directories and include directories globally
+    link_directories(${CUDA_LIBRARY_DIRS})
+    include_directories(SYSTEM ${CUDA_INCLUDE_DIRS})
+endif()
 
 #--- Host compiler flags ---
 # Enforce C++20 for GCC 14

--- a/src/compat/CMakeLists.txt
+++ b/src/compat/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(sep_compat STATIC
 
 if(NOT SEP_CUDA_AVAILABLE)
   target_sources(sep_compat PRIVATE core/core_stub.cpp)
+  target_sources(sep_compat PRIVATE cuda_stubs.cpp)
 endif()
 
 # Comment out CUDA configuration

--- a/src/compat/cuda_stubs.cpp
+++ b/src/compat/cuda_stubs.cpp
@@ -1,0 +1,31 @@
+#if !SEP_CUDA_AVAILABLE
+#include "compat/cuda_runtime.h"
+#include <cstring>
+#include <cstdlib>
+
+namespace sep { namespace cuda {
+
+cudaError_t cudaMallocManaged(void** ptr, size_t size) {
+    if (!ptr) return cudaErrorInvalidValue;
+    *ptr = std::malloc(size);
+    return *ptr ? cudaSuccess : cudaErrorMemoryAllocation;
+}
+
+cudaError_t cudaFree(void* ptr) {
+    std::free(ptr);
+    return cudaSuccess;
+}
+
+cudaError_t cudaMemcpy(void* dst, const void* src, size_t size, int kind) {
+    (void)kind;
+    if (dst && src) std::memcpy(dst, src, size);
+    return cudaSuccess;
+}
+
+cudaError_t cudaMemcpyAsync(void* dst, const void* src, size_t size, int kind, cudaStream_t stream) {
+    (void)stream;
+    return cudaMemcpy(dst, src, size, kind);
+}
+
+} } // namespace sep::cuda
+#endif


### PR DESCRIPTION
## Summary
- disable CUDA when library directory absent
- link fmt and spdlog libraries
- add CPU-only CUDA stubs and include when CUDA unavailable
- adjust library order for linker

## Testing
- `./build.sh build sep_engine` *(fails: undefined vtable for BlenderBridge)*

------
https://chatgpt.com/codex/tasks/task_e_685adae7b090832aa88d980704d66cda