### PR TITLE
Improve library detection and docs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,6 +157,25 @@ endif()
 find_library(OPENSUBDIV_CPU_LIBRARY NAMES osdCPU)
 find_library(OPENSUBDIV_GPU_LIBRARY NAMES osdGPU)
 
+# OpenPGL (Path Guiding Library)
+find_library(OpenPGL_LIBRARY
+    NAMES openpgl pgl
+    PATHS
+        ${CMAKE_INSTALL_PREFIX}/lib
+        /usr/lib64
+        /usr/local/lib
+        /usr/lib
+)
+if(OpenPGL_LIBRARY)
+    set(SEP_HAS_OPENPGL 1)
+    message(STATUS "[FOUND] OpenPGL: ${OpenPGL_LIBRARY}")
+else()
+    set(SEP_HAS_OPENPGL 0)
+    message(WARNING "OpenPGL library not found. Path guiding disabled.")
+    set(OpenPGL_LIBRARY "")
+endif()
+add_compile_definitions(SEP_HAS_OPENPGL=${SEP_HAS_OPENPGL})
+
 # Other critical dependencies
 find_library(OPENIMAGEIO_LIBRARY OpenImageIO)
 find_library(OPENIMAGEIO_UTIL_LIBRARY OpenImageIO_Util)
@@ -236,6 +255,9 @@ set(EXTERNAL_LINK_ORDER
     ${OPENSUBDIV_CPU_LIBRARY}
     ${OPENSUBDIV_GPU_LIBRARY}
     ${TBB2_LIBRARY}  # Specific version for OpenSubdiv
+
+    # Path guiding
+    ${OpenPGL_LIBRARY}
     
     # Core graphics libraries
     ${OPENIMAGEIO_LIBRARY}

--- a/docs/GAMEPLAN.md
+++ b/docs/GAMEPLAN.md
@@ -329,3 +329,24 @@ nm -u build/sep_engine | grep -E "(ccl::|osd::)" || echo "✓ No undefined Cycle
 ## Conclusion
 
 The SEP Engine's build system requires systematic refactoring to properly bridge stub implementations with real components. The key is implementing a flexible component detection and loading system that gracefully degrades when optional dependencies are unavailable. This approach maintains build determinism while supporting diverse deployment environments.
+
+## Component Dependency Matrix
+
+The table below lists optional components, their required libraries, and the CMake options controlling them.
+
+| Component | Libraries | CMake Option |
+|-----------|-----------|--------------|
+| Cycles renderer | libcycles\_* | `SEP_HAS_CYCLES` |
+| PipeWire audio  | libpipewire-0.3 | `SEP_HAS_PIPEWIRE` |
+| OpenSubdiv      | libosdCPU, libosdGPU | `SEP_HAS_OPENSUBDIV` |
+| Path Guiding    | libopenpgl | `SEP_HAS_OPENPGL` |
+
+To enable or disable a component, pass the corresponding `-D` flag when invoking CMake. If a library is missing, the build system falls back to a stub via the `component_bridge` mechanism.
+
+### Troubleshooting Missing Libraries
+
+1. Verify that libraries reside in standard locations such as `/usr/lib64`, `/usr/local/lib`, or `${CMAKE_INSTALL_PREFIX}/lib`.
+2. When OpenSubdiv libraries are unavailable, create symlinks in the project's `lib/` directory pointing to the system versions.
+3. If `pkg-config` yields an empty path for PipeWire, the audio module is disabled automatically.
+
+The `component_bridge` pattern ensures that missing optional components do not cause build failures while still allowing real implementations when the libraries are present.

--- a/sep-build.sh
+++ b/sep-build.sh
@@ -33,6 +33,20 @@ if [ ! -d "${CYCLES_ROOT_DIR}" ]; then
 fi
 echo "Using Cycles root: ${CYCLES_ROOT_DIR}"
 
+# Ensure OpenSubdiv libraries are present in lib/
+mkdir -p "${LIB_DIR}"
+for lib in libosdCPU.so libosdGPU.so; do
+  if [ ! -e "${LIB_DIR}/${lib}" ]; then
+    if [ -f "/usr/lib64/${lib}" ]; then
+      ln -sf "/usr/lib64/${lib}" "${LIB_DIR}/${lib}"
+      echo "Symlinked ${lib} from /usr/lib64"
+    elif [ -f "/usr/lib/${lib}" ]; then
+      ln -sf "/usr/lib/${lib}" "${LIB_DIR}/${lib}"
+      echo "Symlinked ${lib} from /usr/lib"
+    fi
+  fi
+done
+
 # --- Dependency Detection ---
 # Check for PipeWire using pkg-config (most reliable method)
 echo "Checking for PipeWire development headers..."
@@ -40,13 +54,16 @@ PIPEWIRE_CMAKE_ARGS="-DSEP_HAS_PIPEWIRE=OFF"
 if command -v pkg-config >/dev/null && pkg-config --exists libpipewire-0.3; then
   PIPEWIRE_INCLUDE_DIR=$(pkg-config --variable=includedir libpipewire-0.3)
   PIPEWIRE_LIB_PATH=$(pkg-config --libs-only-L libpipewire-0.3 | sed 's/-L//g')
-  PIPEWIRE_LIB_FILE="${PIPEWIRE_LIB_PATH}/libpipewire-0.3.so"
-
-  if [ -f "${PIPEWIRE_LIB_FILE}" ]; then
-    echo "PipeWire found via pkg-config: ${PIPEWIRE_LIB_FILE}"
-    PIPEWIRE_CMAKE_ARGS="-DSEP_HAS_PIPEWIRE=ON -DPIPEWIRE_INCLUDE_DIR=${PIPEWIRE_INCLUDE_DIR} -DPIPEWIRE_LIBRARY=${PIPEWIRE_LIB_FILE}"
+  if [ -z "${PIPEWIRE_LIB_PATH}" ]; then
+    echo "Warning: pkg-config returned empty PipeWire library path. Audio module disabled."
   else
-    echo "Warning: pkg-config found libpipewire-0.3 but library file not at ${PIPEWIRE_LIB_FILE}. PipeWire disabled."
+    PIPEWIRE_LIB_FILE="${PIPEWIRE_LIB_PATH}/libpipewire-0.3.so"
+    if [ -f "${PIPEWIRE_LIB_FILE}" ]; then
+      echo "PipeWire found via pkg-config: ${PIPEWIRE_LIB_FILE}"
+      PIPEWIRE_CMAKE_ARGS="-DSEP_HAS_PIPEWIRE=ON -DPIPEWIRE_INCLUDE_DIR=${PIPEWIRE_INCLUDE_DIR} -DPIPEWIRE_LIBRARY=${PIPEWIRE_LIB_FILE}"
+    else
+      echo "Warning: pkg-config found libpipewire-0.3 but library file not at ${PIPEWIRE_LIB_FILE}. PipeWire disabled."
+    fi
   fi
 else
   echo "Warning: pkg-config not found or libpipewire-0.3 is not available. Audio capture will be disabled."


### PR DESCRIPTION
## Summary
- search for OpenPGL in additional system locations
- symlink system OpenSubdiv libs when missing
- handle empty PipeWire pkg-config results gracefully
- document optional components and library dependencies

## Testing
- `bash -n sep-build.sh`

------
https://chatgpt.com/codex/tasks/task_e_685fef3b70ac832a94df3b5bde3218df