### PR TITLE
Add QuantumManifoldOptimizer with basic tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,7 @@ add_subdirectory(src/core)
 add_subdirectory(src/memory)
 add_subdirectory(src/quantum)
 add_subdirectory(src/tests)
+add_subdirectory(tests/quantum)
 
 
 target_include_directories(sep_engine

--- a/include/quantum/quantum_manifold_optimizer.h
+++ b/include/quantum/quantum_manifold_optimizer.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "quantum/types.h"
+#include <vector>
+
+namespace sep::quantum {
+
+class QuantumManifoldOptimizer {
+public:
+    QuantumManifoldOptimizer() = default;
+
+    std::vector<Pattern> optimize(const std::vector<Pattern>& patterns);
+};
+
+} // namespace sep::quantum

--- a/src/quantum/CMakeLists.txt
+++ b/src/quantum/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(sep_quantum STATIC qbsa.cpp qbsa_qfh.cpp qfh.cpp quantum_processor.cpp quantum_processor_qfh.cpp quantum_processor_qfh_common.cpp evolution.cpp processor.cpp types_serialization.cpp pattern_processor.cpp pattern_processor_interface.cpp)
+add_library(sep_quantum STATIC qbsa.cpp qbsa_qfh.cpp qfh.cpp quantum_processor.cpp quantum_processor_qfh.cpp quantum_processor_qfh_common.cpp evolution.cpp processor.cpp types_serialization.cpp pattern_processor.cpp pattern_processor_interface.cpp quantum_manifold_optimizer.cpp)
 
 target_include_directories(sep_quantum
     PUBLIC

--- a/src/quantum/quantum_manifold_optimizer.cpp
+++ b/src/quantum/quantum_manifold_optimizer.cpp
@@ -1,0 +1,11 @@
+#include "quantum/quantum_manifold_optimizer.h"
+#include <spdlog/spdlog.h>
+
+namespace sep::quantum {
+
+std::vector<Pattern> QuantumManifoldOptimizer::optimize(const std::vector<Pattern>& patterns) {
+    spdlog::info("QuantumManifoldOptimizer::optimize called with {} patterns", patterns.size());
+    return patterns;
+}
+
+} // namespace sep::quantum

--- a/tests/quantum/CMakeLists.txt
+++ b/tests/quantum/CMakeLists.txt
@@ -1,0 +1,23 @@
+if(NOT BUILD_TESTING)
+    return()
+endif()
+
+find_package(GTest REQUIRED)
+
+add_executable(quantum_optimizer_tests
+    quantum_manifold_optimizer_test.cpp
+)
+
+target_include_directories(quantum_optimizer_tests
+    PRIVATE
+        ${CMAKE_SOURCE_DIR}/include
+)
+
+target_link_libraries(quantum_optimizer_tests
+    PRIVATE
+        sep_quantum
+        GTest::GTest
+        GTest::Main
+)
+
+add_test(NAME quantum_optimizer_tests COMMAND quantum_optimizer_tests)

--- a/tests/quantum/quantum_manifold_optimizer_test.cpp
+++ b/tests/quantum/quantum_manifold_optimizer_test.cpp
@@ -1,0 +1,11 @@
+#include "quantum/quantum_manifold_optimizer.h"
+#include <gtest/gtest.h>
+
+using namespace sep::quantum;
+
+TEST(QuantumManifoldOptimizerTest, OptimizeReturnsInput) {
+    QuantumManifoldOptimizer optimizer;
+    std::vector<Pattern> patterns(1);
+    auto result = optimizer.optimize(patterns);
+    EXPECT_EQ(result.size(), patterns.size());
+}


### PR DESCRIPTION
## Summary
- introduce `QuantumManifoldOptimizer` class and initial stub implementation
- hook optimizer build into quantum library
- expose optimizer tests through a new CMake subdirectory
- add simple GoogleTest verifying instantiation

## Testing
- `g++ -std=c++17 -Iinclude -I/usr/include -pthread src/quantum/quantum_manifold_optimizer.cpp tests/quantum/quantum_manifold_optimizer_test.cpp /usr/lib/x86_64-linux-gnu/libgtest.a /usr/lib/x86_64-linux-gnu/libgtest_main.a -lfmt -lspdlog -o /tmp/quantum_optimizer_tests`
- `/tmp/quantum_optimizer_tests --gtest_output=xml:/tmp/test_results.xml`

------
https://chatgpt.com/codex/tasks/task_e_685f3a63afd4832aad0ebbb289f5b0b2