### PR TITLE
Fix MemoryTier namespace

### DIFF
--- a/src/memory/memory_tier.cpp
+++ b/src/memory/memory_tier.cpp
@@ -25,8 +25,9 @@
 #include "memory/manager.h"
 #include "memory/memory_tier_manager.hpp"
 #include "core/allocation_metrics.h"
+#include "memory/types.h"
 
-namespace sep::memory::cuda {
+namespace sep::memory {
 
 using namespace sep::cuda;
 


### PR DESCRIPTION
## Summary
- ensure MemoryTier methods reside in `sep::memory`
- include missing `memory/types.h`

## Testing
- `./tests/blender/run_all_tests.sh` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_68606add3ac4832ab80068f720d2a2ef