### PR TITLE
Handle missing cycles_osl library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,9 +67,13 @@ list(APPEND SEP_LINK_LIBS
     ${CYCLES_KERNEL_LIBRARY}
     ${CYCLES_DEVICE_LIBRARY}
     ${CYCLES_UTIL_LIBRARY}
-    ${CYCLES_OSL_LIBRARY}
     ${CYCLES_BVH_LIBRARY}
 )
+if(CYCLES_OSL_LIBRARY)
+    list(APPEND SEP_LINK_LIBS ${CYCLES_OSL_LIBRARY})
+else()
+    message(WARNING "Cycles OSL library not found. Features depending on it will be disabled.")
+endif()
 
 # Find and add Blender internal libraries
 find_library(BF_BLENKERNEL_LIBRARY NAMES bf_blenkernel PATHS ${CMAKE_SOURCE_DIR}/lib)


### PR DESCRIPTION
## Summary
- avoid build failure when `cycles_osl` isn't present

## Testing
- `./build.sh` *(fails: Cycles directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f02297b88832a92c931b48d0af966