### PR TITLE
Refactor CUDA includes and tidy audio namespaces

### DIFF
--- a/include/core/types.h
+++ b/include/core/types.h
@@ -3,7 +3,7 @@
 
 // Include order optimized for CUDA compatibility
 #ifdef __CUDACC__
-#include <cuda_runtime.h>
+#include "compat/cuda_common.h"
 #include "compat/cuda_helpers.h"
 #endif
 

--- a/include/memory/spdlog_isolation.h
+++ b/include/memory/spdlog_isolation.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#ifdef __CUDACC__
-#    include <cuda_runtime.h>
-#endif
+#include "compat/cuda_common.h"
 
 #include <sstream>
 #include <string>

--- a/include/memory/unified_memory.h
+++ b/include/memory/unified_memory.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "compat/raii.h"
-#include "compat/cuda_defs.h"
+#include "compat/cuda_common.h"
 #include "memory/memory_tier_manager.hpp"
 #include "memory/types.h"
 #include "memory/memory_tier.hpp"

--- a/include/quantum/types.h
+++ b/include/quantum/types.h
@@ -72,6 +72,7 @@ struct BatchProcessingResult {
     bool success{false};
     std::vector<ProcessingResult> results;
     std::string error_message;
+    int error_code{0};
 };
 
 } // namespace sep::quantum

--- a/src/audio/pipewire_capture.cpp
+++ b/src/audio/pipewire_capture.cpp
@@ -4,6 +4,7 @@
 #include "audio/config.h"
 #include "audio/pipewire_includes.h"
 #include "compat/component_bridge.h"
+#include "compat/math_common.h"
 
 
 // Standard library headers
@@ -17,7 +18,9 @@
 #include <glm/gtc/constants.hpp>
 #include <cmath>
 
-using namespace sep::audio;
+namespace sep::audio {
+
+namespace {
 
 struct PWInit
 {
@@ -34,7 +37,7 @@ static PWInit pw_init_once;
 
 PipeWireCapture::PipeWireCapture() = default;
 
-namespace PipeWireCapture {
+namespace {
 const struct pw_stream_events createStreamEvents()
 {
     struct pw_stream_events events = {};
@@ -43,6 +46,8 @@ const struct pw_stream_events createStreamEvents()
     events.process       = &streamProcess;
     return events;
 }
+
+}  // namespace
 
 
 void PipeWireCapture::cleanup()
@@ -326,4 +331,5 @@ std::unique_ptr<AudioCapture> AudioCapture::create()
     return compat::createAudioCapture();
 }
 
-}  // namespace audio
+}  // namespace
+}  // namespace sep::audio

--- a/src/compat/cuda_api.cu
+++ b/src/compat/cuda_api.cu
@@ -6,11 +6,7 @@
 #ifndef SEP_CUDACC_DISABLE_EXCEPTION_SPEC_CHECKS
 #define SEP_CUDACC_DISABLE_EXCEPTION_SPEC_CHECKS 1
 #endif
-#if defined(__CUDACC__) || defined(SEP_USE_CUDA)
-#include <cuda_runtime.h>
-#else
-#include "compat/cuda_impl.h"
-#endif
+#include "compat/cuda_common.h"
 #include "compat/cuda_helpers.h"
 
 // Standard library includes - only for host compilation

--- a/src/compat/event.cu
+++ b/src/compat/event.cu
@@ -2,15 +2,9 @@
 
 #include "compat/cuda_unified_fix.h"
 
-
 #include "compat/cuda_helpers.h"
 
 // GLM isolation layer
-#if defined(__CUDACC__) || defined(SEP_USE_CUDA)
-#include <cuda_runtime.h>
-#else
-#include "compat/cuda_impl.h"
-#endif
 
 #include "compat/core.h"
 #include "compat/event.h"

--- a/src/compat/raii.cpp
+++ b/src/compat/raii.cpp
@@ -15,7 +15,7 @@
 #include "compat/raii.h"
 #include "memory/memory_tier_manager.hpp" // Include header for interface
 #include "compat/cuda_helpers.h" // Fix: Include cuda_helpers for CUDA_CHECK
