### PR TITLE
Implement metrics accessors and rate limiter factory

### DIFF
--- a/include/memory/quantum_coherence_manager.h
+++ b/include/memory/quantum_coherence_manager.h
@@ -127,9 +127,18 @@ class QuantumCoherenceManager {
     CoherenceSnapshot createSnapshot() const;
     bool restoreFromSnapshot(const CoherenceSnapshot& snapshot);
 
+    // Metrics and diagnostics
+    const CoherenceMetrics& getMetrics() const;
+    uint64_t getGlobalTick() const;
+    uint32_t getPatternCountByTier(MemoryTierEnum tier) const;
+    float getTierFragmentation(MemoryTierEnum tier) const;
+
   private:
     class Impl;
     std::unique_ptr<Impl> impl_;
 };
+
+// Factory helper
+std::unique_ptr<QuantumCoherenceManager> createQuantumCoherenceManager(const QuantumCoherenceManager::Config& config);
 
 } // namespace sep::memory


### PR DESCRIPTION
## Summary
- add missing declarations for metrics accessors in `QuantumCoherenceManager`
- export factory helper `createQuantumCoherenceManager`

## Testing
- `npx turbo lint` *(fails: Invalid tag name)*
- `npx turbo test` *(fails: Invalid tag name)*

------
https://chatgpt.com/codex/tasks/task_e_6860ac4d4df0832a993347e67d7804ba