### PR TITLE
Refactor test linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,18 @@ find_and_add_library(OPENIMAGEIO_LIBRARY "OpenImageIO")
 find_and_add_library(OPENIMAGEIO_UTIL_LIBRARY "OpenImageIO_Util")
 find_and_add_library(ZLIB_LIBRARY "z")
 
+# Consolidate internal libraries and all dependencies for reuse across targets
+set(SEP_INTERNAL_LIBS
+    sep_api sep_memory sep_quantum sep_core sep_audio sep_blender sep_compat
+)
+set(SEP_ENGINE_LIBS
+    ${SEP_INTERNAL_LIBS}
+    ${SEP_LINK_LIBS}
+    ${CURL_LIBRARIES} ${HIREDIS_LIBRARIES} ${CUDA_LIBRARIES}
+    Threads::Threads fmt::fmt spdlog::spdlog
+    -ldl -lm
+)
+
 # --- Project Structure and Includes ---
 include_directories(
     ${CMAKE_SOURCE_DIR}/include
@@ -122,14 +134,4 @@ add_subdirectory(src/tests)
 # --- Main Executable Target ---
 add_executable(sep_engine src/main.cpp)
 
-target_link_libraries(sep_engine
-    PRIVATE
-    # Your internal project libraries first
-    sep_api sep_memory sep_quantum sep_core sep_audio sep_blender sep_compat
-    # Then all found external dependencies
-    ${SEP_LINK_LIBS}
-    # Then required package libraries
-    ${CURL_LIBRARIES} ${HIREDIS_LIBRARIES} ${CUDA_LIBRARIES} Threads::Threads fmt::fmt spdlog::spdlog
-    # Finally, standard system libs
-    -ldl -lm
-)
+target_link_libraries(sep_engine PRIVATE ${SEP_ENGINE_LIBS})

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -4,17 +4,7 @@ add_executable(cycles_test cycles_test.cpp)
 
 # Link against the same libraries as the main executable to ensure consistency.
 # The SEP_LINK_LIBS variable is defined in the root CMakeLists.txt.
-target_link_libraries(cycles_test
-    PRIVATE
-    # Your internal project libraries
-    sep_api sep_memory sep_quantum sep_core sep_audio sep_blender sep_compat
-    # All external dependencies (same as sep_engine)
-    ${SEP_LINK_LIBS}
-    # Required package libraries
-    ${CURL_LIBRARIES} ${HIREDIS_LIBRARIES} ${CUDA_LIBRARIES} Threads::Threads fmt::fmt spdlog::spdlog
-    # Standard system libs
-    -ldl -lm
-)
+target_link_libraries(cycles_test PRIVATE ${SEP_ENGINE_LIBS})
 
 add_custom_target(run_cycles_test
     COMMAND cycles_test ${CMAKE_BINARY_DIR}/cycles_render.ppm


### PR DESCRIPTION
## Summary
- centralize link libraries in CMakeLists
- use new SEP_ENGINE_LIBS in test build

## Testing
- `cmake -S . -B build` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_685ecec206ec832aa8a99b1a735c55b3