### PR TITLE
Fix build when Hiredis not available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,13 @@ find_package(CURL REQUIRED)
 find_library(HIREDIS_LIBRARIES NAMES hiredis)
 find_path(HIREDIS_INCLUDE_DIR hiredis/hiredis.h)
 
+if(HIREDIS_LIBRARIES AND HIREDIS_INCLUDE_DIR)
+    set(HIREDIS_FOUND TRUE)
+else()
+    set(HIREDIS_FOUND FALSE)
+    message(WARNING "Hiredis not found, Redis persistence disabled")
+endif()
+
 if(CUDAToolkit_FOUND)
     set(SEP_CUDA_AVAILABLE 1)
 else()
@@ -97,9 +104,10 @@ add_executable(sep_engine src/main.cpp)
 target_include_directories(sep_engine
     PUBLIC
         ${CMAKE_SOURCE_DIR}/include
-    PRIVATE 
-        ${HIREDIS_INCLUDE_DIR}
 )
+if(HIREDIS_FOUND)
+    target_include_directories(sep_engine PRIVATE ${HIREDIS_INCLUDE_DIR})
+endif()
 
 target_link_libraries(sep_engine
     sep_api

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -6,4 +6,7 @@ target_include_directories(sep_api
 )
 
 # Link external dependencies when available
-target_link_libraries(sep_api PRIVATE ${CURL_LIBRARIES} ${HIREDIS_LIBRARIES})
+target_link_libraries(sep_api PRIVATE ${CURL_LIBRARIES})
+if(HIREDIS_FOUND)
+    target_link_libraries(sep_api PRIVATE ${HIREDIS_LIBRARIES})
+endif()

--- a/src/blender/api.cpp
+++ b/src/blender/api.cpp
@@ -1,14 +1,15 @@
 #include "compat/math_common.h"
 
 #include "blender/types.h"
-#include "blender/bridge.h"
+#include "blender/config.h"
+#include "blender/pattern_bridge.h"
 #include <memory>
 #include <stdexcept>
 #include <string>
 // Bridge implementation structure
 struct SEPBlenderBridge
 {
-    std::unique_ptr<sep::pattern::BlenderBridge> impl;
+    std::shared_ptr<sep::pattern::BlenderBridge> impl;
     SEPAudioMetrics                              audio_metrics{};    // last computed audio metrics
     SEPPatternMetrics                            pattern_metrics{};  // last collected pattern metrics
 };

--- a/src/core/engine.cpp
+++ b/src/core/engine.cpp
@@ -1,7 +1,7 @@
 #include "core/engine.h"
 
 #include "audio/capture.h"
-#include "blender/bridge.h"
+#include "blender/pattern_bridge.h"
 #include "memory/manager.h"
 
 #include "compat/shim.h"

--- a/tests/blender/mocks/mock_blender_bridge.cpp
+++ b/tests/blender/mocks/mock_blender_bridge.cpp
@@ -12,7 +12,7 @@
 #include <condition_variable>
 #include <atomic>
 
-#include "blender/bridge.h"
+#include "blender/pattern_bridge.h"
 #include "blender/types.h"
 #include "core/common.h"
 


### PR DESCRIPTION
## Summary
- check for Hiredis library and only link when found
- adjust `sep_engine` include paths accordingly
- include Blender config in API and use `shared_ptr` for bridge
- switch all users to `pattern_bridge.h` to avoid ODR issues

## Testing
- `./build.sh build`

------
https://chatgpt.com/codex/tasks/task_e_685ae60cc328832aa8afbce5a32e52b8