### PR TITLE
Fix namespace and unify blender bridge creation

### DIFF
--- a/include/blender/types.h
+++ b/include/blender/types.h
@@ -1,10 +1,14 @@
 #pragma once
 
 #include "core/common.h"
+#include <memory>
 
 // Forward declaration for MemoryTierEnum from sep::math_common.h
 namespace sep {
   enum class MemoryTierEnum : int;
+  namespace pattern {
+    class BlenderBridge;
+  }
 }
 
 // Using the SEPResult enum from sep namespace
@@ -43,3 +47,10 @@ inline const char* sep_result_to_string(sep::SEPResult result) {
       return "UNKNOWN_SEP_RESULT";
   }
 }
+
+// Bridge structure used by the C API
+struct SEPBlenderBridge {
+    std::shared_ptr<sep::pattern::BlenderBridge> impl;
+    SEPAudioMetrics                              audio_metrics{};
+    SEPPatternMetrics                            pattern_metrics{};
+};

--- a/include/compat/component_bridge.h
+++ b/include/compat/component_bridge.h
@@ -8,13 +8,14 @@ class AudioCapture;
 namespace pattern {
 class BlenderBridge;
 }
+struct SEPBlenderBridge;
 namespace blender {
 class CyclesRenderer; // Forward declaration if header not available
 }
 namespace compat {
 
 std::unique_ptr<audio::AudioCapture> createAudioCapture();
-std::shared_ptr<pattern::BlenderBridge> createBlenderBridge();
+std::unique_ptr<SEPBlenderBridge> createBlenderBridge();
 std::unique_ptr<blender::CyclesRenderer> createCyclesRenderer();
 
 } // namespace compat

--- a/include/core/engine.h
+++ b/include/core/engine.h
@@ -25,6 +25,7 @@ class AudioCapture;
 namespace pattern {
 class BlenderBridge;
 }  // namespace pattern
+struct SEPBlenderBridge;
 }  // namespace sep
 
 namespace sep {
@@ -83,7 +84,7 @@ class Engine {
   // Managed components
   std::unique_ptr<::sep::audio::AudioCapture> audio_capture_;
 #if SEP_HAS_BLENDER
-  std::shared_ptr<::sep::pattern::BlenderBridge> blender_bridge_;
+  std::unique_ptr<SEPBlenderBridge> blender_bridge_;
 #endif
 };
 

--- a/src/audio/pipewire_capture.cpp
+++ b/src/audio/pipewire_capture.cpp
@@ -4,6 +4,7 @@
 #include "audio/config.h"
 #include "audio/pipewire_includes.h"
 #include "compat/component_bridge.h"
+#include "compat/math_common.h"
 
 
 // Standard library headers
@@ -17,7 +18,8 @@
 #include <glm/gtc/constants.hpp>
 #include <cmath>
 
-using namespace sep::audio;
+namespace sep {
+namespace audio {
 
 struct PWInit
 {
@@ -327,3 +329,4 @@ std::unique_ptr<AudioCapture> AudioCapture::create()
 }
 
 }  // namespace audio
+}  // namespace sep

--- a/src/blender/api.cpp
+++ b/src/blender/api.cpp
@@ -6,13 +6,6 @@
 #include "compat/component_bridge.h"
 #include <memory>
 #include <string>
-// Bridge implementation structure
-struct SEPBlenderBridge
-{
-    std::shared_ptr<sep::pattern::BlenderBridge> impl;
-    SEPAudioMetrics                              audio_metrics{};    // last computed audio metrics
-    SEPPatternMetrics                            pattern_metrics{};  // last collected pattern metrics
-};
 
 namespace {
 // Version information
@@ -48,12 +41,11 @@ extern "C" sep::SEPResult sep_blender_init(sep::GPUContext* gpu_ctx, const SEPCo
     // Use config parameter to avoid unused warning
     (void)config;
 
-    auto bridge_ptr = std::unique_ptr<SEPBlenderBridge>(new (std::nothrow) SEPBlenderBridge());
+    auto bridge_ptr = sep::compat::createBlenderBridge();
     if (!bridge_ptr)
     {
         return sep::SEPResult::ALLOCATION_FAILED;
     }
-    bridge_ptr->impl            = sep::compat::createBlenderBridge();
     bridge_ptr->audio_metrics   = SEPAudioMetrics{};
     bridge_ptr->pattern_metrics = SEPPatternMetrics{};
 

--- a/src/compat/component_bridge.cpp
+++ b/src/compat/component_bridge.cpp
@@ -3,6 +3,7 @@
 #include "audio/pipewire_stubs.h"
 #include "blender/bridge.h"
 #include "blender/cycles_renderer.h"
+#include "blender/types.h"
 
 namespace sep {
 namespace compat {
@@ -19,8 +20,10 @@ std::unique_ptr<audio::AudioCapture> createAudioCapture() {
 std::unique_ptr<audio::AudioCapture> createAudioCaptureStub() { // Fix: Add missing stub definition
     return std::make_unique<audio::PipeWireCaptureStub>();
 }
-std::shared_ptr<pattern::BlenderBridge> createBlenderBridge() {
-    return std::make_shared<pattern::BlenderBridge>();
+std::unique_ptr<SEPBlenderBridge> createBlenderBridge() {
+    auto bridge = std::make_unique<SEPBlenderBridge>();
+    bridge->impl = std::make_shared<pattern::BlenderBridge>();
+    return bridge;
 }
 
 std::unique_ptr<blender::CyclesRenderer> createCyclesRenderer() {


### PR DESCRIPTION
## Summary
- fix PipeWireCapture namespace and include math header
- change createBlenderBridge to return unique_ptr
- expose SEPBlenderBridge struct in header
- update Engine to hold unique_ptr to SEPBlenderBridge

## Testing
- `cmake -S . -B build -DBUILD_TESTING=ON` *(fails: Could not find nvcc)*
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_686056a987ac832aa54ea36af0a2b5f9