### PR TITLE
Add audio pipeline diagram

### DIFF
--- a/docs/diagrams/src-audio.md
+++ b/docs/diagrams/src-audio.md
@@ -1,0 +1,20 @@
+# Audio Pipeline Flow
+
+This diagram outlines how audio data moves through the SEP engine. Raw samples originate from a PipeWire stream and are transformed into pattern vectors that other modules consume.
+
+## Stages
+1. **PipeWireCapture** – Connects to a PipeWire device and reads audio frames.
+2. **AudioPipeline** – Buffers frames, applies a Hann window, runs an FFT, and extracts spectral features.
+3. **Pattern Conversion** – Spectral features are mapped into `glm::vec3` pattern vectors which are enqueued for the engine.
+
+```mermaid
+graph TD
+    A([PipeWire Device]) --> B(PipeWireCapture)
+    B --> C[processAudioFrame]
+    C --> D[applyHannWindow]
+    D --> E[performFFT]
+    E --> F[calculateSpectralFeatures]
+    F --> G[convertToPattern]
+    G --> H([Pattern Queue])
+    H --> I([Memory Tiers / Engine])
+```


### PR DESCRIPTION
## Summary
- document how audio flows from PipeWire into the engine
- show main pipeline operations using Mermaid

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685b3ca5915c832ab79daddd0303a833