### PR TITLE
Fix Hiredis lookup and Blender bridge

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,16 @@ find_package(CURL REQUIRED)
 find_library(HIREDIS_LIBRARIES NAMES hiredis)
 find_path(HIREDIS_INCLUDE_DIR hiredis/hiredis.h)
 
+if(HIREDIS_LIBRARIES AND HIREDIS_INCLUDE_DIR)
+    set(SEP_HAS_HIREDIS 1)
+    message(STATUS "Hiredis found: ${HIREDIS_INCLUDE_DIR}")
+else()
+    set(SEP_HAS_HIREDIS 0)
+    message(WARNING "Hiredis not found, Redis support disabled")
+endif()
+
+add_compile_definitions(SEP_HAS_HIREDIS=${SEP_HAS_HIREDIS})
+
 if(CUDAToolkit_FOUND)
     set(SEP_CUDA_AVAILABLE 1)
 else()
@@ -97,8 +107,8 @@ add_executable(sep_engine src/main.cpp)
 target_include_directories(sep_engine
     PUBLIC
         ${CMAKE_SOURCE_DIR}/include
-    PRIVATE 
-        ${HIREDIS_INCLUDE_DIR}
+    PRIVATE
+        $<$<BOOL:${SEP_HAS_HIREDIS}>:${HIREDIS_INCLUDE_DIR}>
 )
 
 target_link_libraries(sep_engine
@@ -111,6 +121,7 @@ target_link_libraries(sep_engine
     sep_compat
     ${CURL_LIBRARIES}
     ${CUDA_LIBRARIES}
+    $<$<BOOL:${SEP_HAS_HIREDIS}>:${HIREDIS_LIBRARIES}>
     fmt::fmt
     spdlog::spdlog
 )

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -6,4 +6,4 @@ target_include_directories(sep_api
 )
 
 # Link external dependencies when available
-target_link_libraries(sep_api PRIVATE ${CURL_LIBRARIES} ${HIREDIS_LIBRARIES})
+target_link_libraries(sep_api PRIVATE ${CURL_LIBRARIES} $<$<BOOL:${SEP_HAS_HIREDIS}>:${HIREDIS_LIBRARIES}>)

--- a/src/blender/api.cpp
+++ b/src/blender/api.cpp
@@ -1,14 +1,15 @@
 #include "compat/math_common.h"
 
 #include "blender/types.h"
-#include "blender/bridge.h"
+#include "blender/pattern_bridge.h"
+#include "blender/config.h"
 #include <memory>
 #include <stdexcept>
 #include <string>
 // Bridge implementation structure
 struct SEPBlenderBridge
 {
-    std::unique_ptr<sep::pattern::BlenderBridge> impl;
+    std::shared_ptr<sep::pattern::BlenderBridge> impl;
     SEPAudioMetrics                              audio_metrics{};    // last computed audio metrics
     SEPPatternMetrics                            pattern_metrics{};  // last collected pattern metrics
 };

--- a/src/core/engine.cpp
+++ b/src/core/engine.cpp
@@ -1,7 +1,7 @@
 #include "core/engine.h"
 
 #include "audio/capture.h"
-#include "blender/bridge.h"
+#include "blender/pattern_bridge.h"
 #include "memory/manager.h"
 
 #include "compat/shim.h"


### PR DESCRIPTION
## Summary
- handle missing Hiredis gracefully in CMake
- link Hiredis only if it is available
- use new pattern_bridge header in engine and Blender API
- store Blender bridge pointer as shared_ptr

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_685ae60cc328832aa8afbce5a32e52b8