### PR TITLE
Improve library discovery and docs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,31 @@ if(NOT OpenVDB_FOUND)
     find_path(OPENVDB_INCLUDE_DIR openvdb/openvdb.h)
 endif()
 
+# Helper to locate optional libraries with extended search paths
+function(find_and_add_library _var)
+  set(options)
+  set(oneValueArgs)
+  set(multiValueArgs NAMES PATHS)
+  cmake_parse_arguments(_FAAL "" "" "NAMES;PATHS" ${ARGN})
+  find_library(${_var}
+    NAMES ${_FAAL_NAMES}
+    PATHS ${_FAAL_PATHS}
+    PATH_SUFFIXES lib lib64
+  )
+  if(${_var})
+    message(STATUS "[FOUND] ${_var}: ${${_var}}")
+  else()
+    message(WARNING "[MISSING] ${_var}")
+    set(${_var} "" PARENT_SCOPE)
+  endif()
+  set(${_var} ${${_var}} PARENT_SCOPE)
+endfunction()
+
+# OpenPGL (Path Guiding Library)
+find_and_add_library(OpenPGL_LIBRARY
+  NAMES pgl
+  PATHS ${CMAKE_SOURCE_DIR}/lib ${CMAKE_INSTALL_PREFIX}/lib /usr/lib64 /usr/local/lib /usr/lib)
+
 # TBB (multiple versions for compatibility)
 find_library(TBB_LIBRARY NAMES tbb)
 find_library(TBB_MALLOC_LIBRARY NAMES tbbmalloc)
@@ -156,6 +181,35 @@ endif()
 # OpenSubdiv
 find_library(OPENSUBDIV_CPU_LIBRARY NAMES osdCPU)
 find_library(OPENSUBDIV_GPU_LIBRARY NAMES osdGPU)
+
+# If libraries are missing, try pointing to system versions and create
+# symlinks in the project's lib directory so subsequent builds succeed.
+set(_OPENSUBDIV_LIB_DIR "${CMAKE_SOURCE_DIR}/lib")
+if(NOT OPENSUBDIV_CPU_LIBRARY)
+  foreach(_loc /usr/lib64/libosdCPU.so /usr/local/lib/libosdCPU.so /usr/lib/libosdCPU.so)
+    if(EXISTS "${_loc}")
+      file(MAKE_DIRECTORY "${_OPENSUBDIV_LIB_DIR}")
+      if(NOT EXISTS "${_OPENSUBDIV_LIB_DIR}/libosdCPU.so")
+        execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink "${_loc}" "${_OPENSUBDIV_LIB_DIR}/libosdCPU.so")
+      endif()
+      set(OPENSUBDIV_CPU_LIBRARY "${_loc}")
+      break()
+    endif()
+  endforeach()
+endif()
+
+if(NOT OPENSUBDIV_GPU_LIBRARY)
+  foreach(_loc /usr/lib64/libosdGPU.so /usr/local/lib/libosdGPU.so /usr/lib/libosdGPU.so)
+    if(EXISTS "${_loc}")
+      file(MAKE_DIRECTORY "${_OPENSUBDIV_LIB_DIR}")
+      if(NOT EXISTS "${_OPENSUBDIV_LIB_DIR}/libosdGPU.so")
+        execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink "${_loc}" "${_OPENSUBDIV_LIB_DIR}/libosdGPU.so")
+      endif()
+      set(OPENSUBDIV_GPU_LIBRARY "${_loc}")
+      break()
+    endif()
+  endforeach()
+endif()
 
 # Other critical dependencies
 find_library(OPENIMAGEIO_LIBRARY OpenImageIO)
