### PR TITLE
Fix build by using correct BlenderBridge header

### DIFF
--- a/src/core/engine.cpp
+++ b/src/core/engine.cpp
@@ -1,7 +1,7 @@
 #include "core/engine.h"
 
 #include "audio/capture.h"
-#include "blender/bridge.h"
+#include "blender/pattern_bridge.h"
 #include "memory/manager.h"
 
 #include "compat/shim.h"


### PR DESCRIPTION
## Summary
- include `blender/pattern_bridge.h` in `Engine`

## Testing
- `./build.sh build all`
- `./build.sh test`

------
https://chatgpt.com/codex/tasks/task_e_685ae60cc328832aa8afbce5a32e52b8