### PR TITLE
Apply build advice

### DIFF
--- a/include/compat/cuda_helpers.h
+++ b/include/compat/cuda_helpers.h
@@ -6,6 +6,13 @@
 #include "compat/cuda_helpers.h"
 #else
 #include "compat/cuda_impl.h"
+// Provide minimal definitions when CUDA is unavailable
+#ifndef cudaSuccess
+constexpr cudaError_t cudaSuccess = 0;
+#endif
+#ifndef cudaGetErrorString
+inline const char* cudaGetErrorString(cudaError_t) { return "CUDA not available"; }
+#endif
 #endif
 
 #include <cstdio>

--- a/include/compat/cuda_impl.h
+++ b/include/compat/cuda_impl.h
@@ -232,3 +232,5 @@ inline cudaError_t cudaMemcpyAsync(void* dst, const void* src, size_t count, cud
 }
 
 #endif // !SEP_CUDA_AVAILABLE
+
+#endif // SEP_CUDA_IMPL_H

--- a/include/memory/quantum_coherence_manager.h
+++ b/include/memory/quantum_coherence_manager.h
@@ -95,6 +95,8 @@ class QuantumCoherenceManager {
         float global_coherence{0.f};
         float memory_pressure{0.f};
         std::size_t total_migrations{0};
+        float tier_fragmentation[3]{0.f, 0.f, 0.f};
+        std::uint32_t tier_pattern_count[3]{0, 0, 0};
         std::vector<CoherenceAnomaly> anomalies;
         std::vector<TierMigration> tier_migrations;
     };

--- a/include/quantum/types.h
+++ b/include/quantum/types.h
@@ -28,6 +28,9 @@ struct QuantumState {
     float stability;
     float entropy;
     float phase{0.0f};
+    float evolution_rate{0.0f};
+    float energy{0.0f};
+    float coupling_strength{0.0f};
     float mutation_rate;
     int generation;
     int mutation_count;

--- a/src/core/metrics_collector.cpp
+++ b/src/core/metrics_collector.cpp
@@ -235,7 +235,6 @@ class MetricsCollector::Impl {
 };
 
 // MetricsCollector implementation
-MetricsCollector::MetricsCollector() : pImpl(std::make_unique<Impl>()) {}
 
 MetricsCollector& MetricsCollector::instance() {
     // Use a function-local static variable for thread-safe singleton initialization


### PR DESCRIPTION
## Summary
- guard cuda helpers for CPU-only builds
- close header guard in cuda_impl.h
- extend quantum coherence and state data structs
- drop redundant MetricsCollector constructor

## Testing
- `npm test` *(fails: `turbo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860877f4a0c832ab6afd93e48684956