### PR TITLE
Fix build warnings from advice

### DIFF
--- a/include/audio/pipewire_capture.h
+++ b/include/audio/pipewire_capture.h
@@ -13,6 +13,10 @@
 #include "audio/pipewire_includes.h"
 #include "audio/capture.h"
 
+#if __has_include(<pipewire/stream.h>)
+#include <pipewire/stream.h>
+#endif
+
 // Forward declarations to avoid exposing PipeWire types in header
 struct pw_context;
 struct pw_core;

--- a/include/quantum/qfh.h
+++ b/include/quantum/qfh.h
@@ -62,7 +62,6 @@ struct QFHResult {
     float flip_ratio{0.0f};
     float collapse_threshold{0.0f};
     bool collapse_detected{false};
-    float collapse_threshold{0.0f};
 };
 
 // QFH analysis options

--- a/src/compat/stream.cpp
+++ b/src/compat/stream.cpp
@@ -2,6 +2,10 @@
 
 #include "compat/stream.h"
 
+#if SEP_CUDA_AVAILABLE
+#include <cuda_runtime.h>
+#endif
+
 namespace sep::cuda {
 
 // Implementation storing the underlying CUDA stream handle

--- a/src/core/dag_graph.cpp
+++ b/src/core/dag_graph.cpp
@@ -62,8 +62,8 @@ void DagGraph::removeNode(uint64_t id)
     if (it != nodes_.end())
     {
         nodes_.erase(it);
-        for (auto& pair : nodes_) // Fix: use a named pair instead of structured binding
-        {
+        for (auto& pair : nodes_) {
+            auto& node = pair.second;
             node.parents.erase(std::remove(node.parents.begin(), node.parents.end(), id), node.parents.end());
         }
     }

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -4,6 +4,7 @@
 #include "memory/logger.hpp"
 #include "memory/memory_tier_manager.hpp"
 #include "quantum/pattern_evolution_bridge.h"
+#include "quantum/data.hpp"
 
 
 namespace sep::memory {


### PR DESCRIPTION
## Summary
- include CUDA runtime when CUDA is available
- remove duplicate field from `QFHResult`
- fix DAG node removal loop
- include quantum data definitions for memory tier manager
- pull pipewire stream header when present

## Testing
- `g++ -std=c++20 -Iinclude -c src/core/dag_graph.cpp -o /tmp/dag_graph.o`
- `g++ -std=c++20 -Iinclude -c src/compat/stream.cpp -o /tmp/stream.o` *(fails: nlohmann/json.hpp not found)*

------
https://chatgpt.com/codex/tasks/task_e_686032304070832a80005f54450f0daf