### PR TITLE
Improve external library handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,6 +157,40 @@ endif()
 find_library(OPENSUBDIV_CPU_LIBRARY NAMES osdCPU)
 find_library(OPENSUBDIV_GPU_LIBRARY NAMES osdGPU)
 
+# If OpenSubdiv libraries are missing, try system locations and create
+# symlinks in the project's lib directory so the build can continue.
+if(NOT OPENSUBDIV_CPU_LIBRARY)
+  find_library(SYS_OSD_CPU_LIBRARY NAMES osdCPU
+    PATHS /usr/lib64 /usr/local/lib /usr/lib
+    NO_DEFAULT_PATH)
+  if(SYS_OSD_CPU_LIBRARY)
+    file(MAKE_DIRECTORY "${CMAKE_SOURCE_DIR}/lib")
+    get_filename_component(_cpu_name "${SYS_OSD_CPU_LIBRARY}" NAME)
+    set(_cpu_link "${CMAKE_SOURCE_DIR}/lib/${_cpu_name}")
+    if(NOT EXISTS "${_cpu_link}")
+      file(CREATE_LINK "${SYS_OSD_CPU_LIBRARY}" "${_cpu_link}" SYMBOLIC)
+    endif()
+    set(OPENSUBDIV_CPU_LIBRARY "${_cpu_link}")
+    message(STATUS "Linked OpenSubdiv CPU library: ${OPENSUBDIV_CPU_LIBRARY}")
+  endif()
+endif()
+
+if(NOT OPENSUBDIV_GPU_LIBRARY)
+  find_library(SYS_OSD_GPU_LIBRARY NAMES osdGPU
+    PATHS /usr/lib64 /usr/local/lib /usr/lib
+    NO_DEFAULT_PATH)
+  if(SYS_OSD_GPU_LIBRARY)
+    file(MAKE_DIRECTORY "${CMAKE_SOURCE_DIR}/lib")
+    get_filename_component(_gpu_name "${SYS_OSD_GPU_LIBRARY}" NAME)
+    set(_gpu_link "${CMAKE_SOURCE_DIR}/lib/${_gpu_name}")
+    if(NOT EXISTS "${_gpu_link}")
+      file(CREATE_LINK "${SYS_OSD_GPU_LIBRARY}" "${_gpu_link}" SYMBOLIC)
+    endif()
+    set(OPENSUBDIV_GPU_LIBRARY "${_gpu_link}")
+    message(STATUS "Linked OpenSubdiv GPU library: ${OPENSUBDIV_GPU_LIBRARY}")
+  endif()
+endif()
+
 # Other critical dependencies
 find_library(OPENIMAGEIO_LIBRARY OpenImageIO)
 find_library(OPENIMAGEIO_UTIL_LIBRARY OpenImageIO_Util)
@@ -170,6 +204,26 @@ find_library(GFLAGS_LIBRARY gflags)
 find_library(BLOSC_LIBRARY blosc)
 find_library(ZSTD_LIBRARY zstd)
 find_library(PUGIXML_LIBRARY pugixml)
