### PR TITLE
Fix struct references for MemoryTierEnum

### DIFF
--- a/include/memory/quantum_coherence_manager.h
+++ b/include/memory/quantum_coherence_manager.h
@@ -44,8 +44,8 @@ class QuantumCoherenceManager {
 
     struct TierMigration {
         std::string pattern_id;
-        MemoryTierEnum from_tier{MemoryTierEnum::STM};
-        MemoryTierEnum to_tier{MemoryTierEnum::STM};
+        ::sep::memory::MemoryTierEnum from_tier{::sep::memory::MemoryTierEnum::STM};
+        ::sep::memory::MemoryTierEnum to_tier{::sep::memory::MemoryTierEnum::STM};
         float coherence{0.f};
         MigrationReason reason{MigrationReason::LowActivity};
     };
@@ -88,7 +88,7 @@ class QuantumCoherenceManager {
         float stability{0.f};
         std::uint32_t access_count{0};
         std::uint64_t last_access_tick{0};
-        MemoryTierEnum current_tier{MemoryTierEnum::STM};
+        ::sep::memory::MemoryTierEnum current_tier{::sep::memory::MemoryTierEnum::STM};
         std::vector<std::string> entangled_patterns;
         float fragmentation_score{0.f};
     };

--- a/include/quantum/data.hpp
+++ b/include/quantum/data.hpp
@@ -20,7 +20,7 @@ struct PatternData {
     float entropy{0.0f};
     float mutation_rate{0.0f};
     std::uint32_t mutation_count{0};
-    MemoryTierEnum memory_tier{MemoryTierEnum::STM};
+    ::sep::memory::MemoryTierEnum memory_tier{::sep::memory::MemoryTierEnum::STM};
     std::vector<quantum::PatternRelationship> relationships;
 };
 

--- a/include/quantum/pattern_processor.h
+++ b/include/quantum/pattern_processor.h
@@ -26,7 +26,7 @@ constexpr float MTM_COHERENCE_THRESHOLD = 0.7F;
 struct PatternProcessResult {
     QuantumState state;
     std::string pattern_id;
-    MemoryTierEnum memory_tier{MemoryTierEnum::STM};
+    ::sep::memory::MemoryTierEnum memory_tier{::sep::memory::MemoryTierEnum::STM};
     bool tier_changed{false};
     float coherence_score{0.0F};
     float stability_score{0.0F};

--- a/src/blender/blender_integration.cpp
+++ b/src/blender/blender_integration.cpp
@@ -15,6 +15,8 @@
 #include "blender/pattern_observer.h"
 #include "quantum/types.h"
 #include "memory/types.h"
+
+using ::sep::memory::MemoryTierEnum;
 #include "core/common.h"  // For sep::SEPResult
 
 #include "memory/memory_tier_manager.hpp"

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -1,6 +1,8 @@
 #include "memory/memory_tier_manager.hpp"
 #include "memory/types.h"
 #include "quantum/types.h"        // For MemoryTierEnum definition
+
+using ::sep::memory::MemoryTierEnum;
 #include "quantum/pattern.h"      // For QuantumPattern definition
 
 #include "compat/cuda_common.h"

--- a/src/memory/quantum_coherence_manager.cpp
+++ b/src/memory/quantum_coherence_manager.cpp
@@ -6,6 +6,8 @@
 #include "memory/memory_tier_manager.hpp"
 #include "quantum/quantum_processor_qfh.h"
 #include "memory/types.h"
+
+using ::sep::memory::MemoryTierEnum;
 #include <tbb/parallel_for.h>
 #include <tbb/concurrent_hash_map.h>
 #include <algorithm>

--- a/src/quantum/pattern_processor.cpp
+++ b/src/quantum/pattern_processor.cpp
@@ -3,6 +3,8 @@
 #include "quantum/types.h"
 #include "memory/types.h"
 
+using ::sep::memory::MemoryTierEnum;
+
 #include <glm/vec3.hpp>
 
 #include <algorithm>

--- a/src/quantum/processor.cpp
+++ b/src/quantum/processor.cpp
@@ -3,6 +3,9 @@
 #include "quantum/pattern_evolution_bridge.h"
 #include "quantum/quantum_processor_qfh.h"
 #include <glm/glm.hpp>
+#include "memory/types.h"
+
+using ::sep::memory::MemoryTierEnum;
 #include <mutex>
 #include <unordered_map>
 #include <chrono>


### PR DESCRIPTION
## Summary
- use fully-qualified MemoryTierEnum in PatternData, PatternProcessResult and coherence manager
- adjust cpp includes to import MemoryTierEnum with `using` statements

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6860ac3bd86c832aa87e71452fd98da3