### PR TITLE
Refactor CUDA includes and cleanup components

### DIFF
--- a/include/compat/component_bridge.h
+++ b/include/compat/component_bridge.h
@@ -11,10 +11,12 @@ class BlenderBridge;
 namespace blender {
 class CyclesRenderer; // Forward declaration if header not available
 }
+struct SEPBlenderBridge;
 namespace compat {
 
 std::unique_ptr<audio::AudioCapture> createAudioCapture();
-std::shared_ptr<pattern::BlenderBridge> createBlenderBridge();
+std::unique_ptr<audio::AudioCapture> createAudioCaptureStub();
+std::unique_ptr<SEPBlenderBridge> createBlenderBridge();
 std::unique_ptr<blender::CyclesRenderer> createCyclesRenderer();
 
 } // namespace compat

--- a/include/compat/event.h
+++ b/include/compat/event.h
@@ -2,11 +2,9 @@
 #define SEP_CUDA_EVENT_H
 
 #include "compat/macros.h"
+#include "compat/cuda_common.h"
 #if SEP_CUDA_AVAILABLE
-#include <cuda_runtime.h>
 #include "compat/cuda_helpers.h"
-#else
-#include "cuda_impl.h"
 #endif
 #include "core/types.h"
 

--- a/include/compat/memory.h
+++ b/include/compat/memory.h
@@ -8,11 +8,9 @@
 
 // Include CUDA runtime only when CUDA is available
 #include "compat/macros.h"
+#include "compat/cuda_common.h"
 #if SEP_CUDA_AVAILABLE
-#include <cuda_runtime.h>
 #include "compat/cuda_helpers.h"
