### PR TITLE
Fix setupSepApiRoutes capture and include APIConfig

### DIFF
--- a/src/api/crow_adapter.cpp
+++ b/src/api/crow_adapter.cpp
@@ -20,6 +20,7 @@
 #include "api/types.h"
 #include "api/sep_engine.h"
 #include "api/server.h" // Include server header
+#include "core/types.h"  // For sep::config::APIConfig
 #include "memory/memory_tier_manager.hpp"
 
 // Include standard headers
@@ -80,10 +81,10 @@ std::unique_ptr<HttpRequest> makeRequest(::crow::request &req) {
  *
  * @param app The Crow application instance
  */
-void setupSepApiRoutes(::crow::crow<>* app)
+void setupSepApiRoutes(::crow::Crow<>* app)
 {
     // Get singleton engine instance and initialize
-    auto&                  engine = sep::api::SepEngine::getInstance();
+    auto& engine = SepEngine::getInstance();
     sep::config::APIConfig config{};
     engine.initialize(config);
 


### PR DESCRIPTION
## Summary
- include `core/types.h` for `APIConfig`
- fix function signature and singleton access in `setupSepApiRoutes`

## Testing
- `cmake -B build -S . -DSEP_BUILD_TESTS=ON` *(fails: Could not find nvcc)*
- `npm run lint` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68606adfb6d0832aace0f61642f9aeac