### PR TITLE
Refactor CMake libs usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,18 @@ add_compile_definitions(SEP_HAS_BLENDER=${SEP_HAS_BLENDER})
 set(SEP_HAS_CYCLES 1)
 add_compile_definitions(SEP_HAS_CYCLES=${SEP_HAS_CYCLES})
 
-# This list will hold all libraries to be linked by the final targets.
+# Internal libraries used by all executables
+set(SEP_INTERNAL_LIBS
+    sep_api
+    sep_memory
+    sep_quantum
+    sep_core
+    sep_audio
+    sep_blender
+    sep_compat
+)
+
+# This list will hold all external libraries to be linked by the final targets.
 set(SEP_LINK_LIBS "")
 
 # Find and add all static Cycles component libraries to our link list
@@ -124,8 +135,8 @@ add_executable(sep_engine src/main.cpp)
 
 target_link_libraries(sep_engine
     PRIVATE
-    # Your internal project libraries first
-    sep_api sep_memory sep_quantum sep_core sep_audio sep_blender sep_compat
+    # Internal libraries first
+    ${SEP_INTERNAL_LIBS}
     # Then all found external dependencies
     ${SEP_LINK_LIBS}
     # Then required package libraries

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -6,8 +6,8 @@ add_executable(cycles_test cycles_test.cpp)
 # The SEP_LINK_LIBS variable is defined in the root CMakeLists.txt.
 target_link_libraries(cycles_test
     PRIVATE
-    # Your internal project libraries
-    sep_api sep_memory sep_quantum sep_core sep_audio sep_blender sep_compat
+    # Internal project libraries
+    ${SEP_INTERNAL_LIBS}
     # All external dependencies (same as sep_engine)
     ${SEP_LINK_LIBS}
     # Required package libraries


### PR DESCRIPTION
## Summary
- define `SEP_INTERNAL_LIBS` in the root CMake file
- use the new variable when linking the main executable
- use `SEP_INTERNAL_LIBS` for the `cycles_test` target
- ensure both CMake files end with a newline

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685ecec206ec832aa8a99b1a735c55b3