### PR TITLE
Refactor pattern result enum and qualify SEPResult

### DIFF
--- a/include/quantum/data.hpp
+++ b/include/quantum/data.hpp
@@ -34,7 +34,7 @@ inline bool isValidConfig(const PatternConfig& cfg) {
     return cfg.max_patterns > 0 && cfg.batch_size > 0;
 }
 
-enum class SEPResult {
+enum class PatternResult {
     SUCCESS = 0,
     INVALID_ARGUMENT = -1,
     ALLOCATION_FAILED = -2,

--- a/include/quantum/pattern_evolution.h
+++ b/include/quantum/pattern_evolution.h
@@ -17,7 +17,7 @@ public:
 
     static std::vector<sep::pattern::PatternData> getPatterns(const nlohmann::json& args = {});
 
-    static pattern::SEPResult processPatterns(const std::vector<sep::pattern::PatternData>& input,
+    static pattern::PatternResult processPatterns(const std::vector<sep::pattern::PatternData>& input,
                                           const sep::pattern::PatternConfig& config,
                                           std::vector<sep::pattern::PatternData>& output);
 

--- a/src/api/ollama_client.cpp
+++ b/src/api/ollama_client.cpp
@@ -34,52 +34,52 @@ OllamaClient &OllamaClient::operator=(OllamaClient &&) noexcept = default;
 
 namespace ollama {
 
-SEPResult OllamaClient::get(const std::string &endpoint, std::string &response_out) {
+sep::SEPResult OllamaClient::get(const std::string &endpoint, std::string &response_out) {
   if (impl_->config.host.rfind("file://", 0) == 0) {
     std::string path = impl_->config.host.substr(7) + endpoint;
     std::ifstream file(path);
     if (!file) {
-      return SEPResult::INVALID_ARGUMENT;
+      return sep::SEPResult::INVALID_ARGUMENT;
     }
     std::ostringstream ss;
     ss << file.rdbuf();
     response_out = ss.str();
-    return SEPResult::SUCCESS;
+    return sep::SEPResult::SUCCESS;
   }
   sep::api::APIResponse resp = impl_->client.get(endpoint);
   if (!resp.success) {
     response_out.clear();
     if (resp.error.code == sep::api::ErrorCode::ApiError) {
-      return SEPResult::PROCESSING_ERROR;
+      return sep::SEPResult::PROCESSING_ERROR;
     }
-    return SEPResult::UNKNOWN_ERROR;
+    return sep::SEPResult::UNKNOWN_ERROR;
   }
   response_out = resp.body;
-  return SEPResult::SUCCESS;
+  return sep::SEPResult::SUCCESS;
 }
 
-SEPResult OllamaClient::post(const std::string &endpoint, const nlohmann::json &payload,
+sep::SEPResult OllamaClient::post(const std::string &endpoint, const nlohmann::json &payload,
                              std::string &response_out) {
   if (impl_->config.host.rfind("file://", 0) == 0) {
-    return SEPResult::INVALID_ARGUMENT;
+    return sep::SEPResult::INVALID_ARGUMENT;
   }
   sep::api::APIResponse resp = impl_->client.post(endpoint, payload.dump());
   if (!resp.success) {
     response_out.clear();
     if (resp.error.code == sep::api::ErrorCode::ApiError) {
-      return SEPResult::PROCESSING_ERROR;
+      return sep::SEPResult::PROCESSING_ERROR;
     }
-    return SEPResult::UNKNOWN_ERROR;
+    return sep::SEPResult::UNKNOWN_ERROR;
   }
   response_out = resp.body;
-  return SEPResult::SUCCESS;
+  return sep::SEPResult::SUCCESS;
 }
 
 GenerateResponse OllamaClient::generate(const GenerateRequest &request) {
   nlohmann::json payload{{"model", request.model}, {"prompt", request.prompt}};
   std::string result;
-  SEPResult res = post("/api/generate", payload, result);
-  if (res != SEPResult::SUCCESS) {
+  sep::SEPResult res = post("/api/generate", payload, result);
+  if (res != sep::SEPResult::SUCCESS) {
     return {};
   }
   nlohmann::json json_result = nlohmann::json::parse(result);
@@ -94,8 +94,8 @@ EmbeddingResponse OllamaClient::getEmbedding(
     const EmbeddingRequest &request) {
   nlohmann::json payload{{"model", request.model}, {"prompt", request.prompt}};
   std::string result;
-  SEPResult res = post("/api/embeddings", payload, result);
-  if (res != SEPResult::SUCCESS) {
+  sep::SEPResult res = post("/api/embeddings", payload, result);
+  if (res != sep::SEPResult::SUCCESS) {
     return {};
   }
   nlohmann::json json_result = nlohmann::json::parse(result);

--- a/src/blender/blender_integration.cpp
+++ b/src/blender/blender_integration.cpp
@@ -174,26 +174,26 @@ void BlenderBridge::notifyError(sep::SEPResult error, const char* message)
     std::lock_guard<std::mutex> lock(m_observer_mutex);
     for (const auto& observer : m_observers)
     {
-        // Convert from sep::SEPResult to sep::pattern::SEPResult
-        sep::pattern::SEPResult pattern_error;
+        // Convert from sep::SEPResult to sep::pattern::PatternResult
+        sep::pattern::PatternResult pattern_error;
         
         // Map the most common error codes
         switch (error) {
             case sep::SEPResult::SUCCESS:
-                pattern_error = sep::pattern::SEPResult::SUCCESS;
+                pattern_error = sep::pattern::PatternResult::SUCCESS;
                 break;
             case sep::SEPResult::INVALID_ARGUMENT:
-                pattern_error = sep::pattern::SEPResult::INVALID_ARGUMENT;
+                pattern_error = sep::pattern::PatternResult::INVALID_ARGUMENT;
                 break;
             case sep::SEPResult::ALLOCATION_FAILED:
-                pattern_error = sep::pattern::SEPResult::ALLOCATION_FAILED;
+                pattern_error = sep::pattern::PatternResult::ALLOCATION_FAILED;
                 break;
             case sep::SEPResult::PROCESSING_ERROR:
-                pattern_error = sep::pattern::SEPResult::PROCESSING_ERROR;
+                pattern_error = sep::pattern::PatternResult::PROCESSING_ERROR;
                 break;
             default:
                 // Default to PROCESSING_ERROR for any unmapped error
-                pattern_error = sep::pattern::SEPResult::PROCESSING_ERROR;
+                pattern_error = sep::pattern::PatternResult::PROCESSING_ERROR;
                 break;
         }
         

--- a/src/blender/mesh_handler.cpp
+++ b/src/blender/mesh_handler.cpp
@@ -6,8 +6,6 @@
 #include "blender/mesh_handler.h"
 #include "core/types.h"  // for sep::SEPResult
 
-// Use the SEPResult from sep namespace
-using sep::SEPResult;
 
 // Minimal stand-ins for Blender API functions. These are no-ops here but allow
 // the library to link without the real Blender environment.
@@ -28,42 +26,42 @@ MeshHandler::MeshHandler()
 
 MeshHandler::~MeshHandler() { cleanupCustomData(); }
 
-SEPResult MeshHandler::init(Object* bl_object, Mesh* bl_mesh) {
+sep::SEPResult MeshHandler::init(Object* bl_object, Mesh* bl_mesh) {
   if (!bl_object || !bl_mesh) {
-    return SEPResult::INVALID_ARGUMENT;
+    return sep::SEPResult::INVALID_ARGUMENT;
   }
 
   object_ = bl_object;
   mesh_ = bl_mesh;
   initialized_ = true;
   cache_.metrics_valid = false;
-  return SEPResult::SUCCESS;
+  return sep::SEPResult::SUCCESS;
 }
 
-SEPResult MeshHandler::update(const sep::pattern::PatternData& pattern_data) {
+sep::SEPResult MeshHandler::update(const sep::pattern::PatternData& pattern_data) {
   if (!initialized_) {
-    return SEPResult::INITIALIZATION_FAILED;
+    return sep::SEPResult::INITIALIZATION_FAILED;
   }
 
   if (!validatePattern(pattern_data)) {
-    return SEPResult::INVALID_ARGUMENT;
+    return sep::SEPResult::INVALID_ARGUMENT;
   }
 
   pattern_state_.coherence = pattern_data.coherence;
 
-  SEPResult res = updateVertices(pattern_data);
-  if (res != SEPResult::SUCCESS) {
+  sep::SEPResult res = updateVertices(pattern_data);
+  if (res != sep::SEPResult::SUCCESS) {
     return res;
   }
 
   res = updateCustomData(pattern_data);
-  if (res != SEPResult::SUCCESS) {
+  if (res != sep::SEPResult::SUCCESS) {
     return res;
   }
 
   updateNormals();
   cache_.metrics_valid = false;
-  return SEPResult::SUCCESS;
+  return sep::SEPResult::SUCCESS;
 }
 
 MeshHandler::MeshMetrics MeshHandler::getMetrics() const {
@@ -83,21 +81,21 @@ MeshHandler::MeshMetrics MeshHandler::getMetrics() const {
   return metrics;
 }
 
-SEPResult MeshHandler::addCustomDataLayer(const char* name, int type) {
+sep::SEPResult MeshHandler::addCustomDataLayer(const char* name, int type) {
   if (!initialized_) {
-    return SEPResult::INITIALIZATION_FAILED;
+    return sep::SEPResult::INITIALIZATION_FAILED;
   }
 
   if (!name || std::strlen(name) == 0) {
-    return SEPResult::INVALID_ARGUMENT;
+    return sep::SEPResult::INVALID_ARGUMENT;
   }
 
   if (hasCustomDataLayer(name)) {
-    return SEPResult::ALREADY_EXISTS;
+    return sep::SEPResult::ALREADY_EXISTS;
   }
 
   if (custom_layers_.size() >= 16) {
-    return SEPResult::INVALID_STATE;
+    return sep::SEPResult::INVALID_STATE;
   }
 
   CustomDataLayer layer;
@@ -115,27 +113,27 @@ SEPResult MeshHandler::addCustomDataLayer(const char* name, int type) {
 
   custom_layers_.push_back(layer);
   cache_.metrics_valid = false;
-  return SEPResult::SUCCESS;
+  return sep::SEPResult::SUCCESS;
 }
 
-SEPResult MeshHandler::removeCustomDataLayer(const char* name) {
+sep::SEPResult MeshHandler::removeCustomDataLayer(const char* name) {
   if (!initialized_) {
-    return SEPResult::INITIALIZATION_FAILED;
+    return sep::SEPResult::INITIALIZATION_FAILED;
   }
 
   if (!name || std::strlen(name) == 0) {
-    return SEPResult::INVALID_ARGUMENT;
+    return sep::SEPResult::INVALID_ARGUMENT;
   }
 
   for (auto it = custom_layers_.begin(); it != custom_layers_.end(); ++it) {
     if (std::strcmp(it->name, name) == 0) {
       custom_layers_.erase(it);
       cache_.metrics_valid = false;
-      return SEPResult::SUCCESS;
+      return sep::SEPResult::SUCCESS;
     }
   }
 
-  return SEPResult::NOT_FOUND;
+  return sep::SEPResult::NOT_FOUND;
 }
 
 bool MeshHandler::hasCustomDataLayer(const char* name) const {
@@ -151,13 +149,13 @@ bool MeshHandler::hasCustomDataLayer(const char* name) const {
   return false;
 }
 
-SEPResult MeshHandler::setUniformFloatLayer(const char* name, float value) {
+sep::SEPResult MeshHandler::setUniformFloatLayer(const char* name, float value) {
   if (!initialized_) {
-    return SEPResult::INITIALIZATION_FAILED;
+    return sep::SEPResult::INITIALIZATION_FAILED;
   }
 
   if (!name || std::strlen(name) == 0) {
-    return SEPResult::INVALID_ARGUMENT;
+    return sep::SEPResult::INVALID_ARGUMENT;
   }
 
   for (auto& layer : custom_layers_) {
@@ -167,21 +165,21 @@ SEPResult MeshHandler::setUniformFloatLayer(const char* name, float value) {
       for (size_t i = 0; i < count; ++i) {
         data[i] = value;
       }
-      return SEPResult::SUCCESS;
+      return sep::SEPResult::SUCCESS;
     }
   }
 
-  return SEPResult::NOT_FOUND;
+  return sep::SEPResult::NOT_FOUND;
 }
 
-SEPResult MeshHandler::applyDeformation(const DeformParams& params) {
+sep::SEPResult MeshHandler::applyDeformation(const DeformParams& params) {
   if (!initialized_) {
-    return SEPResult::INITIALIZATION_FAILED;
+    return sep::SEPResult::INITIALIZATION_FAILED;
   }
 
   if (pattern_state_.weights.empty()) {
     // No pattern data applied yet; nothing to deform
-    return SEPResult::SUCCESS;
+    return sep::SEPResult::SUCCESS;
   }
 
   for (int i = 0; i < mesh_->totvert; ++i) {
@@ -195,13 +193,13 @@ SEPResult MeshHandler::applyDeformation(const DeformParams& params) {
   return notifyDepsgraph();
 }
 
-SEPResult MeshHandler::generateHyperMesh(const sep::pattern::PatternData& pattern,
+sep::SEPResult MeshHandler::generateHyperMesh(const sep::pattern::PatternData& pattern,
                                          int dimensions) {
   if (!initialized_) {
-    return SEPResult::INITIALIZATION_FAILED;
+    return sep::SEPResult::INITIALIZATION_FAILED;
   }
   if (dimensions < 3 || !validatePattern(pattern)) {
-    return SEPResult::INVALID_ARGUMENT;
+    return sep::SEPResult::INVALID_ARGUMENT;
   }
 
   for (int d = 3; d < dimensions; ++d) {
@@ -213,16 +211,16 @@ SEPResult MeshHandler::generateHyperMesh(const sep::pattern::PatternData& patter
   }
 
   cache_.metrics_valid = false;
-  return SEPResult::SUCCESS;
+  return sep::SEPResult::SUCCESS;
 }
 
 // ---------------------------------------------------------------------------
 // Private helpers
 // ---------------------------------------------------------------------------
 
-SEPResult MeshHandler::updateVertices(const sep::pattern::PatternData& pattern_data) {
+sep::SEPResult MeshHandler::updateVertices(const sep::pattern::PatternData& pattern_data) {
   if (!validateMesh()) {
-    return SEPResult::INVALID_STATE;
+    return sep::SEPResult::INVALID_STATE;
   }
 
   pattern_state_.weights.resize(static_cast<size_t>(mesh_->totvert));
@@ -233,10 +231,10 @@ SEPResult MeshHandler::updateVertices(const sep::pattern::PatternData& pattern_d
     pattern_state_.weights[i] = w;
   }
 
-  return SEPResult::SUCCESS;
+  return sep::SEPResult::SUCCESS;
 }
 
-SEPResult MeshHandler::updateCustomData(const sep::pattern::PatternData& pattern_data) {
+sep::SEPResult MeshHandler::updateCustomData(const sep::pattern::PatternData& pattern_data) {
   if (custom_layers_.empty()) {
     (void)addCustomDataLayer("pattern_weight", 0);
   }
@@ -251,15 +249,15 @@ SEPResult MeshHandler::updateCustomData(const sep::pattern::PatternData& pattern
     }
   }
 
-  return SEPResult::SUCCESS;
+  return sep::SEPResult::SUCCESS;
 }
 
-SEPResult MeshHandler::notifyDepsgraph() {
+sep::SEPResult MeshHandler::notifyDepsgraph() {
   if (mesh_) {
     BKE_mesh_batch_cache_dirty_tag(mesh_, BKE_MESH_BATCH_DIRTY_ALL);
     DEG_id_tag_update(mesh_, ID_RECALC_GEOMETRY);
   }
-  return SEPResult::SUCCESS;
+  return sep::SEPResult::SUCCESS;
 }
 
 bool MeshHandler::validateMesh() const { return initialized_ && mesh_ != nullptr; }

--- a/src/blender/pattern_visualization_pipeline.cpp
+++ b/src/blender/pattern_visualization_pipeline.cpp
@@ -29,47 +29,47 @@ std::array<float, 3> PatternVisualizationPipeline::projectNDim(
   return out;
 }
 
-SEPResult PatternVisualizationPipeline::checkShaderReload() {
+sep::SEPResult PatternVisualizationPipeline::checkShaderReload() {
   if (!gpu_ctx_)
-    return SEPResult::SUCCESS;
-  SEPResult res = gpu_ctx_->reloadComputeShaderIfNeeded();
-  if (res != SEPResult::SUCCESS)
+    return sep::SEPResult::SUCCESS;
+  sep::SEPResult res = gpu_ctx_->reloadComputeShaderIfNeeded();
+  if (res != sep::SEPResult::SUCCESS)
     return res;
   last_shader_revision_ = gpu_ctx_->getShaderRevision();
-  return SEPResult::SUCCESS;
+  return sep::SEPResult::SUCCESS;
 }
 
-SEPResult PatternVisualizationPipeline::updatePattern(
+sep::SEPResult PatternVisualizationPipeline::updatePattern(
     const sep::pattern::PatternData &pattern) {
   if (!handler_) {
-    return SEPResult::INVALID_STATE;
+    return sep::SEPResult::INVALID_STATE;
   }
   checkShaderReload();
   // MeshHandler handles depsgraph updates internally.
   return handler_->update(pattern);
 }
 
-SEPResult PatternVisualizationPipeline::deformMesh(
+sep::SEPResult PatternVisualizationPipeline::deformMesh(
     const MeshHandler::DeformParams &params) {
   if (!handler_) {
-    return SEPResult::INVALID_STATE;
+    return sep::SEPResult::INVALID_STATE;
   }
   // Deformation already triggers a depsgraph notification via MeshHandler.
   return handler_->applyDeformation(params);
 }
 
-SEPResult PatternVisualizationPipeline::generateMesh(
+sep::SEPResult PatternVisualizationPipeline::generateMesh(
     const sep::pattern::PatternData &pattern, int dimensionality) {
   if (!handler_ || dimensionality < 2) {
-    return SEPResult::INVALID_ARGUMENT;
+    return sep::SEPResult::INVALID_ARGUMENT;
   }
   return handler_->generateHyperMesh(pattern, dimensionality);
 }
 
-SEPResult PatternVisualizationPipeline::renderManifold(
+sep::SEPResult PatternVisualizationPipeline::renderManifold(
     const sep::pattern::PatternData &pattern, int dimensionality) {
-  SEPResult r = generateMesh(pattern, dimensionality);
-  if (r != SEPResult::SUCCESS)
+  sep::SEPResult r = generateMesh(pattern, dimensionality);
+  if (r != sep::SEPResult::SUCCESS)
     return r;
 
   ::sep::shim::vector<float> coords;
@@ -107,16 +107,16 @@ SEPResult PatternVisualizationPipeline::renderManifold(
   return updatePattern(projected_pattern);
 }
 
-SEPResult PatternVisualizationPipeline::applyCoherenceOverlay(
+sep::SEPResult PatternVisualizationPipeline::applyCoherenceOverlay(
     const ::sep::shim::vector<float> &history) {
   if (!handler_ || history.empty()) {
-    return SEPResult::INVALID_ARGUMENT;
+    return sep::SEPResult::INVALID_ARGUMENT;
   }
   float avg =
       std::accumulate(history.begin(), history.end(), 0.0f) / history.size();
-  SEPResult r =
+  sep::SEPResult r =
       handler_->setUniformFloatLayer("coherence_overlay", history.back());
-  if (r != SEPResult::SUCCESS)
+  if (r != sep::SEPResult::SUCCESS)
     return r;
   return handler_->setUniformFloatLayer("coherence_average", avg);
 }

--- a/src/compat/core.cu
+++ b/src/compat/core.cu
@@ -14,7 +14,7 @@ CudaCore::CudaCore() = default;
 
 Error CudaCore::initialize(int device_id) {
   if (initialized_) {
-    return {Status::Success, "", "", SEPResult::SUCCESS};
+    return {Status::Success, "", "", sep::SEPResult::SUCCESS};
   }
 
   Error error = initializeDevice(device_id);
@@ -33,18 +33,18 @@ Error CudaCore::initialize(int device_id) {
   }
 
   initialized_ = true;
-  return {Status::Success, "", "", SEPResult::SUCCESS};
+  return {Status::Success, "", "", sep::SEPResult::SUCCESS};
 }
 
 Error CudaCore::setDevice(int device) {
   if (device < 0 || device >= getDeviceCount()) {
-    return {Status::Error, "Invalid device ID", "", SEPResult::INVALID_ARGUMENT};
+    return {Status::Error, "Invalid device ID", "", sep::SEPResult::INVALID_ARGUMENT};
   }
 
   CUDA_CHECK(cudaSetDevice(device));
 
   current_device_ = device;
-  return {Status::Success, "", "", SEPResult::SUCCESS};
+  return {Status::Success, "", "", sep::SEPResult::SUCCESS};
 }
 
 int CudaCore::getDeviceCount() const {
@@ -55,12 +55,12 @@ int CudaCore::getDeviceCount() const {
 
 Error CudaCore::getDeviceProperties(cudaDeviceProp& props, int device) const {
   if (device < 0 || device >= getDeviceCount()) {
-    return {Status::Error, "Invalid device ID", "", SEPResult::INVALID_ARGUMENT};
+    return {Status::Error, "Invalid device ID", "", sep::SEPResult::INVALID_ARGUMENT};
   }
 
   CUDA_CHECK(cudaGetDeviceProperties(&props, device));
 
-  return {Status::Success, "", "", SEPResult::SUCCESS};
+  return {Status::Success, "", "", sep::SEPResult::SUCCESS};
 }
 
 StreamPtr CudaCore::createStream(sep::StreamFlags flags) {
@@ -69,35 +69,35 @@ StreamPtr CudaCore::createStream(sep::StreamFlags flags) {
 
 Error CudaCore::destroyStream(cudaStream_t stream) {
   if (!stream) {
-    return {Status::Success, "", "", SEPResult::SUCCESS};
+    return {Status::Success, "", "", sep::SEPResult::SUCCESS};
   }
 
   CUDA_CHECK(cudaStreamDestroy(stream));
 
-  return {Status::Success, "", "", SEPResult::SUCCESS};
+  return {Status::Success, "", "", sep::SEPResult::SUCCESS};
 }
 
 Error CudaCore::synchronizeStream(cudaStream_t stream) {
   if (!stream) {
-    return {Status::Success, "", "", SEPResult::SUCCESS};
+    return {Status::Success, "", "", sep::SEPResult::SUCCESS};
   }
 
   CUDA_CHECK(cudaStreamSynchronize(stream));
 
-  return {Status::Success, "", "", SEPResult::SUCCESS};
+  return {Status::Success, "", "", sep::SEPResult::SUCCESS};
 }
 
 Error CudaCore::getMemoryInfo(size_t& free, size_t& total) const {
   CUDA_CHECK(cudaMemGetInfo(&free, &total));
 
-  return {Status::Success, "", "", SEPResult::SUCCESS};
+  return {Status::Success, "", "", sep::SEPResult::SUCCESS};
 }
 
 Error CudaCore::getLastError() const {
   cudaError_t error = cudaGetLastError();
   return {error == cudaSuccess ? Status::Success : Status::Error,
           error != cudaSuccess ? cudaGetErrorString(error) : "", "",
-          error == cudaSuccess ? SEPResult::SUCCESS : SEPResult::CUDA_ERROR};
+          error == cudaSuccess ? sep::SEPResult::SUCCESS : sep::SEPResult::CUDA_ERROR};
 }
 
 std::string CudaCore::getErrorString(cudaError_t error) const { return cudaGetErrorString(error); }
@@ -125,24 +125,24 @@ Error CudaCore::updateMetrics() {
     current_metrics_.active_kernels = 0;
   }
 
-  return {Status::Success, "", "", SEPResult::SUCCESS};
+  return {Status::Success, "", "", sep::SEPResult::SUCCESS};
 }
 
 Error CudaCore::initializeDevice(int device) {
   if (device < 0) {
-    return {Status::Error, "Invalid device ID", "", SEPResult::INVALID_ARGUMENT};
+    return {Status::Error, "Invalid device ID", "", sep::SEPResult::INVALID_ARGUMENT};
   }
 
   CUDA_CHECK(cudaSetDevice(device));
 
   current_device_ = device;
-  return {Status::Success, "", "", SEPResult::SUCCESS};
+  return {Status::Success, "", "", sep::SEPResult::SUCCESS};
 }
 
 Error CudaCore::queryDeviceProperties() {
   int count = getDeviceCount();
   if (count <= 0) {
-    return {Status::Error, "No CUDA devices found", "", SEPResult::INVALID_ARGUMENT};
+    return {Status::Error, "No CUDA devices found", "", sep::SEPResult::INVALID_ARGUMENT};
   }
 
   device_properties_.resize(count);
@@ -150,7 +150,7 @@ Error CudaCore::queryDeviceProperties() {
     CUDA_CHECK(cudaGetDeviceProperties(&device_properties_[i], i));
   }
 
-  return {Status::Success, "", "", SEPResult::SUCCESS};
+  return {Status::Success, "", "", sep::SEPResult::SUCCESS};
 }
 
 Error CudaCore::launchQBSA(const DeviceMemory<std::uint32_t>& probe_indices,
@@ -163,7 +163,7 @@ Error CudaCore::launchQBSA(const DeviceMemory<std::uint32_t>& probe_indices,
                        corrections.get(), correction_count.get(), static_cast<cudaStream_t>(stream.handle()));
   return {result == cudaSuccess ? Status::Success : Status::Error,
           result != cudaSuccess ? cudaGetErrorString(result) : "", "",
-          result == cudaSuccess ? SEPResult::SUCCESS : SEPResult::CUDA_ERROR};
+          result == cudaSuccess ? sep::SEPResult::SUCCESS : sep::SEPResult::CUDA_ERROR};
 }
 
 Error CudaCore::launchQSH(const DeviceMemory<std::uint64_t>& chunks, std::uint32_t num_chunks,
@@ -173,7 +173,7 @@ Error CudaCore::launchQSH(const DeviceMemory<std::uint64_t>& chunks, std::uint32
                                        collapse_counts.get(), static_cast<cudaStream_t>(stream.handle()));
   return {result == cudaSuccess ? Status::Success : Status::Error,
           result != cudaSuccess ? cudaGetErrorString(result) : "", "",
-          result == cudaSuccess ? SEPResult::SUCCESS : SEPResult::CUDA_ERROR};
+          result == cudaSuccess ? sep::SEPResult::SUCCESS : sep::SEPResult::CUDA_ERROR};
 }
 
 Error CudaCore::launchSimilarity(const DeviceMemory<float>& similarity,
@@ -183,7 +183,7 @@ Error CudaCore::launchSimilarity(const DeviceMemory<float>& similarity,
                                              emb_b.get(), embedding_size, static_cast<cudaStream_t>(stream.handle()));
   return {result == cudaSuccess ? Status::Success : Status::Error,
           result != cudaSuccess ? cudaGetErrorString(result) : "", "",
-          result == cudaSuccess ? SEPResult::SUCCESS : SEPResult::CUDA_ERROR};
+          result == cudaSuccess ? sep::SEPResult::SUCCESS : sep::SEPResult::CUDA_ERROR};
 }
 
 Error CudaCore::launchBlend(DeviceMemory<float>& output, const DeviceMemory<float>& embeddings,
@@ -193,7 +193,7 @@ Error CudaCore::launchBlend(DeviceMemory<float>& output, const DeviceMemory<floa
                                         num_contexts, embedding_size, static_cast<cudaStream_t>(stream.handle()));
   return {result == cudaSuccess ? Status::Success : Status::Error,
           result != cudaSuccess ? cudaGetErrorString(result) : "", "",
-          result == cudaSuccess ? SEPResult::SUCCESS : SEPResult::CUDA_ERROR};
+          result == cudaSuccess ? sep::SEPResult::SUCCESS : sep::SEPResult::CUDA_ERROR};
 }
 
 }  // namespace sep::cuda

--- a/src/compat/core_stub.cpp
+++ b/src/compat/core_stub.cpp
@@ -33,12 +33,12 @@ CudaCore::CudaCore() = default;
 Error CudaCore::initialize(int device_id) {
   initialized_ = true;
   current_device_ = device_id;
-  return {Status::Success, "", "", SEPResult::SUCCESS};
+  return {Status::Success, "", "", sep::SEPResult::SUCCESS};
 }
 
 Error CudaCore::setDevice(int device) {
   current_device_ = device;
-  return {Status::Success, "", "", SEPResult::SUCCESS};
+  return {Status::Success, "", "", sep::SEPResult::SUCCESS};
 }
 
 int CudaCore::getDeviceCount() const { return 1; }
@@ -46,7 +46,7 @@ int CudaCore::getDeviceCount() const { return 1; }
 Error CudaCore::getDeviceProperties(cudaDeviceProp& props, int device) const {
   (void)device;
   std::memset(&props, 0, sizeof(props));
-  return {Status::Success, "", "", SEPResult::SUCCESS};
+  return {Status::Success, "", "", sep::SEPResult::SUCCESS};
 }
 
 // Dummy implementation of Stream for CPU-only mode
@@ -67,52 +67,52 @@ StreamPtr CudaCore::createStream(sep::StreamFlags) {
     return std::make_shared<DummyStream>();
 }
 
-Error CudaCore::destroyStream(cudaStream_t) { return {Status::Success, "", "", SEPResult::SUCCESS}; }
+Error CudaCore::destroyStream(cudaStream_t) { return {Status::Success, "", "", sep::SEPResult::SUCCESS}; }
 
-Error CudaCore::synchronizeStream(cudaStream_t) { return {Status::Success, "", "", SEPResult::SUCCESS}; }
+Error CudaCore::synchronizeStream(cudaStream_t) { return {Status::Success, "", "", sep::SEPResult::SUCCESS}; }
 
 Error CudaCore::getMemoryInfo(size_t& free, size_t& total) const {
   free = total = 0;
-  return {Status::Success, "", "", SEPResult::SUCCESS};
+  return {Status::Success, "", "", sep::SEPResult::SUCCESS};
 }
 
-Error CudaCore::getLastError() const { return {Status::Success, "", "", SEPResult::SUCCESS}; }
+Error CudaCore::getLastError() const { return {Status::Success, "", "", sep::SEPResult::SUCCESS}; }
 
 std::string CudaCore::getErrorString(cudaError_t) const { return ""; }
 
 CudaMetrics CudaCore::getMetrics() const { return {}; }
 
-Error CudaCore::updateMetrics() { return {Status::Success, "", "", SEPResult::SUCCESS}; }
+Error CudaCore::updateMetrics() { return {Status::Success, "", "", sep::SEPResult::SUCCESS}; }
 
 Error CudaCore::initializeDevice(int device) {
   current_device_ = device;
-  return {Status::Success, "", "", SEPResult::SUCCESS};
+  return {Status::Success, "", "", sep::SEPResult::SUCCESS};
 }
 
-Error CudaCore::queryDeviceProperties() { return {Status::Success, "", "", SEPResult::SUCCESS}; }
+Error CudaCore::queryDeviceProperties() { return {Status::Success, "", "", sep::SEPResult::SUCCESS}; }
 
 Error CudaCore::launchQBSA(const DeviceMemory<std::uint32_t>&, const DeviceMemory<std::uint32_t>&,
                            std::uint32_t, DeviceMemory<std::uint32_t>&,
                            DeviceMemory<std::uint32_t>&, DeviceMemory<std::uint32_t>&,
                            Stream&) {
-  return {Status::Success, "", "", SEPResult::SUCCESS};
+    return {Status::Success, "", "", sep::SEPResult::SUCCESS};
 }
 
 Error CudaCore::launchQSH(const DeviceMemory<std::uint64_t>&, std::uint32_t,
                           DeviceMemory<std::uint32_t>&, DeviceMemory<std::uint32_t>&,
                           Stream&) {
-  return {Status::Success, "", "", SEPResult::SUCCESS};
+    return {Status::Success, "", "", sep::SEPResult::SUCCESS};
 }
 
 Error CudaCore::launchSimilarity(const DeviceMemory<float>&, const DeviceMemory<float>&,
                                  const DeviceMemory<float>&, std::uint32_t, Stream&) {
-  return {Status::Success, "", "", SEPResult::SUCCESS};
+    return {Status::Success, "", "", sep::SEPResult::SUCCESS};
 }
 
 Error CudaCore::launchBlend(DeviceMemory<float>&, const DeviceMemory<float>&,
                             const DeviceMemory<float>&, std::uint32_t, std::uint32_t,
                             Stream&) {
-  return {Status::Success, "", "", SEPResult::SUCCESS};
+    return {Status::Success, "", "", sep::SEPResult::SUCCESS};
 }
 
 }  // namespace sep::cuda

--- a/src/core/engine.cpp
+++ b/src/core/engine.cpp
@@ -66,7 +66,7 @@ bool Engine::init(const sep::config::APIConfig& config) {
            static_cast<int>(init_err.code), init_err.message.c_str());
     fflush(stdout);
     
-    if (init_err.code != SEPResult::SUCCESS) {
+    if (init_err.code != sep::SEPResult::SUCCESS) {
         printf("DEBUG: Engine::init - Trying GPU device 1\n");
         fflush(stdout);
         
@@ -76,7 +76,7 @@ bool Engine::init(const sep::config::APIConfig& config) {
                static_cast<int>(init_err.code), init_err.message.c_str());
         fflush(stdout);
         
-        if (init_err.code != SEPResult::SUCCESS) {
+        if (init_err.code != sep::SEPResult::SUCCESS) {
             printf("DEBUG: Engine::init - All GPU devices failed, giving up\n");
             fflush(stdout);
             return false;
@@ -249,7 +249,7 @@ void Engine::generate_probes(const ::sep::shim::vector<::sep::PinState>& inputs,
                              ::sep::shim::vector<std::uint32_t>& expectations, std::uint64_t tick ) {
     if (inputs.empty()) {
         ::sep::core::ErrorHandler::instance().reportError(
-            {SEPResult::INVALID_ARGUMENT, "No input states", "Engine::generate_probes"});
+            {sep::SEPResult::INVALID_ARGUMENT, "No input states", "Engine::generate_probes"});
         return;
     }
 
@@ -283,13 +283,13 @@ void Engine::process_batch(const ::sep::shim::vector<::sep::PinState>& inputs, s
                            ::sep::quantum::QBSAResult& qbsa_result, ::sep::cuda::QSHResult& qsh_result) {
     if (inputs.empty()) {
         ::sep::core::ErrorHandler::instance().reportError(
-            {SEPResult::INVALID_ARGUMENT, "No input states", "Engine::process_batch"});
+            {sep::SEPResult::INVALID_ARGUMENT, "No input states", "Engine::process_batch"});
         return;
     }
 
     if (inputs.size() > DEFAULT_SIZE) {
         ::sep::core::ErrorHandler::instance().reportError(
-            {SEPResult::INVALID_ARGUMENT, "Batch too large", "Engine::process_batch"});
+            {sep::SEPResult::INVALID_ARGUMENT, "Batch too large", "Engine::process_batch"});
         return;
     }
 

--- a/src/memory/memory_tier.cpp
+++ b/src/memory/memory_tier.cpp
@@ -145,7 +145,7 @@ void MemoryTier::deallocate(MemoryBlock* block) {
     mergeAdjacentBlocks();
 }
 
-SEPResult MemoryTier::defragment() {
+sep::SEPResult MemoryTier::defragment() {
     auto logger = sep::logging::Manager::getInstance().getLogger("memory");
     if (logger) {
         LOG_DEBUG(logger, "Defragmenting tier {}", static_cast<int>(config_.type));
@@ -166,7 +166,7 @@ SEPResult MemoryTier::defragment() {
                 if (err != cudaSuccess) {
                     if (logger)
                         LOG_ERROR(logger, "Defragment cudaMemcpy failed: {}", cudaGetErrorString(err));
-                    return SEPResult::CUDA_ERROR;
+                    return sep::SEPResult::CUDA_ERROR;
                 }
 #else
                 std::memmove(new_location, block.ptr, block.size);
@@ -201,7 +201,7 @@ SEPResult MemoryTier::defragment() {
     if (logger) {
         LOG_INFO(logger, "Tier {} fragmentation now {:.2f}", static_cast<int>(config_.type), calculateFragmentation());
     }
-    return SEPResult::SUCCESS;
+    return sep::SEPResult::SUCCESS;
 }
 
 float MemoryTier::calculateFragmentation() const {

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -136,53 +136,53 @@ MemoryTier& MemoryTierManager::getLTM() {
     return *ltm_;
 }
 
-SEPResult MemoryTierManager::promoteBlock(MemoryBlock* block, MemoryBlock*& out_block) {
+sep::SEPResult MemoryTierManager::promoteBlock(MemoryBlock* block, MemoryBlock*& out_block) {
     if (!block)
-        return SEPResult::INVALID_ARGUMENT;
+        return sep::SEPResult::INVALID_ARGUMENT;
     sep::memory::TierType next = block->tier == static_cast<TierType>(MemoryTierEnum::STM)
                                      ? static_cast<TierType>(MemoryTierEnum::MTM)
                                      : static_cast<TierType>(MemoryTierEnum::LTM);
     MemoryTier* dst = getTier(next);
     if (!dst)
-        return SEPResult::INVALID_ARGUMENT;
+        return sep::SEPResult::INVALID_ARGUMENT;
     out_block = dst->allocate(block->size);
     if (!out_block)
-        return SEPResult::ALLOCATION_FAILED;
+        return sep::SEPResult::ALLOCATION_FAILED;
     dst->moveData(out_block, block);  // block is already a pointer
     lookup_map_[out_block->ptr] = out_block;
     getTier(block->tier)->deallocate(block);
     lookup_map_.erase(block->ptr);
     out_block->tier = next;
-    return SEPResult::SUCCESS;
+    return sep::SEPResult::SUCCESS;
 }
 
-SEPResult MemoryTierManager::demoteBlock(MemoryBlock* block, MemoryBlock*& out_block) {
+sep::SEPResult MemoryTierManager::demoteBlock(MemoryBlock* block, MemoryBlock*& out_block) {
     if (!block)
-        return SEPResult::INVALID_ARGUMENT;
+        return sep::SEPResult::INVALID_ARGUMENT;
     sep::memory::TierType next = block->tier == static_cast<TierType>(MemoryTierEnum::LTM)
                                      ? static_cast<TierType>(MemoryTierEnum::MTM)
                                      : static_cast<TierType>(MemoryTierEnum::STM);
     MemoryTier* dst = getTier(next);
     if (!dst)
-        return SEPResult::INVALID_ARGUMENT;
+        return sep::SEPResult::INVALID_ARGUMENT;
     out_block = dst->allocate(block->size);
     if (!out_block)
-        return SEPResult::ALLOCATION_FAILED;
+        return sep::SEPResult::ALLOCATION_FAILED;
     dst->moveData(out_block, block);  // block is already a pointer
     lookup_map_[out_block->ptr] = out_block;
     getTier(block->tier)->deallocate(block);
     lookup_map_.erase(block->ptr);
     out_block->tier = next;
-    return SEPResult::SUCCESS;
+    return sep::SEPResult::SUCCESS;
 }
 
-SEPResult MemoryTierManager::launch_pattern_processing(pattern::PatternData* patterns, pattern::PatternData* results,
+sep::SEPResult MemoryTierManager::launch_pattern_processing(pattern::PatternData* patterns, pattern::PatternData* results,
                                                        const pattern::PatternConfig& config, size_t pattern_count,
                                                        const pattern::PatternData* previous_patterns, void* stream) {
 #ifdef __CUDACC__
     cudaError_t err =
         sep::cuda::launch_pattern_processing(patterns, results, config, pattern_count, previous_patterns, stream);
-    return err == cudaSuccess ? SEPResult::SUCCESS : SEPResult::PROCESSING_ERROR;
+      return err == cudaSuccess ? sep::SEPResult::SUCCESS : sep::SEPResult::PROCESSING_ERROR;
 #else
     (void)patterns;
     (void)results;
@@ -190,7 +190,7 @@ SEPResult MemoryTierManager::launch_pattern_processing(pattern::PatternData* pat
     (void)pattern_count;
     (void)previous_patterns;
     (void)stream;
-    return SEPResult::SUCCESS;
+      return sep::SEPResult::SUCCESS;
 #endif
 }
 

--- a/src/quantum/pattern_evolution.cpp
+++ b/src/quantum/pattern_evolution.cpp
@@ -78,14 +78,14 @@ std::vector<sep::pattern::PatternData> sep::quantum::mcp::PatternEvolution::getP
     return patterns;
 }
 
-sep::pattern::SEPResult sep::quantum::mcp::PatternEvolution::processPatterns(const std::vector<sep::pattern::PatternData>& input,
+sep::pattern::PatternResult sep::quantum::mcp::PatternEvolution::processPatterns(const std::vector<sep::pattern::PatternData>& input,
                                                               const ::sep::pattern::PatternConfig& config,
                                                               std::vector<sep::pattern::PatternData>& output)
 {
     if (input.empty())
     {
         output.clear();
-        return pattern::SEPResult::SUCCESS;
+        return pattern::PatternResult::SUCCESS;
     }
     
     output.resize(input.size());
@@ -102,7 +102,7 @@ sep::pattern::SEPResult sep::quantum::mcp::PatternEvolution::processPatterns(con
         output[i].id = shim::string(api::SepEngine::generateId("pat").c_str());
     }
     
-    return pattern::SEPResult::SUCCESS;
+    return pattern::PatternResult::SUCCESS;
 }
 
 float sep::quantum::mcp::PatternEvolution::calculateRelationshipStrength(const sep::pattern::PatternData& pattern1,

--- a/src/quantum/pattern_processor.cpp
+++ b/src/quantum/pattern_processor.cpp
@@ -113,9 +113,9 @@ namespace sep::pattern {
 
 PatternProcessor::PatternProcessor(Implementation impl) : implementation_(impl) {}
 
-SEPResult PatternProcessor::init(quantum::GPUContext* ctx) {
+sep::SEPResult PatternProcessor::init(quantum::GPUContext* ctx) {
     (void)ctx;
-    return SEPResult::SUCCESS;
+    return sep::SEPResult::SUCCESS;
 }
 
 void PatternProcessor::evolvePatterns() {
@@ -131,16 +131,16 @@ PatternData PatternProcessor::mutatePattern(const PatternData& parent) {
     return child;
 }
 
-SEPResult PatternProcessor::addPattern(const PatternData& pattern) {
+sep::SEPResult PatternProcessor::addPattern(const PatternData& pattern) {
     patterns_.push_back(pattern);
-    return SEPResult::SUCCESS;
+    return sep::SEPResult::SUCCESS;
 }
 
 const std::vector<PatternData>& PatternProcessor::getPatterns() const { return patterns_; }
 
 CPUPatternProcessor::CPUPatternProcessor() : PatternProcessor(Implementation::CPU), patterns_(PatternProcessor::patterns_) {}
 
-SEPResult CPUPatternProcessor::init(quantum::GPUContext* ctx) { return PatternProcessor::init(ctx); }
+sep::SEPResult CPUPatternProcessor::init(quantum::GPUContext* ctx) { return PatternProcessor::init(ctx); }
 
 void CPUPatternProcessor::evolvePatterns() {
     for (auto& p : patterns_) {

--- a/src/quantum/pattern_processor_interface.cpp
+++ b/src/quantum/pattern_processor_interface.cpp
@@ -5,10 +5,10 @@ namespace sep::pattern {
 PatternProcessor::PatternProcessor(Implementation impl)
     : implementation_(impl) {}
 
-SEPResult PatternProcessor::init(quantum::GPUContext* ctx)
+sep::SEPResult PatternProcessor::init(quantum::GPUContext* ctx)
 {
     (void)ctx;
-    return SEPResult::SUCCESS;
+    return sep::SEPResult::SUCCESS;
 }
 
 void PatternProcessor::evolvePatterns()
@@ -26,10 +26,10 @@ PatternData PatternProcessor::mutatePattern(const PatternData& parent)
     return child;
 }
 
-SEPResult PatternProcessor::addPattern(const PatternData& pattern)
+sep::SEPResult PatternProcessor::addPattern(const PatternData& pattern)
 {
     patterns_.push_back(pattern);
-    return SEPResult::SUCCESS;
+    return sep::SEPResult::SUCCESS;
 }
 
 const std::vector<PatternData>& PatternProcessor::getPatterns() const
@@ -42,7 +42,7 @@ CPUPatternProcessor::CPUPatternProcessor()
 {
 }
 
-SEPResult CPUPatternProcessor::init(quantum::GPUContext* ctx)
+sep::SEPResult CPUPatternProcessor::init(quantum::GPUContext* ctx)
 {
     return PatternProcessor::init(ctx);
 }

--- a/src/quantum/processor.cpp
+++ b/src/quantum/processor.cpp
@@ -23,11 +23,11 @@ public:
     explicit ProcessorImpl(const ProcessingConfig& config)
         : config_(config), initialized_(false), gpu_context_(nullptr), hooks_(nullptr) {}
 
-    SEPResult init(GPUContext* gpu_context) {
+    sep::SEPResult init(GPUContext* gpu_context) {
         std::lock_guard<std::mutex> lock(mutex_);
         gpu_context_ = gpu_context;
         initialized_ = true;
-        return SEPResult::SUCCESS;
+        return sep::SEPResult::SUCCESS;
     }
 
     void setHooks(core::SystemHooks* hooks) {
@@ -35,34 +35,34 @@ public:
         hooks_ = hooks;
     }
 
-    SEPResult addPattern(const Pattern& pattern) {
+    sep::SEPResult addPattern(const Pattern& pattern) {
         std::lock_guard<std::mutex> lock(mutex_);
         if (patterns_.size() >= config_.max_patterns) {
         }
         patterns_.push_back(pattern);
         pattern_map_[pattern.id] = patterns_.size() - 1;
-        return SEPResult::SUCCESS;
+        return sep::SEPResult::SUCCESS;
     }
 
-    SEPResult removePattern(const std::string& pattern_id) {
+    sep::SEPResult removePattern(const std::string& pattern_id) {
         std::lock_guard<std::mutex> lock(mutex_);
         auto it = pattern_map_.find(pattern_id);
         if (it == pattern_map_.end()) {
-            return SEPResult::NOT_FOUND;
+            return sep::SEPResult::NOT_FOUND;
         }
         patterns_.erase(patterns_.begin() + it->second);
         rebuildPatternMap();
-        return SEPResult::SUCCESS;
+        return sep::SEPResult::SUCCESS;
     }
 
-    SEPResult updatePattern(const std::string& pattern_id, const Pattern& pattern) {
+    sep::SEPResult updatePattern(const std::string& pattern_id, const Pattern& pattern) {
         std::lock_guard<std::mutex> lock(mutex_);
         auto it = pattern_map_.find(pattern_id);
         if (it == pattern_map_.end()) {
-            return SEPResult::NOT_FOUND;
+            return sep::SEPResult::NOT_FOUND;
         }
         patterns_[it->second] = pattern;
-        return SEPResult::SUCCESS;
+        return sep::SEPResult::SUCCESS;
     }
 
     Pattern getPattern(const std::string& pattern_id) const {
@@ -219,19 +219,19 @@ public:
         rebuildPatternMap();
     }
 
-    SEPResult addRelationship(const std::string& pattern_id1, const std::string& pattern_id2,
+    sep::SEPResult addRelationship(const std::string& pattern_id1, const std::string& pattern_id2,
                                float strength, RelationshipType type) {
         std::lock_guard<std::mutex> lock(mutex_);
         auto it1 = pattern_map_.find(pattern_id1);
         auto it2 = pattern_map_.find(pattern_id2);
         if (it1 == pattern_map_.end() || it2 == pattern_map_.end()) {
-            return SEPResult::NOT_FOUND;
+            return sep::SEPResult::NOT_FOUND;
         }
         Pattern& p1 = patterns_[it1->second];
         Pattern& p2 = patterns_[it2->second];
         p1.relationships.push_back({pattern_id2, strength, type});
         p2.relationships.push_back({pattern_id1, strength, type});
-        return SEPResult::SUCCESS;
+        return sep::SEPResult::SUCCESS;
     }
 
     float calculateCoherence(const std::string& pattern_id1, const std::string& pattern_id2) const {
@@ -351,11 +351,11 @@ Processor::~Processor() = default;
 Processor::Processor(Processor&&) noexcept = default;
 Processor& Processor::operator=(Processor&&) noexcept = default;
 
-SEPResult Processor::init(GPUContext* gpu_context) { return impl_->init(gpu_context); }
+sep::SEPResult Processor::init(GPUContext* gpu_context) { return impl_->init(gpu_context); }
 void Processor::setHooks(core::SystemHooks* hooks) { impl_->setHooks(hooks); }
-SEPResult Processor::addPattern(const Pattern& pattern) { return impl_->addPattern(pattern); }
-SEPResult Processor::removePattern(const std::string& pattern_id) { return impl_->removePattern(pattern_id); }
-SEPResult Processor::updatePattern(const std::string& pattern_id, const Pattern& pattern) { return impl_->updatePattern(pattern_id, pattern); }
+sep::SEPResult Processor::addPattern(const Pattern& pattern) { return impl_->addPattern(pattern); }
+sep::SEPResult Processor::removePattern(const std::string& pattern_id) { return impl_->removePattern(pattern_id); }
+sep::SEPResult Processor::updatePattern(const std::string& pattern_id, const Pattern& pattern) { return impl_->updatePattern(pattern_id, pattern); }
 Pattern Processor::getPattern(const std::string& pattern_id) const { return impl_->getPattern(pattern_id); }
 std::vector<Pattern> Processor::getPatterns() const { return impl_->getPatterns(); }
 std::vector<Pattern> Processor::getPatternsByTier(MemoryTierEnum tier) const { return impl_->getPatternsByTier(tier); }
@@ -370,7 +370,7 @@ ProcessingResult Processor::mutatePattern(const std::string& parent_id) { return
 void Processor::promotePatterns() { impl_->promotePatterns(); }
 void Processor::demotePatterns() { impl_->demotePatterns(); }
 void Processor::removeWeakPatterns() { impl_->removeWeakPatterns(); }
-SEPResult Processor::addRelationship(const std::string& pattern_id1, const std::string& pattern_id2, float strength, RelationshipType type) {
+sep::SEPResult Processor::addRelationship(const std::string& pattern_id1, const std::string& pattern_id2, float strength, RelationshipType type) {
     return impl_->addRelationship(pattern_id1, pattern_id2, strength, type);
 }
 float Processor::calculateCoherence(const std::string& pattern_id1, const std::string& pattern_id2) const {

--- a/tests/api/ollama_client_test.cpp
+++ b/tests/api/ollama_client_test.cpp
@@ -49,7 +49,7 @@ TEST(OllamaClientTest, GetInvalidHostReturnsError) {
 
   OllamaClient client(config);
   std::string result;
-  EXPECT_EQ(client.get("endpoint", result), SEPResult::PROCESSING_ERROR);
+  EXPECT_EQ(client.get("endpoint", result), sep::SEPResult::PROCESSING_ERROR);
 }
 
 TEST(OllamaClientTest, PostInvalidHostReturnsError) {
@@ -64,7 +64,7 @@ TEST(OllamaClientTest, PostInvalidHostReturnsError) {
   OllamaClient client(config);
   json payload = {{"prompt", "hello"}};
   std::string result;
-  EXPECT_EQ(client.post("endpoint", payload, result), SEPResult::PROCESSING_ERROR);
+  EXPECT_EQ(client.post("endpoint", payload, result), sep::SEPResult::PROCESSING_ERROR);
 }
 
 // Test request/response formatting using file:// protocol

--- a/tests/api/ollama_test.cpp
+++ b/tests/api/ollama_test.cpp
@@ -15,7 +15,7 @@ TEST(OllamaClientTest, FileGet) {
     cfg.host = std::string("file://") + std::string("./");
     OllamaClient client(cfg);
     std::string result;
-    EXPECT_EQ(client.get(path, result), SEPResult::SUCCESS);
+    EXPECT_EQ(client.get(path, result), sep::SEPResult::SUCCESS);
     EXPECT_NE(result.find("ok"), std::string::npos);
     std::remove(path);
 }

--- a/tests/blender/gpu_context_perf_test.cpp
+++ b/tests/blender/gpu_context_perf_test.cpp
@@ -15,7 +15,7 @@ class GPUContextPerfTest : public ::testing::Test {
  protected:
   void SetUp() override {
     context_ = std::make_unique<sep::GPUContext>();
-    ASSERT_EQ(SEPResult::SUCCESS, context_->init());
+    ASSERT_EQ(sep::SEPResult::SUCCESS, context_->init());
   }
 
   void TearDown() override { context_.reset(); }
@@ -209,22 +209,22 @@ TEST_F(GPUContextPerfTest, ConcurrentStreamPerformance) {
 
   // Cleanup
   for (int i = 0; i < num_streams; ++i) {
-    EXPECT_EQ(SEPResult::SUCCESS, context_->freeMemory(device_ptrs[i]));
-    EXPECT_EQ(SEPResult::SUCCESS, context_->destroyStream(streams[i]));
+    EXPECT_EQ(sep::SEPResult::SUCCESS, context_->freeMemory(device_ptrs[i]));
+    EXPECT_EQ(sep::SEPResult::SUCCESS, context_->destroyStream(streams[i]));
   }
 }
 
 TEST_F(GPUContextPerfTest, StreamLatencyTest) {
   const int iterations = 1000;
   cudaStream_t stream;
-  ASSERT_EQ(SEPResult::SUCCESS, context_->createStream(stream));
+  ASSERT_EQ(sep::SEPResult::SUCCESS, context_->createStream(stream));
 
   std::vector<double> latencies;
   latencies.reserve(iterations);
 
   for (int i = 0; i < iterations; ++i) {
     latencies.push_back(measureOperation(
-        [&]() { ASSERT_EQ(SEPResult::SUCCESS, context_->synchronizeStream(stream)); }));
+        [&]() { ASSERT_EQ(sep::SEPResult::SUCCESS, context_->synchronizeStream(stream)); }));
   }
 
   TimingStats stats(latencies);
@@ -233,6 +233,6 @@ TEST_F(GPUContextPerfTest, StreamLatencyTest) {
   EXPECT_LT(stats.avg, 0.1) << "Average stream sync latency too high";
   EXPECT_LT(stats.max, 1.0) << "Maximum stream sync latency too high";
 
-  EXPECT_EQ(SEPResult::SUCCESS, context_->destroyStream(stream));
+  EXPECT_EQ(sep::SEPResult::SUCCESS, context_->destroyStream(stream));
 }
 

--- a/tests/blender/gpu_context_test.cpp
+++ b/tests/blender/gpu_context_test.cpp
@@ -22,7 +22,7 @@ class GPUContextTest : public ::testing::Test {
 protected:
     void SetUp() override {
         context_ = std::make_unique<sep::GPUContext>();
-        ASSERT_EQ(SEPResult::SUCCESS, context_->init());
+        ASSERT_EQ(sep::SEPResult::SUCCESS, context_->init());
     }
 
     void TearDown() override {
@@ -43,18 +43,18 @@ protected:
 
 TEST_F(GPUContextTest, InitializationTest) {
     sep::GPUContext ctx;
-    EXPECT_EQ(SEPResult::SUCCESS, ctx.init());
+    EXPECT_EQ(sep::SEPResult::SUCCESS, ctx.init());
     EXPECT_FALSE(ctx.hasError());
 }
 
 TEST_F(GPUContextTest, DeviceSelectionTest) {
     int device_count;
-    ASSERT_EQ(SEPResult::SUCCESS, context_->getDeviceCount(device_count));
+    ASSERT_EQ(sep::SEPResult::SUCCESS, context_->getDeviceCount(device_count));
     if (device_count > 1) {
-        EXPECT_EQ(SEPResult::SUCCESS, context_->selectDevice(1));
+        EXPECT_EQ(sep::SEPResult::SUCCESS, context_->selectDevice(1));
         EXPECT_FALSE(context_->hasError());
     }
-    EXPECT_EQ(SEPResult::INVALID_DEVICE, context_->selectDevice(device_count + 1));
+    EXPECT_EQ(sep::SEPResult::INVALID_DEVICE, context_->selectDevice(device_count + 1));
     EXPECT_TRUE(context_->hasError());
 }
 
@@ -71,11 +71,11 @@ TEST_F(GPUContextTest, MemoryAllocationTest) {
     void* ptr = nullptr;
     const size_t size = 1024 * 1024;  // 1MB
 
-    EXPECT_EQ(SEPResult::SUCCESS, context_->allocateMemory(&ptr, size));
+    EXPECT_EQ(sep::SEPResult::SUCCESS, context_->allocateMemory(&ptr, size));
     EXPECT_NE(nullptr, ptr);
     EXPECT_GE(context_->getUsedMemory(), size);
 
-    EXPECT_EQ(SEPResult::SUCCESS, context_->freeMemory(ptr));
+    EXPECT_EQ(sep::SEPResult::SUCCESS, context_->freeMemory(ptr));
     EXPECT_EQ(0u, context_->getUsedMemory());
 }
 
@@ -85,49 +85,49 @@ TEST_F(GPUContextTest, MemoryTransferTest) {
     std::vector<float> result_data(size);
 
     void* device_ptr = nullptr;
-    ASSERT_EQ(SEPResult::SUCCESS, context_->allocateMemory(&device_ptr, size * sizeof(float)));
+    ASSERT_EQ(sep::SEPResult::SUCCESS, context_->allocateMemory(&device_ptr, size * sizeof(float)));
 
     // Host to Device
-    EXPECT_EQ(SEPResult::SUCCESS, context_->copyHostToDevice(device_ptr, host_data.data(), size * sizeof(float)));
+    EXPECT_EQ(sep::SEPResult::SUCCESS, context_->copyHostToDevice(device_ptr, host_data.data(), size * sizeof(float)));
 
     // Device to Host
-    EXPECT_EQ(SEPResult::SUCCESS, context_->copyDeviceToHost(result_data.data(), device_ptr, size * sizeof(float)));
+    EXPECT_EQ(sep::SEPResult::SUCCESS, context_->copyDeviceToHost(result_data.data(), device_ptr, size * sizeof(float)));
 
     // Verify data
     for (size_t i = 0; i < size; ++i) {
         EXPECT_FLOAT_EQ(host_data[i], result_data[i]);
     }
 
-    EXPECT_EQ(SEPResult::SUCCESS, context_->freeMemory(device_ptr));
+    EXPECT_EQ(sep::SEPResult::SUCCESS, context_->freeMemory(device_ptr));
 }
 
 TEST_F(GPUContextTest, StreamOperationsTest) {
     cudaStream_t stream;
-    EXPECT_EQ(SEPResult::SUCCESS, context_->createStream(stream));
-    EXPECT_EQ(SEPResult::SUCCESS, context_->synchronizeStream(stream));
-    EXPECT_EQ(SEPResult::SUCCESS, context_->destroyStream(stream));
+    EXPECT_EQ(sep::SEPResult::SUCCESS, context_->createStream(stream));
+    EXPECT_EQ(sep::SEPResult::SUCCESS, context_->synchronizeStream(stream));
+    EXPECT_EQ(sep::SEPResult::SUCCESS, context_->destroyStream(stream));
 }
 
 TEST_F(GPUContextTest, EventOperationsTest) {
     cudaEvent_t event;
-    EXPECT_EQ(SEPResult::SUCCESS, context_->createEvent(event));
-    EXPECT_EQ(SEPResult::SUCCESS, context_->destroyEvent(event));
+    EXPECT_EQ(sep::SEPResult::SUCCESS, context_->createEvent(event));
+    EXPECT_EQ(sep::SEPResult::SUCCESS, context_->destroyEvent(event));
 }
 
 TEST_F(GPUContextTest, EventRecordAndSyncTest) {
     cudaEvent_t event;
     cudaStream_t stream;
-    ASSERT_EQ(SEPResult::SUCCESS, context_->createStream(stream));
-    ASSERT_EQ(SEPResult::SUCCESS, context_->createEvent(event));
-    EXPECT_EQ(SEPResult::SUCCESS, context_->recordEvent(event, stream));
-    EXPECT_EQ(SEPResult::SUCCESS, context_->synchronizeEvent(event));
-    EXPECT_EQ(SEPResult::SUCCESS, context_->destroyEvent(event));
-    EXPECT_EQ(SEPResult::SUCCESS, context_->destroyStream(stream));
+    ASSERT_EQ(sep::SEPResult::SUCCESS, context_->createStream(stream));
+    ASSERT_EQ(sep::SEPResult::SUCCESS, context_->createEvent(event));
+    EXPECT_EQ(sep::SEPResult::SUCCESS, context_->recordEvent(event, stream));
+    EXPECT_EQ(sep::SEPResult::SUCCESS, context_->synchronizeEvent(event));
+    EXPECT_EQ(sep::SEPResult::SUCCESS, context_->destroyEvent(event));
+    EXPECT_EQ(sep::SEPResult::SUCCESS, context_->destroyStream(stream));
 }
 
 TEST_F(GPUContextTest, DeviceInfoTest) {
     cudaDeviceProp prop{};
-    EXPECT_EQ(SEPResult::SUCCESS, context_->getDeviceInfo(prop));
+    EXPECT_EQ(sep::SEPResult::SUCCESS, context_->getDeviceInfo(prop));
     EXPECT_GT(prop.totalGlobalMem, 0u);
 }
 
@@ -135,7 +135,7 @@ TEST_F(GPUContextTest, ErrorHandlingTest) {
     // Invalid memory allocation
     void* ptr = nullptr;
     const size_t huge_size = 1ULL << 40;  // 1TB
-    EXPECT_EQ(SEPResult::MEMORY_ERROR, context_->allocateMemory(&ptr, huge_size));
+    EXPECT_EQ(sep::SEPResult::MEMORY_ERROR, context_->allocateMemory(&ptr, huge_size));
     EXPECT_TRUE(context_->hasError());
     EXPECT_FALSE(context_->getLastError().empty());
 
@@ -153,22 +153,22 @@ TEST_F(GPUContextTest, ConcurrentOperationsTest) {
 
     // Initialize streams and allocate memory
     for (int i = 0; i < num_streams; ++i) {
-        ASSERT_EQ(SEPResult::SUCCESS, context_->createStream(streams[i]));
-        ASSERT_EQ(SEPResult::SUCCESS, context_->allocateMemory(&device_ptrs[i], size_per_stream * sizeof(float)));
+        ASSERT_EQ(sep::SEPResult::SUCCESS, context_->createStream(streams[i]));
+        ASSERT_EQ(sep::SEPResult::SUCCESS, context_->allocateMemory(&device_ptrs[i], size_per_stream * sizeof(float))); 
         host_data[i] = createTestData(size_per_stream);
         result_data[i].resize(size_per_stream);
     }
 
     // Perform concurrent operations
     for (int i = 0; i < num_streams; ++i) {
-        EXPECT_EQ(SEPResult::SUCCESS,
+        EXPECT_EQ(sep::SEPResult::SUCCESS,
                   context_->copyHostToDevice(device_ptrs[i], host_data[i].data(), size_per_stream * sizeof(float)));
     }
 
     // Synchronize and verify
     for (int i = 0; i < num_streams; ++i) {
-        EXPECT_EQ(SEPResult::SUCCESS, context_->synchronizeStream(streams[i]));
-        EXPECT_EQ(SEPResult::SUCCESS,
+        EXPECT_EQ(sep::SEPResult::SUCCESS, context_->synchronizeStream(streams[i]));
+        EXPECT_EQ(sep::SEPResult::SUCCESS,
                   context_->copyDeviceToHost(result_data[i].data(), device_ptrs[i], size_per_stream * sizeof(float)));
 
         for (size_t j = 0; j < size_per_stream; ++j) {
@@ -178,8 +178,8 @@ TEST_F(GPUContextTest, ConcurrentOperationsTest) {
 
     // Cleanup
     for (int i = 0; i < num_streams; ++i) {
-        EXPECT_EQ(SEPResult::SUCCESS, context_->freeMemory(device_ptrs[i]));
-        EXPECT_EQ(SEPResult::SUCCESS, context_->destroyStream(streams[i]));
+        EXPECT_EQ(sep::SEPResult::SUCCESS, context_->freeMemory(device_ptrs[i]));
+        EXPECT_EQ(sep::SEPResult::SUCCESS, context_->destroyStream(streams[i]));
     }
 }
 
@@ -190,13 +190,13 @@ TEST_F(GPUContextTest, MemoryTrackingTest) {
 
     size_t total_allocated = 0;
     for (size_t i = 0; i < num_allocs; ++i) {
-        ASSERT_EQ(SEPResult::SUCCESS, context_->allocateMemory(&ptrs[i], alloc_size));
+        ASSERT_EQ(sep::SEPResult::SUCCESS, context_->allocateMemory(&ptrs[i], alloc_size));
         total_allocated += alloc_size;
         EXPECT_EQ(total_allocated, context_->getUsedMemory());
     }
 
     for (size_t i = 0; i < num_allocs; ++i) {
-        EXPECT_EQ(SEPResult::SUCCESS, context_->freeMemory(ptrs[i]));
+        EXPECT_EQ(sep::SEPResult::SUCCESS, context_->freeMemory(ptrs[i]));
         total_allocated -= alloc_size;
         EXPECT_EQ(total_allocated, context_->getUsedMemory());
     }

--- a/tests/blender/mesh_handler_perf_test.cpp
+++ b/tests/blender/mesh_handler_perf_test.cpp
@@ -92,7 +92,7 @@ class MeshHandlerPerfTest : public ::testing::Test {
 
     // Initialize handler
     handler_ = std::make_unique<MeshHandler>();
-    ASSERT_EQ(SEPResult::SUCCESS, handler_->init(object_.get(), mesh_.get()));
+    ASSERT_EQ(sep::SEPResult::SUCCESS, handler_->init(object_.get(), mesh_.get()));
   }
 
   void setupPatterns() {
@@ -211,7 +211,7 @@ TEST_F(MeshHandlerPerfTest, MemoryUsage) {
   for (int i = 0; i < 5; ++i) {
     char name[32];
     (void)snprintf(name, sizeof(name), "memory_layer_%d", i);
-    EXPECT_EQ(SEPResult::SUCCESS, handler_->addCustomDataLayer(name, CD_PROP_FLOAT3));
+    EXPECT_EQ(sep::SEPResult::SUCCESS, handler_->addCustomDataLayer(name, CD_PROP_FLOAT3));
   }
 
   auto metrics = handler_->getMetrics();

--- a/tests/blender/mesh_handler_stress_test.cpp
+++ b/tests/blender/mesh_handler_stress_test.cpp
@@ -66,7 +66,7 @@ class MeshHandlerStressTest : public ::testing::Test {
 
     // Initialize handler
     handler_ = std::make_unique<MeshHandler>();
-    ASSERT_EQ(SEPResult::SUCCESS, handler_->init(object_.get(), mesh_.get()));
+    ASSERT_EQ(sep::SEPResult::SUCCESS, handler_->init(object_.get(), mesh_.get()));
   }
 
   void setupGridTopology(int GRID_SIZE) {
@@ -138,8 +138,8 @@ TEST_F(MeshHandlerStressTest, MassiveUpdateTest) {
 
   // OpenMP pragma removed to avoid compiler warnings
   for (int i = 0; i < ITERATIONS; ++i) {
-    SEPResult result = handler_->update(patterns_[i % patterns_.size()]);
-    if (result == SEPResult::SUCCESS) {
+    sep::SEPResult result = handler_->update(patterns_[i % patterns_.size()]);
+    if (result == sep::SEPResult::SUCCESS) {
       success_count++;
     } else {
       error_count++;
@@ -175,7 +175,7 @@ TEST_F(MeshHandlerStressTest, ConcurrentOperationsTest) {
       switch (i % 4) {
         case 0: {
           // Update pattern
-          if (handler_->update(patterns_[pattern_idx]) != SEPResult::SUCCESS) {
+          if (handler_->update(patterns_[pattern_idx]) != sep::SEPResult::SUCCESS) {
             errors++;
           }
           break;
@@ -184,7 +184,7 @@ TEST_F(MeshHandlerStressTest, ConcurrentOperationsTest) {
           // Add/remove custom data
           char name[32];
           (void)snprintf(name, sizeof(name), "stress_layer_%d_%d", thread_id, i);
-          if (handler_->addCustomDataLayer(name, CD_PROP_FLOAT) == SEPResult::SUCCESS) {
+          if (handler_->addCustomDataLayer(name, CD_PROP_FLOAT) == sep::SEPResult::SUCCESS) {
             handler_->removeCustomDataLayer(name);
           }
           break;
@@ -199,7 +199,7 @@ TEST_F(MeshHandlerStressTest, ConcurrentOperationsTest) {
           MeshHandler::DeformParams params;
           params.strength = 0.1f;
           params.smoothness = 0.3f;
-          if (handler_->applyDeformation(params) != SEPResult::SUCCESS) {
+          if (handler_->applyDeformation(params) != sep::SEPResult::SUCCESS) {
             errors++;
           }
           break;
@@ -246,7 +246,7 @@ TEST_F(MeshHandlerStressTest, MemoryStressTest) {
     char name[32];
     (void)snprintf(name, sizeof(name), "stress_memory_%d", i);
 
-    if (handler_->addCustomDataLayer(name, CD_PROP_FLOAT3) == SEPResult::SUCCESS) {
+    if (handler_->addCustomDataLayer(name, CD_PROP_FLOAT3) == sep::SEPResult::SUCCESS) {
       layer_names.push_back(name);
       successful_layers++;
     }
@@ -254,7 +254,7 @@ TEST_F(MeshHandlerStressTest, MemoryStressTest) {
 
   // Update patterns with all layers
   for (int i = 0; i < 10; ++i) {
-    ASSERT_EQ(SEPResult::SUCCESS, handler_->update(patterns_[i]));
+    ASSERT_EQ(sep::SEPResult::SUCCESS, handler_->update(patterns_[i]));
   }
 
   // Get final metrics
@@ -289,14 +289,14 @@ TEST_F(MeshHandlerStressTest, PatternEvolutionStressTest) {
       pattern.stability *= (1.0f - pattern.mutation_rate);
 
       // Apply to mesh
-      ASSERT_EQ(SEPResult::SUCCESS, handler_->update(pattern));
+      ASSERT_EQ(sep::SEPResult::SUCCESS, handler_->update(pattern));
     }
 
     // Apply deformation
     MeshHandler::DeformParams params;
     params.strength = 0.1f;
     params.smoothness = 0.3f;
-    ASSERT_EQ(SEPResult::SUCCESS, handler_->applyDeformation(params));
+    ASSERT_EQ(sep::SEPResult::SUCCESS, handler_->applyDeformation(params));
   }
 
   auto end = std::chrono::high_resolution_clock::now();

--- a/tests/blender/mesh_handler_test.cpp
+++ b/tests/blender/mesh_handler_test.cpp
@@ -70,7 +70,7 @@ class MeshHandlerTest : public ::testing::Test {
 
     // Initialize handler
     handler_ = std::make_unique<MeshHandler>();
-    ASSERT_EQ(SEPResult::SUCCESS, handler_->init(object_.get(), mesh_.get()));
+    ASSERT_EQ(sep::SEPResult::SUCCESS, handler_->init(object_.get(), mesh_.get()));
   }
 
   void TearDown() override {
@@ -101,7 +101,7 @@ class MeshHandlerTest : public ::testing::Test {
 
 TEST_F(MeshHandlerTest, InitializationTest) {
   MeshHandler handler;
-  EXPECT_EQ(SEPResult::SUCCESS, handler.init(object_.get(), mesh_.get()));
+  EXPECT_EQ(sep::SEPResult::SUCCESS, handler.init(object_.get(), mesh_.get()));
 }
 
 TEST_F(MeshHandlerTest, MetricsTest) {
@@ -114,20 +114,20 @@ TEST_F(MeshHandlerTest, MetricsTest) {
 }
 
 TEST_F(MeshHandlerTest, CustomDataTest) {
-  EXPECT_EQ(SEPResult::SUCCESS, handler_->addCustomDataLayer("test_float", CD_PROP_FLOAT));
+  EXPECT_EQ(sep::SEPResult::SUCCESS, handler_->addCustomDataLayer("test_float", CD_PROP_FLOAT));
   EXPECT_TRUE(handler_->hasCustomDataLayer("test_float"));
 
-  EXPECT_EQ(SEPResult::SUCCESS, handler_->addCustomDataLayer("test_float3", CD_PROP_FLOAT3));
+  EXPECT_EQ(sep::SEPResult::SUCCESS, handler_->addCustomDataLayer("test_float3", CD_PROP_FLOAT3));
   EXPECT_TRUE(handler_->hasCustomDataLayer("test_float3"));
 
-  EXPECT_EQ(SEPResult::SUCCESS, handler_->removeCustomDataLayer("test_float"));
+  EXPECT_EQ(sep::SEPResult::SUCCESS, handler_->removeCustomDataLayer("test_float"));
   EXPECT_FALSE(handler_->hasCustomDataLayer("test_float"));
   EXPECT_TRUE(handler_->hasCustomDataLayer("test_float3"));
 }
 
 TEST_F(MeshHandlerTest, PatternUpdateTest) {
   auto pattern = createTestPattern();
-  EXPECT_EQ(SEPResult::SUCCESS, handler_->update(pattern));
+  EXPECT_EQ(sep::SEPResult::SUCCESS, handler_->update(pattern));
 
   // Verify metrics after update
   auto metrics = handler_->getMetrics();
@@ -137,7 +137,7 @@ TEST_F(MeshHandlerTest, PatternUpdateTest) {
 
 TEST_F(MeshHandlerTest, DeformationTest) {
   auto pattern = createTestPattern();
-  EXPECT_EQ(SEPResult::SUCCESS, handler_->update(pattern));
+  EXPECT_EQ(sep::SEPResult::SUCCESS, handler_->update(pattern));
 
   MeshHandler::DeformParams params;
   params.strength = 0.5f;
@@ -145,7 +145,7 @@ TEST_F(MeshHandlerTest, DeformationTest) {
   params.preserve_volume = true;
   params.use_falloff = true;
 
-  EXPECT_EQ(SEPResult::SUCCESS, handler_->applyDeformation(params));
+  EXPECT_EQ(sep::SEPResult::SUCCESS, handler_->applyDeformation(params));
 
   // Verify deformation
   float* v0 = mesh_->mvert[0].co;
@@ -157,24 +157,24 @@ TEST_F(MeshHandlerTest, DeformationTest) {
 TEST_F(MeshHandlerTest, InvalidInputTest) {
   // Test null object
   MeshHandler handler;
-  EXPECT_EQ(SEPResult::INVALID_OBJECT, handler.init(nullptr, mesh_.get()));
+  EXPECT_EQ(sep::SEPResult::INVALID_OBJECT, handler.init(nullptr, mesh_.get()));
 
   // Test null mesh
-  EXPECT_EQ(SEPResult::INVALID_OBJECT, handler.init(object_.get(), nullptr));
+  EXPECT_EQ(sep::SEPResult::INVALID_OBJECT, handler.init(object_.get(), nullptr));
 
   // Test invalid object type
   object_->type = OB_EMPTY;
-  EXPECT_EQ(SEPResult::INVALID_OBJECT, handler.init(object_.get(), mesh_.get()));
+  EXPECT_EQ(sep::SEPResult::INVALID_OBJECT, handler.init(object_.get(), mesh_.get()));
 }
 
 TEST_F(MeshHandlerTest, PatternValidationTest) {
   PatternData pattern = createTestPattern();
   pattern.coherence = 2.0f;  // Invalid value
-  EXPECT_EQ(SEPResult::INVALID_STATE, handler_->update(pattern));
+  EXPECT_EQ(sep::SEPResult::INVALID_STATE, handler_->update(pattern));
 
   pattern.coherence = 0.5f;
   pattern.entropy = -1.0f;  // Invalid value
-  EXPECT_EQ(SEPResult::INVALID_STATE, handler_->update(pattern));
+  EXPECT_EQ(sep::SEPResult::INVALID_STATE, handler_->update(pattern));
 }
 
 TEST_F(MeshHandlerTest, CustomDataLayerLimitsTest) {
@@ -182,7 +182,7 @@ TEST_F(MeshHandlerTest, CustomDataLayerLimitsTest) {
   for (int i = 0; i < 16; ++i) {
     char name[32];
     (void)snprintf(name, sizeof(name), "layer_%d", i);
-    EXPECT_EQ(SEPResult::SUCCESS, handler_->addCustomDataLayer(name, CD_PROP_FLOAT));
+    EXPECT_EQ(sep::SEPResult::SUCCESS, handler_->addCustomDataLayer(name, CD_PROP_FLOAT));
   }
 
   // Verify metrics
@@ -190,6 +190,6 @@ TEST_F(MeshHandlerTest, CustomDataLayerLimitsTest) {
   EXPECT_TRUE(metrics.has_custom_data);
 
   // Try to add one more layer
-  EXPECT_EQ(SEPResult::INVALID_STATE, handler_->addCustomDataLayer("overflow", CD_PROP_FLOAT));
+  EXPECT_EQ(sep::SEPResult::INVALID_STATE, handler_->addCustomDataLayer("overflow", CD_PROP_FLOAT));
 }
 

--- a/tests/blender/mocks/mock_blender_bridge.cpp
+++ b/tests/blender/mocks/mock_blender_bridge.cpp
@@ -37,25 +37,25 @@ void BlenderBridge::processingThreadMain() {
 }
 
 // Implementation of updateObject
-::SEPResult BlenderBridge::updateObject(ObjectHandle handle, const PatternMetrics& metrics) {
+sep::SEPResult BlenderBridge::updateObject(ObjectHandle handle, const PatternMetrics& metrics) {
     (void)handle;
     (void)metrics;
     if (!initialized_) {
-        return ::SEPResult::NOT_INITIALIZED;
+        return sep::SEPResult::NOT_INITIALIZED;
     }
 
     // In a mock implementation, we just return success
-    return ::SEPResult::SUCCESS;
+    return sep::SEPResult::SUCCESS;
 }
 
 // Implementation of processPatterns
-::SEPResult BlenderBridge::processPatterns() {
+sep::SEPResult BlenderBridge::processPatterns() {
     if (!initialized_) {
-        return ::SEPResult::NOT_INITIALIZED;
+        return sep::SEPResult::NOT_INITIALIZED;
     }
     
     // In a mock implementation, we just return success
-    return ::SEPResult::SUCCESS;
+    return sep::SEPResult::SUCCESS;
 }
 
 // Implementation of updateResourceStats

--- a/tests/blender/mocks/mock_mesh_handler.cpp
+++ b/tests/blender/mocks/mock_mesh_handler.cpp
@@ -36,9 +36,9 @@ MeshHandler::~MeshHandler() {
 }
 
 // Initialize with Blender mesh
-SEPResult MeshHandler::init(Object* bl_object, Mesh* bl_mesh) {
+sep::SEPResult MeshHandler::init(Object* bl_object, Mesh* bl_mesh) {
   if (!bl_object || !bl_mesh) {
-    return SEPResult::INVALID_ARGUMENT;
+    return sep::SEPResult::INVALID_ARGUMENT;
   }
   
   object_ = bl_object;
@@ -48,17 +48,17 @@ SEPResult MeshHandler::init(Object* bl_object, Mesh* bl_mesh) {
   // Reset cache
   cache_.metrics_valid = false;
   
-  return SEPResult::SUCCESS;
+  return sep::SEPResult::SUCCESS;
 }
 
 // Update mesh based on pattern data
-SEPResult MeshHandler::update(const sep::pattern::PatternData& pattern_data) {
+sep::SEPResult MeshHandler::update(const sep::pattern::PatternData& pattern_data) {
   if (!initialized_) {
-    return SEPResult::NOT_INITIALIZED;
+    return sep::SEPResult::NOT_INITIALIZED;
   }
   
   if (!validatePattern(pattern_data)) {
-    return SEPResult::INVALID_ARGUMENT;
+    return sep::SEPResult::INVALID_ARGUMENT;
   }
   
   // Store pattern coherence for later use
@@ -68,7 +68,7 @@ SEPResult MeshHandler::update(const sep::pattern::PatternData& pattern_data) {
   // For the mock, we'll just invalidate the cache
   cache_.metrics_valid = false;
   
-  return SEPResult::SUCCESS;
+  return sep::SEPResult::SUCCESS;
 }
 
 // Get mesh metrics
@@ -90,18 +90,18 @@ MeshHandler::MeshMetrics MeshHandler::getMetrics() const {
 }
 
 // Custom data layer management
-SEPResult MeshHandler::addCustomDataLayer(const char* name, int type) {
+sep::SEPResult MeshHandler::addCustomDataLayer(const char* name, int type) {
   if (!initialized_) {
-    return SEPResult::NOT_INITIALIZED;
+    return sep::SEPResult::NOT_INITIALIZED;
   }
   
   if (!name || strlen(name) == 0) {
-    return SEPResult::INVALID_ARGUMENT;
+    return sep::SEPResult::INVALID_ARGUMENT;
   }
   
   // Check if layer already exists
   if (hasCustomDataLayer(name)) {
-    return SEPResult::ALREADY_INITIALIZED;
+    return sep::SEPResult::ALREADY_INITIALIZED;
   }
   
   // Create new layer
@@ -122,16 +122,16 @@ SEPResult MeshHandler::addCustomDataLayer(const char* name, int type) {
   // Invalidate cache
   cache_.metrics_valid = false;
   
-  return SEPResult::SUCCESS;
+  return sep::SEPResult::SUCCESS;
 }
 
-SEPResult MeshHandler::removeCustomDataLayer(const char* name) {
+sep::SEPResult MeshHandler::removeCustomDataLayer(const char* name) {
   if (!initialized_) {
-    return SEPResult::NOT_INITIALIZED;
+    return sep::SEPResult::NOT_INITIALIZED;
   }
   
   if (!name || strlen(name) == 0) {
-    return SEPResult::INVALID_ARGUMENT;
+    return sep::SEPResult::INVALID_ARGUMENT;
   }
   
   // Find layer
@@ -143,11 +143,11 @@ SEPResult MeshHandler::removeCustomDataLayer(const char* name) {
       // Invalidate cache
       cache_.metrics_valid = false;
       
-      return SEPResult::SUCCESS;
+      return sep::SEPResult::SUCCESS;
     }
   }
   
-  return SEPResult::OBJECT_NOT_FOUND;
+  return sep::SEPResult::OBJECT_NOT_FOUND;
 }
 
 bool MeshHandler::hasCustomDataLayer(const char* name) const {
@@ -165,13 +165,13 @@ bool MeshHandler::hasCustomDataLayer(const char* name) const {
   return false;
 }
 
-SEPResult MeshHandler::setUniformFloatLayer(const char* name, float value) {
+sep::SEPResult MeshHandler::setUniformFloatLayer(const char* name, float value) {
   if (!initialized_) {
-    return SEPResult::NOT_INITIALIZED;
+    return sep::SEPResult::NOT_INITIALIZED;
   }
   
   if (!name || strlen(name) == 0) {
-    return SEPResult::INVALID_ARGUMENT;
+    return sep::SEPResult::INVALID_ARGUMENT;
   }
   
   // Find layer
@@ -185,40 +185,40 @@ SEPResult MeshHandler::setUniformFloatLayer(const char* name, float value) {
         data[i] = value;
       }
       
-      return SEPResult::SUCCESS;
+      return sep::SEPResult::SUCCESS;
     }
   }
   
-  return SEPResult::OBJECT_NOT_FOUND;
+  return sep::SEPResult::OBJECT_NOT_FOUND;
 }
 
 // Pattern-driven deformation
-SEPResult MeshHandler::applyDeformation(const DeformParams& params) {
+sep::SEPResult MeshHandler::applyDeformation(const DeformParams& params) {
   (void)params;
   if (!initialized_) {
-    return SEPResult::NOT_INITIALIZED;
+    return sep::SEPResult::NOT_INITIALIZED;
   }
   
   // In a real implementation, this would deform the mesh
   // For the mock, we'll just invalidate the cache
   cache_.metrics_valid = false;
   
-  return SEPResult::SUCCESS;
+  return sep::SEPResult::SUCCESS;
 }
 
 // Generate an N-dimensional mesh
-SEPResult MeshHandler::generateHyperMesh(const sep::pattern::PatternData& pattern,
+sep::SEPResult MeshHandler::generateHyperMesh(const sep::pattern::PatternData& pattern,
                                          int dimensions) {
   if (!initialized_) {
-    return SEPResult::NOT_INITIALIZED;
+    return sep::SEPResult::NOT_INITIALIZED;
   }
   
   if (dimensions < 3) {
-    return SEPResult::INVALID_ARGUMENT;
+    return sep::SEPResult::INVALID_ARGUMENT;
   }
   
   if (!validatePattern(pattern)) {
-    return SEPResult::INVALID_ARGUMENT;
+    return sep::SEPResult::INVALID_ARGUMENT;
   }
   
   // In a real implementation, this would generate a hypermesh
@@ -236,31 +236,31 @@ SEPResult MeshHandler::generateHyperMesh(const sep::pattern::PatternData& patter
   // Invalidate cache
   cache_.metrics_valid = false;
   
-  return SEPResult::SUCCESS;
+  return sep::SEPResult::SUCCESS;
 }
 
 // Private methods
 
 // Mesh operations
-SEPResult MeshHandler::updateVertices(const sep::pattern::PatternData& pattern_data) {
+sep::SEPResult MeshHandler::updateVertices(const sep::pattern::PatternData& pattern_data) {
   (void)pattern_data;
   // Mock implementation
-  return SEPResult::SUCCESS;
+  return sep::SEPResult::SUCCESS;
 }
 
-SEPResult MeshHandler::updateCustomData(const sep::pattern::PatternData& pattern_data) {
+sep::SEPResult MeshHandler::updateCustomData(const sep::pattern::PatternData& pattern_data) {
   (void)pattern_data;
   // Mock implementation
-  return SEPResult::SUCCESS;
+  return sep::SEPResult::SUCCESS;
 }
 
-SEPResult MeshHandler::notifyDepsgraph() {
+sep::SEPResult MeshHandler::notifyDepsgraph() {
   // Mock implementation
   if (mesh_) {
     BKE_mesh_batch_cache_dirty_tag(mesh_, BKE_MESH_BATCH_DIRTY_ALL);
     DEG_id_tag_update(mesh_, ID_RECALC_GEOMETRY);
   }
-  return SEPResult::SUCCESS;
+  return sep::SEPResult::SUCCESS;
 }
 
 // Validation

--- a/tests/blender/shader_test.cpp
+++ b/tests/blender/shader_test.cpp
@@ -8,15 +8,15 @@ using namespace sep;
 
 TEST(GPUContextTestbed, ShaderReload) {
     GPUContext ctx;
-    ASSERT_EQ(ctx.init(), SEPResult::SUCCESS);
+    ASSERT_EQ(ctx.init(), sep::SEPResult::SUCCESS);
 
     sep::shim::string shader = "src/blender/shaders/pattern_process.spv";
-    ASSERT_EQ(ctx.loadComputeShader(shader), SEPResult::SUCCESS);
+    ASSERT_EQ(ctx.loadComputeShader(shader), sep::SEPResult::SUCCESS);
     uint32_t rev1 = ctx.getShaderRevision();
     EXPECT_GT(rev1, 0u);
 
     // Reload without modification should keep revision
-    EXPECT_EQ(ctx.reloadComputeShaderIfNeeded(), SEPResult::SUCCESS);
+    EXPECT_EQ(ctx.reloadComputeShaderIfNeeded(), sep::SEPResult::SUCCESS);
     EXPECT_EQ(ctx.getShaderRevision(), rev1);
 
     // Copy shader to temp file to simulate update
@@ -26,7 +26,7 @@ TEST(GPUContextTestbed, ShaderReload) {
         std::ofstream out(temp, std::ios::binary);
         out << in.rdbuf();
     }
-    ASSERT_EQ(ctx.loadComputeShader(temp), SEPResult::SUCCESS);
+    ASSERT_EQ(ctx.loadComputeShader(temp), sep::SEPResult::SUCCESS);
     uint32_t rev2 = ctx.getShaderRevision();
     EXPECT_GT(rev2, rev1);
 

--- a/tests/context/gpu_context_fix_example.cpp
+++ b/tests/context/gpu_context_fix_example.cpp
@@ -4,12 +4,12 @@
 int main()
 {
     sep::GPUContext ctx;
-    if (ctx.init() != SEPResult::SUCCESS)
+    if (ctx.init() != sep::SEPResult::SUCCESS)
     {
         return 1;
     }
     int count = 0;
-    if (ctx.getDeviceCount(count) != SEPResult::SUCCESS)
+    if (ctx.getDeviceCount(count) != sep::SEPResult::SUCCESS)
     {
         return 1;
     }

--- a/tests/memory/memory_tier_manager_block_test.cpp
+++ b/tests/memory/memory_tier_manager_block_test.cpp
@@ -9,12 +9,12 @@ TEST(MemoryTierManagerBlockTest, PromoteAndDemoteBlock) {
     ASSERT_NE(blk, nullptr);
 
     MemoryBlock* promoted = nullptr;
-    EXPECT_EQ(mgr.promoteBlock(blk, promoted), SEPResult::SUCCESS);
+    EXPECT_EQ(mgr.promoteBlock(blk, promoted), sep::SEPResult::SUCCESS);
     ASSERT_NE(promoted, nullptr);
     EXPECT_EQ(promoted->tier, TierType::MTM);
 
     MemoryBlock* demoted = nullptr;
-    EXPECT_EQ(mgr.demoteBlock(promoted, demoted), SEPResult::SUCCESS);
+    EXPECT_EQ(mgr.demoteBlock(promoted, demoted), sep::SEPResult::SUCCESS);
     ASSERT_NE(demoted, nullptr);
     EXPECT_EQ(demoted->tier, TierType::STM);
 

--- a/tests/pattern/pattern_basic_mutation_test.cpp
+++ b/tests/pattern/pattern_basic_mutation_test.cpp
@@ -6,7 +6,7 @@ using namespace sep;
 TEST(PatternProcessorBasic, MutationCreatesChild)
 {
     pattern::PatternProcessor proc(pattern::PatternProcessor::Implementation::CPU);
-    ASSERT_EQ(proc.init(nullptr), SEPResult::Success);
+    ASSERT_EQ(proc.init(nullptr), sep::SEPResult::SUCCESS);
     pattern::PatternData parent{};
     parent.id = "parent";
     parent.coherence = 0.5f;

--- a/tests/pattern/pattern_determinism_test.cpp
+++ b/tests/pattern/pattern_determinism_test.cpp
@@ -15,8 +15,8 @@ TEST(PatternDeterminism, ProcessPatternsConsistent) {
     sep::pattern::PatternConfig cfg{0.1f, false, 1, 1};
     std::vector<PatternData> out1;
     std::vector<PatternData> out2;
-    ASSERT_EQ(PatternEvolution::processPatterns(input, cfg, out1), sep::pattern::SEPResult::SUCCESS);
-    ASSERT_EQ(PatternEvolution::processPatterns(input, cfg, out2), sep::pattern::SEPResult::SUCCESS);
+    ASSERT_EQ(PatternEvolution::processPatterns(input, cfg, out1), sep::pattern::PatternResult::SUCCESS);
+    ASSERT_EQ(PatternEvolution::processPatterns(input, cfg, out2), sep::pattern::PatternResult::SUCCESS);
     ASSERT_EQ(out1.size(), out2.size());
     if (!out1.empty()) {
         EXPECT_EQ(PatternEvolution::toJson(out1[0]).dump(), PatternEvolution::toJson(out2[0]).dump());

--- a/tests/pattern/pattern_error_propagation_test.cpp
+++ b/tests/pattern/pattern_error_propagation_test.cpp
@@ -24,5 +24,5 @@ TEST(PatternEvolutionError, KernelFailurePropagates) {
     PatternConfig cfg{0.1f, false, 1, 1};
     std::vector<PatternData> output;
     EXPECT_EQ(PatternEvolution::processPatterns(input, cfg, output),
-              SEPResult::PROCESSING_ERROR);
+              sep::pattern::PatternResult::PROCESSING_ERROR);
 }

--- a/tests/pattern/pattern_relationship_update_test.cpp
+++ b/tests/pattern/pattern_relationship_update_test.cpp
@@ -6,7 +6,7 @@ using namespace sep;
 TEST(PatternProcessorRelationships, UpdatesBidirectional)
 {
     pattern::PatternProcessor proc(pattern::PatternProcessor::Implementation::CPU);
-    ASSERT_EQ(proc.init(nullptr), SEPResult::Success);
+    ASSERT_EQ(proc.init(nullptr), sep::SEPResult::SUCCESS);
 
     pattern::PatternData a{};
     a.id = "a";


### PR DESCRIPTION
## Summary
- rename `SEPResult` in `quantum/data.hpp` to `PatternResult`
- update evolution header and implementation to use `PatternResult`
- prefix all unqualified `SEPResult` usages with `sep::`
- adjust tests for new enum name and namespace prefixes

## Testing
- `cmake -B build -S .` *(fails: Parse error)*

------
https://chatgpt.com/codex/tasks/task_e_685fe609dbe0832a926d64e0301e5dee