### PR TITLE
Fix ConfigManager Impl namespace

### DIFF
--- a/src/core/manager.cpp
+++ b/src/core/manager.cpp
@@ -7,7 +7,6 @@
 
 namespace sep::config {
 
-namespace {
 using namespace env_keys;
 
 class ConfigManager::Impl {
@@ -133,7 +132,6 @@ public:
 
   SystemConfig config;
 };
-} // anonymous namespace
 
 ConfigManager::ConfigManager() : impl_(std::make_unique<Impl>()) {}
 ConfigManager::~ConfigManager() {}


### PR DESCRIPTION
## Summary
- move `ConfigManager::Impl` definition into `sep::config`
- confirm compilation of `src/core/manager.cpp`

## Testing
- `g++ -std=c++17 -Iinclude src/core/manager.cpp -c -o /tmp/manager.o`

------
https://chatgpt.com/codex/tasks/task_e_68606adf3940832a8e82f8e562c8fc03