### PR TITLE
Refactor CUDA headers and bridge API

### DIFF
--- a/include/compat/component_bridge.h
+++ b/include/compat/component_bridge.h
@@ -14,7 +14,7 @@ class CyclesRenderer; // Forward declaration if header not available
 namespace compat {
 
 std::unique_ptr<audio::AudioCapture> createAudioCapture();
-std::shared_ptr<pattern::BlenderBridge> createBlenderBridge();
+std::unique_ptr<pattern::BlenderBridge> createBlenderBridge();
 std::unique_ptr<blender::CyclesRenderer> createCyclesRenderer();
 
 } // namespace compat

--- a/include/core/engine.h
+++ b/include/core/engine.h
@@ -83,7 +83,7 @@ class Engine {
   // Managed components
   std::unique_ptr<::sep::audio::AudioCapture> audio_capture_;
 #if SEP_HAS_BLENDER
-  std::shared_ptr<::sep::pattern::BlenderBridge> blender_bridge_;
+  std::unique_ptr<::sep::pattern::BlenderBridge> blender_bridge_;
 #endif
 };
 

--- a/include/memory/redis_manager.h
+++ b/include/memory/redis_manager.h
@@ -1,0 +1,24 @@
+#pragma once
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace sep::persistence {
+struct PatternData;
+
+class IRedisManager {
+public:
+    virtual ~IRedisManager() = default;
+    virtual void storePattern(std::uint64_t id, const PatternData& data, const std::string& tier) = 0;
+    virtual std::optional<PatternData> loadPattern(std::uint64_t id, const std::string& tier) = 0;
+    virtual std::vector<std::uint64_t> getPatternIds(const std::string& tier) = 0;
+    virtual void removePattern(std::uint64_t id, const std::string& tier) = 0;
+    virtual void bulkStore(const std::vector<std::pair<std::uint64_t, PatternData>>& patterns, const std::string& tier) = 0;
+    virtual std::vector<PatternData> bulkLoad(const std::vector<std::uint64_t>& ids, const std::string& tier) = 0;
+    virtual bool isConnected() const = 0;
+};
+
+std::shared_ptr<IRedisManager> createRedisManager(const std::string& host = "localhost", int port = 6379);
+}

--- a/include/memory/types.h
+++ b/include/memory/types.h
@@ -11,6 +11,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include "memory/redis_manager.h"
 #include <glm/glm.hpp>
 #include <chrono>
 #include <glm/vec3.hpp>
@@ -39,7 +40,7 @@ struct PatternData {
     uint64_t dag_node_id = 0;              // DAG node ID for pattern
 };
 
