### PR TITLE
Fix CUDA namespace wrapper and add runtime headers

### DIFF
--- a/include/compat/cuda_impl.h
+++ b/include/compat/cuda_impl.h
@@ -21,7 +21,7 @@ struct CudaMemcpyParams {
 
 // Helper function for memory copies to avoid parameter similarity issues
 inline cudaError_t performCudaMemcpyAsync(const CudaMemcpyParams& params) {
-    return ::cudaMemcpyAsync(params.destination, params.source, params.sizeInBytes, params.direction, params.stream);
+    return ::sep::cuda::cudaMemcpyAsync(params.destination, params.source, params.sizeInBytes, params.direction, params.stream);
 }
 
 // Asynchronous memory copy using the helper function

--- a/src/api/bridge_c.cpp
+++ b/src/api/bridge_c.cpp
@@ -5,6 +5,9 @@
 #include "core/manager.h"
 #include "compat/cuda_helpers.h"
 #include "compat/shim.h"
+#if !SEP_CUDA_AVAILABLE
+#include "compat/cuda_runtime.h"
+#endif
 #include "crow/asio_isolation.h"
 #include "crow/socket_adaptors.h"
 #include <ios>

--- a/src/core/engine.cpp
+++ b/src/core/engine.cpp
@@ -19,6 +19,9 @@ namespace logging = sep::logging;
 
 #include "compat/core.h"
 #include "compat/cuda_common.h"
+#if !SEP_CUDA_AVAILABLE
+#include "compat/cuda_runtime.h"
+#endif
 
 #include "compat/macros.h"
 #include "compat/memory.h"

--- a/src/memory/memory_tier.cpp
+++ b/src/memory/memory_tier.cpp
@@ -18,6 +18,9 @@
 
 // CUDA headers after standard library
 #include "compat/cuda_common.h"
+#if !SEP_CUDA_AVAILABLE
+#include "compat/cuda_runtime.h"
+#endif
 #include "compat/macros.h"
 
 #include "compat/math_common.h"

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -4,6 +4,9 @@
 #include "quantum/pattern.h"      // For QuantumPattern definition
 
 #include "compat/cuda_common.h"
+#if !SEP_CUDA_AVAILABLE
+#include "compat/cuda_runtime.h"
+#endif
 
 #include "compat/component_bridge.h"
 #include "compat/cuda_helpers.h"

--- a/src/memory/quantum_coherence_manager.cpp
+++ b/src/memory/quantum_coherence_manager.cpp
@@ -1,6 +1,9 @@
 #include "memory/quantum_coherence_manager.h"
 #include "compat/cuda.h"
 #include "compat/core.h"
+#if !SEP_CUDA_AVAILABLE
+#include "compat/cuda_runtime.h"
+#endif
 #include "quantum/pattern_evolution_bridge.h"
 #include "quantum/quantum_manifold_optimizer.h"
 #include "memory/memory_tier_manager.hpp"

--- a/src/memory/redis_manager.cpp
+++ b/src/memory/redis_manager.cpp
@@ -4,6 +4,9 @@
 #include <mutex>
 // Define namespace alias to clarify that Manager is in the logging namespace
 namespace logging = sep::logging;
+#if !SEP_CUDA_AVAILABLE
+#include "compat/cuda_runtime.h"
+#endif
 #include <cstdint>
 #if __has_include(<hiredis/hiredis.h>)
 #    include <hiredis/hiredis.h>


### PR DESCRIPTION
## Summary
- call the CUDA stub through `sep::cuda::cudaMemcpyAsync`
- include `compat/cuda_runtime.h` when CUDA is unavailable for several sources

## Testing
- `pnpm lint` *(fails: turbo not found)*
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860ac2a72b8832a8483f7d388826f36