### PR TITLE
Make build paths configurable

### DIFF
--- a/scripts/local_env_paths.sh.example
+++ b/scripts/local_env_paths.sh.example
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Customize these paths to match your local library installations.
+# Copy this file to local_env_paths.sh and edit the variables as needed.
+
+# Python
+export PYTHON_VERSION="3.11"
+export PYTHON_LIBRARY="/usr/lib64/libpython3.11.so"
+export PYTHON_LIBPATH="/usr/lib64"
+export PYTHON_INCLUDE_DIR="/usr/include/python3.11"
+export PYTHON_INCLUDE_CONFIG_DIR="/usr/include/python3.11"
+
+# Zlib
+export ZLIB_INCLUDE_DIR="/usr/include"
+export ZLIB_LIBRARY="/usr/lib/libz.so"
+
+# OpenImageIO
+export OPENIMAGEIO_ROOT_DIR="/usr"
+export OPENIMAGEIO_INCLUDE_DIR="/usr/include"
+export OPENIMAGEIO_LIBRARY="/usr/lib64/libOpenImageIO.so"
+export OPENIMAGEIO_UTIL_LIBRARY="/usr/lib64/libOpenImageIO_Util.so"
+
+# OpenJPEG
+export OPENJPEG_INCLUDE_DIR="/usr/include/openjpeg-2.5"
+export OPENJPEG_LIBRARY="/usr/lib64/libopenjp2.so"
+
+# JPEG
+export JPEG_INCLUDE_DIR="/usr/include"
+export JPEG_LIBRARY="/usr/lib64/libjpeg.so"
+
+# TIFF
+export TIFF_INCLUDE_DIR="/usr/include"
+export TIFF_LIBRARY="/usr/lib64/libtiff.so"
+
+# PNG
+export PNG_INCLUDE_DIR="/usr/include"
+export PNG_LIBRARY="/usr/lib64/libpng.so"
+
+# Jemalloc
+export JEMALLOC_INCLUDE_DIR="/usr/include/jemalloc"
+export JEMALLOC_LIBRARY="/usr/lib64/libjemalloc.so.2"
+
+# OpenColorIO
+export OPENCOLORIO_INCLUDE_DIR="/usr/include"
+export OPENCOLORIO_LIBRARY="/usr/lib64/libOpenColorIO.so"
+
+# OpenSubdiv
+export OPENSUBDIV_INCLUDE_DIR="/usr/include"
+export OPENSUBDIV_OSDCPU_LIBRARY="/usr/lib64/libosdCPU.so"
+export OPENSUBDIV_OSDGPU_LIBRARY="/usr/lib64/libosdGPU.so"
+
+# OpenEXR / Imath
+export OPENEXR_INCLUDE_DIR="/usr/include/OpenEXR"
+export OPENEXR_LIBRARY="/usr/lib64/libOpenEXR.so"
+export OPENEXR_ROOT_DIR="/usr"
+
+# Boost / TBB
+export BOOST_ROOT="/usr"
+export Boost_INCLUDE_DIR="/usr/include"
+export Boost_LIBRARY_DIR="/usr/lib64"
+export TBB_INCLUDE_DIR="/usr/include"
+export TBB_LIBRARY="/usr/lib64/libtbb.so"
+
+# OptiX (optional)
+export OPTIX_ROOT_DIR="/sep/extern/optix-dev"
+
+# OpenVDB (optional if building with volumetrics)
+export OPENVDB_ROOT_DIR="/usr"
+export OPENVDB_INCLUDE_DIR="/usr/include"
+export OPENVDB_LIBRARY="/usr/lib64/libopenvdb.so"
+

--- a/sep-build.sh
+++ b/sep-build.sh
@@ -2,6 +2,12 @@
 set -eo pipefail
 clear
 
+# Source user-provided library paths if available
+if [ -f "scripts/local_env_paths.sh" ]; then
+  echo "Loading local library paths from scripts/local_env_paths.sh"
+  source scripts/local_env_paths.sh
+fi
+
 echo "==== SEP Engine Build Script with FULL Cycles and PipeWire Support ===="
 echo "Setting up build environment with real library paths - NO STUBS!"
 
@@ -27,70 +33,75 @@ fi
 # directly set needed environment variables for real libraries
 
 # Direct system paths for Python - NO STUBS!
-export PYTHON_VERSION="3.11"
-export PYTHON_LIBRARY="/usr/lib64/libpython3.11.so"
-export PYTHON_LIBPATH="/usr/lib64"
-export PYTHON_INCLUDE_DIR="/usr/include/python3.11"
-export PYTHON_INCLUDE_CONFIG_DIR="/usr/include/python3.11"
-export PYTHONLIBS_FOUND=TRUE
-export PYTHONLIBS_VERSION_STRING="3.11"
+export PYTHON_VERSION="${PYTHON_VERSION:-3.11}"
+export PYTHON_LIBRARY="${PYTHON_LIBRARY:-/usr/lib64/libpython${PYTHON_VERSION}.so}"
+export PYTHON_LIBPATH="${PYTHON_LIBPATH:-/usr/lib64}"
+export PYTHON_INCLUDE_DIR="${PYTHON_INCLUDE_DIR:-/usr/include/python${PYTHON_VERSION}}"
+export PYTHON_INCLUDE_CONFIG_DIR="${PYTHON_INCLUDE_CONFIG_DIR:-/usr/include/python${PYTHON_VERSION}}"
+export PYTHONLIBS_FOUND="${PYTHONLIBS_FOUND:-TRUE}"
+export PYTHONLIBS_VERSION_STRING="${PYTHONLIBS_VERSION_STRING:-${PYTHON_VERSION}}"
 
 # Direct system paths for libraries - NO STUBS!
 # Set up zlib
