### PR TITLE
Implement fixes from build advice

### DIFF
--- a/include/api/bridge_internal.hpp
+++ b/include/api/bridge_internal.hpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include "quantum/processor.h"
 // Forward declarations
 namespace sep {
 namespace context {
@@ -40,4 +41,11 @@ extern size_t g_required_buffer_size;
 extern std::mutex g_bridge_mutex;
 extern std::unordered_map<std::string, std::vector<void (*)(const char *)>>
     g_callback_map;
+
+void setLastError(const std::string& error);
+std::string getLastError();
+void setRequiredBufferSize(size_t size);
+size_t getRequiredBufferSize();
+::sep::api::ErrorCode mapSepError(::sep::api::ErrorCode code);
+void invokeCallbacks(const std::string& event_type, const std::string& event_data);
 } // namespace sep::api::bridge::detail

--- a/include/audio/pipewire_capture.h
+++ b/include/audio/pipewire_capture.h
@@ -19,7 +19,6 @@ struct pw_core;
 struct pw_stream;
 struct pw_thread_loop;
 struct spa_hook;
-struct pw_stream_state;
 
 namespace sep {
 namespace audio {

--- a/include/quantum/qfh.h
+++ b/include/quantum/qfh.h
@@ -61,6 +61,7 @@ struct QFHResult {
     float rupture_ratio{0.0f};
     float flip_ratio{0.0f};
     bool collapse_detected{false};
+    float collapse_threshold{0.0f};
 };
 
 // QFH analysis options

--- a/include/quantum/types.h
+++ b/include/quantum/types.h
@@ -27,6 +27,7 @@ struct QuantumState {
     float coherence;
     float stability;
     float entropy;
+    float phase{0.0f};
     float mutation_rate;
     int generation;
     int mutation_count;

--- a/src/api/bridge.cpp
+++ b/src/api/bridge.cpp
@@ -50,10 +50,10 @@ std::unordered_map<std::string, std::vector<void (*)(const char *)>>
 
 namespace sep::api::bridge::detail {
 
-void setLastError(const std::string &error) { g_last_error = error; }
 void setLastError(const std::string& error) {
+  g_last_error = error;
 #if !SEP_HAS_EXCEPTIONS
-    sep::crow::error::set_last_error(error.c_str());
+  sep::crow::error::set_last_error(error.c_str());
 #endif
 }
 std::string getLastError() { return g_last_error; }


### PR DESCRIPTION
## Summary
- expose bridge error helpers in internal API header and include processor
- remove unused PipeWire stream state forward declaration
- expand quantum data types to include phase and collapse threshold
- fix duplicate `setLastError` definition

## Testing
- `pnpm test` *(fails: turbo not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bpy')*

------
https://chatgpt.com/codex/tasks/task_e_6860297e8764832a9f6c7ebf4a1ea8fd