-#include "compat/cuda_impl.h"
+#include "compat/cuda_common.h"
 
 // Simple debug flag check without external logger dependency
 namespace {

--- a/src/compat/stream.cpp
+++ b/src/compat/stream.cpp
@@ -1,8 +1,6 @@
 #include <memory>
 
-#if SEP_CUDA_AVAILABLE
-#include <cuda_runtime.h>
-#endif
+#include "compat/cuda_common.h"
 
 #include "compat/stream.h"
 #include "compat/cuda_runtime.h" // ensure cudaStream_t is defined

--- a/src/compat/utils.cu
+++ b/src/compat/utils.cu
@@ -10,11 +10,7 @@
 #endif
 #include "compat/constants.h"
 
-#if defined(__CUDACC__) || defined(SEP_USE_CUDA)
-#include <cuda_runtime.h>
-#else
-#include "compat/cuda_impl.h"
-#endif
+#include "compat/cuda_common.h"
 
 #if !defined(__CUDACC__)
 #include <cstdlib>

--- a/src/memory/memory.cu
+++ b/src/memory/memory.cu
@@ -2,11 +2,7 @@
 // Include CUDA compatibility layer for C++ standard library functions
 
 // Include CUDA headers
-#if defined(__CUDACC__) || defined(SEP_USE_CUDA)
-#include <cuda_runtime.h>
-#else
-#include "compat/cuda_impl.h"
-#endif
+#include "compat/cuda_common.h"
 
 
 #include "compat/raii.h"

--- a/src/memory/memory_tier.cpp
+++ b/src/memory/memory_tier.cpp
@@ -19,7 +19,6 @@
 // CUDA headers after standard library
 #include "compat/cuda_common.h"
 #include "compat/macros.h"
-#include "compat/cuda_impl.h"
 
 #include "compat/math_common.h"
 #include "memory/logger.hpp"

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -1,9 +1,7 @@
 #include "memory/memory_tier_manager.hpp"
 #include "memory/types.h"
 
-#if SEP_CUDA_AVAILABLE
-#include <cuda_runtime.h>
-#endif
+#include "compat/cuda_common.h"
 
 #include "compat/component_bridge.h"
 #include "compat/cuda_helpers.h"
@@ -33,7 +31,7 @@ MemoryTierManager::~MemoryTierManager() {
     shutdown();
 }
 
-void MemoryTierManager::init(const sep::memory::Config& config) override {
+void MemoryTierManager::init(const sep::memory::Config& config) {
     config_ = config;
     MemoryTier::Config scfg{static_cast<TierType>(sep::MemoryTierEnum::STM), config.stm_size};
     MemoryTier::Config mcfg{static_cast<TierType>(sep::MemoryTierEnum::MTM), config.mtm_size};
@@ -43,7 +41,7 @@ void MemoryTierManager::init(const sep::memory::Config& config) override {
     ltm_ = std::make_unique<MemoryTier>(lcfg);
 }
 
-void MemoryTierManager::shutdown() override {
+void MemoryTierManager::shutdown() {
     stm_.reset();
     mtm_.reset();
     ltm_.reset();
@@ -53,7 +51,7 @@ void MemoryTierManager::shutdown() override {
     redis_manager_.reset();
 }
 
-MemoryBlock* MemoryTierManager::allocate(std::size_t size, sep::memory::TierType tier) override {
+MemoryBlock* MemoryTierManager::allocate(std::size_t size, sep::memory::TierType tier) {
     MemoryTier* t = getTier(tier);
     if (!t)
         return nullptr;
@@ -63,7 +61,7 @@ MemoryBlock* MemoryTierManager::allocate(std::size_t size, sep::memory::TierType
     return blk;
 }
 
-void MemoryTierManager::deallocate(MemoryBlock* block) override {
+void MemoryTierManager::deallocate(MemoryBlock* block) {
     if (!block)
         return;
     lookup_map_.erase(block->ptr);
@@ -84,24 +82,24 @@ MemoryTier* MemoryTierManager::getTier(sep::memory::TierType tier) {
     }
 }
 
-double MemoryTierManager::getTierUtilization(sep::memory::TierType tier) const override {
+double MemoryTierManager::getTierUtilization(sep::memory::TierType tier) const {
     const MemoryTier* t = const_cast<MemoryTierManager*>(this)->getTier(tier);
     return t ? t->calculateUtilization() : 0.0;
 }
 
-double MemoryTierManager::getTierFragmentation(sep::memory::TierType tier) const override {
+double MemoryTierManager::getTierFragmentation(sep::memory::TierType tier) const {
     const MemoryTier* t = const_cast<MemoryTierManager*>(this)->getTier(tier);
     return t ? t->calculateFragmentation() : 0.0;
 }
 
-double MemoryTierManager::getTotalUtilization() const override {
+double MemoryTierManager::getTotalUtilization() const {
     double stm_util = getTierUtilization(static_cast<TierType>(MemoryTierEnum::STM));
     double mtm_util = getTierUtilization(static_cast<TierType>(MemoryTierEnum::MTM));
     double ltm_util = getTierUtilization(static_cast<TierType>(MemoryTierEnum::LTM));
     return (stm_util + mtm_util + ltm_util) / 3.0;
 }
 
-double MemoryTierManager::getTotalFragmentation() const override {
+double MemoryTierManager::getTotalFragmentation() const {
     double stm_frag = getTierFragmentation(static_cast<TierType>(MemoryTierEnum::STM));
     double mtm_frag = getTierFragmentation(static_cast<TierType>(MemoryTierEnum::MTM));
     double ltm_frag = getTierFragmentation(static_cast<TierType>(MemoryTierEnum::LTM));
@@ -115,7 +113,7 @@ std::size_t MemoryTierManager::getTotalAllocated() const {
     return used_stm + used_mtm + used_ltm;
 }
 
-void MemoryTierManager::rebuildLookup() override {
+void MemoryTierManager::rebuildLookup() {
     lookup_map_.clear();
 
     auto rebuild = [this](MemoryTier* tier) {
@@ -132,28 +130,28 @@ void MemoryTierManager::rebuildLookup() override {
     rebuild(ltm_.get());
 }
 
-void MemoryTierManager::defragmentTier(sep::memory::TierType tier) override {
+void MemoryTierManager::defragmentTier(sep::memory::TierType tier) {
     if (MemoryTier* t = getTier(tier))
         t->defragment();
 }
 
-void MemoryTierManager::optimizeBlocks() override {
+void MemoryTierManager::optimizeBlocks() {
     stm_->defragment();
     mtm_->defragment();
     ltm_->defragment();
 }
 
-void MemoryTierManager::optimizeTiers() override {
+void MemoryTierManager::optimizeTiers() {
     optimizeBlocks();
 }
 
-MemoryTier& MemoryTierManager::getSTM() override {
+MemoryTier& MemoryTierManager::getSTM() {
     return *stm_;
 }
-MemoryTier& MemoryTierManager::getMTM() override {
+MemoryTier& MemoryTierManager::getMTM() {
     return *mtm_;
 }
-MemoryTier& MemoryTierManager::getLTM() override {
+MemoryTier& MemoryTierManager::getLTM() {
     return *ltm_;
 }
 
@@ -202,7 +200,7 @@ sep::SEPResult MemoryTierManager::launch_pattern_processing(pattern::PatternData
                                                             const pattern::PatternConfig& config,
                                                             size_t pattern_count,
                                                             const pattern::PatternData* previous_patterns,
-                                                            void* stream) override {
+                                                            void* stream) {
 #ifdef SEP_USE_CUDA
     cudaStream_t cuda_stream = static_cast<cudaStream_t>(stream);
     cudaError_t err = sep::cuda::launch_pattern_processing(
@@ -222,7 +220,7 @@ sep::SEPResult MemoryTierManager::launch_pattern_processing(pattern::PatternData
 }
 
 void MemoryTierManager::updateBlockMetrics(MemoryBlock* block, float coherence, float stability,
-                                         std::uint32_t generation, float context_score) override {
+                                         std::uint32_t generation, float context_score) {
     if (!block)
         return;
     block->coherence = coherence;
@@ -253,13 +251,13 @@ MemoryTier* MemoryTierManager::determineTier(float coherence, float stability, i
     return stm_.get();
 }
 
-void MemoryTierManager::updateRelationship(std::size_t id_a, std::size_t id_b, uint8_t type) override {
+void MemoryTierManager::updateRelationship(std::size_t id_a, std::size_t id_b, uint8_t type) {
     pattern_relationships_[id_a][id_b] = 1.0;  // Already using double
     pattern_relationships_[id_b][id_a] = 1.0;  // Already using double
     (void)type;  // Prevent unused parameter warning
 }
 
-void MemoryTierManager::removePattern(std::size_t id) override {
+void MemoryTierManager::removePattern(std::size_t id) {
     auto it = pattern_registry_.find(id);
     if (it == pattern_registry_.end())
         return;
@@ -272,7 +270,7 @@ void MemoryTierManager::removePattern(std::size_t id) override {
         r.second.erase(id);
 }
 
-void MemoryTierManager::pruneWeakRelationships() override {
+void MemoryTierManager::pruneWeakRelationships() {
     for (auto& map : pattern_relationships_)
         for (auto it = map.second.begin(); it != map.second.end();)
             if (it->second < config_.demote_threshold)
@@ -281,7 +279,7 @@ void MemoryTierManager::pruneWeakRelationships() override {
                 ++it;
 }
 
-void MemoryTierManager::calculateRelationshipCoherence() override {
+void MemoryTierManager::calculateRelationshipCoherence() {
     for (auto& entry : pattern_relationships_) {
         std::size_t id = entry.first;
         const auto& rels = entry.second;
@@ -299,7 +297,7 @@ void MemoryTierManager::calculateRelationshipCoherence() override {
     }
 }
 
-void MemoryTierManager::loadLTMFromPersistence() override {
+void MemoryTierManager::loadLTMFromPersistence() {
     if (!redis_manager_ || !redis_manager_->isConnected())
         return;
     auto ids = redis_manager_->getPatternIds("ltm");
@@ -328,7 +326,7 @@ void MemoryTierManager::loadLTMFromPersistence() override {
     }
 }
 
-void MemoryTierManager::storeLTMToPersistence(const quantum::Pattern& pattern) override {
+void MemoryTierManager::storeLTMToPersistence(const quantum::Pattern& pattern) {
     if (!redis_manager_ || !redis_manager_->isConnected())
         return;
 
@@ -351,7 +349,7 @@ void MemoryTierManager::storeLTMToPersistence(const quantum::Pattern& pattern) o
     redis_manager_->storePattern(id, data, "ltm");
 }
 
-quantum::Pattern* MemoryTierManager::findPattern(std::size_t id) override {
+quantum::Pattern* MemoryTierManager::findPattern(std::size_t id) {
     auto it = pattern_registry_.find(id);
     if (it == pattern_registry_.end()) {
         return nullptr;
@@ -368,7 +366,7 @@ quantum::Pattern* MemoryTierManager::findPattern(std::size_t id) override {
     return pattern;
 }
 
-const quantum::Pattern* MemoryTierManager::findPattern(std::size_t id) const override {
+const quantum::Pattern* MemoryTierManager::findPattern(std::size_t id) const {
     auto it = pattern_registry_.find(id);
     if (it == pattern_registry_.end()) {
         return nullptr;
@@ -385,7 +383,7 @@ const quantum::Pattern* MemoryTierManager::findPattern(std::size_t id) const ove
     return pattern;
 }
 
-void MemoryTierManager::cleanupExpiredPatterns() override {
+void MemoryTierManager::cleanupExpiredPatterns() {
     std::vector<std::size_t> to_remove;
     for (const auto& p : pattern_registry_) {
         if (p.second->coherence < static_cast<double>(config_.demote_threshold))
@@ -395,7 +393,7 @@ void MemoryTierManager::cleanupExpiredPatterns() override {
         removePattern(id);
 }
 
-void MemoryTierManager::prunePatternsByPriority(sep::memory::TierType tier, size_t max_count) override {
+void MemoryTierManager::prunePatternsByPriority(sep::memory::TierType tier, size_t max_count) {
     MemoryTier* t = getTier(tier);
     if (!t)
         return;
@@ -417,11 +415,11 @@ void MemoryTierManager::prunePatternsByPriority(sep::memory::TierType tier, size
     }
 }
 
-void MemoryTierManager::registerPattern(std::size_t id, const pattern::PatternData& pattern) override {
+void MemoryTierManager::registerPattern(std::size_t id, const pattern::PatternData& pattern) {
     pattern_registry_[id] = std::make_unique<pattern::PatternData>(pattern);
 }
 
-const pattern::PatternData* MemoryTierManager::getPatternData(std::size_t id) const override {
+const pattern::PatternData* MemoryTierManager::getPatternData(std::size_t id) const {
     auto it = pattern_registry_.find(id);
     return it == pattern_registry_.end() ? nullptr : it->second.get();
 }


### PR DESCRIPTION
## Summary
- centralize CUDA usage via `compat/cuda_common.h`
- clean up namespace usage in PipeWire capture implementation
- add error_code to `BatchProcessingResult`
- ensure CUDA headers are isolated in memory components
- remove stray `override` specifiers

## Testing
- `cmake -S . -B build` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6860584ef45c832a99dd0851d92ab06e