### PR TITLE
Fix SEPBlenderBridge forward declaration

### DIFF
--- a/src/core/engine.cpp
+++ b/src/core/engine.cpp
@@ -1,9 +1,8 @@
 #include "core/engine.h"
 
 #include "audio/capture.h"
-#include "blender/types.h"
+#include "blender/types.h"  // For SEPBlenderBridge definition
 #include "blender/pattern_bridge.h"
-#include "blender/types.h"
 #include "memory/memory_tier_manager.hpp"
 #include "compat/component_bridge.h"
 


### PR DESCRIPTION
## Summary
- include `blender/types.h` early in `core/engine.cpp`
- remove duplicate include

This ensures the full definition of `SEPBlenderBridge` is available
where `std::unique_ptr<SEPBlenderBridge>` is used.

## Testing
- `No tests run`

------
https://chatgpt.com/codex/tasks/task_e_6860ac44cd28832abf5e9c17eb2d3ddb