-export ZLIB_INCLUDE_DIR="/usr/include"
-export ZLIB_LIBRARY="/usr/lib/libz.so"
+export ZLIB_INCLUDE_DIR="${ZLIB_INCLUDE_DIR:-/usr/include}"
+export ZLIB_LIBRARY="${ZLIB_LIBRARY:-/usr/lib/libz.so}"
 
 # Set up OpenImageIO - use real system paths
-export OPENIMAGEIO_ROOT_DIR="/usr"
-export OPENIMAGEIO_INCLUDE_DIR="/usr/include"
-export OPENIMAGEIO_LIBRARY="/usr/lib64/libOpenImageIO.so"
-export OPENIMAGEIO_UTIL_LIBRARY="/usr/lib64/libOpenImageIO_Util.so"
+export OPENIMAGEIO_ROOT_DIR="${OPENIMAGEIO_ROOT_DIR:-/usr}"
+export OPENIMAGEIO_INCLUDE_DIR="${OPENIMAGEIO_INCLUDE_DIR:-/usr/include}"
+export OPENIMAGEIO_LIBRARY="${OPENIMAGEIO_LIBRARY:-/usr/lib64/libOpenImageIO.so}"
+export OPENIMAGEIO_UTIL_LIBRARY="${OPENIMAGEIO_UTIL_LIBRARY:-/usr/lib64/libOpenImageIO_Util.so}"
 
 # Set up OpenJPEG
-export OPENJPEG_INCLUDE_DIR="/usr/include/openjpeg-2.5"
-export OPENJPEG_LIBRARY="/usr/lib64/libopenjp2.so"
+export OPENJPEG_INCLUDE_DIR="${OPENJPEG_INCLUDE_DIR:-/usr/include/openjpeg-2.5}"
+export OPENJPEG_LIBRARY="${OPENJPEG_LIBRARY:-/usr/lib64/libopenjp2.so}"
 
 # Set up JPEG
-export JPEG_INCLUDE_DIR="/usr/include"
-export JPEG_LIBRARY="/usr/lib64/libjpeg.so"
+export JPEG_INCLUDE_DIR="${JPEG_INCLUDE_DIR:-/usr/include}"
+export JPEG_LIBRARY="${JPEG_LIBRARY:-/usr/lib64/libjpeg.so}"
 
 # Set up TIFF
-export TIFF_INCLUDE_DIR="/usr/include"
-export TIFF_LIBRARY="/usr/lib64/libtiff.so"
+export TIFF_INCLUDE_DIR="${TIFF_INCLUDE_DIR:-/usr/include}"
+export TIFF_LIBRARY="${TIFF_LIBRARY:-/usr/lib64/libtiff.so}"
 
 # Set up PNG
-export PNG_INCLUDE_DIR="/usr/include"
-export PNG_LIBRARY="/usr/lib64/libpng.so"
+export PNG_INCLUDE_DIR="${PNG_INCLUDE_DIR:-/usr/include}"
+export PNG_LIBRARY="${PNG_LIBRARY:-/usr/lib64/libpng.so}"
 
 # Set up Jemalloc
-export JEMALLOC_INCLUDE_DIR="/usr/include/jemalloc"
-export JEMALLOC_LIBRARY="/usr/lib64/libjemalloc.so.2"
+export JEMALLOC_INCLUDE_DIR="${JEMALLOC_INCLUDE_DIR:-/usr/include/jemalloc}"
+export JEMALLOC_LIBRARY="${JEMALLOC_LIBRARY:-/usr/lib64/libjemalloc.so.2}"
 
 # Set up OpenColorIO and its dependencies
-export OPENCOLORIO_INCLUDE_DIR="/usr/include"
-export OPENCOLORIO_LIBRARY="/usr/lib64/libOpenColorIO.so"
+export OPENCOLORIO_INCLUDE_DIR="${OPENCOLORIO_INCLUDE_DIR:-/usr/include}"
+export OPENCOLORIO_LIBRARY="${OPENCOLORIO_LIBRARY:-/usr/lib64/libOpenColorIO.so}"
 
 # Set up OpenSubdiv
