### PR TITLE
Refactor CMake libs usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,13 @@ set(SEP_INTERNAL_LIBS
 # This list will hold all external libraries to be linked by the final targets.
 set(SEP_LINK_LIBS "")
 
+# Internal libraries built as part of this project. Having them in a
+# separate variable lets us easily link the same set of libraries in
+# tests and executables.
+set(SEP_INTERNAL_LIBS
+    sep_api sep_memory sep_quantum sep_core sep_audio sep_blender sep_compat
+)
+
 # Find and add all static Cycles component libraries to our link list
 find_library(CYCLES_SESSION_LIBRARY NAMES cycles_session libcycles_session.a PATHS ${CMAKE_SOURCE_DIR}/lib)
 find_library(CYCLES_SCENE_LIBRARY NAMES cycles_scene libcycles_scene.a PATHS ${CMAKE_SOURCE_DIR}/lib)
@@ -135,7 +142,7 @@ add_executable(sep_engine src/main.cpp)
 
 target_link_libraries(sep_engine
     PRIVATE
-    # Internal libraries first
+    # Your internal project libraries first
     ${SEP_INTERNAL_LIBS}
     # Then all found external dependencies
     ${SEP_LINK_LIBS}
@@ -144,3 +151,4 @@ target_link_libraries(sep_engine
     # Finally, standard system libs
     -ldl -lm
 )
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,18 @@ find_and_add_library(OPENIMAGEIO_LIBRARY "OpenImageIO")
 find_and_add_library(OPENIMAGEIO_UTIL_LIBRARY "OpenImageIO_Util")
 find_and_add_library(ZLIB_LIBRARY "z")
 
+# Consolidate internal libraries and all dependencies for reuse across targets
+set(SEP_INTERNAL_LIBS
+    sep_api sep_memory sep_quantum sep_core sep_audio sep_blender sep_compat
+)
+set(SEP_ENGINE_LIBS
+    ${SEP_INTERNAL_LIBS}
+    ${SEP_LINK_LIBS}
+    ${CURL_LIBRARIES} ${HIREDIS_LIBRARIES} ${CUDA_LIBRARIES}
+    Threads::Threads fmt::fmt spdlog::spdlog
+    -ldl -lm
+)
+
 # --- Project Structure and Includes ---
 include_directories(
     ${CMAKE_SOURCE_DIR}/include
@@ -122,14 +134,4 @@ add_subdirectory(src/tests)
 # --- Main Executable Target ---
 add_executable(sep_engine src/main.cpp)
 
-target_link_libraries(sep_engine
-    PRIVATE
-    # Your internal project libraries first
-    sep_api sep_memory sep_quantum sep_core sep_audio sep_blender sep_compat
-    # Then all found external dependencies
-    ${SEP_LINK_LIBS}
-    # Then required package libraries
-    ${CURL_LIBRARIES} ${HIREDIS_LIBRARIES} ${CUDA_LIBRARIES} Threads::Threads fmt::fmt spdlog::spdlog
-    # Finally, standard system libs
-    -ldl -lm
-)
+target_link_libraries(sep_engine PRIVATE ${SEP_ENGINE_LIBS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,18 @@ add_compile_definitions(SEP_HAS_BLENDER=${SEP_HAS_BLENDER})
 set(SEP_HAS_CYCLES 1)
 add_compile_definitions(SEP_HAS_CYCLES=${SEP_HAS_CYCLES})
 
-# This list will hold all libraries to be linked by the final targets.
+# Internal libraries used by all executables
+set(SEP_INTERNAL_LIBS
+    sep_api
+    sep_memory
+    sep_quantum
+    sep_core
+    sep_audio
+    sep_blender
+    sep_compat
+)
+
+# This list will hold all external libraries to be linked by the final targets.
 set(SEP_LINK_LIBS "")
 
 # Find and add all static Cycles component libraries to our link list
@@ -124,8 +135,8 @@ add_executable(sep_engine src/main.cpp)
 
 target_link_libraries(sep_engine
     PRIVATE
-    # Your internal project libraries first
-    sep_api sep_memory sep_quantum sep_core sep_audio sep_blender sep_compat
+    # Internal libraries first
+    ${SEP_INTERNAL_LIBS}
     # Then all found external dependencies
     ${SEP_LINK_LIBS}
     # Then required package libraries

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,13 @@ add_compile_definitions(SEP_HAS_CYCLES=${SEP_HAS_CYCLES})
 # This list will hold all libraries to be linked by the final targets.
 set(SEP_LINK_LIBS "")
 
+# Internal libraries built as part of this project. Having them in a
+# separate variable lets us easily link the same set of libraries in
+# tests and executables.
+set(SEP_INTERNAL_LIBS
+    sep_api sep_memory sep_quantum sep_core sep_audio sep_blender sep_compat
+)
+
 # Find and add all static Cycles component libraries to our link list
 find_library(CYCLES_SESSION_LIBRARY NAMES cycles_session libcycles_session.a PATHS ${CMAKE_SOURCE_DIR}/lib)
 find_library(CYCLES_SCENE_LIBRARY NAMES cycles_scene libcycles_scene.a PATHS ${CMAKE_SOURCE_DIR}/lib)
@@ -125,7 +132,7 @@ add_executable(sep_engine src/main.cpp)
 target_link_libraries(sep_engine
     PRIVATE
     # Your internal project libraries first
-    sep_api sep_memory sep_quantum sep_core sep_audio sep_blender sep_compat
+    ${SEP_INTERNAL_LIBS}
     # Then all found external dependencies
     ${SEP_LINK_LIBS}
     # Then required package libraries

--- a/build.log
+++ b/build.log
@@ -19,31 +19,31 @@ Running CMake configuration...
 -- Found OSL_COMP_LIBRARY: /usr/lib64/liboslcomp.so
 -- Found OSL_EXEC_LIBRARY: /usr/lib64/liboslexec.so
 -- Found OSL_QUERY_LIBRARY: /usr/lib64/liboslquery.so
-CMake Warning at CMakeLists.txt:81 (message):
+CMake Warning at CMakeLists.txt:92 (message):
   OPENSUBDIV_CPU_LIBRARY (osdCPU libosdCPU.so.3.6.0) not found.  Linking may
   fail if required.
 Call Stack (most recent call first):
-  CMakeLists.txt:88 (find_and_add_library)
+  CMakeLists.txt:99 (find_and_add_library)
 
 
-CMake Warning at CMakeLists.txt:81 (message):
+CMake Warning at CMakeLists.txt:92 (message):
   OPENSUBDIV_GPU_LIBRARY (osdGPU libosdGPU.so.3.6.0) not found.  Linking may
   fail if required.
 Call Stack (most recent call first):
-  CMakeLists.txt:89 (find_and_add_library)
+  CMakeLists.txt:100 (find_and_add_library)
 
 
-CMake Warning at CMakeLists.txt:81 (message):
+CMake Warning at CMakeLists.txt:92 (message):
   TBB_OPENSUBDIV_LIBRARY (tbb.so.2 libtbb.so.2) not found.  Linking may fail
   if required.
 Call Stack (most recent call first):
-  CMakeLists.txt:90 (find_and_add_library)
+  CMakeLists.txt:101 (find_and_add_library)
 
 
-CMake Warning at CMakeLists.txt:81 (message):
+CMake Warning at CMakeLists.txt:92 (message):
   OpenPGL_LIBRARY (OpenPGL pgl) not found.  Linking may fail if required.
 Call Stack (most recent call first):
-  CMakeLists.txt:91 (find_and_add_library)
+  CMakeLists.txt:102 (find_and_add_library)
 
 
 -- Found OPENVDB_LIBRARY: /usr/lib64/libopenvdb.so

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -6,8 +6,8 @@ add_executable(cycles_test cycles_test.cpp)
 # The SEP_LINK_LIBS variable is defined in the root CMakeLists.txt.
 target_link_libraries(cycles_test
     PRIVATE
-    # Your internal project libraries
-    sep_api sep_memory sep_quantum sep_core sep_audio sep_blender sep_compat
+    # Internal project libraries
+    ${SEP_INTERNAL_LIBS}
     # All external dependencies (same as sep_engine)
     ${SEP_LINK_LIBS}
     # Required package libraries

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -6,6 +6,8 @@ add_executable(cycles_test cycles_test.cpp)
 # The SEP_LINK_LIBS variable is defined in the root CMakeLists.txt.
 target_link_libraries(cycles_test
     PRIVATE
+    # Your internal project libraries
+    ${SEP_INTERNAL_LIBS}
     # Internal project libraries
     ${SEP_INTERNAL_LIBS}
     # All external dependencies (same as sep_engine)
@@ -22,3 +24,4 @@ add_custom_target(run_cycles_test
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     COMMENT "Running Cycles renderer test"
 )
+

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -7,7 +7,7 @@ add_executable(cycles_test cycles_test.cpp)
 target_link_libraries(cycles_test
     PRIVATE
     # Your internal project libraries
-    sep_api sep_memory sep_quantum sep_core sep_audio sep_blender sep_compat
+    ${SEP_INTERNAL_LIBS}
     # All external dependencies (same as sep_engine)
     ${SEP_LINK_LIBS}
     # Required package libraries

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -4,17 +4,7 @@ add_executable(cycles_test cycles_test.cpp)
 
 # Link against the same libraries as the main executable to ensure consistency.
 # The SEP_LINK_LIBS variable is defined in the root CMakeLists.txt.
-target_link_libraries(cycles_test
-    PRIVATE
-    # Your internal project libraries
-    sep_api sep_memory sep_quantum sep_core sep_audio sep_blender sep_compat
-    # All external dependencies (same as sep_engine)
-    ${SEP_LINK_LIBS}
-    # Required package libraries
-    ${CURL_LIBRARIES} ${HIREDIS_LIBRARIES} ${CUDA_LIBRARIES} Threads::Threads fmt::fmt spdlog::spdlog
-    # Standard system libs
-    -ldl -lm
-)
+target_link_libraries(cycles_test PRIVATE ${SEP_ENGINE_LIBS})
 
 add_custom_target(run_cycles_test
     COMMAND cycles_test ${CMAKE_BINARY_DIR}/cycles_render.ppm

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -2,19 +2,28 @@
 
 add_executable(cycles_test cycles_test.cpp)
 
-# Link against the same libraries as the main executable to ensure consistency.
-# The SEP_LINK_LIBS variable is defined in the root CMakeLists.txt.
-target_link_libraries(cycles_test
-    PRIVATE
-    # Your internal project libraries
-    sep_api sep_memory sep_quantum sep_core sep_audio sep_blender sep_compat
-    # All external dependencies (same as sep_engine)
+# Consolidate all required libraries for the test executable.  This mirrors the
+# main engine's link list while keeping the file readable.
+set(CYCLES_TEST_LIBS
+    sep_api
+    sep_memory
+    sep_quantum
+    sep_core
+    sep_audio
+    sep_blender
+    sep_compat
     ${SEP_LINK_LIBS}
-    # Required package libraries
-    ${CURL_LIBRARIES} ${HIREDIS_LIBRARIES} ${CUDA_LIBRARIES} Threads::Threads fmt::fmt spdlog::spdlog
-    # Standard system libs
-    -ldl -lm
+    ${CURL_LIBRARIES}
+    ${HIREDIS_LIBRARIES}
+    ${CUDA_LIBRARIES}
+    Threads::Threads
+    fmt::fmt
+    spdlog::spdlog
+    dl
+    m
 )
+
+target_link_libraries(cycles_test PRIVATE ${CYCLES_TEST_LIBS})
 
 add_custom_target(run_cycles_test
     COMMAND cycles_test ${CMAKE_BINARY_DIR}/cycles_render.ppm


### PR DESCRIPTION
## Summary
- define `SEP_INTERNAL_LIBS` in the root CMake file
- use the new variable when linking the main executable
- use `SEP_INTERNAL_LIBS` for the `cycles_test` target
- ensure both CMake files end with a newline

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685ecec206ec832aa8a99b1a735c55b3