@@ -231,6 +285,9 @@ set(EXTERNAL_LINK_ORDER
     ${OSL_COMP_LIBRARY}
     ${OSL_EXEC_LIBRARY}
     ${OSL_QUERY_LIBRARY}
+
+    # Path guiding
+    ${OpenPGL_LIBRARY}
     
     # OpenSubdiv with its TBB dependency
     ${OPENSUBDIV_CPU_LIBRARY}

--- a/docs/GAMEPLAN.md
+++ b/docs/GAMEPLAN.md
@@ -246,6 +246,32 @@ configure_component(PipeWire OPTIONAL ${SEP_HAS_PIPEWIRE})
 configure_component(OpenSubdiv OPTIONAL ${OPENSUBDIV_FOUND})
 ```
 
+### Component Dependencies and Configuration
+
+The build is organized around optional components that can be toggled via CMake
+options. The most common options are:
+
+| Component | CMake Option | Required Libraries |
+|-----------|-------------|--------------------|
+| Cycles Renderer | `SEP_HAS_CYCLES` | Cycles static libs, OSL |
+| PipeWire Audio | `SEP_HAS_PIPEWIRE` | `libpipewire-0.3` |
+| OpenSubdiv | `OPENSUBDIV_FOUND` | `libosdCPU.so`, `libosdGPU.so`, TBB |
+| Path Guiding | `OpenPGL_LIBRARY` | `libpgl.so` |
+
+Enable or disable a component by passing `-D<option>=ON/OFF` to CMake. Missing
+libraries fall back to stub implementations through the `component_bridge`
+helpers.
+
+Troubleshooting tips:
+
+- Ensure `CMAKE_PREFIX_PATH` includes locations of the libraries.
+- If PipeWire detection prints an empty library path, the audio module will be
+  disabled. Verify `pkg-config --libs libpipewire-0.3` returns a valid `-L`
+  directory.
+- When OpenSubdiv libraries cannot be found, symlinks are automatically created
+  under `lib/` pointing to system installations.
+
+
 #### 5.2 Implement Graceful Degradation
 ```cpp
 // src/blender/renderer_factory.cpp

--- a/src/audio/CMakeLists.txt
+++ b/src/audio/CMakeLists.txt
@@ -8,23 +8,28 @@ set(PIPEWIRE_FOUND FALSE)
 if(PKG_CONFIG_FOUND)
   pkg_check_modules(PIPEWIRE_PKG libpipewire-0.3 QUIET)
   if(PIPEWIRE_PKG_FOUND)
-    message(STATUS "PipeWire found via pkg-config: pipewire-0.3")
-    
-    # Verify that the library actually exists at the expected location
-    find_library(PIPEWIRE_ACTUAL_LIB
-      NAMES pipewire-0.3 libpipewire-0.3
-      PATHS ${PIPEWIRE_PKG_LIBRARY_DIRS} /usr/lib /usr/lib64 /usr/local/lib /usr/local/lib64
-      NO_DEFAULT_PATH
-    )
-      
-    if(PIPEWIRE_ACTUAL_LIB)
-      message(STATUS "Verified PipeWire library: ${PIPEWIRE_ACTUAL_LIB}")
-      set(PIPEWIRE_FOUND TRUE)
-      set(PIPEWIRE_LIBRARIES ${PIPEWIRE_ACTUAL_LIB})
-      set(PIPEWIRE_INCLUDE_DIRS ${PIPEWIRE_PKG_INCLUDE_DIRS})
-    else()
-      message(WARNING "PipeWire libraries found by pkg-config but could not verify their existence")
+    if(NOT PIPEWIRE_PKG_LIBRARY_DIRS)
+      message(WARNING "PipeWire pkg-config returned empty library path; disabling audio module")
       set(PIPEWIRE_FOUND FALSE)
+    else()
+      message(STATUS "PipeWire found via pkg-config: pipewire-0.3")
+
+      # Verify that the library actually exists at the expected location
+      find_library(PIPEWIRE_ACTUAL_LIB
+        NAMES pipewire-0.3 libpipewire-0.3
+        PATHS ${PIPEWIRE_PKG_LIBRARY_DIRS} /usr/lib /usr/lib64 /usr/local/lib /usr/local/lib64
+        NO_DEFAULT_PATH
+      )
+
+      if(PIPEWIRE_ACTUAL_LIB)
+        message(STATUS "Verified PipeWire library: ${PIPEWIRE_ACTUAL_LIB}")
+        set(PIPEWIRE_FOUND TRUE)
+        set(PIPEWIRE_LIBRARIES ${PIPEWIRE_ACTUAL_LIB})
+        set(PIPEWIRE_INCLUDE_DIRS ${PIPEWIRE_PKG_INCLUDE_DIRS})
+      else()
+        message(WARNING "PipeWire libraries found by pkg-config but could not verify their existence")
+        set(PIPEWIRE_FOUND FALSE)
+      endif()
     endif()
   endif()
 endif()


### PR DESCRIPTION
## Summary
- extend helper to locate optional libraries and locate OpenPGL in common paths
- create symlinks for missing OpenSubdiv libraries so build can continue
- warn and disable audio when PipeWire pkg-config lacks a library path
- document component dependencies and configuration options

## Testing
- `cmake -S . -B build -DSEP_HAS_PIPEWIRE=OFF` *(failed: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_685fef3b70ac832a94df3b5bde3218df