### PR TITLE
Fix API server start conflict and health metrics

### DIFF
--- a/include/api/ollama_client.h
+++ b/include/api/ollama_client.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "api/client.h"
+#include "api/ollama_types.h"
+

--- a/src/api/sep_engine.cpp
+++ b/src/api/sep_engine.cpp
@@ -400,25 +400,19 @@ nlohmann::json SepEngine::getHealthStatus()
         return result;
     }
     auto now    = std::chrono::steady_clock::now();
-    auto uptime = std::chrono::duration_cast<std::chrono::seconds>(now - getMetrics(startTime).count());
-    
-        json metrics_json;
-        metrics_json["total_requests"]        = getMetrics(totalRequests.load);
-        metrics_json["successful_requests"]   = getMetrics(successfulRequests.load);
-        metrics_json["failed_requests"]       = getMetrics(failedRequests.load);
-        metrics_json["timeout_requests"]      = getMetrics(timeoutRequests.load);
-        metrics_json["rate_limited_requests"] = getMetrics(rateLimitedCount.load);
-        metrics_json["average_response_time"] = getMetrics(averageResponseTime.load);
-        metrics_json["last_response_time"]    = getMetrics(lastResponseTime.count);
-        metrics_json["last_error_code"]       = getMetrics(ErrorCode);
+    auto uptime = std::chrono::duration_cast<std::chrono::seconds>(
+        now - impl_->health_metrics.startTime)
+                       .count();
 
-        json result;
-        result["success"]        = true;
-        result["status"]         = "healthy";
-        result["uptime_seconds"] = uptime;
-        result["initialized"]    = impl_->initialized;
-        result["metrics"]        = metrics_json;
-        return result;
+    auto metrics_json = getMetrics(impl_->health_metrics);
+
+    json result;
+    result["success"]        = true;
+    result["status"]         = "healthy";
+    result["uptime_seconds"] = uptime;
+    result["initialized"]    = impl_->initialized;
+    result["metrics"]        = metrics_json;
+    return result;
 }
 
 nlohmann::json SepEngine::getMemoryMetrics()

--- a/src/api/server.cpp
+++ b/src/api/server.cpp
@@ -4,7 +4,7 @@
 #include "api/crow_request.h"
 #include "api/json_helpers.h"
 #include "api/types.h"
-#include "api/client.h"
+#include "api/ollama_client.h"
 #include "api/rate_limit_middleware.h"
 #include "api/request_interface.h"
 #include "api/sep_engine.h"
@@ -77,16 +77,6 @@ bool SEPApiServer::run() {
   // Ensure routes are registered just before starting
   setup_routes();
   return start();
-}
-
-void SEPApiServer::start() {
-    if (!app_) return;
-
-    app_->port(config_.port);
-    app_->multithreaded();
-
-    setup_middleware();
-    setup_routes();
 }
 
 


### PR DESCRIPTION
## Summary
- add missing `include/api/ollama_client.h`
- remove redundant `void SEPApiServer::start()` definition
- correct health metric handling in `SepEngine::getHealthStatus`

## Testing
- `cmake .. -DSEP_BUILD_TESTS=ON` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_68606ae0709c832a9299f1a1576719b0