-class RedisManager {
+class RedisManager : public IRedisManager {
 public:
     RedisManager(const std::string& host = "localhost", int port = 6379);
     ~RedisManager();

--- a/include/quantum/types.h
+++ b/include/quantum/types.h
@@ -72,6 +72,7 @@ struct BatchProcessingResult {
     bool success{false};
     std::vector<ProcessingResult> results;
     std::string error_message;
+    int error_code{0};
 };
 
 } // namespace sep::quantum

--- a/src/audio/pipewire_capture.cpp
+++ b/src/audio/pipewire_capture.cpp
@@ -4,6 +4,7 @@
 #include "audio/config.h"
 #include "audio/pipewire_includes.h"
 #include "compat/component_bridge.h"
+#include "compat/math_common.h"
 
 
 // Standard library headers
@@ -17,7 +18,8 @@
 #include <glm/gtc/constants.hpp>
 #include <cmath>
 
-using namespace sep::audio;
+
+namespace sep::audio {
 
 struct PWInit
 {
@@ -33,8 +35,6 @@ struct PWInit
 static PWInit pw_init_once;
 
 PipeWireCapture::PipeWireCapture() = default;
-
-namespace PipeWireCapture {
 const struct pw_stream_events createStreamEvents()
 {
     struct pw_stream_events events = {};
@@ -327,3 +327,4 @@ std::unique_ptr<AudioCapture> AudioCapture::create()
 }
 
 }  // namespace audio
+}  // namespace sep

--- a/src/blender/api.cpp
+++ b/src/blender/api.cpp
@@ -9,7 +9,7 @@
 // Bridge implementation structure
 struct SEPBlenderBridge
 {
-    std::shared_ptr<sep::pattern::BlenderBridge> impl;
+    std::unique_ptr<sep::pattern::BlenderBridge> impl;
     SEPAudioMetrics                              audio_metrics{};    // last computed audio metrics
     SEPPatternMetrics                            pattern_metrics{};  // last collected pattern metrics
 };

--- a/src/compat/component_bridge.cpp
+++ b/src/compat/component_bridge.cpp
@@ -19,8 +19,8 @@ std::unique_ptr<audio::AudioCapture> createAudioCapture() {
 std::unique_ptr<audio::AudioCapture> createAudioCaptureStub() { // Fix: Add missing stub definition
     return std::make_unique<audio::PipeWireCaptureStub>();
 }
-std::shared_ptr<pattern::BlenderBridge> createBlenderBridge() {
-    return std::make_shared<pattern::BlenderBridge>();
+std::unique_ptr<pattern::BlenderBridge> createBlenderBridge() {
+    return std::make_unique<pattern::BlenderBridge>();
 }
 
 std::unique_ptr<blender::CyclesRenderer> createCyclesRenderer() {

--- a/src/compat/cuda_api.cu
+++ b/src/compat/cuda_api.cu
@@ -6,11 +6,6 @@
 #ifndef SEP_CUDACC_DISABLE_EXCEPTION_SPEC_CHECKS
 #define SEP_CUDACC_DISABLE_EXCEPTION_SPEC_CHECKS 1
 #endif
-#if defined(__CUDACC__) || defined(SEP_USE_CUDA)
-#include <cuda_runtime.h>
-#else
-#include "compat/cuda_impl.h"
-#endif
 #include "compat/cuda_helpers.h"
 
 // Standard library includes - only for host compilation

--- a/src/compat/event.cu
+++ b/src/compat/event.cu
@@ -6,11 +6,6 @@
 #include "compat/cuda_helpers.h"
 
 // GLM isolation layer
-#if defined(__CUDACC__) || defined(SEP_USE_CUDA)
-#include <cuda_runtime.h>
-#else
-#include "compat/cuda_impl.h"
-#endif
 
 #include "compat/core.h"
 #include "compat/event.h"

--- a/src/compat/raii.cpp
+++ b/src/compat/raii.cpp
@@ -15,7 +15,7 @@
 #include "compat/raii.h"
 #include "memory/memory_tier_manager.hpp" // Include header for interface
 #include "compat/cuda_helpers.h" // Fix: Include cuda_helpers for CUDA_CHECK
-#include "compat/cuda_impl.h"
+#include "compat/cuda_common.h"
 
 // Simple debug flag check without external logger dependency
 namespace {

--- a/src/compat/stream.cpp
+++ b/src/compat/stream.cpp
@@ -1,8 +1,6 @@
 #include <memory>
 
-#if SEP_CUDA_AVAILABLE
-#include <cuda_runtime.h>
-#endif
+#include "compat/cuda_common.h"
 
 #include "compat/stream.h"
 #include "compat/cuda_runtime.h" // ensure cudaStream_t is defined

--- a/src/compat/utils.cu
+++ b/src/compat/utils.cu
@@ -10,12 +10,6 @@
 #endif
 #include "compat/constants.h"
 
-#if defined(__CUDACC__) || defined(SEP_USE_CUDA)
-#include <cuda_runtime.h>
-#else
-#include "compat/cuda_impl.h"
-#endif
-
 #if !defined(__CUDACC__)
 #include <cstdlib>
 #include <sstream>

--- a/src/memory/memory.cu
+++ b/src/memory/memory.cu
@@ -2,11 +2,7 @@
 // Include CUDA compatibility layer for C++ standard library functions
 
 // Include CUDA headers
-#if defined(__CUDACC__) || defined(SEP_USE_CUDA)
-#include <cuda_runtime.h>
-#else
-#include "compat/cuda_impl.h"
-#endif
+#include "compat/cuda_common.h"
 
 
 #include "compat/raii.h"

--- a/src/memory/memory_tier.cpp
+++ b/src/memory/memory_tier.cpp
@@ -19,7 +19,6 @@
 // CUDA headers after standard library
 #include "compat/cuda_common.h"
 #include "compat/macros.h"
-#include "compat/cuda_impl.h"
 
 #include "compat/math_common.h"
 #include "memory/logger.hpp"

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -1,13 +1,12 @@
 #include "memory/memory_tier_manager.hpp"
 #include "memory/types.h"
 
-#if SEP_CUDA_AVAILABLE
-#include <cuda_runtime.h>
-#endif
+#include "compat/cuda_common.h"
 
 #include "compat/component_bridge.h"
 #include "compat/cuda_helpers.h"
 #include "memory/logger.hpp"
+#include "memory/redis_manager.h"
 #include "quantum/pattern_evolution_bridge.h"
 #include "quantum/data.hpp" // For PatternData definition
 
@@ -33,7 +32,7 @@ MemoryTierManager::~MemoryTierManager() {
     shutdown();
 }
 
-void MemoryTierManager::init(const sep::memory::Config& config) override {
+void MemoryTierManager::init(const sep::memory::Config& config) {
     config_ = config;
     MemoryTier::Config scfg{static_cast<TierType>(sep::MemoryTierEnum::STM), config.stm_size};
     MemoryTier::Config mcfg{static_cast<TierType>(sep::MemoryTierEnum::MTM), config.mtm_size};
@@ -43,7 +42,7 @@ void MemoryTierManager::init(const sep::memory::Config& config) override {
     ltm_ = std::make_unique<MemoryTier>(lcfg);
 }
 
-void MemoryTierManager::shutdown() override {
+void MemoryTierManager::shutdown() {
     stm_.reset();
     mtm_.reset();
     ltm_.reset();
@@ -53,7 +52,7 @@ void MemoryTierManager::shutdown() override {
     redis_manager_.reset();
 }
 
-MemoryBlock* MemoryTierManager::allocate(std::size_t size, sep::memory::TierType tier) override {
+MemoryBlock* MemoryTierManager::allocate(std::size_t size, sep::memory::TierType tier) {
     MemoryTier* t = getTier(tier);
     if (!t)
         return nullptr;
@@ -63,7 +62,7 @@ MemoryBlock* MemoryTierManager::allocate(std::size_t size, sep::memory::TierType
     return blk;
 }
 
-void MemoryTierManager::deallocate(MemoryBlock* block) override {
+void MemoryTierManager::deallocate(MemoryBlock* block) {
     if (!block)
         return;
     lookup_map_.erase(block->ptr);
@@ -84,24 +83,24 @@ MemoryTier* MemoryTierManager::getTier(sep::memory::TierType tier) {
     }
 }
 
-double MemoryTierManager::getTierUtilization(sep::memory::TierType tier) const override {
+double MemoryTierManager::getTierUtilization(sep::memory::TierType tier) const {
     const MemoryTier* t = const_cast<MemoryTierManager*>(this)->getTier(tier);
     return t ? t->calculateUtilization() : 0.0;
 }
 
-double MemoryTierManager::getTierFragmentation(sep::memory::TierType tier) const override {
+double MemoryTierManager::getTierFragmentation(sep::memory::TierType tier) const {
     const MemoryTier* t = const_cast<MemoryTierManager*>(this)->getTier(tier);
     return t ? t->calculateFragmentation() : 0.0;
 }
 
-double MemoryTierManager::getTotalUtilization() const override {
+double MemoryTierManager::getTotalUtilization() const {
     double stm_util = getTierUtilization(static_cast<TierType>(MemoryTierEnum::STM));
     double mtm_util = getTierUtilization(static_cast<TierType>(MemoryTierEnum::MTM));
     double ltm_util = getTierUtilization(static_cast<TierType>(MemoryTierEnum::LTM));
     return (stm_util + mtm_util + ltm_util) / 3.0;
 }
 
-double MemoryTierManager::getTotalFragmentation() const override {
+double MemoryTierManager::getTotalFragmentation() const {
     double stm_frag = getTierFragmentation(static_cast<TierType>(MemoryTierEnum::STM));
     double mtm_frag = getTierFragmentation(static_cast<TierType>(MemoryTierEnum::MTM));
     double ltm_frag = getTierFragmentation(static_cast<TierType>(MemoryTierEnum::LTM));
@@ -115,7 +114,7 @@ std::size_t MemoryTierManager::getTotalAllocated() const {
     return used_stm + used_mtm + used_ltm;
 }
 
-void MemoryTierManager::rebuildLookup() override {
+void MemoryTierManager::rebuildLookup() {
     lookup_map_.clear();
 
     auto rebuild = [this](MemoryTier* tier) {
@@ -132,28 +131,28 @@ void MemoryTierManager::rebuildLookup() override {
     rebuild(ltm_.get());
 }
 
-void MemoryTierManager::defragmentTier(sep::memory::TierType tier) override {
+void MemoryTierManager::defragmentTier(sep::memory::TierType tier) {
     if (MemoryTier* t = getTier(tier))
         t->defragment();
 }
 
-void MemoryTierManager::optimizeBlocks() override {
+void MemoryTierManager::optimizeBlocks() {
     stm_->defragment();
     mtm_->defragment();
     ltm_->defragment();
 }
 
-void MemoryTierManager::optimizeTiers() override {
+void MemoryTierManager::optimizeTiers() {
     optimizeBlocks();
 }
 
-MemoryTier& MemoryTierManager::getSTM() override {
+MemoryTier& MemoryTierManager::getSTM() {
     return *stm_;
 }
-MemoryTier& MemoryTierManager::getMTM() override {
+MemoryTier& MemoryTierManager::getMTM() {
     return *mtm_;
 }
-MemoryTier& MemoryTierManager::getLTM() override {
+MemoryTier& MemoryTierManager::getLTM() {
     return *ltm_;
 }
 
@@ -202,7 +201,7 @@ sep::SEPResult MemoryTierManager::launch_pattern_processing(pattern::PatternData
                                                             const pattern::PatternConfig& config,
                                                             size_t pattern_count,
                                                             const pattern::PatternData* previous_patterns,
-                                                            void* stream) override {
+                                                            void* stream) {
 #ifdef SEP_USE_CUDA
     cudaStream_t cuda_stream = static_cast<cudaStream_t>(stream);
     cudaError_t err = sep::cuda::launch_pattern_processing(
@@ -222,7 +221,7 @@ sep::SEPResult MemoryTierManager::launch_pattern_processing(pattern::PatternData
 }
 
 void MemoryTierManager::updateBlockMetrics(MemoryBlock* block, float coherence, float stability,
-                                         std::uint32_t generation, float context_score) override {
+                                         std::uint32_t generation, float context_score) {
     if (!block)
         return;
     block->coherence = coherence;
@@ -253,13 +252,13 @@ MemoryTier* MemoryTierManager::determineTier(float coherence, float stability, i
     return stm_.get();
 }
 
-void MemoryTierManager::updateRelationship(std::size_t id_a, std::size_t id_b, uint8_t type) override {
+void MemoryTierManager::updateRelationship(std::size_t id_a, std::size_t id_b, uint8_t type) {
     pattern_relationships_[id_a][id_b] = 1.0;  // Already using double
     pattern_relationships_[id_b][id_a] = 1.0;  // Already using double
     (void)type;  // Prevent unused parameter warning
 }
 
-void MemoryTierManager::removePattern(std::size_t id) override {
+void MemoryTierManager::removePattern(std::size_t id) {
     auto it = pattern_registry_.find(id);
     if (it == pattern_registry_.end())
         return;
@@ -272,7 +271,7 @@ void MemoryTierManager::removePattern(std::size_t id) override {
         r.second.erase(id);
 }
 
-void MemoryTierManager::pruneWeakRelationships() override {
+void MemoryTierManager::pruneWeakRelationships() {
     for (auto& map : pattern_relationships_)
         for (auto it = map.second.begin(); it != map.second.end();)
             if (it->second < config_.demote_threshold)
@@ -281,7 +280,7 @@ void MemoryTierManager::pruneWeakRelationships() override {
                 ++it;
 }
 
-void MemoryTierManager::calculateRelationshipCoherence() override {
+void MemoryTierManager::calculateRelationshipCoherence() {
     for (auto& entry : pattern_relationships_) {
         std::size_t id = entry.first;
         const auto& rels = entry.second;
@@ -299,7 +298,7 @@ void MemoryTierManager::calculateRelationshipCoherence() override {
     }
 }
 
-void MemoryTierManager::loadLTMFromPersistence() override {
+void MemoryTierManager::loadLTMFromPersistence() {
     if (!redis_manager_ || !redis_manager_->isConnected())
         return;
     auto ids = redis_manager_->getPatternIds("ltm");
@@ -328,7 +327,7 @@ void MemoryTierManager::loadLTMFromPersistence() override {
     }
 }
 
-void MemoryTierManager::storeLTMToPersistence(const quantum::Pattern& pattern) override {
+void MemoryTierManager::storeLTMToPersistence(const quantum::Pattern& pattern) {
     if (!redis_manager_ || !redis_manager_->isConnected())
         return;
 
@@ -351,7 +350,7 @@ void MemoryTierManager::storeLTMToPersistence(const quantum::Pattern& pattern) o
     redis_manager_->storePattern(id, data, "ltm");
 }
 
-quantum::Pattern* MemoryTierManager::findPattern(std::size_t id) override {
+quantum::Pattern* MemoryTierManager::findPattern(std::size_t id) {
     auto it = pattern_registry_.find(id);
     if (it == pattern_registry_.end()) {
         return nullptr;
@@ -368,7 +367,7 @@ quantum::Pattern* MemoryTierManager::findPattern(std::size_t id) override {
     return pattern;
 }
 
-const quantum::Pattern* MemoryTierManager::findPattern(std::size_t id) const override {
+const quantum::Pattern* MemoryTierManager::findPattern(std::size_t id) const {
     auto it = pattern_registry_.find(id);
     if (it == pattern_registry_.end()) {
         return nullptr;
@@ -385,7 +384,7 @@ const quantum::Pattern* MemoryTierManager::findPattern(std::size_t id) const ove
     return pattern;
 }
 
-void MemoryTierManager::cleanupExpiredPatterns() override {
+void MemoryTierManager::cleanupExpiredPatterns() {
     std::vector<std::size_t> to_remove;
     for (const auto& p : pattern_registry_) {
         if (p.second->coherence < static_cast<double>(config_.demote_threshold))
@@ -395,7 +394,7 @@ void MemoryTierManager::cleanupExpiredPatterns() override {
         removePattern(id);
 }
 
-void MemoryTierManager::prunePatternsByPriority(sep::memory::TierType tier, size_t max_count) override {
+void MemoryTierManager::prunePatternsByPriority(sep::memory::TierType tier, size_t max_count) {
     MemoryTier* t = getTier(tier);
     if (!t)
         return;
@@ -417,11 +416,11 @@ void MemoryTierManager::prunePatternsByPriority(sep::memory::TierType tier, size
     }
 }
 
-void MemoryTierManager::registerPattern(std::size_t id, const pattern::PatternData& pattern) override {
+void MemoryTierManager::registerPattern(std::size_t id, const pattern::PatternData& pattern) {
     pattern_registry_[id] = std::make_unique<pattern::PatternData>(pattern);
 }
 
-const pattern::PatternData* MemoryTierManager::getPatternData(std::size_t id) const override {
+const pattern::PatternData* MemoryTierManager::getPatternData(std::size_t id) const {
     auto it = pattern_registry_.find(id);
     return it == pattern_registry_.end() ? nullptr : it->second.get();
 }

--- a/src/memory/quantum_coherence_manager.cpp
+++ b/src/memory/quantum_coherence_manager.cpp
@@ -18,120 +18,6 @@
 
 namespace sep::memory {
 
-// Correct and unified definition of QuantumCoherenceManager class and its nested types
-class QuantumCoherenceManager {
-public:
-    struct Config {
-        bool enable_cuda{false};
-        size_t max_patterns{10000};
-        float anomaly_threshold{0.1f};
-    };
-
-    enum class MigrationReason {
-        HighCoherence,
-        HighStability,
-        FrequentAccess,
-        Entanglement,
-        MemoryPressure,
-        LowActivity
-    };
-
-    struct TierMigration {
-        std::string pattern_id;
-        MemoryTierEnum from_tier{MemoryTierEnum::STM};
-        MemoryTierEnum to_tier{MemoryTierEnum::STM};
-        float coherence{0.0f};
-        MigrationReason reason{MigrationReason::LowActivity};
-    };
-
-    enum class AnomalyType { ExcessiveCoherence, InsufficientCoherence, RapidChange };
-
-    struct CoherenceAnomaly {
-        std::string pattern_id;
-        float coherence_value{0.0f};
-        float expected_value{0.0f};
-        float severity{0.0f};
-        AnomalyType type{AnomalyType::RapidChange};
-    };
-
-    struct CoherenceMetrics {
-        float global_coherence{1.0f};
-        float tier_coherence[3]{1.0f,1.0f,1.0f};
-        float tier_fragmentation[3]{0.0f, 0.0f, 0.0f}; // Added missing field
-        uint64_t total_patterns{0};
-        uint64_t coherent_patterns{0};
-        uint64_t fragmented_patterns{0}; // Added missing field
-        float memory_pressure{0.0f};
-        float entanglement_density{0.0f};
-    };
-
-    struct CoherenceSnapshot {
-        uint64_t timestamp{0};
-        CoherenceMetrics global_metrics{};
-        std::vector<PatternCoherenceData> pattern_states;
-        uint32_t tier_distribution[3]{0,0,0};
-    };
-
-    struct EntanglementNode { std::string pattern_id; glm::vec4 position; float coherence{0.0f}; };
-    struct EntanglementEdge { size_t node1_idx{0}; size_t node2_idx{0}; float strength{0.0f}; float phase_correlation{0.0f}; };
-    struct EntanglementGraph {
-        std::vector<EntanglementNode> nodes;
-        std::vector<EntanglementEdge> edges;
-        float total_entanglement{0.0f};
-        uint32_t max_degree{0}; // Added missing field
-        float clustering_coefficient{0.0f}; // Added missing field
-    };
-
-    struct TierAnalysis {
-        float tier_coherence[3]{0.0f,0.0f,0.0f};
-        uint32_t tier_pattern_count[3]{0,0,0};
-        std::array<float,3> optimal_distribution{};
-    };
-
-    struct CoherenceResult {
-        bool success{false};
-        float global_coherence{0.0f};
-        float memory_pressure{0.0f};
-        size_t total_migrations{0};
-        std::vector<CoherenceAnomaly> anomalies;
-        std::vector<TierMigration> tier_migrations;
-        float tier_fragmentation[3]{0.0f, 0.0f, 0.0f}; // Added missing field
-        uint32_t tier_pattern_count[3]{0,0,0}; // Added missing field
-    };
-
-    explicit QuantumCoherenceManager(const Config& config = {});
-    ~QuantumCoherenceManager();
-
-    CoherenceResult updateCoherence(const std::vector<sep::quantum::Pattern>& patterns);
-    std::vector<TierMigration> optimizeMemoryLayout();
-    EntanglementGraph computeEntanglementGraph(const std::vector<sep::quantum::Pattern>& patterns);
-    void applyCoherenceDecay(float decay_factor);
-    CoherenceSnapshot createSnapshot() const;
-    bool restoreFromSnapshot(const CoherenceSnapshot& snapshot);
-
-    // Public accessors for metrics and state
-    const CoherenceMetrics& getMetrics() const;
-    uint64_t getGlobalTick() const;
-    uint32_t getPatternCountByTier(MemoryTierEnum tier) const;
-    float getTierFragmentation(MemoryTierEnum tier) const;
-
-private:
-    // Pattern coherence data struct used internally by Impl
-    struct PatternCoherenceData {
-        std::string pattern_id;
-        float coherence{0.0f};
-        float stability{0.0f};
-        uint32_t access_count{0};
-        uint64_t last_access_tick{0};
-        MemoryTierEnum current_tier{MemoryTierEnum::STM};
-        float fragmentation_score{0.0f}; // Added missing field
-        std::vector<std::string> entangled_patterns;
-    };
-
-    class Impl;
-    std::unique_ptr<Impl> impl_;
-};
-
 namespace {
     // Memory coherence constants from quantum information theory
     constexpr float COHERENCE_DECAY_RATE = 0.02f;
@@ -221,10 +107,11 @@ public:
         auto tier_analysis = analyzeTierCoherence();
         
         // Identify patterns that should migrate
-        coherence_map_.for_each([&](const auto& pair) {
+        for (auto it = coherence_map_.begin(); it != coherence_map_.end(); ++it) {
+            const auto& pair = *it;
             const auto& data = pair.second;
             MemoryTierEnum target_tier = determineOptimalTier(data);
-            
+
             if (target_tier != data.current_tier) {
                 TierMigration migration;
                 migration.pattern_id = data.pattern_id;
@@ -234,7 +121,7 @@ public:
                 migration.reason = determineMigrationReason(data, target_tier);
                 migrations.push_back(migration);
             }
-        });
+        }
         
         // Apply memory pressure optimizations
         if (metrics_.memory_pressure > MEMORY_PRESSURE_FACTOR) {
@@ -286,15 +173,16 @@ public:
     }
     
     void applyCoherenceDecay(float decay_factor) {
-        coherence_map_.for_each([decay_factor](auto& pair) {
+        for (auto it = coherence_map_.begin(); it != coherence_map_.end(); ++it) {
+            auto& pair = *it;
             auto& data = pair.second;
             data.coherence *= (1.0f - decay_factor * COHERENCE_DECAY_RATE);
-            
+
             // Remove patterns below minimum coherence
             if (data.coherence < MIN_COHERENCE_FOR_PERSISTENCE) {
                 data.coherence = 0.0f;
             }
-        });
+        }
         
         // Clean up zero-coherence patterns
         cleanupZeroCoherencePatterns();
@@ -306,9 +194,10 @@ public:
         snapshot.global_metrics = metrics_;
         
         // Capture pattern states
-        coherence_map_.for_each([&snapshot](const auto& pair) {
+        for (auto it = coherence_map_.begin(); it != coherence_map_.end(); ++it) {
+            const auto& pair = *it;
             snapshot.pattern_states.push_back(pair.second);
-        });
+        }
         
         // Capture tier distributions
         snapshot.tier_distribution[0] = countPatternsInTier(MemoryTierEnum::STM);

--- a/src/memory/redis_manager.cpp
+++ b/src/memory/redis_manager.cpp
@@ -1,3 +1,4 @@
+#include "memory/redis_manager.h"
 #include "memory/types.h"
 #include "memory/manager.h" // For logging manager
 


### PR DESCRIPTION
## Summary
- consolidate CUDA includes under `compat/cuda_common.h`
- clean up PipeWire capture implementation and namespace usage
- introduce `IRedisManager` interface
- switch Blender bridge creation to `std::unique_ptr`
- extend `BatchProcessingResult` with `error_code`

## Testing
- `ninja -C build tests/audio` *(fails: no such directory)*

------
https://chatgpt.com/codex/tasks/task_e_6860584ef45c832a99dd0851d92ab06e