### PR TITLE
Fix BlenderBridge type definition

### DIFF
--- a/include/blender/types.h
+++ b/include/blender/types.h
@@ -55,3 +55,9 @@ struct SEPBlenderBridge {
     SEPAudioMetrics                              audio_metrics{};
     SEPPatternMetrics                            pattern_metrics{};
 };
+
+#ifdef __cplusplus
+namespace sep {
+using SEPBlenderBridge = ::SEPBlenderBridge;
+}  // namespace sep
+#endif

--- a/include/compat/component_bridge.h
+++ b/include/compat/component_bridge.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <memory>
+#include "blender/types.h"
 
 namespace sep {
 namespace audio {
@@ -8,11 +9,9 @@ class AudioCapture;
 namespace pattern {
 class BlenderBridge;
 }
-struct SEPBlenderBridge;
 namespace blender {
 class CyclesRenderer; // Forward declaration if header not available
 }
-struct SEPBlenderBridge;
 namespace compat {
 
 std::unique_ptr<audio::AudioCapture> createAudioCapture();

--- a/include/core/engine.h
+++ b/include/core/engine.h
@@ -25,7 +25,6 @@ class AudioCapture;
 namespace pattern {
 class BlenderBridge;
 }  // namespace pattern
-struct SEPBlenderBridge;
 }  // namespace sep
 
 namespace sep {

--- a/src/core/engine.cpp
+++ b/src/core/engine.cpp
@@ -3,7 +3,6 @@
 #include "audio/capture.h"
 #include "blender/types.h"
 #include "blender/pattern_bridge.h"
-#include "blender/types.h"
 #include "memory/memory_tier_manager.hpp"
 #include "compat/component_bridge.h"
 


### PR DESCRIPTION
## Summary
- alias `SEPBlenderBridge` into the `sep` namespace so users get a complete type
- stop forward declaring this struct in headers and include the defining header where needed
- remove duplicate include in `Engine`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6860ac44cd28832abf5e9c17eb2d3ddb