### PR TITLE
Implement QFHResult collapse threshold

### DIFF
--- a/include/quantum/qfh.h
+++ b/include/quantum/qfh.h
@@ -60,6 +60,7 @@ struct QFHResult {
     int rupture_count{0};
     float rupture_ratio{0.0f};
     float flip_ratio{0.0f};
+    float collapse_threshold{0.0f};
     bool collapse_detected{false};
 };
 


### PR DESCRIPTION
## Summary
- expose collapse_threshold in QFHResult so analyze() can set it properly

## Testing
- `pnpm lint` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860297e8764832a9f6c7ebf4a1ea8fd