### PR TITLE
Implement fixes from build advice

### DIFF
--- a/include/compat/memory.h
+++ b/include/compat/memory.h
@@ -109,7 +109,7 @@ void freeUnifiedMemory(void* ptr);
 template <typename T>
 bool copyToDevice(T* dst, const T* src, size_t count, Stream* stream  = nullptr) {
 #if SEP_CUDA_AVAILABLE
-    cudaError_t error = cudaMemcpyAsync(dst, src, count * sizeof(T), cudaMemcpyHostToDevice, nullptr);
+    cudaError_t error = ::sep::cuda::cudaMemcpyAsync(dst, src, count * sizeof(T), cudaMemcpyHostToDevice, nullptr);
     return error == cudaSuccess;
 #else
     (void)stream;
@@ -121,7 +121,7 @@ bool copyToDevice(T* dst, const T* src, size_t count, Stream* stream  = nullptr)
 template <typename T>
 bool copyToHost(T* dst, const T* src, size_t count, Stream* stream  = nullptr) {
 #if SEP_CUDA_AVAILABLE
-    cudaError_t error = cudaMemcpyAsync(dst, src, count * sizeof(T), cudaMemcpyDeviceToHost, nullptr);
+    cudaError_t error = ::sep::cuda::cudaMemcpyAsync(dst, src, count * sizeof(T), cudaMemcpyDeviceToHost, nullptr);
     return error == cudaSuccess;
 #else
     (void)stream;

--- a/include/quantum/data.hpp
+++ b/include/quantum/data.hpp
@@ -2,6 +2,7 @@
 
 #include "compat/shim.h"
 #include "quantum/types.h"
+#include "memory/types.h"
 #include <glm/glm.hpp>
 #include <vector>
 

--- a/include/quantum/processor.h
+++ b/include/quantum/processor.h
@@ -8,6 +8,7 @@
 // Removed duplicate include of core/types.h
 #include "quantum/gpu_context.h"
 #include "quantum/data.hpp"
+#include "memory/types.h"
 #include <memory>
 #include <vector>
 #include <string>

--- a/include/quantum/quantum_manifold_optimizer.h
+++ b/include/quantum/quantum_manifold_optimizer.h
@@ -26,9 +26,9 @@ using ::sep::quantum::QuantumState;
 using QuantumPattern = ::sep::quantum::Pattern;
 using ::sep::quantum::QFHResult;
 using ::sep::quantum::QuantumProcessorQFH;
-using ::sep::CUDAConfig;
-using ::sep::APIConfig;
-using ::sep::LogConfig;
+using ::sep::config::CUDAConfig;
+using ::sep::config::APIConfig;
+using ::sep::config::LogConfig;
 
 class QuantumManifoldOptimizer {
 public:

--- a/include/quantum/types.h
+++ b/include/quantum/types.h
@@ -5,7 +5,7 @@
 #include <vector>
 #include <string>
 
-
+#include "memory/types.h"
 
 namespace sep::quantum {
 

--- a/src/core/engine.cpp
+++ b/src/core/engine.cpp
@@ -2,6 +2,7 @@
 
 #include "audio/capture.h"
 #include "blender/pattern_bridge.h"
+#include "blender/types.h"
 #include "memory/memory_tier_manager.hpp"
 #include "compat/component_bridge.h"
 

--- a/src/memory/quantum_coherence_manager.cpp
+++ b/src/memory/quantum_coherence_manager.cpp
@@ -5,6 +5,7 @@
 #include "quantum/quantum_manifold_optimizer.h"
 #include "memory/memory_tier_manager.hpp"
 #include "quantum/quantum_processor_qfh.h"
+#include "memory/types.h"
 #include <tbb/parallel_for.h>
 #include <tbb/concurrent_hash_map.h>
 #include <algorithm>

--- a/src/quantum/pattern_processor.cpp
+++ b/src/quantum/pattern_processor.cpp
@@ -1,6 +1,7 @@
 #include "quantum/pattern_processor.h"
 #include "quantum/quantum_processor.h"
 #include "quantum/types.h"
+#include "memory/types.h"
 
 #include <glm/vec3.hpp>
 


### PR DESCRIPTION
## Summary
- include `memory/types.h` where `MemoryTierEnum` is used
- include `blender/types.h` when constructing `SEPBlenderBridge`
- prefix CUDA async copies with `sep::cuda` namespace
- use `sep::config` types in quantum manifold optimizer

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6860a8052190832aa107b39193c17d71