### PR TITLE
Fix missing interface and headers for build

### DIFF
--- a/include/memory/quantum_coherence_manager.hpp
+++ b/include/memory/quantum_coherence_manager.hpp
@@ -1,0 +1,130 @@
+#pragma once
+
+#include "quantum/types.h"
+#include <glm/vec4.hpp>
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace sep::memory {
+
+class QuantumCoherenceManager {
+public:
+    struct Config {
+        std::size_t max_patterns{1000};
+        float anomaly_threshold{0.1f};
+        bool enable_cuda{false};
+    };
+
+    enum class AnomalyType {
+        ExcessiveCoherence,
+        InsufficientCoherence,
+        RapidChange
+    };
+
+    enum class MigrationReason {
+        HighCoherence,
+        HighStability,
+        FrequentAccess,
+        Entanglement,
+        MemoryPressure,
+        LowActivity
+    };
+
+    struct CoherenceAnomaly {
+        std::string pattern_id;
+        float coherence_value{0.f};
+        float expected_value{0.f};
+        float severity{0.f};
+        AnomalyType type{AnomalyType::RapidChange};
+    };
+
+    struct TierMigration {
+        std::string pattern_id;
+        MemoryTierEnum from_tier{MemoryTierEnum::STM};
+        MemoryTierEnum to_tier{MemoryTierEnum::STM};
+        float coherence{0.f};
+        MigrationReason reason{MigrationReason::LowActivity};
+    };
+
+    struct EntanglementNode {
+        std::string pattern_id;
+        float coherence{0.f};
+        glm::vec4 position{0.f};
+    };
+
+    struct EntanglementEdge {
+        std::size_t node1_idx{0};
+        std::size_t node2_idx{0};
+        float strength{0.f};
+        float phase_correlation{0.f};
+    };
+
+    struct EntanglementGraph {
+        std::vector<EntanglementNode> nodes;
+        std::vector<EntanglementEdge> edges;
+        float total_entanglement{0.f};
+        std::uint32_t max_degree{0};
+        float clustering_coefficient{0.f};
+    };
+
+    struct CoherenceMetrics {
+        float global_coherence{0.f};
+        float tier_coherence[3]{0.f, 0.f, 0.f};
+        std::uint64_t total_patterns{0};
+        std::uint64_t coherent_patterns{0};
+        float memory_pressure{0.f};
+        float entanglement_density{0.f};
+    };
+
+    struct PatternCoherenceData {
+        std::string pattern_id;
+        float coherence{0.f};
+        float stability{0.f};
+        std::uint32_t access_count{0};
+        std::uint64_t last_access_tick{0};
+        MemoryTierEnum current_tier{MemoryTierEnum::STM};
+        std::vector<std::string> entangled_patterns;
+    };
+
+    struct CoherenceResult {
+        bool success{false};
+        float global_coherence{0.f};
+        float memory_pressure{0.f};
+        std::size_t total_migrations{0};
+        std::vector<CoherenceAnomaly> anomalies;
+        std::vector<TierMigration> tier_migrations;
+    };
+
+    struct TierAnalysis {
+        float tier_coherence[3]{0.f, 0.f, 0.f};
+        std::uint32_t tier_pattern_count[3]{0, 0, 0};
+        std::array<float, 3> optimal_distribution{};
+    };
+
+    struct CoherenceSnapshot {
+        std::uint64_t timestamp{0};
+        CoherenceMetrics global_metrics;
+        std::vector<PatternCoherenceData> pattern_states;
+        std::array<std::uint32_t, 3> tier_distribution{};
+    };
+
+    explicit QuantumCoherenceManager(const Config& config);
+    ~QuantumCoherenceManager();
+
+    CoherenceResult updateCoherence(const std::vector<quantum::Pattern>& patterns);
+    std::vector<TierMigration> optimizeMemoryLayout();
+    EntanglementGraph computeEntanglementGraph(const std::vector<quantum::Pattern>& patterns);
+    void applyCoherenceDecay(float decay_factor);
+    CoherenceSnapshot createSnapshot() const;
+    bool restoreFromSnapshot(const CoherenceSnapshot& snapshot);
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace sep::memory
+

--- a/include/quantum/quantum_manifold_optimizer.h
+++ b/include/quantum/quantum_manifold_optimizer.h
@@ -39,7 +39,7 @@ struct ManifoldConfig {
     } quantum;
 
     // CUDA acceleration parameters
-    struct {
+    struct CudaConfig {
         int warp_tile_size = 16;
         int coherence_block_size = 256;
         int similarity_grid_dim = 32;

--- a/src/api/server.cpp
+++ b/src/api/server.cpp
@@ -1,3 +1,4 @@
+#include "memory/manager.h"
 #include "memory/memory_tier_manager.hpp"
 #include "crow/crow_isolation.h"
 #include "api/crow_request.h"

--- a/src/memory/quantum_coherence_manager.cpp
+++ b/src/memory/quantum_coherence_manager.cpp
@@ -1,4 +1,5 @@
 // /sep/src/memory/quantum_coherence_manager.cpp
+#include "memory/quantum_coherence_manager.hpp"
 #include "quantum/pattern_evolution_bridge.h"
 #include "quantum/quantum_manifold_optimizer.h"
 #include "memory/memory_tier_manager.hpp"

--- a/src/memory/redis_manager.cpp
+++ b/src/memory/redis_manager.cpp
@@ -1,4 +1,5 @@
 #include "memory/types.h"
+#include "memory/manager.h"
 #include <cstdint>
 #if __has_include(<hiredis/hiredis.h>)
 #    include <hiredis/hiredis.h>


### PR DESCRIPTION
## Summary
- provide public QuantumCoherenceManager interface
- fix CUDA config struct name in quantum_manifold_optimizer.h
- include logging manager headers in server and redis modules
- use the new coherence manager header in implementation

## Testing
- `cmake -S . -B build` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_685ffba44808832ab599ea0ddd9a4288