### PR TITLE
Fix PipeWire detection in build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -36,17 +36,18 @@ echo "Using Cycles root: ${CYCLES_ROOT_DIR}"
 # --- Dependency Detection ---
 # Check for PipeWire using pkg-config (most reliable method)
 echo "Checking for PipeWire development headers..."
+export PKG_CONFIG_PATH=/usr/lib64/pkgconfig:$PKG_CONFIG_PATH
 PIPEWIRE_CMAKE_ARGS="-DSEP_HAS_PIPEWIRE=OFF"
 if command -v pkg-config >/dev/null && pkg-config --exists libpipewire-0.3; then
   PIPEWIRE_INCLUDE_DIR=$(pkg-config --variable=includedir libpipewire-0.3)
   PIPEWIRE_LIB_PATH=$(pkg-config --libs-only-L libpipewire-0.3 | sed 's/-L//g')
   PIPEWIRE_LIB_FILE="${PIPEWIRE_LIB_PATH}/libpipewire-0.3.so"
 
-  if [ -f "${PIPEWIRE_LIB_FILE}" ]; then
+  if [ -d "${PIPEWIRE_INCLUDE_DIR}" ] && [ -f "${PIPEWIRE_LIB_FILE}" ]; then
     echo "PipeWire found via pkg-config: ${PIPEWIRE_LIB_FILE}"
     PIPEWIRE_CMAKE_ARGS="-DSEP_HAS_PIPEWIRE=ON -DPIPEWIRE_INCLUDE_DIR=${PIPEWIRE_INCLUDE_DIR} -DPIPEWIRE_LIBRARY=${PIPEWIRE_LIB_FILE}"
   else
-    echo "Warning: pkg-config found libpipewire-0.3 but library file not at ${PIPEWIRE_LIB_FILE}. PipeWire disabled."
+    echo "Warning: PipeWire headers or library missing. PipeWire disabled."
   fi
 else
   echo "Warning: pkg-config not found or libpipewire-0.3 is not available. Audio capture will be disabled."


### PR DESCRIPTION
## Summary
- set `PKG_CONFIG_PATH` before checking for PipeWire
- enable PipeWire only when headers and library exist

## Testing
- `shellcheck build.sh`

------
https://chatgpt.com/codex/tasks/task_e_685fe4b279ec832aaff4ca68a641b68c