### PR TITLE
Fix compile guidance from build.advice

### DIFF
--- a/include/blender/api.h
+++ b/include/blender/api.h
@@ -50,7 +50,7 @@ sep::SEPResult sep_process_audio(
 // Synchronize SEP memory tiers with Blender
 sep::SEPResult sep_sync_memory(
     SEPBlenderBridge* bridge,      // [in] Bridge instance
-    sep::MemoryTierEnum tier,      // [in] Target memory tier
+    ::sep::memory::MemoryTierEnum tier,      // [in] Target memory tier
     bool force                     // [in] Force immediate sync
 );
 

--- a/include/compat/cuda_unified_fix.h
+++ b/include/compat/cuda_unified_fix.h
@@ -92,11 +92,15 @@ CUDA_UNIFIED_FIX_END_SCOPE()
 #if (__CUDACC__)
 #define SEP_HOST __host__
 #define SEP_DEVICE __device__
+#ifndef SEP_HD
 #define SEP_HD __host__ __device__
+#endif
 #else
 #define SEP_HOST
 #define SEP_DEVICE
+#ifndef SEP_HD
 #define SEP_HD
+#endif
 #endif
 
 // *** CRITICAL: DISABLE EXCEPTION SPECIFICATION CHECKS ***

--- a/include/memory/memory_tier.hpp
+++ b/include/memory/memory_tier.hpp
@@ -27,13 +27,13 @@ enum class TierType {
 // Macros for CUDA kernel compatibility
 #ifdef __CUDACC__
 #ifndef SEP_MEMORY_TIER_STM
-#define SEP_MEMORY_TIER_STM static_cast<int>(sep::MemoryTierEnum::STM)
+#define SEP_MEMORY_TIER_STM static_cast<int>(::sep::memory::MemoryTierEnum::STM)
 #endif
 #ifndef SEP_MEMORY_TIER_MTM
-#define SEP_MEMORY_TIER_MTM static_cast<int>(sep::MemoryTierEnum::MTM)
+#define SEP_MEMORY_TIER_MTM static_cast<int>(::sep::memory::MemoryTierEnum::MTM)
 #endif
 #ifndef SEP_MEMORY_TIER_LTM
-#define SEP_MEMORY_TIER_LTM static_cast<int>(sep::MemoryTierEnum::LTM)
+#define SEP_MEMORY_TIER_LTM static_cast<int>(::sep::memory::MemoryTierEnum::LTM)
 #endif
 #endif
 

--- a/include/quantum/data.hpp
+++ b/include/quantum/data.hpp
@@ -2,6 +2,7 @@
 
 #include "compat/shim.h"
 #include "quantum/types.h"
+#include "memory/types.h"
 #include <glm/glm.hpp>
 #include <vector>
 

--- a/include/quantum/processor.h
+++ b/include/quantum/processor.h
@@ -8,6 +8,7 @@
 // Removed duplicate include of core/types.h
 #include "quantum/gpu_context.h"
 #include "quantum/data.hpp"
+#include "memory/types.h"
 #include <memory>
 #include <vector>
 #include <string>
@@ -91,7 +92,7 @@ public:
     SEPResult updatePattern(const std::string& pattern_id, const Pattern& pattern);
     Pattern getPattern(const std::string& pattern_id) const;
     std::vector<sep::quantum::Pattern> getPatterns() const;
-    std::vector<sep::quantum::Pattern> getPatternsByTier(MemoryTierEnum tier) const;
+    std::vector<sep::quantum::Pattern> getPatternsByTier(::sep::memory::MemoryTierEnum tier) const;
     size_t getPatternCount() const;
 
     ProcessingResult processPattern(const std::string& pattern_id);

--- a/include/quantum/quantum_manifold_optimizer.h
+++ b/include/quantum/quantum_manifold_optimizer.h
@@ -26,9 +26,9 @@ using ::sep::quantum::QuantumState;
 using QuantumPattern = ::sep::quantum::Pattern;
 using ::sep::quantum::QFHResult;
 using ::sep::quantum::QuantumProcessorQFH;
-using ::sep::CUDAConfig;
-using ::sep::APIConfig;
-using ::sep::LogConfig;
+using ::sep::config::CUDAConfig;
+using ::sep::config::APIConfig;
+using ::sep::config::LogConfig;
 
 class QuantumManifoldOptimizer {
 public:

--- a/include/quantum/quantum_processor_qfh.h
+++ b/include/quantum/quantum_processor_qfh.h
@@ -61,7 +61,7 @@ public:
 
     const QFHResult& getLastQFHResult() const;
 
-    sep::MemoryTierEnum determineMemoryTier(float coherence, float stability, uint32_t generation_count) const;
+    ::sep::memory::MemoryTierEnum determineMemoryTier(float coherence, float stability, uint32_t generation_count) const;
 };
 
 }  // namespace sep::quantum

--- a/include/quantum/types.h
+++ b/include/quantum/types.h
@@ -4,6 +4,7 @@
 #include <glm/glm.hpp>
 #include <vector>
 #include <string>
+#include "memory/types.h"
 
 
 

--- a/src/blender/api.cpp
+++ b/src/blender/api.cpp
@@ -139,7 +139,7 @@ sep_process_audio(SEPBlenderBridge* bridge, const float* samples, size_t count, 
     return sep::SEPResult::SUCCESS;
 }
 
-extern "C" sep::SEPResult sep_sync_memory(SEPBlenderBridge* bridge, sep::MemoryTierEnum tier, bool force)
+extern "C" sep::SEPResult sep_sync_memory(SEPBlenderBridge* bridge, ::sep::memory::MemoryTierEnum tier, bool force)
 {
     if (!validateBridge(bridge))
     {

--- a/src/blender/blender_integration.cpp
+++ b/src/blender/blender_integration.cpp
@@ -383,11 +383,11 @@ sep::SEPResult BlenderBridge::updateResourceStats()
     auto& manager = sep::memory::MemoryTierManager::getInstance();
 
     float stm_util = manager.getTierUtilization(
-        static_cast<sep::memory::TierType>(sep::MemoryTierEnum::STM));
+        static_cast<sep::memory::TierType>(::sep::memory::MemoryTierEnum::STM));
     float mtm_util = manager.getTierUtilization(
-        static_cast<sep::memory::TierType>(sep::MemoryTierEnum::MTM));
+        static_cast<sep::memory::TierType>(::sep::memory::MemoryTierEnum::MTM));
     float ltm_util = manager.getTierUtilization(
-        static_cast<sep::memory::TierType>(sep::MemoryTierEnum::LTM));
+        static_cast<sep::memory::TierType>(::sep::memory::MemoryTierEnum::LTM));
 
     if (stm_util > 0.9f)
         notifyResourceWarning(ResourceType::HOST_MEMORY, stm_util);

