### PR TITLE
Add missing includes and helper declaration

### DIFF
--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -1,5 +1,7 @@
 #include "memory/memory_tier_manager.hpp"
 #include "memory/types.h"
+#include "quantum/types.h"        // For MemoryTierEnum definition
+#include "quantum/pattern.h"      // For QuantumPattern definition
 
 #include "compat/cuda_common.h"
 

--- a/src/quantum/quantum_manifold_optimizer.cpp
+++ b/src/quantum/quantum_manifold_optimizer.cpp
@@ -193,6 +193,9 @@ private:
     std::vector<ManifoldPoint> manifold_points_;
     glm::mat4 riemannian_metric_;
     std::unique_ptr<QuantumProcessorQFH> qfh_processor_;
+
+    // Forward declaration for helper
+    float computeResonanceFromCurvature(float curvature) const;
     
     void initializeManifold() {
         // Initialize manifold with quantum-inspired geometry


### PR DESCRIPTION
## Summary
- include `quantum/types.h` and `quantum/pattern.h` where MemoryTierEnum and QuantumPattern are used
- forward declare `computeResonanceFromCurvature` helper in `QuantumManifoldOptimizer::Impl`

## Testing
- `g++ -c /tmp/test.cpp`

------
https://chatgpt.com/codex/tasks/task_e_68606ae44490832a99f51eae63f0c9bd