### PR TITLE
Fix namespace definitions and missing include

### DIFF
--- a/include/blender/types.h
+++ b/include/blender/types.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "core/common.h"
+#include "blender/config.h"
 #include <memory>
 
 // Forward declaration for MemoryTierEnum from sep::math_common.h

--- a/src/core/manager.cpp
+++ b/src/core/manager.cpp
@@ -7,7 +7,6 @@
 
 namespace sep::config {
 
-namespace {
 using namespace env_keys;
 
 class ConfigManager::Impl {
@@ -133,7 +132,6 @@ public:
 
   SystemConfig config;
 };
-} // anonymous namespace
 
 ConfigManager::ConfigManager() : impl_(std::make_unique<Impl>()) {}
 ConfigManager::~ConfigManager() {}

--- a/src/memory/memory_tier.cpp
+++ b/src/memory/memory_tier.cpp
@@ -26,7 +26,7 @@
 #include "memory/memory_tier_manager.hpp"
 #include "core/allocation_metrics.h"
 
-namespace sep::memory::cuda {
+namespace sep::memory {
 
 using namespace sep::cuda;
 


### PR DESCRIPTION
## Summary
- include config in blender types
- align ConfigManager::Impl with namespace
- start memory tier implementation in correct namespace

## Testing
- `g++ -std=c++17 -Iinclude -c src/core/manager.cpp`
- `g++ -std=c++17 -Iinclude src/memory/memory_tier.cpp -c -o /tmp/mt.o` *(fails: ‘config’ in namespace ‘sep::sep’ does not name a type)*

------
https://chatgpt.com/codex/tasks/task_e_68606ae8273c832aa1e3d9980166c866