--- a/src/core/engine.cpp
+++ b/src/core/engine.cpp
@@ -1,6 +1,7 @@
 #include "core/engine.h"
 
 #include "audio/capture.h"
+#include "blender/types.h"
 #include "blender/pattern_bridge.h"
 #include "memory/memory_tier_manager.hpp"
 #include "compat/component_bridge.h"
@@ -260,7 +261,7 @@ void Engine::generate_probes(const ::sep::shim::vector<::sep::PinState>& inputs,
     auto& cuda_core = cuda::CudaCore::instance();
 
     // Copy input states to device
-    SEP_CUDA_CHECK(cudaMemcpyAsync(impl_->d_chunks_.get(), reinterpret_cast<const std::uint64_t*>(inputs.data()),
+    SEP_CUDA_CHECK(::sep::cuda::cudaMemcpyAsync(impl_->d_chunks_.get(), reinterpret_cast<const std::uint64_t*>(inputs.data()),
                                    inputs.size() * sizeof(std::uint64_t), cudaMemcpyHostToDevice,
                                    reinterpret_cast<cudaStream_t>(impl_->stream_->handle())));
 
@@ -272,10 +273,10 @@ void Engine::generate_probes(const ::sep::shim::vector<::sep::PinState>& inputs,
                          impl_->d_bitfield_, impl_->d_corrections_, impl_->d_correction_count_, *impl_->stream_);
 
     // Copy results back to host
-    SEP_CUDA_CHECK(cudaMemcpyAsync(indices.data(), impl_->d_probe_indices_.get(), inputs.size() * sizeof(std::uint32_t),
+    SEP_CUDA_CHECK(::sep::cuda::cudaMemcpyAsync(indices.data(), impl_->d_probe_indices_.get(), inputs.size() * sizeof(std::uint32_t),
                                    cudaMemcpyDeviceToHost, reinterpret_cast<cudaStream_t>(impl_->stream_->handle())));
 
-    SEP_CUDA_CHECK(cudaMemcpyAsync(expectations.data(), impl_->d_expectations_.get(),
+    SEP_CUDA_CHECK(::sep::cuda::cudaMemcpyAsync(expectations.data(), impl_->d_expectations_.get(),
                                    inputs.size() * sizeof(std::uint32_t), cudaMemcpyDeviceToHost,
                                    reinterpret_cast<cudaStream_t>(impl_->stream_->handle())));
 
@@ -300,7 +301,7 @@ void Engine::process_batch(const ::sep::shim::vector<::sep::PinState>& inputs, s
     auto& cuda_core = cuda::CudaCore::instance();
 
     // Copy input states to device
-    SEP_CUDA_CHECK(cudaMemcpyAsync(impl_->d_chunks_.get(), reinterpret_cast<const std::uint64_t*>(inputs.data()),
+    SEP_CUDA_CHECK(::sep::cuda::cudaMemcpyAsync(impl_->d_chunks_.get(), reinterpret_cast<const std::uint64_t*>(inputs.data()),
                                    inputs.size() * sizeof(std::uint64_t), cudaMemcpyHostToDevice,
                                    reinterpret_cast<cudaStream_t>(impl_->stream_->handle())));
 
@@ -314,7 +315,7 @@ void Engine::process_batch(const ::sep::shim::vector<::sep::PinState>& inputs, s
 
     // Copy QBSA results
     std::uint32_t correction_count = 0;
-    SEP_CUDA_CHECK(cudaMemcpyAsync(&correction_count, impl_->d_correction_count_.get(), sizeof(std::uint32_t),
+    SEP_CUDA_CHECK(::sep::cuda::cudaMemcpyAsync(&correction_count, impl_->d_correction_count_.get(), sizeof(std::uint32_t),
                                    cudaMemcpyDeviceToHost, reinterpret_cast<cudaStream_t>(impl_->stream_->handle())));
 
     // Set corrections count and calculate correction ratio
@@ -325,7 +326,7 @@ void Engine::process_batch(const ::sep::shim::vector<::sep::PinState>& inputs, s
 
     if (correction_count > 0) {
         ::sep::shim::vector<uint32_t> temp_corr(correction_count);
-        SEP_CUDA_CHECK(cudaMemcpyAsync(temp_corr.data(), impl_->d_corrections_.get(),
+        SEP_CUDA_CHECK(::sep::cuda::cudaMemcpyAsync(temp_corr.data(), impl_->d_corrections_.get(),
                                        correction_count * sizeof(uint32_t), cudaMemcpyDeviceToHost,
                                        reinterpret_cast<cudaStream_t>(impl_->stream_->handle())));
         cuda_core.synchronizeStream(reinterpret_cast<cudaStream_t>(impl_->stream_->handle()));
@@ -342,11 +343,11 @@ void Engine::process_batch(const ::sep::shim::vector<::sep::PinState>& inputs, s
     // Temporary buffer for all possible indices
     ::sep::shim::vector<uint32_t> temp_indices(inputs.size() * PAIRS_PER_CHUNK);
 
-    SEP_CUDA_CHECK(cudaMemcpyAsync(temp_indices.data(), impl_->d_collapse_indices_.get(),
+    SEP_CUDA_CHECK(::sep::cuda::cudaMemcpyAsync(temp_indices.data(), impl_->d_collapse_indices_.get(),
                                    temp_indices.size() * sizeof(std::uint32_t), cudaMemcpyDeviceToHost,
                                    reinterpret_cast<cudaStream_t>(impl_->stream_->handle())));
 
-    SEP_CUDA_CHECK(cudaMemcpyAsync(qsh_result.collapse_counts.data(), impl_->d_collapse_counts_.get(),
+    SEP_CUDA_CHECK(::sep::cuda::cudaMemcpyAsync(qsh_result.collapse_counts.data(), impl_->d_collapse_counts_.get(),
 
                                    inputs.size() * sizeof(std::uint32_t), cudaMemcpyDeviceToHost,
                                    reinterpret_cast<cudaStream_t>(impl_->stream_->handle())));

--- a/src/memory/quantum_coherence_manager.cpp
+++ b/src/memory/quantum_coherence_manager.cpp
@@ -110,7 +110,7 @@ public:
         for (auto it = coherence_map_.begin(); it != coherence_map_.end(); ++it) {
             const auto& pair = *it;
             const auto& data = pair.second;
-            sep::MemoryTierEnum target_tier = determineOptimalTier(data);
+            ::sep::memory::MemoryTierEnum target_tier = determineOptimalTier(data);
 
             if (target_tier != data.current_tier) {
                 TierMigration migration;
@@ -562,8 +562,8 @@ private:
         for (size_t i = 0; i < demote_count && i < demotion_candidates.size(); ++i) {
             TierMigration migration;
             migration.pattern_id = demotion_candidates[i].first;
-            migration.from_tier = sep::MemoryTierEnum::LTM;
-            migration.to_tier = sep::MemoryTierEnum::MTM;
+            migration.from_tier = ::sep::memory::MemoryTierEnum::LTM;
+            migration.to_tier = ::sep::memory::MemoryTierEnum::MTM;
             migration.coherence = demotion_candidates[i].second;
             migration.reason = MigrationReason::MemoryPressure;
             
@@ -676,9 +676,9 @@ private:
     
     float getThresholdForTier(sep::memory::MemoryTierEnum tier) const {
         switch (tier) {
-            case sep::MemoryTierEnum::LTM: return LTM_COHERENCE_THRESHOLD;
-            case sep::MemoryTierEnum::MTM: return MTM_COHERENCE_THRESHOLD;
-            case sep::MemoryTierEnum::STM: return STM_COHERENCE_THRESHOLD;
+            case ::sep::memory::MemoryTierEnum::LTM: return LTM_COHERENCE_THRESHOLD;
+            case ::sep::memory::MemoryTierEnum::MTM: return MTM_COHERENCE_THRESHOLD;
+            case ::sep::memory::MemoryTierEnum::STM: return STM_COHERENCE_THRESHOLD;
             default: return 0.0f;
         }
     }
@@ -688,7 +688,7 @@ private:
         
         for (int i = 0; i < 3; ++i) {
             analysis.tier_coherence[i] = metrics_.tier_coherence[i];
-            analysis.tier_pattern_count[i] = countPatternsInTier(static_cast<sep::MemoryTierEnum>(i));
+            analysis.tier_pattern_count[i] = countPatternsInTier(static_cast<::sep::memory::MemoryTierEnum>(i));
         }
         
         analysis.optimal_distribution = computeOptimalDistribution();
@@ -750,11 +750,11 @@ uint64_t QuantumCoherenceManager::getGlobalTick() const {
     return impl_->getGlobalTick();
 }
 
-uint32_t QuantumCoherenceManager::getPatternCountByTier(sep::MemoryTierEnum tier) const {
+uint32_t QuantumCoherenceManager::getPatternCountByTier(::sep::memory::MemoryTierEnum tier) const {
     return impl_->getPatternCountByTier(tier);
 }
 
-float QuantumCoherenceManager::getTierFragmentation(sep::MemoryTierEnum tier) const {
+float QuantumCoherenceManager::getTierFragmentation(::sep::memory::MemoryTierEnum tier) const {
     return impl_->getTierFragmentation(tier);
 }
 


### PR DESCRIPTION
## Summary
- include `memory/types.h` where missing and use fully qualified `MemoryTierEnum`
- fix `cudaMemcpyAsync` namespace use
- avoid SEP_HD redefinition
- ensure Blender API has correct type for tier sync
- correct config namespace in QuantumManifoldOptimizer

## Testing
- `pnpm lint` *(fails: recursive turbo invocations)*
- `pnpm test` *(fails: recursive turbo invocations)*

------
https://chatgpt.com/codex/tasks/task_e_6860a8052190832aa107b39193c17d71