### PR TITLE
Fix memory tier manager prototypes and includes

### DIFF
--- a/include/memory/memory_tier_manager.hpp
+++ b/include/memory/memory_tier_manager.hpp
@@ -122,6 +122,8 @@ public:
     void storeLTMToPersistence(const quantum::Pattern& pattern);
     quantum::Pattern* findPattern(std::size_t id);
     const quantum::Pattern* findPattern(std::size_t id) const;
+    void registerPattern(std::size_t id, const pattern::PatternData& pattern);
+    const pattern::PatternData* getPatternData(std::size_t id) const;
     void cleanupExpiredPatterns();
     void prunePatternsByPriority(TierType tier, size_t max_count);
 

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -7,6 +7,7 @@
 #include "compat/cuda_helpers.h"
 #include "memory/logger.hpp"
 #include "memory/redis_manager.h"
+#include "quantum/types.h"
 #include "quantum/pattern_evolution_bridge.h"
 #include "quantum/data.hpp"
 


### PR DESCRIPTION
## Summary
- include `quantum/types.h` for Pattern and MemoryTierEnum definitions
- declare registerPattern and getPatternData in the MemoryTierManager header

## Testing
- `git commit -m "fix memory tier manager interfaces"`

------
https://chatgpt.com/codex/tasks/task_e_68606adda0c8832aade3392d98fda557