### PR TITLE
Fix MemoryTierEnum usage and add processor factory

### DIFF
--- a/include/blender/bridge.h
+++ b/include/blender/bridge.h
@@ -54,7 +54,7 @@ class BlenderBridge {
   virtual sep::SEPResult processPatterns();  // Changed to global SEPResult
 
   virtual sep::SEPResult syncMemory(  // Changed to global SEPResult
-      MemoryTierEnum tier, bool force = false);
+      ::sep::memory::MemoryTierEnum tier, bool force = false);
 
   void addObserver(std::shared_ptr<PatternObserver> observer);
   void removeObserver(std::shared_ptr<PatternObserver> observer);
@@ -106,7 +106,7 @@ class BlenderBridge {
   sep::SEPResult allocatePatternMemory(ObjectState& state);  // Changed to global SEPResult
   sep::SEPResult freePatternMemory(ObjectState& state);      // Changed to global SEPResult
   sep::SEPResult promotePatterns(sep::pattern::ObjectHandle handle,
-                              MemoryTierEnum target_tier);  // Changed to global SEPResult
+                              ::sep::memory::MemoryTierEnum target_tier);  // Changed to global SEPResult
   sep::SEPResult syncPatternData(sep::pattern::ObjectHandle handle,
                               bool force);  // Changed to global SEPResult
 

--- a/include/blender/types.h
+++ b/include/blender/types.h
@@ -4,12 +4,14 @@
 #include "blender/config.h"
 #include <memory>
 
-// Forward declaration for MemoryTierEnum from sep::math_common.h
+// Forward declaration for MemoryTierEnum
 namespace sep {
+namespace memory {
   enum class MemoryTierEnum : int;
-  namespace pattern {
-    class BlenderBridge;
-  }
+}
+namespace pattern {
+  class BlenderBridge;
+}
 }
 
 // Using the SEPResult enum from sep namespace

--- a/include/quantum/data.hpp
+++ b/include/quantum/data.hpp
@@ -20,7 +20,7 @@ struct PatternData {
     float entropy{0.0f};
     float mutation_rate{0.0f};
     std::uint32_t mutation_count{0};
-    MemoryTierEnum memory_tier{MemoryTierEnum::STM};
+    ::sep::memory::MemoryTierEnum memory_tier{::sep::memory::MemoryTierEnum::STM};
     std::vector<quantum::PatternRelationship> relationships;
 };
 

--- a/include/quantum/pattern_processor.h
+++ b/include/quantum/pattern_processor.h
@@ -26,7 +26,7 @@ constexpr float MTM_COHERENCE_THRESHOLD = 0.7F;
 struct PatternProcessResult {
     QuantumState state;
     std::string pattern_id;
-    MemoryTierEnum memory_tier{MemoryTierEnum::STM};
+    ::sep::memory::MemoryTierEnum memory_tier{::sep::memory::MemoryTierEnum::STM};
     bool tier_changed{false};
     float coherence_score{0.0F};
     float stability_score{0.0F};

--- a/src/blender/blender_integration.cpp
+++ b/src/blender/blender_integration.cpp
@@ -263,7 +263,7 @@ sep::SEPResult BlenderBridge::freePatternMemory(ObjectState& state)
     return sep::SEPResult::SUCCESS;
 }
 
