### PR TITLE
Simplify cycles test CMake

### DIFF
--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -2,19 +2,28 @@
 
 add_executable(cycles_test cycles_test.cpp)
 
-# Link against the same libraries as the main executable to ensure consistency.
-# The SEP_LINK_LIBS variable is defined in the root CMakeLists.txt.
-target_link_libraries(cycles_test
-    PRIVATE
-    # Your internal project libraries
-    sep_api sep_memory sep_quantum sep_core sep_audio sep_blender sep_compat
-    # All external dependencies (same as sep_engine)
+# Consolidate all required libraries for the test executable.  This mirrors the
+# main engine's link list while keeping the file readable.
+set(CYCLES_TEST_LIBS
+    sep_api
+    sep_memory
+    sep_quantum
+    sep_core
+    sep_audio
+    sep_blender
+    sep_compat
     ${SEP_LINK_LIBS}
-    # Required package libraries
-    ${CURL_LIBRARIES} ${HIREDIS_LIBRARIES} ${CUDA_LIBRARIES} Threads::Threads fmt::fmt spdlog::spdlog
-    # Standard system libs
-    -ldl -lm
+    ${CURL_LIBRARIES}
+    ${HIREDIS_LIBRARIES}
+    ${CUDA_LIBRARIES}
+    Threads::Threads
+    fmt::fmt
+    spdlog::spdlog
+    dl
+    m
 )
+
+target_link_libraries(cycles_test PRIVATE ${CYCLES_TEST_LIBS})
 
 add_custom_target(run_cycles_test
     COMMAND cycles_test ${CMAKE_BINARY_DIR}/cycles_render.ppm


### PR DESCRIPTION
## Summary
- update `src/tests/CMakeLists.txt`
  - consolidate library list into a single variable
  - keep consistent library ordering

## Testing
- `pre-commit` *(skipped: no logic changes)*

------
https://chatgpt.com/codex/tasks/task_e_685ecec206ec832aa8a99b1a735c55b3