### PR TITLE
Fix SEPBlenderBridge include usage

### DIFF
--- a/include/blender/types.h
+++ b/include/blender/types.h
@@ -49,7 +49,8 @@ inline const char* sep_result_to_string(sep::SEPResult result) {
   }
 }
 
-// Bridge structure used by the C API
+// Bridge structure used by the C API.  This definition must be
+// visible wherever SEPBlenderBridge is managed by std::unique_ptr.
 struct SEPBlenderBridge {
     std::shared_ptr<sep::pattern::BlenderBridge> impl;
     SEPAudioMetrics                              audio_metrics{};

--- a/include/compat/component_bridge.h
+++ b/include/compat/component_bridge.h
@@ -7,12 +7,11 @@ class AudioCapture;
 }
 namespace pattern {
 class BlenderBridge;
-}
+}  // namespace pattern
 struct SEPBlenderBridge;
 namespace blender {
 class CyclesRenderer; // Forward declaration if header not available
 }
-struct SEPBlenderBridge;
 namespace compat {
 
 std::unique_ptr<audio::AudioCapture> createAudioCapture();

--- a/src/core/engine.cpp
+++ b/src/core/engine.cpp
@@ -1,9 +1,8 @@
 #include "core/engine.h"
 
 #include "audio/capture.h"
-#include "blender/types.h"
+#include "blender/types.h"  // For SEPBlenderBridge definition
 #include "blender/pattern_bridge.h"
-#include "blender/types.h"
 #include "memory/memory_tier_manager.hpp"
 #include "compat/component_bridge.h"
 


### PR DESCRIPTION
## Summary
- clarify SEPBlenderBridge definition comment
- clean up forward declarations in component_bridge.h
- remove duplicate includes and ensure SEPBlenderBridge definition is included

## Testing
- `git diff --cached --name-only`

------
https://chatgpt.com/codex/tasks/task_e_6860ac44cd28832abf5e9c17eb2d3ddb