-#else
-#include "cuda_impl.h"
 #endif
 
 namespace sep {

--- a/include/core/engine.h
+++ b/include/core/engine.h
@@ -25,6 +25,7 @@ class AudioCapture;
 namespace pattern {
 class BlenderBridge;
 }  // namespace pattern
+struct SEPBlenderBridge;
 }  // namespace sep
 
 namespace sep {
@@ -83,7 +84,7 @@ class Engine {
   // Managed components
   std::unique_ptr<::sep::audio::AudioCapture> audio_capture_;
 #if SEP_HAS_BLENDER
-  std::shared_ptr<::sep::pattern::BlenderBridge> blender_bridge_;
+  std::unique_ptr<SEPBlenderBridge> blender_bridge_;
 #endif
 };
 

--- a/include/memory/redis_manager.h
+++ b/include/memory/redis_manager.h
@@ -1,0 +1,22 @@
+#pragma once
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+#include "memory/types.h"
+
+namespace sep::persistence {
+
+class IRedisManager {
+public:
+    virtual ~IRedisManager() = default;
+    virtual void storePattern(std::uint64_t id, const PatternData& data, const std::string& tier) = 0;
+    virtual std::optional<PatternData> loadPattern(std::uint64_t id, const std::string& tier) = 0;
+    virtual std::vector<std::uint64_t> getPatternIds(const std::string& tier) = 0;
+    virtual void removePattern(std::uint64_t id, const std::string& tier) = 0;
+    virtual void bulkStore(const std::vector<std::pair<std::uint64_t, PatternData>>& patterns, const std::string& tier) = 0;
+    virtual std::vector<PatternData> bulkLoad(const std::vector<std::uint64_t>& ids, const std::string& tier) = 0;
+    virtual bool isConnected() const = 0;
+};
+
+} // namespace sep::persistence

--- a/include/memory/types.h
+++ b/include/memory/types.h
@@ -15,6 +15,7 @@
 #include <chrono>
 #include <glm/vec3.hpp>
 #include <vector>
+#include "memory/redis_manager.h"
 
 namespace sep {
 namespace persistence {
@@ -39,7 +40,7 @@ struct PatternData {
     uint64_t dag_node_id = 0;              // DAG node ID for pattern
 };
 
-class RedisManager {
+class RedisManager : public IRedisManager {
 public:
     RedisManager(const std::string& host = "localhost", int port = 6379);
     ~RedisManager();

--- a/include/quantum/types.h
+++ b/include/quantum/types.h
@@ -72,6 +72,7 @@ struct BatchProcessingResult {
     bool success{false};
     std::vector<ProcessingResult> results;
     std::string error_message;
+    int error_code{0};
 };
 
 } // namespace sep::quantum

--- a/src/api/bridge_c.cpp
+++ b/src/api/bridge_c.cpp
@@ -88,6 +88,7 @@ SEP_API int sep_process_context(const char *context_json, const char *layer,
       // Replacing with a dummy success for now, assuming the actual processing logic will be integrated later.
       sep::quantum::BatchProcessingResult process_result;
       process_result.success = true;
+      process_result.error_code = static_cast<int>(sep::api::ErrorCode::Success);
       
       if (!process_result.success) {
         sep::api::bridge::detail::setLastError(process_result.error_message.c_str());

--- a/src/audio/pipewire_capture.cpp
+++ b/src/audio/pipewire_capture.cpp
@@ -4,6 +4,7 @@
 #include "audio/config.h"
 #include "audio/pipewire_includes.h"
 #include "compat/component_bridge.h"
+#include "compat/math_common.h"
 
 
 // Standard library headers
@@ -33,8 +34,6 @@ struct PWInit
 static PWInit pw_init_once;
 
 PipeWireCapture::PipeWireCapture() = default;
-
-namespace PipeWireCapture {
 const struct pw_stream_events createStreamEvents()
 {
     struct pw_stream_events events = {};

--- a/src/compat/component_bridge.cpp
+++ b/src/compat/component_bridge.cpp
@@ -2,6 +2,7 @@
 #include "audio/pipewire_capture.h"
 #include "audio/pipewire_stubs.h"
 #include "blender/bridge.h"
+#include "blender/api.h"
 #include "blender/cycles_renderer.h"
 
 namespace sep {
@@ -19,8 +20,10 @@ std::unique_ptr<audio::AudioCapture> createAudioCapture() {
 std::unique_ptr<audio::AudioCapture> createAudioCaptureStub() { // Fix: Add missing stub definition
     return std::make_unique<audio::PipeWireCaptureStub>();
 }
-std::shared_ptr<pattern::BlenderBridge> createBlenderBridge() {
-    return std::make_shared<pattern::BlenderBridge>();
+std::unique_ptr<SEPBlenderBridge> createBlenderBridge() {
+    auto bridge = std::make_unique<SEPBlenderBridge>();
+    bridge->impl = std::make_shared<pattern::BlenderBridge>();
+    return bridge;
 }
 
 std::unique_ptr<blender::CyclesRenderer> createCyclesRenderer() {

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -2,7 +2,7 @@
 #include "memory/types.h"
 
 #if SEP_CUDA_AVAILABLE
-#include <cuda_runtime.h>
+#include "compat/cuda_common.h"
 #endif
 
 #include "compat/component_bridge.h"
@@ -33,7 +33,7 @@ MemoryTierManager::~MemoryTierManager() {
     shutdown();
 }
 
-void MemoryTierManager::init(const sep::memory::Config& config) override {
+void MemoryTierManager::init(const sep::memory::Config& config) {
     config_ = config;
     MemoryTier::Config scfg{static_cast<TierType>(sep::MemoryTierEnum::STM), config.stm_size};
     MemoryTier::Config mcfg{static_cast<TierType>(sep::MemoryTierEnum::MTM), config.mtm_size};
@@ -43,7 +43,7 @@ void MemoryTierManager::init(const sep::memory::Config& config) override {
     ltm_ = std::make_unique<MemoryTier>(lcfg);
 }
 
-void MemoryTierManager::shutdown() override {
+void MemoryTierManager::shutdown() {
     stm_.reset();
     mtm_.reset();
     ltm_.reset();
@@ -53,7 +53,7 @@ void MemoryTierManager::shutdown() override {
     redis_manager_.reset();
 }
 
-MemoryBlock* MemoryTierManager::allocate(std::size_t size, sep::memory::TierType tier) override {
+MemoryBlock* MemoryTierManager::allocate(std::size_t size, sep::memory::TierType tier) {
     MemoryTier* t = getTier(tier);
     if (!t)
         return nullptr;
@@ -63,7 +63,7 @@ MemoryBlock* MemoryTierManager::allocate(std::size_t size, sep::memory::TierType
     return blk;
 }
 
-void MemoryTierManager::deallocate(MemoryBlock* block) override {
+void MemoryTierManager::deallocate(MemoryBlock* block) {
     if (!block)
         return;
     lookup_map_.erase(block->ptr);
@@ -84,24 +84,24 @@ MemoryTier* MemoryTierManager::getTier(sep::memory::TierType tier) {
     }
 }
 
-double MemoryTierManager::getTierUtilization(sep::memory::TierType tier) const override {
+double MemoryTierManager::getTierUtilization(sep::memory::TierType tier) const {
     const MemoryTier* t = const_cast<MemoryTierManager*>(this)->getTier(tier);
     return t ? t->calculateUtilization() : 0.0;
 }
 
-double MemoryTierManager::getTierFragmentation(sep::memory::TierType tier) const override {
+double MemoryTierManager::getTierFragmentation(sep::memory::TierType tier) const {
     const MemoryTier* t = const_cast<MemoryTierManager*>(this)->getTier(tier);
     return t ? t->calculateFragmentation() : 0.0;
 }
 
-double MemoryTierManager::getTotalUtilization() const override {
+double MemoryTierManager::getTotalUtilization() const {
     double stm_util = getTierUtilization(static_cast<TierType>(MemoryTierEnum::STM));
     double mtm_util = getTierUtilization(static_cast<TierType>(MemoryTierEnum::MTM));
     double ltm_util = getTierUtilization(static_cast<TierType>(MemoryTierEnum::LTM));
     return (stm_util + mtm_util + ltm_util) / 3.0;
 }
 
-double MemoryTierManager::getTotalFragmentation() const override {
+double MemoryTierManager::getTotalFragmentation() const {
     double stm_frag = getTierFragmentation(static_cast<TierType>(MemoryTierEnum::STM));
     double mtm_frag = getTierFragmentation(static_cast<TierType>(MemoryTierEnum::MTM));
     double ltm_frag = getTierFragmentation(static_cast<TierType>(MemoryTierEnum::LTM));
@@ -115,7 +115,7 @@ std::size_t MemoryTierManager::getTotalAllocated() const {
     return used_stm + used_mtm + used_ltm;
 }
 
-void MemoryTierManager::rebuildLookup() override {
+void MemoryTierManager::rebuildLookup() {
     lookup_map_.clear();
 
     auto rebuild = [this](MemoryTier* tier) {
@@ -132,28 +132,28 @@ void MemoryTierManager::rebuildLookup() override {
     rebuild(ltm_.get());
 }
 
-void MemoryTierManager::defragmentTier(sep::memory::TierType tier) override {
+void MemoryTierManager::defragmentTier(sep::memory::TierType tier) {
     if (MemoryTier* t = getTier(tier))
         t->defragment();
 }
 
-void MemoryTierManager::optimizeBlocks() override {
+void MemoryTierManager::optimizeBlocks() {
     stm_->defragment();
     mtm_->defragment();
     ltm_->defragment();
 }
 
-void MemoryTierManager::optimizeTiers() override {
+void MemoryTierManager::optimizeTiers() {
     optimizeBlocks();
 }
 
-MemoryTier& MemoryTierManager::getSTM() override {
+MemoryTier& MemoryTierManager::getSTM() {
     return *stm_;
 }
-MemoryTier& MemoryTierManager::getMTM() override {
+MemoryTier& MemoryTierManager::getMTM() {
     return *mtm_;
 }
-MemoryTier& MemoryTierManager::getLTM() override {
+MemoryTier& MemoryTierManager::getLTM() {
     return *ltm_;
 }
 
@@ -202,7 +202,7 @@ sep::SEPResult MemoryTierManager::launch_pattern_processing(pattern::PatternData
                                                             const pattern::PatternConfig& config,
                                                             size_t pattern_count,
                                                             const pattern::PatternData* previous_patterns,
-                                                            void* stream) override {
+                                                            void* stream) {
 #ifdef SEP_USE_CUDA
     cudaStream_t cuda_stream = static_cast<cudaStream_t>(stream);
     cudaError_t err = sep::cuda::launch_pattern_processing(
@@ -222,7 +222,7 @@ sep::SEPResult MemoryTierManager::launch_pattern_processing(pattern::PatternData
 }
 
 void MemoryTierManager::updateBlockMetrics(MemoryBlock* block, float coherence, float stability,
-                                         std::uint32_t generation, float context_score) override {
+                                         std::uint32_t generation, float context_score) {
     if (!block)
         return;
     block->coherence = coherence;
@@ -253,13 +253,13 @@ MemoryTier* MemoryTierManager::determineTier(float coherence, float stability, i
     return stm_.get();
 }
 
-void MemoryTierManager::updateRelationship(std::size_t id_a, std::size_t id_b, uint8_t type) override {
+void MemoryTierManager::updateRelationship(std::size_t id_a, std::size_t id_b, uint8_t type) {
     pattern_relationships_[id_a][id_b] = 1.0;  // Already using double
     pattern_relationships_[id_b][id_a] = 1.0;  // Already using double
     (void)type;  // Prevent unused parameter warning
 }
 
-void MemoryTierManager::removePattern(std::size_t id) override {
+void MemoryTierManager::removePattern(std::size_t id) {
     auto it = pattern_registry_.find(id);
     if (it == pattern_registry_.end())
         return;
@@ -272,7 +272,7 @@ void MemoryTierManager::removePattern(std::size_t id) override {
         r.second.erase(id);
 }
 
-void MemoryTierManager::pruneWeakRelationships() override {
+void MemoryTierManager::pruneWeakRelationships() {
     for (auto& map : pattern_relationships_)
         for (auto it = map.second.begin(); it != map.second.end();)
             if (it->second < config_.demote_threshold)
@@ -281,7 +281,7 @@ void MemoryTierManager::pruneWeakRelationships() override {
                 ++it;
 }
 
-void MemoryTierManager::calculateRelationshipCoherence() override {
+void MemoryTierManager::calculateRelationshipCoherence() {
     for (auto& entry : pattern_relationships_) {
         std::size_t id = entry.first;
         const auto& rels = entry.second;
@@ -299,7 +299,7 @@ void MemoryTierManager::calculateRelationshipCoherence() override {
     }
 }
 
-void MemoryTierManager::loadLTMFromPersistence() override {
+void MemoryTierManager::loadLTMFromPersistence() {
     if (!redis_manager_ || !redis_manager_->isConnected())
         return;
     auto ids = redis_manager_->getPatternIds("ltm");
@@ -328,7 +328,7 @@ void MemoryTierManager::loadLTMFromPersistence() override {
     }
 }
 
-void MemoryTierManager::storeLTMToPersistence(const quantum::Pattern& pattern) override {
+void MemoryTierManager::storeLTMToPersistence(const quantum::Pattern& pattern) {
     if (!redis_manager_ || !redis_manager_->isConnected())
         return;
 
@@ -351,7 +351,7 @@ void MemoryTierManager::storeLTMToPersistence(const quantum::Pattern& pattern) o
     redis_manager_->storePattern(id, data, "ltm");
 }
 
-quantum::Pattern* MemoryTierManager::findPattern(std::size_t id) override {
+quantum::Pattern* MemoryTierManager::findPattern(std::size_t id) {
     auto it = pattern_registry_.find(id);
     if (it == pattern_registry_.end()) {
         return nullptr;
@@ -368,7 +368,7 @@ quantum::Pattern* MemoryTierManager::findPattern(std::size_t id) override {
     return pattern;
 }
 
-const quantum::Pattern* MemoryTierManager::findPattern(std::size_t id) const override {
+const quantum::Pattern* MemoryTierManager::findPattern(std::size_t id) const {
     auto it = pattern_registry_.find(id);
     if (it == pattern_registry_.end()) {
         return nullptr;
@@ -385,7 +385,7 @@ const quantum::Pattern* MemoryTierManager::findPattern(std::size_t id) const ove
     return pattern;
 }
 
-void MemoryTierManager::cleanupExpiredPatterns() override {
+void MemoryTierManager::cleanupExpiredPatterns() {
     std::vector<std::size_t> to_remove;
     for (const auto& p : pattern_registry_) {
         if (p.second->coherence < static_cast<double>(config_.demote_threshold))
@@ -395,7 +395,7 @@ void MemoryTierManager::cleanupExpiredPatterns() override {
         removePattern(id);
 }
 
-void MemoryTierManager::prunePatternsByPriority(sep::memory::TierType tier, size_t max_count) override {
+void MemoryTierManager::prunePatternsByPriority(sep::memory::TierType tier, size_t max_count) {
     MemoryTier* t = getTier(tier);
     if (!t)
         return;
@@ -417,11 +417,11 @@ void MemoryTierManager::prunePatternsByPriority(sep::memory::TierType tier, size
     }
 }
 
-void MemoryTierManager::registerPattern(std::size_t id, const pattern::PatternData& pattern) override {
+void MemoryTierManager::registerPattern(std::size_t id, const pattern::PatternData& pattern) {
     pattern_registry_[id] = std::make_unique<pattern::PatternData>(pattern);
 }
 
-const pattern::PatternData* MemoryTierManager::getPatternData(std::size_t id) const override {
+const pattern::PatternData* MemoryTierManager::getPatternData(std::size_t id) const {
     auto it = pattern_registry_.find(id);
     return it == pattern_registry_.end() ? nullptr : it->second.get();
 }

--- a/src/memory/quantum_coherence_manager.cpp
+++ b/src/memory/quantum_coherence_manager.cpp
@@ -221,7 +221,8 @@ public:
         auto tier_analysis = analyzeTierCoherence();
         
         // Identify patterns that should migrate
-        coherence_map_.for_each([&](const auto& pair) {
+        for (auto it = coherence_map_.begin(); it != coherence_map_.end(); ++it) {
+            const auto& pair = *it;
             const auto& data = pair.second;
             MemoryTierEnum target_tier = determineOptimalTier(data);
             
@@ -234,7 +235,7 @@ public:
                 migration.reason = determineMigrationReason(data, target_tier);
                 migrations.push_back(migration);
             }
-        });
+        }
         
         // Apply memory pressure optimizations
         if (metrics_.memory_pressure > MEMORY_PRESSURE_FACTOR) {
@@ -286,15 +287,16 @@ public:
     }
     
     void applyCoherenceDecay(float decay_factor) {
-        coherence_map_.for_each([decay_factor](auto& pair) {
+        for (auto it = coherence_map_.begin(); it != coherence_map_.end(); ++it) {
+            auto& pair = *it;
             auto& data = pair.second;
             data.coherence *= (1.0f - decay_factor * COHERENCE_DECAY_RATE);
-            
+
             // Remove patterns below minimum coherence
             if (data.coherence < MIN_COHERENCE_FOR_PERSISTENCE) {
                 data.coherence = 0.0f;
             }
-        });
+        }
         
         // Clean up zero-coherence patterns
         cleanupZeroCoherencePatterns();
@@ -306,9 +308,10 @@ public:
         snapshot.global_metrics = metrics_;
         
         // Capture pattern states
-        coherence_map_.for_each([&snapshot](const auto& pair) {
+        for (auto it = coherence_map_.begin(); it != coherence_map_.end(); ++it) {
+            const auto& pair = *it;
             snapshot.pattern_states.push_back(pair.second);
-        });
+        }
         
         // Capture tier distributions
         snapshot.tier_distribution[0] = countPatternsInTier(MemoryTierEnum::STM);
@@ -443,7 +446,8 @@ private:
         float tier_frag_sums[3] = {0.0f, 0.0f, 0.0f};
         uint32_t tier_counts[3] = {0, 0, 0};
         
-        coherence_map_.for_each([&](const auto& pair) {
+        for (auto it = coherence_map_.begin(); it != coherence_map_.end(); ++it) {
+            const auto& pair = *it;
             const auto& data = pair.second;
             total_coherence += data.coherence;
             pattern_count++;
@@ -456,7 +460,7 @@ private:
             tier_sums[tier_idx] += data.coherence;
             tier_frag_sums[tier_idx] += data.fragmentation_score;
             tier_counts[tier_idx]++;
-        });
+        }
         
         // Update metrics
         metrics_.global_coherence = (pattern_count > 0) ? 
@@ -478,15 +482,17 @@ private:
         
         // Compute entanglement density
         uint32_t total_entanglements = 0;
-        coherence_map_.for_each([&](const auto& pair) {
+        for (auto it = coherence_map_.begin(); it != coherence_map_.end(); ++it) {
+            const auto& pair = *it;
             total_entanglements += pair.second.entangled_patterns.size();
-        });
+        }
 
         // Compute fragmented patterns (example: fragmentation score > 0.5)
         uint64_t fragmented_count = 0;
-        coherence_map_.for_each([&](const auto& pair) {
+        for (auto it = coherence_map_.begin(); it != coherence_map_.end(); ++it) {
+            const auto& pair = *it;
             if (pair.second.fragmentation_score > 0.5f) fragmented_count++;
-        });
+        }
         metrics_.fragmented_patterns = fragmented_count;
 
         metrics_.entanglement_density = (pattern_count > 1) ?
@@ -548,7 +554,8 @@ private:
     std::vector<TierMigration> performTierMigrations() {
         std::vector<TierMigration> migrations;
         
-        coherence_map_.for_each([&](auto& pair) {
+        for (auto it = coherence_map_.begin(); it != coherence_map_.end(); ++it) {
+            auto& pair = *it;
             auto& data = pair.second;
             MemoryTierEnum current_tier = data.current_tier;
             MemoryTierEnum target_tier = determineOptimalTier(data);
@@ -569,16 +576,17 @@ private:
                     data.current_tier = target_tier;
                 }
             }
-        });
+        }
         
         return migrations;
     }
     
     void updateEntanglementGraph(const std::vector<sep::quantum::Pattern>& patterns) {
         // Clear existing entanglements
-        coherence_map_.for_each([](auto& pair) {
+        for (auto it = coherence_map_.begin(); it != coherence_map_.end(); ++it) {
+            auto& pair = *it;
             pair.second.entangled_patterns.clear();
-        });
+        }
         
         // Compute new entanglements
         for (size_t i = 0; i < patterns.size(); ++i) {
@@ -651,12 +659,13 @@ private:
         // Sort by coherence ascending for demotion candidates
         std::vector<std::pair<std::string, float>> demotion_candidates;
         
-        coherence_map_.for_each([&](const auto& pair) {
+        for (auto it = coherence_map_.begin(); it != coherence_map_.end(); ++it) {
+            const auto& pair = *it;
             if (pair.second.current_tier == MemoryTierEnum::LTM &&
                 pair.second.coherence < LTM_COHERENCE_THRESHOLD) {
                 demotion_candidates.push_back({pair.first, pair.second.coherence});
             }
-        });
+        }
         
         std::sort(demotion_candidates.begin(), demotion_candidates.end(),
                  [](const auto& a, const auto& b) { return a.second < b.second; });
@@ -679,11 +688,12 @@ private:
     void cleanupZeroCoherencePatterns() {
         std::vector<std::string> to_remove;
         
-        coherence_map_.for_each([&](const auto& pair) {
+        for (auto it = coherence_map_.begin(); it != coherence_map_.end(); ++it) {
+            const auto& pair = *it;
             if (pair.second.coherence <= 0.0f) {
                 to_remove.push_back(pair.first);
             }
-        });
+        }
         
         for (const auto& id : to_remove) {
             coherence_map_.erase(id);
@@ -695,11 +705,12 @@ private:
         float variance = 0.0f;
         uint64_t count = 0;
         
-        coherence_map_.for_each([&](const auto& pair) {
+        for (auto it = coherence_map_.begin(); it != coherence_map_.end(); ++it) {
+            const auto& pair = *it;
             float diff = pair.second.coherence - mean;
             variance += diff * diff;
             count++;
-        });
+        }
         
         return (count > 0) ? variance / count : 0.0f;
     }

--- a/src/memory/redis_manager.cpp
+++ b/src/memory/redis_manager.cpp
@@ -1,4 +1,5 @@
 #include "memory/types.h"
+#include "memory/redis_manager.h"
 #include "memory/manager.h" // For logging manager
 
 // Define namespace alias to clarify that Manager is in the logging namespace

--- a/src/quantum/evolution.cpp
+++ b/src/quantum/evolution.cpp
@@ -20,7 +20,7 @@ namespace sep::quantum {
 class EvolutionEngine::EvolutionEngineImpl {
 public:
     explicit EvolutionEngineImpl(Processor* processor)
-        : processor_(processor), generation_number_(0), noise_state_(0) {
+        : processor_(processor), generation_number_(0), noise_state_(0), current_stats_() {
         if (!processor) {
             throw std::invalid_argument("Processor cannot be null");
         }
@@ -104,13 +104,13 @@ public:
         child_state.entropy = glm::mix(state1.entropy, state2.entropy, alpha);
         child_state.mutation_rate = glm::mix(state1.mutation_rate, state2.mutation_rate, alpha);
 
-        child.position = glm::mix(parent1.position, parent2.position, alpha);
+        child.position = parent1.position * (1.0f - alpha) + parent2.position * alpha;
 
         if (!parent1.data.empty() && !parent2.data.empty()) {
             size_t size = std::min(parent1.data.size(), parent2.data.size());
             child.data.resize(size);
             for (size_t i = 0; i < size; ++i) { // Fix: Iterate up to size
-                child.data[i] = glm::mix(parent1.data[i], parent2.data[i], alpha);
+                child.data[i] = parent1.data[i] * (1.0f - alpha) + parent2.data[i] * alpha;
             }
         }
 
@@ -356,7 +356,7 @@ Pattern blendCrossover(const Pattern& parent1, const Pattern& parent2, float alp
     child_state.phase = glm::mix(state1.phase, state2.phase, alpha); // Add phase crossover
     child_state.stability = glm::mix(state1.stability, state2.stability, alpha);
     child_state.entropy = glm::mix(state1.entropy, state2.entropy, alpha);
-    child.position = glm::mix(parent1.position, parent2.position, alpha);
+    child.position = parent1.position * (1.0f - alpha) + parent2.position * alpha;
     return child;
 }
 


### PR DESCRIPTION
## Summary
- route CUDA headers through `cuda_common.h`
- expose `error_code` in `BatchProcessingResult`
- tidy PipeWire capture implementation
- provide minimal Redis manager interface
- convert internal loops from for_each helper
- minor fixes for engine and component bridge

## Testing
- `cmake -S . -B build -DBUILD_TESTING=ON` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6860584ef45c832a99dd0851d92ab06e