### PR TITLE
Fix mismatched return type and add missing include

### DIFF
--- a/include/quantum/quantum_processor_qfh.h
+++ b/include/quantum/quantum_processor_qfh.h
@@ -61,7 +61,7 @@ public:
 
     const QFHResult& getLastQFHResult() const;
 
-    ::sep::MemoryTierEnum determineMemoryTier(float coherence, float stability, uint32_t generation_count) const;
+    sep::MemoryTierEnum determineMemoryTier(float coherence, float stability, uint32_t generation_count) const;
 };
 
 }  // namespace sep::quantum

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -9,6 +9,7 @@
 #include "memory/redis_manager.h"
 #include "quantum/pattern_evolution_bridge.h"
 #include "quantum/data.hpp"
+#include "quantum/types.h"
 
 
 namespace sep::memory {


### PR DESCRIPTION
## Summary
- match `determineMemoryTier` return type with header
- include `quantum/types.h` for `RelationshipType`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68606ae332cc832aa4c2fdda76284747