### PR TITLE
Fix CUDA namespace wrappers

### DIFF
--- a/include/compat/cuda_impl.h
+++ b/include/compat/cuda_impl.h
@@ -5,6 +5,7 @@
 #include <stdlib.h>  // For malloc/free
 #include <string.h>  // For strcpy, memcpy, memset
 #include "compat/cuda_defs.h"
+#include "compat/cuda_runtime.h"  // for sep::cuda::cudaMemcpyAsync declaration
 
 #ifndef SEP_HD
 #define SEP_HD __host__ __device__
@@ -21,7 +22,10 @@ struct CudaMemcpyParams {
 
 // Helper function for memory copies to avoid parameter similarity issues
 inline cudaError_t performCudaMemcpyAsync(const CudaMemcpyParams& params) {
-    return ::cudaMemcpyAsync(params.destination, params.source, params.sizeInBytes, params.direction, params.stream);
+    // Use the namespaced wrapper to work both with CUDA and stub builds
+    return sep::cuda::cudaMemcpyAsync(params.destination, params.source,
+                                      params.sizeInBytes, params.direction,
+                                      params.stream);
 }
 
 // Asynchronous memory copy using the helper function

--- a/src/compat/cuda_api.cu
+++ b/src/compat/cuda_api.cu
@@ -8,6 +8,7 @@
 #endif
 #include "compat/cuda_common.h"
 #include "compat/cuda_helpers.h"
+#include "compat/cuda_runtime.h"  // for sep::cuda::cudaMemcpyAsync
 
 // Standard library includes - only for host compilation
 #if !defined(__CUDACC__)
@@ -104,11 +105,11 @@ int sep_cuda_process_batch(const std::uint32_t* probe_indices, const std::uint32
 
         // Memory transfers with error checking
         CUDA_CHECK(
-            cudaMemcpyAsync(d_probe_indices.get(), probe_indices, probe_size, cudaMemcpyHostToDevice, g_stream->get()));
+            sep::cuda::cudaMemcpyAsync(d_probe_indices.get(), probe_indices, probe_size, cudaMemcpyHostToDevice, g_stream->get()));
         CUDA_CHECK(cudaStreamSynchronize(g_stream->get()));
 
         CUDA_CHECK(
-            cudaMemcpyAsync(d_expectations.get(), expectations, probe_size, cudaMemcpyHostToDevice, g_stream->get()));
+            sep::cuda::cudaMemcpyAsync(d_expectations.get(), expectations, probe_size, cudaMemcpyHostToDevice, g_stream->get()));
         CUDA_CHECK(cudaStreamSynchronize(g_stream->get()));
 
         CUDA_CHECK(cudaMemsetAsync(d_correction_count.get(), 0, count_size, g_stream->get()));
@@ -118,12 +119,12 @@ int sep_cuda_process_batch(const std::uint32_t* probe_indices, const std::uint32
                                                d_bitfield.get(), d_corrections.get(), d_correction_count.get(),
                                                g_stream->get()));
 
-        CUDA_CHECK(cudaMemcpyAsync(bitfield, d_bitfield.get(), bitfield_size, cudaMemcpyDeviceToHost, g_stream->get()));
+        CUDA_CHECK(sep::cuda::cudaMemcpyAsync(bitfield, d_bitfield.get(), bitfield_size, cudaMemcpyDeviceToHost, g_stream->get()));
 
