### PR TITLE
Fix PatternQuantumProcessor implementation

### DIFF
--- a/src/quantum/pattern_processor.cpp
+++ b/src/quantum/pattern_processor.cpp
@@ -2,6 +2,7 @@
 #include "quantum/quantum_processor.h"
 #include "quantum/types.h"
 #include "memory/types.h"
+#include "compat/math_common.h"
 
 #include <glm/vec3.hpp>
 
@@ -105,6 +106,16 @@ private:
 };
 } // namespace
 
+std::unique_ptr<PatternQuantumProcessor> createPatternQuantumProcessor(
+    const ProcessingConfig& config)
+{
+    QuantumProcessor::Config qp_cfg{};
+    qp_cfg.max_qubits = config.max_patterns;
+    qp_cfg.decoherence_rate = config.mutation_rate;
+    qp_cfg.measurement_threshold = config.ltm_coherence_threshold;
+    qp_cfg.enable_gpu = config.enable_cuda;
+    return std::make_unique<PatternQuantumProcessorImpl>(qp_cfg);
+}
 
 } // namespace sep::quantum
 


### PR DESCRIPTION
## Summary
- include math constants for thresholds
- add factory function `createPatternQuantumProcessor`
- update pattern processor implementation

## Testing
- `g++ -std=c++17 -Iinclude -I. -c src/quantum/pattern_processor.cpp -o /tmp/pattern_processor.o` *(fails: `nlohmann/json.hpp` missing)*
- `npm test` *(fails: `turbo: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6860ac3bd86c832aa87e71452fd98da3