-export OPENSUBDIV_INCLUDE_DIR="/usr/include"
-export OPENSUBDIV_OSDCPU_LIBRARY="/usr/lib64/libosdCPU.so"
-export OPENSUBDIV_OSDGPU_LIBRARY="/usr/lib64/libosdGPU.so"
+export OPENSUBDIV_INCLUDE_DIR="${OPENSUBDIV_INCLUDE_DIR:-/usr/include}"
+export OPENSUBDIV_OSDCPU_LIBRARY="${OPENSUBDIV_OSDCPU_LIBRARY:-/usr/lib64/libosdCPU.so}"
+export OPENSUBDIV_OSDGPU_LIBRARY="${OPENSUBDIV_OSDGPU_LIBRARY:-/usr/lib64/libosdGPU.so}"
 
 # Set up OpenEXR
-export OPENEXR_INCLUDE_DIR="/usr/include/OpenEXR"
-export OPENEXR_LIBRARY="/usr/lib64/libOpenEXR.so"
-export OPENEXR_ROOT_DIR="/usr"
+export OPENEXR_INCLUDE_DIR="${OPENEXR_INCLUDE_DIR:-/usr/include/OpenEXR}"
+export OPENEXR_LIBRARY="${OPENEXR_LIBRARY:-/usr/lib64/libOpenEXR.so}"
+export OPENEXR_ROOT_DIR="${OPENEXR_ROOT_DIR:-/usr}"
 
 # Set up Boost
-export BOOST_ROOT="/usr"
-export Boost_INCLUDE_DIR="/usr/include"
-export Boost_LIBRARY_DIR="/usr/lib64"
+export BOOST_ROOT="${BOOST_ROOT:-/usr}"
+export Boost_INCLUDE_DIR="${Boost_INCLUDE_DIR:-/usr/include}"
+export Boost_LIBRARY_DIR="${Boost_LIBRARY_DIR:-/usr/lib64}"
 
 # Set up TBB
-export TBB_INCLUDE_DIR="/usr/include"
-export TBB_LIBRARY="/usr/lib64/libtbb.so"
+export TBB_INCLUDE_DIR="${TBB_INCLUDE_DIR:-/usr/include}"
+export TBB_LIBRARY="${TBB_LIBRARY:-/usr/lib64/libtbb.so}"
+
+# Set up OpenVDB (optional)
+export OPENVDB_ROOT_DIR="${OPENVDB_ROOT_DIR:-/usr}"
+export OPENVDB_INCLUDE_DIR="${OPENVDB_INCLUDE_DIR:-/usr/include}"
+export OPENVDB_LIBRARY="${OPENVDB_LIBRARY:-/usr/lib64/libopenvdb.so}"
 
 # Set up OptiX
-export OPTIX_ROOT_DIR="/sep/extern/optix-dev"
+export OPTIX_ROOT_DIR="${OPTIX_ROOT_DIR:-/sep/extern/optix-dev}"
 
 # Print Python settings to confirm
 echo "Using Python settings (REAL PATHS, NO STUBS):"
@@ -154,15 +165,18 @@ cmake -S /sep -B /sep/build \
   -DCMAKE_CXX_COMPILER=/usr/bin/g++-14 \
   ${CYCLES_FLAG} \
   -DWITH_CYCLES_DEVICE_OPTIX=ON \
-  -DOPTIX_ROOT_DIR="/sep/extern/optix-dev" \
-  -DPYTHON_VERSION="3.11" \
-  -DPYTHON_LIBRARY="/usr/lib64/libpython3.11.so" \
-  -DPYTHON_INCLUDE_DIR="/usr/include/python3.11" \
-  -DPYTHON_LIBPATH="/usr/lib64" \
-  -DPYTHON_INCLUDE_CONFIG_DIR="/usr/include/python3.11" \
-  -DPYTHONLIBS_FOUND=TRUE \
-  -DPYTHONLIBS_VERSION_STRING="3.11" \
+  -DOPTIX_ROOT_DIR="${OPTIX_ROOT_DIR}" \
+  -DPYTHON_VERSION="${PYTHON_VERSION}" \
+  -DPYTHON_LIBRARY="${PYTHON_LIBRARY}" \
+  -DPYTHON_INCLUDE_DIR="${PYTHON_INCLUDE_DIR}" \
+  -DPYTHON_LIBPATH="${PYTHON_LIBPATH}" \
+  -DPYTHON_INCLUDE_CONFIG_DIR="${PYTHON_INCLUDE_CONFIG_DIR}" \
+  -DPYTHONLIBS_FOUND=${PYTHONLIBS_FOUND} \
+  -DPYTHONLIBS_VERSION_STRING="${PYTHONLIBS_VERSION_STRING}" \
   ${PIPEWIRE_CMAKE_ARGS} \
+  -DOPENVDB_ROOT_DIR="${OPENVDB_ROOT_DIR}" \
+  -DOPENVDB_INCLUDE_DIR="${OPENVDB_INCLUDE_DIR}" \
+  -DOPENVDB_LIBRARY="${OPENVDB_LIBRARY}" \
   -DWITH_OPENIMAGEDENOISE=OFF \
   -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 


### PR DESCRIPTION
## Summary
- allow sep-build.sh to source user-defined path overrides
- make all library path exports use fallbacks
- expose OpenVDB variables to the build
- provide `local_env_paths.sh.example` template

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e7fc3ce48832a9f1ccd8f2f55f745