-sep::SEPResult BlenderBridge::syncMemory(MemoryTierEnum tier, bool force)
+sep::SEPResult BlenderBridge::syncMemory(::sep::memory::MemoryTierEnum tier, bool force)
 {
     if (!m_processing_thread_active.load())
     {
@@ -274,17 +274,17 @@ sep::SEPResult BlenderBridge::syncMemory(MemoryTierEnum tier, bool force)
 
     switch (tier)
     {
-        case MemoryTierEnum::STM:
+        case ::sep::memory::MemoryTierEnum::STM:
             manager.defragmentTier(sep::memory::TierType::HOST);
             break;
-        case MemoryTierEnum::MTM:
+        case ::sep::memory::MemoryTierEnum::MTM:
             manager.defragmentTier(sep::memory::TierType::DEVICE);
             if (force)
             {
                 manager.defragmentTier(sep::memory::TierType::HOST);
             }
             break;
-        case MemoryTierEnum::LTM:
+        case ::sep::memory::MemoryTierEnum::LTM:
             manager.defragmentTier(sep::memory::TierType::UNIFIED);
             break;
         default:
@@ -473,7 +473,7 @@ sep::SEPResult BlenderBridge::validatePatternCoherence(const ObjectState& state)
     return sep::SEPResult::SUCCESS;
 }
 
-sep::SEPResult BlenderBridge::promotePatterns(ObjectHandle handle, MemoryTierEnum target_tier)
+sep::SEPResult BlenderBridge::promotePatterns(ObjectHandle handle, ::sep::memory::MemoryTierEnum target_tier)
 {
     (void)handle;
     (void)target_tier;

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -17,6 +17,8 @@
 
 namespace sep::memory {
 
+using ::sep::memory::MemoryTierEnum;
+
 // Initialize singleton instance
 std::unique_ptr<MemoryTierManager> MemoryTierManager::instance_;
 std::once_flag MemoryTierManager::once_flag_;

--- a/src/memory/quantum_coherence_manager.cpp
+++ b/src/memory/quantum_coherence_manager.cpp
@@ -19,6 +19,8 @@
 
 namespace sep::memory {
 
+using ::sep::memory::MemoryTierEnum;
+
 namespace {
     // Memory coherence constants from quantum information theory
     constexpr float COHERENCE_DECAY_RATE = 0.02f;

--- a/src/quantum/pattern_processor.cpp
+++ b/src/quantum/pattern_processor.cpp
@@ -22,7 +22,7 @@ public:
         PatternProcessResult result;
         result.state = state;
         result.pattern_id = pattern_id;
-        result.memory_tier = MemoryTierEnum::STM; // Default to Short-Term Memory
+        result.memory_tier = ::sep::memory::MemoryTierEnum::STM; // Default to Short-Term Memory
         
         // Convert state to a format the quantum processor can use
         glm::vec3 stateData(state.coherence, state.stability, state.entropy);
@@ -53,9 +53,9 @@ public:
         // Determine memory tier
         if (result.coherence_score >= constants::LTM_COHERENCE_THRESHOLD &&
             result.stability_score >= pattern::STABILITY_THRESHOLD) {
-            result.memory_tier = MemoryTierEnum::LTM;
+            result.memory_tier = ::sep::memory::MemoryTierEnum::LTM;
         } else if (result.coherence_score >= constants::MTM_COHERENCE_THRESHOLD) {
-            result.memory_tier = MemoryTierEnum::MTM;
+            result.memory_tier = ::sep::memory::MemoryTierEnum::MTM;
         }
 
         return result;
@@ -105,6 +105,17 @@ private:
 };
 } // namespace
 
+} // namespace sep::quantum
+
+std::unique_ptr<PatternQuantumProcessor> createPatternQuantumProcessor(
+    const ProcessingConfig& config) {
+    QuantumProcessor::Config qp_cfg{};
+    qp_cfg.max_qubits = config.max_patterns;
+    qp_cfg.decoherence_rate = config.mutation_rate;
+    qp_cfg.measurement_threshold = config.ltm_coherence_threshold;
+    qp_cfg.enable_gpu = config.enable_cuda;
+    return std::make_unique<PatternQuantumProcessorImpl>(qp_cfg);
+}
 
 } // namespace sep::quantum
 

--- a/src/quantum/processor.cpp
+++ b/src/quantum/processor.cpp
@@ -81,7 +81,7 @@ public:
         return patterns_;
     }
 
-    std::vector<Pattern> getPatternsByTier(MemoryTierEnum tier) const {
+    std::vector<Pattern> getPatternsByTier(::sep::memory::MemoryTierEnum tier) const {
         std::lock_guard<std::mutex> lock(mutex_);
         std::vector<Pattern> result;
         for (const auto& pattern : patterns_) {
@@ -205,9 +205,9 @@ public:
         std::lock_guard<std::mutex> lock(mutex_);
         for (auto& pattern : patterns_) {
             if (pattern.quantum_state.coherence < config_.mtm_coherence_threshold) {
-                pattern.quantum_state.memory_tier = MemoryTierEnum::STM;
+                pattern.quantum_state.memory_tier = ::sep::memory::MemoryTierEnum::STM;
             } else if (pattern.quantum_state.coherence < config_.ltm_coherence_threshold) {
-                pattern.quantum_state.memory_tier = MemoryTierEnum::MTM;
+                pattern.quantum_state.memory_tier = ::sep::memory::MemoryTierEnum::MTM;
             }
         }
     }
@@ -260,9 +260,9 @@ public:
         size_t stm_count = 0, mtm_count = 0, ltm_count = 0;
         for (const auto& pattern : patterns_) {
             switch (pattern.quantum_state.memory_tier) {
-                case MemoryTierEnum::STM: stm_count++; break;
-                case MemoryTierEnum::MTM: mtm_count++; break;
-                case MemoryTierEnum::LTM: ltm_count++; break;
+                case ::sep::memory::MemoryTierEnum::STM: stm_count++; break;
+                case ::sep::memory::MemoryTierEnum::MTM: mtm_count++; break;
+                case ::sep::memory::MemoryTierEnum::LTM: ltm_count++; break;
             }
         }
         status += "  STM patterns: " + std::to_string(stm_count) + "\n";
@@ -303,13 +303,13 @@ private:
 
     void updateMemoryTier(Pattern& pattern) {
         auto& state = pattern.quantum_state;
-        MemoryTierEnum previous_tier = state.memory_tier;
+        ::sep::memory::MemoryTierEnum previous_tier = state.memory_tier;
         if (state.coherence >= config_.ltm_coherence_threshold && state.stability >= config_.stability_threshold) {
-            state.memory_tier = MemoryTierEnum::LTM;
+            state.memory_tier = ::sep::memory::MemoryTierEnum::LTM;
         } else if (state.coherence >= config_.mtm_coherence_threshold) {
-            state.memory_tier = MemoryTierEnum::MTM;
+            state.memory_tier = ::sep::memory::MemoryTierEnum::MTM;
         } else {
-            state.memory_tier = MemoryTierEnum::STM;
+            state.memory_tier = ::sep::memory::MemoryTierEnum::STM;
         }
         if (state.memory_tier != previous_tier) {
             state.access_frequency = 1.0f;
@@ -361,7 +361,7 @@ sep::SEPResult Processor::updatePattern(const std::string& pattern_id, const Pat
 Pattern Processor::getPattern(const std::string& pattern_id) const { return impl_->getPattern(pattern_id); }
 
 std::vector<Pattern> Processor::getPatterns() const { return impl_->getPatterns(); }
-std::vector<Pattern> Processor::getPatternsByTier(MemoryTierEnum tier) const { return impl_->getPatternsByTier(tier); }
+std::vector<Pattern> Processor::getPatternsByTier(::sep::memory::MemoryTierEnum tier) const { return impl_->getPatternsByTier(tier); }
 size_t Processor::getPatternCount() const { return impl_->getPatternCount(); }
 ProcessingResult Processor::processPattern(const std::string& pattern_id) { return impl_->processPattern(pattern_id); }
 

--- a/tests/blender/api_test.cpp
+++ b/tests/blender/api_test.cpp
@@ -111,7 +111,7 @@ TEST_F(APITest, ProcessAudioTest) {
 TEST_F(APITest, SyncMemoryTest) {
   ASSERT_EQ(sep::SEPResult::SUCCESS, sep_blender_init(gpu_ctx_, nullptr, &bridge_));
   EXPECT_EQ(sep::SEPResult::SUCCESS,
-            sep_sync_memory(bridge_, sep::MemoryTierEnum::STM, true));
+            sep_sync_memory(bridge_, sep::memory::MemoryTierEnum::STM, true));
 }
 
 TEST_F(APITest, GetMetricsTest) {

--- a/tests/memory/memory_tier_manager_test.cpp
+++ b/tests/memory/memory_tier_manager_test.cpp
@@ -221,7 +221,7 @@ TEST(MemoryTierManagerTest, PrunePatternsByPriority) {
         sep::pattern::PatternData pat;
         pat.id = std::to_string(i);
         pat.coherence = pdata.coherence;
-        pat.memory_tier = sep::MemoryTierEnum::LTM;
+        pat.memory_tier = sep::memory::MemoryTierEnum::LTM;
         mgr.registerPattern(i, pat);
     }
     mgr.prunePatternsByPriority(sep::memory::TierType::LTM, 2);


### PR DESCRIPTION
## Summary
- fix forward declaration for `MemoryTierEnum`
- qualify `MemoryTierEnum` usages across code
- implement `createPatternQuantumProcessor` factory
- update tests to new enum namespace

## Testing
- `bash tests/blender/run_tests.sh` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6860ac3bd86c832aa87e71452fd98da3