-        CUDA_CHECK(cudaMemcpyAsync(correction_indices, d_corrections.get(), corrections_size, cudaMemcpyDeviceToHost,
+        CUDA_CHECK(sep::cuda::cudaMemcpyAsync(correction_indices, d_corrections.get(), corrections_size, cudaMemcpyDeviceToHost,
                                    g_stream->get()));
 
-        CUDA_CHECK(cudaMemcpyAsync(correction_count, d_correction_count.get(), count_size, cudaMemcpyDeviceToHost,
+        CUDA_CHECK(sep::cuda::cudaMemcpyAsync(correction_count, d_correction_count.get(), count_size, cudaMemcpyDeviceToHost,
                                    g_stream->get()));
 
         CUDA_CHECK(cudaStreamSynchronize(g_stream->get()));
@@ -162,16 +163,16 @@ int sep_cuda_process_symmetry(const std::uint64_t* chunks, std::uint32_t num_chu
         CUDA_CHECK(cudaStreamSynchronize(g_stream->get()));
 
         // Memory transfer with error checking
-        CUDA_CHECK(cudaMemcpyAsync(d_chunks.get(), chunks, chunks_size, cudaMemcpyHostToDevice, g_stream->get()));
+        CUDA_CHECK(sep::cuda::cudaMemcpyAsync(d_chunks.get(), chunks, chunks_size, cudaMemcpyHostToDevice, g_stream->get()));
         CUDA_CHECK(cudaStreamSynchronize(g_stream->get()));
 
         CUDA_CHECK(sep::cuda::launchQSHKernel(d_chunks.get(), num_chunks, d_collapse_indices.get(),
                                               d_collapse_counts.get(), g_stream->get()));
 
-        CUDA_CHECK(cudaMemcpyAsync(collapse_indices, d_collapse_indices.get(), indices_size, cudaMemcpyDeviceToHost,
+        CUDA_CHECK(sep::cuda::cudaMemcpyAsync(collapse_indices, d_collapse_indices.get(), indices_size, cudaMemcpyDeviceToHost,
                                    g_stream->get()));
 
-        CUDA_CHECK(cudaMemcpyAsync(collapse_counts, d_collapse_counts.get(), counts_size, cudaMemcpyDeviceToHost,
+        CUDA_CHECK(sep::cuda::cudaMemcpyAsync(collapse_counts, d_collapse_counts.get(), counts_size, cudaMemcpyDeviceToHost,
                                    g_stream->get()));
 
         CUDA_CHECK(cudaStreamSynchronize(g_stream->get()));

--- a/src/core/engine.cpp
+++ b/src/core/engine.cpp
@@ -19,6 +19,7 @@ namespace logging = sep::logging;
 
 #include "compat/core.h"
 #include "compat/cuda_common.h"
+#include "compat/cuda_runtime.h"  // for sep::cuda::cudaMemcpyAsync
 
 #include "compat/macros.h"
 #include "compat/memory.h"

--- a/src/memory/memory_tier.cpp
+++ b/src/memory/memory_tier.cpp
@@ -18,6 +18,7 @@
 
 // CUDA headers after standard library
 #include "compat/cuda_common.h"
+#include "compat/cuda_runtime.h"  // for sep::cuda::cudaMemcpy
 #include "compat/macros.h"
 
 #include "compat/math_common.h"
@@ -158,7 +159,7 @@ sep::SEPResult MemoryTier::defragment() {
                 // Move memory to new position
                 void* new_location = static_cast<char*>(memory_pool_) + current_offset;
 #if SEP_CUDA_AVAILABLE
-                cudaError_t err = cudaMemcpy(new_location, block.ptr, block.size, cudaMemcpyDefault);
+                cudaError_t err = sep::cuda::cudaMemcpy(new_location, block.ptr, block.size, cudaMemcpyDefault);
                 if (err != cudaSuccess) {
                     if (logger)
                         LOG_ERROR(logger, "Defragment cudaMemcpy failed: {}", cudaGetErrorString(err));


### PR DESCRIPTION
## Summary
- fix usage of cudaMemcpyAsync wrapper in CUDA stub implementation
- update cuda API helpers to use `sep::cuda::cudaMemcpyAsync`
- include `compat/cuda_runtime.h` where needed
- use wrapper for cudaMemcpy in memory tier defragmentation

## Testing
- `pnpm lint` *(fails: turbo not found / recursive invocation)*
- `pnpm test` *(fails: recursive turbo invocation)*

------
https://chatgpt.com/codex/tasks/task_e_6860ac2a72b8832a8483f7d388826f36