### PR TITLE
Apply path fixes from diff patch

### DIFF
--- a/include/memory/types.h
+++ b/include/memory/types.h
@@ -45,20 +45,20 @@ public:
     ~RedisManager();
 
     // Store a pattern in Redis with its full metadata
-    void storePattern(std::size_t id, const sep::persistence::PatternData& data, const std::string& tier);
+    void storePattern(std::uint64_t id, const sep::persistence::PatternData& data, const std::string& tier);
     
     // Load a pattern from Redis
-    std::optional<sep::persistence::PatternData> loadPattern(std::size_t id, const std::string& tier);
+    std::optional<sep::persistence::PatternData> loadPattern(std::uint64_t id, const std::string& tier);
     
     // Get all pattern IDs for a given tier
-    std::vector<std::size_t> getPatternIds(const std::string& tier);
+    std::vector<std::uint64_t> getPatternIds(const std::string& tier);
     
     // Remove a pattern from Redis
-    void removePattern(std::size_t id, const std::string& tier);
+    void removePattern(std::uint64_t id, const std::string& tier);
     
     // Batch operations for optimization
-    void bulkStore(const std::vector<std::pair<std::size_t, sep::persistence::PatternData>>& patterns, const std::string& tier);
-    std::vector<sep::persistence::PatternData> bulkLoad(const std::vector<std::size_t>& ids, const std::string& tier);
+    void bulkStore(const std::vector<std::pair<std::uint64_t, sep::persistence::PatternData>>& patterns, const std::string& tier);
+    std::vector<sep::persistence::PatternData> bulkLoad(const std::vector<std::uint64_t>& ids, const std::string& tier);
     
     // Status check
     bool isConnected() const;

--- a/src/api/crow_adapter.cpp
+++ b/src/api/crow_adapter.cpp
@@ -67,7 +67,7 @@ std::unique_ptr<HttpRequest> makeRequest(::crow::request &req) {
 /**
  * @brief Setup the SEP API routes in a Crow application
  *
- * This function demonstrates how to integrate the SEP Engine API with a Crow web application.
+ * This function integrates the SEP Engine API with a Crow web application.
  * It sets up the following endpoints:
  * - POST /api/v1/context/process - Process and validate context
  * - POST /api/v1/context/relationships - Manage context relationships

--- a/src/compat/raii.cpp
+++ b/src/compat/raii.cpp
@@ -7,7 +7,7 @@
 // Include standard headers first
 #include <cstdint>
 #include <cstdio>
-#include <cstdlib>
+#include <cstdlib>  // for std::malloc and std::free
 #include <iostream>
 #include <utility>
 

--- a/src/compat/stream.cpp
+++ b/src/compat/stream.cpp
@@ -4,8 +4,8 @@
 
 namespace sep::cuda {
 
-// Define Stream::Impl as StreamImpl
-struct Stream::Impl : public impl::StreamImpl {};
+// Minimal implementation to decouple from internal StreamImpl
+struct Stream::Impl {};
 
 Stream::~Stream() = default;
 

--- a/src/core/allocation_metrics.cpp
+++ b/src/core/allocation_metrics.cpp
@@ -1,4 +1,5 @@
 #include "core/allocation_metrics.h"
+#include "core/metrics_collector.h"  // Needed for reporting
 #include "core/prometheus_exporter.h"
 #include "metrics/types.h"
 

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -1,6 +1,7 @@
 #include "memory/memory_tier_manager.hpp"
 
 #include "compat/component_bridge.h"
+#include "memory/logger.hpp"  // for logging tier actions
 #include "memory/memory_tier_manager.hpp"
 #include "quantum/pattern_evolution_bridge.h"
 

--- a/src/memory/quantum_coherence_manager.cpp
+++ b/src/memory/quantum_coherence_manager.cpp
@@ -1,10 +1,11 @@
 #include "memory/quantum_coherence_manager.h"
+#include "compat/cuda.h"              // CUDA API access
+#include "compat/core.h"
 #include "quantum/pattern_evolution_bridge.h"
 #include "quantum/quantum_manifold_optimizer.h"
 #include "memory/memory_tier_manager.hpp"
 #include "quantum/quantum_processor_qfh.h"
 #include "memory/quantum_coherence_manager.hpp"
-#include "compat/core.h"
 #include <tbb/parallel_for.h>
 #include <tbb/concurrent_hash_map.h>
 #include <algorithm>

--- a/src/memory/redis_manager.cpp
+++ b/src/memory/redis_manager.cpp
@@ -281,7 +281,7 @@ public:
     std::vector<std::uint64_t> getPatternIds( const std::string& tier)
     {
 #if SEP_HAS_HIREDIS
-        std::vector<std::size_t> ids;
+        std::vector<std::uint64_t> ids;
         if (!connected_ || !context_)
             return ids;
 
@@ -355,12 +355,12 @@ public:
         }
     }
 
-    std::vector<sep::persistence::PatternData> bulkLoad(const std::vector<std::size_t>& ids, const std::string& tier)
+    std::vector<sep::persistence::PatternData> bulkLoad(const std::vector<std::uint64_t>& ids, const std::string& tier)
     { // Fix: Argument type should match getPatternIds return type (std::vector<uint64_t>)
         std::vector<sep::persistence::PatternData> results; // Keep return type as is, conversion happens inside
         results.reserve(ids.size());
 
-        for (std::size_t id : ids)
+        for (std::uint64_t id : ids)
         {
             auto data_opt = loadPattern(id, tier);
             if (data_opt)
@@ -382,7 +382,7 @@ private:
 RedisManager::RedisManager(const std::string& host, int port) : impl_(std::make_unique<Impl>(host, port)) {}
 RedisManager::~RedisManager() = default;
 std::shared_ptr<IRedisManager> createRedisManager(const std::string& host, int port) { return std::make_shared<RedisManager>(host, port); }
-void RedisManager::storePattern(std::uint64_t id, const sep::persistence::PatternData& data, const std::string& tier) // Fix: Use std::uint64_t for id
+void RedisManager::storePattern(std::uint64_t id, const sep::persistence::PatternData& data, const std::string& tier)
 {
     impl_->storePattern(id, data, tier);
 }
@@ -402,12 +402,12 @@ void RedisManager::removePattern(std::uint64_t id, const std::string& tier)
     impl_->removePattern(id, tier);
 }
 
-void RedisManager::bulkStore(const std::vector<std::pair<std::size_t, sep::persistence::PatternData>>& patterns, const std::string& tier)
+void RedisManager::bulkStore(const std::vector<std::pair<std::uint64_t, sep::persistence::PatternData>>& patterns, const std::string& tier)
 {
     impl_->bulkStore(patterns, tier);
 }
 
-std::vector<sep::persistence::PatternData> RedisManager::bulkLoad(const std::vector<std::size_t>& ids, const std::string& tier)
+std::vector<sep::persistence::PatternData> RedisManager::bulkLoad(const std::vector<std::uint64_t>& ids, const std::string& tier)
 {
     return impl_->bulkLoad(ids, tier);
 }


### PR DESCRIPTION
## Summary
- add missing metrics collector include for allocation metrics
- simplify `Stream::Impl` to remove reference to internal `StreamImpl`
- include logger header in memory tier manager
- add missing CUDA includes for quantum coherence manager
- document standard library use in RAII
- clarify Crow adapter API description
- use consistent 64-bit IDs in Redis manager API

## Testing
- `pnpm lint` *(fails: turbo not found or misconfigured)*
- `pnpm test` *(fails: turbo misconfiguration)*

------
https://chatgpt.com/codex/tasks/task_e_686026528790832a9e2b47cee2817067