### PR TITLE
Fix SEPBlenderBridge namespace

### DIFF
--- a/include/blender/types.h
+++ b/include/blender/types.h
@@ -50,8 +50,13 @@ inline const char* sep_result_to_string(sep::SEPResult result) {
 }
 
 // Bridge structure used by the C API
+namespace sep {
 struct SEPBlenderBridge {
-    std::shared_ptr<sep::pattern::BlenderBridge> impl;
-    SEPAudioMetrics                              audio_metrics{};
-    SEPPatternMetrics                            pattern_metrics{};
+    std::shared_ptr<pattern::BlenderBridge> impl;
+    SEPAudioMetrics                         audio_metrics{};
+    SEPPatternMetrics                       pattern_metrics{};
 };
+}  // namespace sep
+
+// Provide global alias for C API compatibility
+using SEPBlenderBridge = sep::SEPBlenderBridge;


### PR DESCRIPTION
## Summary
- define `SEPBlenderBridge` inside the `sep` namespace and keep a global alias
- ensure bridge definition is available for components that use it

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6860ac44cd28832abf5e9c17eb2d3ddb