### PR TITLE
Fix MetricsCollector namespace and fields

### DIFF
--- a/src/core/metrics_collector.cpp
+++ b/src/core/metrics_collector.cpp
@@ -1,6 +1,9 @@
 #include "core/metrics_collector.h"
 #include "compat/cuda_common.h"
 #include "compat/cuda_helpers.h"
+#if SEP_CUDA_AVAILABLE
+#include <cuda_runtime_api.h>
+#endif
 
 #include <sys/resource.h>
 #include <sys/sysinfo.h>
@@ -23,6 +26,7 @@
 using namespace sep::shim::chrono_literals;
 using namespace sep::cuda;
 
+namespace sep::metrics {
 
 class MetricsCollector::Impl {
  public:
@@ -357,4 +361,6 @@ void MetricsCollector::resetOperation(const std::string& operation_name) {
     sep::shim::string key(operation_name.c_str());
     performance_metrics_.erase(key);
 }
+
+}  // namespace sep::metrics
 


### PR DESCRIPTION
## Summary
- wrap MetricsCollector implementation in `sep::metrics`
- conditionally include CUDA headers

## Testing
- `g++ -std=c++17 -c src/core/metrics_collector.cpp -Iinclude -DSEP_CUDA_AVAILABLE=0 -fPIC -o /tmp/m.o` *(fails: call of overloaded `cudaMemGetInfo` is ambiguous)*
- `npm test` *(fails: `turbo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68606ae23d20832ab7f2dd35e774e240