### PR TITLE
Add component bridge for optional feature instantiation

### DIFF
--- a/include/compat/component_bridge.h
+++ b/include/compat/component_bridge.h
@@ -1,0 +1,21 @@
+#pragma once
+#include <memory>
+
+namespace sep {
+namespace audio {
+class AudioCapture;
+}
+namespace pattern {
+class BlenderBridge;
+}
+namespace blender {
+class CyclesRenderer; // Forward declaration if header not available
+}
+namespace compat {
+
+std::unique_ptr<audio::AudioCapture> createAudioCapture();
+std::shared_ptr<pattern::BlenderBridge> createBlenderBridge();
+std::unique_ptr<blender::CyclesRenderer> createCyclesRenderer();
+
+} // namespace compat
+} // namespace sep

--- a/src/audio/pipewire_capture.cpp
+++ b/src/audio/pipewire_capture.cpp
@@ -3,6 +3,7 @@
 #include "audio/pipewire_capture.h"
 #include "audio/config.h"
 #include "audio/pipewire_includes.h"
+#include "compat/component_bridge.h"
 
 
 // Standard library headers
@@ -349,5 +350,5 @@ void PipeWireCapture::streamProcess(void* data)
 
 std::unique_ptr<AudioCapture> AudioCapture::create()
 {
-    return std::make_unique<PipeWireCapture>();
+    return compat::createAudioCapture();
 }

--- a/src/blender/api.cpp
+++ b/src/blender/api.cpp
@@ -3,6 +3,7 @@
 #include "blender/types.h"
 #include "blender/config.h"
 #include "blender/pattern_bridge.h"
+#include "compat/component_bridge.h"
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -53,7 +54,7 @@ extern "C" sep::SEPResult sep_blender_init(sep::GPUContext* gpu_ctx, const SEPCo
     {
         return sep::SEPResult::ALLOCATION_FAILED;
     }
-    bridge_ptr->impl            = sep::pattern::BlenderBridge::create();
+    bridge_ptr->impl            = sep::compat::createBlenderBridge();
     bridge_ptr->audio_metrics   = SEPAudioMetrics{};
     bridge_ptr->pattern_metrics = SEPPatternMetrics{};
 

--- a/src/compat/CMakeLists.txt
+++ b/src/compat/CMakeLists.txt
@@ -5,6 +5,7 @@ include(${CMAKE_SOURCE_DIR}/cmake/CustomCUDA.cmake)
 add_library(sep_compat STATIC
     stream.cpp
     raii.cpp
+    component_bridge.cpp
     # Add all .cu files here to be compiled by NVCC
     core.cu
     cuda_api.cu

--- a/src/compat/component_bridge.cpp
+++ b/src/compat/component_bridge.cpp
@@ -1,0 +1,43 @@
+#include "compat/component_bridge.h"
+
+#if defined(SEP_HAS_PIPEWIRE) && SEP_HAS_PIPEWIRE
+#include "audio/pipewire_capture.h"
+#endif
+
+#if defined(SEP_HAS_BLENDER) && SEP_HAS_BLENDER
+#include "blender/bridge.h"
+#endif
+
+#if defined(SEP_HAS_CYCLES) && SEP_HAS_CYCLES
+#include "blender/cycles_renderer.h"
+#endif
+
+namespace sep {
+namespace compat {
+
+std::unique_ptr<audio::AudioCapture> createAudioCapture() {
+#if defined(SEP_HAS_PIPEWIRE) && SEP_HAS_PIPEWIRE
+    return std::make_unique<audio::PipeWireCapture>();
+#else
+    return nullptr;
+#endif
+}
+
+std::shared_ptr<pattern::BlenderBridge> createBlenderBridge() {
+#if defined(SEP_HAS_BLENDER) && SEP_HAS_BLENDER
+    return std::make_shared<pattern::BlenderBridge>();
+#else
+    return nullptr;
+#endif
+}
+
+std::unique_ptr<blender::CyclesRenderer> createCyclesRenderer() {
+#if defined(SEP_HAS_CYCLES) && SEP_HAS_CYCLES
+    return std::make_unique<blender::CyclesRenderer>();
+#else
+    return nullptr;
+#endif
+}
+
+} // namespace compat
+} // namespace sep

--- a/src/core/engine.cpp
+++ b/src/core/engine.cpp
@@ -2,6 +2,7 @@
 
 #include "audio/capture.h"
 #include "blender/pattern_bridge.h"
+#include "compat/component_bridge.h"
 #include "memory/manager.h"
 
 #include "compat/shim.h"
@@ -144,7 +145,7 @@ bool Engine::init(const sep::config::APIConfig& config) {
     fflush(stdout);
     
     try {
-        audio_capture_ = audio::AudioCapture::create();
+        audio_capture_ = compat::createAudioCapture();
         if (!audio_capture_) {
             printf("DEBUG: Engine::init - Failed to create audio capture\n");
             fflush(stdout);
@@ -172,7 +173,7 @@ bool Engine::init(const sep::config::APIConfig& config) {
     fflush(stdout);
     
     try {
-        blender_bridge_ = std::make_shared<pattern::BlenderBridge>();
+        blender_bridge_ = compat::createBlenderBridge();
         printf("DEBUG: Engine::init - Blender bridge created successfully\n");
         fflush(stdout);
     } catch (const std::exception& e) {


### PR DESCRIPTION
## Summary
- introduce `component_bridge` with factory helpers
- hook new bridge into `Engine` and Blender API
- expose audio capture creation through bridge
- include new source in compat library

## Testing
- `bash tests/blender/run_tests.sh` *(fails: Parse error in CMake)*

------
https://chatgpt.com/codex/tasks/task_e_685fe60b16e8832aabee2d66a3182717