+
+# Path guiding via OpenPGL
+find_library(OpenPGL_LIBRARY
+    NAMES OpenPGL pgl
+    PATHS
+        ${CMAKE_SOURCE_DIR}/lib
+        ${CMAKE_INSTALL_PREFIX}/lib
+        /usr/lib64
+        /usr/local/lib
+        /usr/lib
+)
+if(OpenPGL_LIBRARY)
+    set(SEP_HAS_OPENPGL 1)
+    message(STATUS "Found OpenPGL: ${OpenPGL_LIBRARY}")
+else()
+    set(SEP_HAS_OPENPGL 0)
+    message(WARNING "OpenPGL not found. Path guiding features disabled")
+    set(OpenPGL_LIBRARY "")
+endif()
+add_compile_definitions(SEP_HAS_OPENPGL=${SEP_HAS_OPENPGL})
 
 # === Include Directories Configuration ===
 set(SEP_INCLUDE_DIRS
@@ -255,6 +309,7 @@ set(EXTERNAL_LINK_ORDER
     ${BLOSC_LIBRARY}
     ${ZSTD_LIBRARY}
     ${PUGIXML_LIBRARY}
+    ${OpenPGL_LIBRARY}
     ${GLOG_LIBRARY}
     ${GFLAGS_LIBRARY}
     

--- a/docs/GAMEPLAN.md
+++ b/docs/GAMEPLAN.md
@@ -326,6 +326,31 @@ nm -u build/sep_engine | grep -E "(ccl::|osd::)" || echo "✓ No undefined Cycle
    sudo ln -sf /usr/lib64/libosdGPU.so.3.5.0 /usr/lib64/libosdGPU.so.3.6.0
    ```
 
+## Component Dependencies
+
+The build is split into optional modules controlled by CMake options.  Each
+module depends on external libraries as shown below:
+
+| Component            | CMake Option        | Required Libraries                 |
+|----------------------|---------------------|------------------------------------|
+| Audio Capture        | `SEP_HAS_PIPEWIRE`  | libpipewire-0.3                    |
+| Renderer (Cycles)    | `SEP_HAS_CYCLES`    | Cycles, OpenImageIO, OpenSubdiv     |
+| Redis Integration    | `SEP_HAS_HIREDIS`   | hiredis                             |
+| Path Guiding         | `SEP_HAS_OPENPGL`   | OpenPGL                             |
+
+Disable a component by passing `-D<OPTION>=OFF` when invoking CMake.  If a
+library is missing, the `component_bridge` infrastructure selects a stub
+implementation so the engine still compiles.
+
+### Troubleshooting Missing Libraries
+
+1. Ensure the development package for the library is installed.
+2. Add custom paths using `CMAKE_PREFIX_PATH` or environment variables.
+3. If OpenSubdiv libraries are installed system-wide, symlinks can be created in
+   the `lib/` directory as shown above.
+4. When disabling a component, verify the corresponding `SEP_HAS_*` option is
+   set to `OFF` to avoid unresolved symbols.
+
 ## Conclusion
 
 The SEP Engine's build system requires systematic refactoring to properly bridge stub implementations with real components. The key is implementing a flexible component detection and loading system that gracefully degrades when optional dependencies are unavailable. This approach maintains build determinism while supporting diverse deployment environments.

--- a/src/audio/CMakeLists.txt
+++ b/src/audio/CMakeLists.txt
@@ -9,14 +9,19 @@ if(PKG_CONFIG_FOUND)
   pkg_check_modules(PIPEWIRE_PKG libpipewire-0.3 QUIET)
   if(PIPEWIRE_PKG_FOUND)
     message(STATUS "PipeWire found via pkg-config: pipewire-0.3")
-    
+
+    if(NOT PIPEWIRE_PKG_LIBRARY_DIRS)
+      message(WARNING "PipeWire pkg-config returned empty library path; disabling audio module")
+      set(PIPEWIRE_FOUND FALSE)
+    else()
+
     # Verify that the library actually exists at the expected location
     find_library(PIPEWIRE_ACTUAL_LIB
       NAMES pipewire-0.3 libpipewire-0.3
       PATHS ${PIPEWIRE_PKG_LIBRARY_DIRS} /usr/lib /usr/lib64 /usr/local/lib /usr/local/lib64
       NO_DEFAULT_PATH
     )
-      
+
     if(PIPEWIRE_ACTUAL_LIB)
       message(STATUS "Verified PipeWire library: ${PIPEWIRE_ACTUAL_LIB}")
       set(PIPEWIRE_FOUND TRUE)
@@ -25,6 +30,7 @@ if(PKG_CONFIG_FOUND)
     else()
       message(WARNING "PipeWire libraries found by pkg-config but could not verify their existence")
       set(PIPEWIRE_FOUND FALSE)
+    endif()
     endif()
   endif()
 endif()


### PR DESCRIPTION
## Summary
- symlink system OpenSubdiv libs if not found
- search OpenPGL in standard directories and expose `SEP_HAS_OPENPGL`
- warn when PipeWire's pkg‑config output is empty
- document component dependencies and how to disable them

## Testing
- `cmake -S . -B test_build` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_685fef3b70ac832a94df3b5bde3218df