### PR TITLE
Fix CUDA namespace usage

### DIFF
--- a/include/compat/cuda_impl.h
+++ b/include/compat/cuda_impl.h
@@ -5,6 +5,7 @@
 #include <stdlib.h>  // For malloc/free
 #include <string.h>  // For strcpy, memcpy, memset
 #include "compat/cuda_defs.h"
+#include "compat/cuda_runtime.h"
 
 #ifndef SEP_HD
 #define SEP_HD __host__ __device__
@@ -21,7 +22,7 @@ struct CudaMemcpyParams {
 
 // Helper function for memory copies to avoid parameter similarity issues
 inline cudaError_t performCudaMemcpyAsync(const CudaMemcpyParams& params) {
-    return ::cudaMemcpyAsync(params.destination, params.source, params.sizeInBytes, params.direction, params.stream);
+    return sep::cuda::cudaMemcpyAsync(params.destination, params.source, params.sizeInBytes, params.direction, params.stream);
 }
 
 // Asynchronous memory copy using the helper function

--- a/src/core/engine.cpp
+++ b/src/core/engine.cpp
@@ -19,6 +19,7 @@ namespace logging = sep::logging;
 
 #include "compat/core.h"
 #include "compat/cuda_common.h"
+#include "compat/cuda_runtime.h"
 
 #include "compat/macros.h"
 #include "compat/memory.h"
@@ -262,7 +263,7 @@ void Engine::generate_probes(const ::sep::shim::vector<::sep::PinState>& inputs,
     auto& cuda_core = cuda::CudaCore::instance();
 
     // Copy input states to device
-    SEP_CUDA_CHECK(::sep::cuda::cudaMemcpyAsync(impl_->d_chunks_.get(), reinterpret_cast<const std::uint64_t*>(inputs.data()),
+    SEP_CUDA_CHECK(sep::cuda::cudaMemcpyAsync(impl_->d_chunks_.get(), reinterpret_cast<const std::uint64_t*>(inputs.data()),
                                    inputs.size() * sizeof(std::uint64_t), cudaMemcpyHostToDevice,
                                    reinterpret_cast<cudaStream_t>(impl_->stream_->handle())));
 
@@ -274,10 +275,10 @@ void Engine::generate_probes(const ::sep::shim::vector<::sep::PinState>& inputs,
                          impl_->d_bitfield_, impl_->d_corrections_, impl_->d_correction_count_, *impl_->stream_);
 
     // Copy results back to host
-    SEP_CUDA_CHECK(::sep::cuda::cudaMemcpyAsync(indices.data(), impl_->d_probe_indices_.get(), inputs.size() * sizeof(std::uint32_t),
+    SEP_CUDA_CHECK(sep::cuda::cudaMemcpyAsync(indices.data(), impl_->d_probe_indices_.get(), inputs.size() * sizeof(std::uint32_t),
                                    cudaMemcpyDeviceToHost, reinterpret_cast<cudaStream_t>(impl_->stream_->handle())));
 
-    SEP_CUDA_CHECK(::sep::cuda::cudaMemcpyAsync(expectations.data(), impl_->d_expectations_.get(),
+    SEP_CUDA_CHECK(sep::cuda::cudaMemcpyAsync(expectations.data(), impl_->d_expectations_.get(),
                                    inputs.size() * sizeof(std::uint32_t), cudaMemcpyDeviceToHost,
                                    reinterpret_cast<cudaStream_t>(impl_->stream_->handle())));
 
@@ -302,7 +303,7 @@ void Engine::process_batch(const ::sep::shim::vector<::sep::PinState>& inputs, s
     auto& cuda_core = cuda::CudaCore::instance();
 
     // Copy input states to device
-    SEP_CUDA_CHECK(::sep::cuda::cudaMemcpyAsync(impl_->d_chunks_.get(), reinterpret_cast<const std::uint64_t*>(inputs.data()),
+    SEP_CUDA_CHECK(sep::cuda::cudaMemcpyAsync(impl_->d_chunks_.get(), reinterpret_cast<const std::uint64_t*>(inputs.data()),
                                    inputs.size() * sizeof(std::uint64_t), cudaMemcpyHostToDevice,
                                    reinterpret_cast<cudaStream_t>(impl_->stream_->handle())));
 
@@ -316,7 +317,7 @@ void Engine::process_batch(const ::sep::shim::vector<::sep::PinState>& inputs, s
 
     // Copy QBSA results
     std::uint32_t correction_count = 0;
-    SEP_CUDA_CHECK(::sep::cuda::cudaMemcpyAsync(&correction_count, impl_->d_correction_count_.get(), sizeof(std::uint32_t),
+    SEP_CUDA_CHECK(sep::cuda::cudaMemcpyAsync(&correction_count, impl_->d_correction_count_.get(), sizeof(std::uint32_t),
                                    cudaMemcpyDeviceToHost, reinterpret_cast<cudaStream_t>(impl_->stream_->handle())));
 
     // Set corrections count and calculate correction ratio
@@ -327,7 +328,7 @@ void Engine::process_batch(const ::sep::shim::vector<::sep::PinState>& inputs, s
 
     if (correction_count > 0) {
         ::sep::shim::vector<uint32_t> temp_corr(correction_count);
-        SEP_CUDA_CHECK(::sep::cuda::cudaMemcpyAsync(temp_corr.data(), impl_->d_corrections_.get(),
+        SEP_CUDA_CHECK(sep::cuda::cudaMemcpyAsync(temp_corr.data(), impl_->d_corrections_.get(),
                                        correction_count * sizeof(uint32_t), cudaMemcpyDeviceToHost,
                                        reinterpret_cast<cudaStream_t>(impl_->stream_->handle())));
         cuda_core.synchronizeStream(reinterpret_cast<cudaStream_t>(impl_->stream_->handle()));
@@ -344,11 +345,11 @@ void Engine::process_batch(const ::sep::shim::vector<::sep::PinState>& inputs, s
     // Temporary buffer for all possible indices
     ::sep::shim::vector<uint32_t> temp_indices(inputs.size() * PAIRS_PER_CHUNK);
 
-    SEP_CUDA_CHECK(::sep::cuda::cudaMemcpyAsync(temp_indices.data(), impl_->d_collapse_indices_.get(),
+    SEP_CUDA_CHECK(sep::cuda::cudaMemcpyAsync(temp_indices.data(), impl_->d_collapse_indices_.get(),
                                    temp_indices.size() * sizeof(std::uint32_t), cudaMemcpyDeviceToHost,
                                    reinterpret_cast<cudaStream_t>(impl_->stream_->handle())));
 
-    SEP_CUDA_CHECK(::sep::cuda::cudaMemcpyAsync(qsh_result.collapse_counts.data(), impl_->d_collapse_counts_.get(),
+    SEP_CUDA_CHECK(sep::cuda::cudaMemcpyAsync(qsh_result.collapse_counts.data(), impl_->d_collapse_counts_.get(),
 
                                               inputs.size() * sizeof(std::uint32_t), cudaMemcpyDeviceToHost,
                                               reinterpret_cast<cudaStream_t>(impl_->stream_->handle())));


### PR DESCRIPTION
## Summary
- qualify `cudaMemcpyAsync` usage with `sep::cuda` namespace
- include `compat/cuda_runtime.h` in engine
- update CPU stub helper to call the namespaced function

## Testing
- `pnpm lint` *(fails: turbo not found)*
- `pnpm test` *(fails: turbo not found)*
- `cmake -S . -B build` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6860ac2a72b8832a8483f7d388826f36