### PR TITLE
Fix struct namespaces for canonical pattern processor

### DIFF
--- a/include/blender/bridge.h
+++ b/include/blender/bridge.h
@@ -54,7 +54,7 @@ class BlenderBridge {
   virtual sep::SEPResult processPatterns();  // Changed to global SEPResult
 
   virtual sep::SEPResult syncMemory(  // Changed to global SEPResult
-      MemoryTierEnum tier, bool force = false);
+      sep::memory::MemoryTierEnum tier, bool force = false);
 
   void addObserver(std::shared_ptr<PatternObserver> observer);
   void removeObserver(std::shared_ptr<PatternObserver> observer);
@@ -106,7 +106,7 @@ class BlenderBridge {
   sep::SEPResult allocatePatternMemory(ObjectState& state);  // Changed to global SEPResult
   sep::SEPResult freePatternMemory(ObjectState& state);      // Changed to global SEPResult
   sep::SEPResult promotePatterns(sep::pattern::ObjectHandle handle,
-                              MemoryTierEnum target_tier);  // Changed to global SEPResult
+                              sep::memory::MemoryTierEnum target_tier);  // Changed to global SEPResult
   sep::SEPResult syncPatternData(sep::pattern::ObjectHandle handle,
                               bool force);  // Changed to global SEPResult
 

--- a/include/blender/types.h
+++ b/include/blender/types.h
@@ -6,10 +6,12 @@
 
 // Forward declaration for MemoryTierEnum from sep::math_common.h
 namespace sep {
+namespace memory {
   enum class MemoryTierEnum : int;
-  namespace pattern {
-    class BlenderBridge;
-  }
+}
+namespace pattern {
+  class BlenderBridge;
+}
 }
 
 // Using the SEPResult enum from sep namespace

--- a/include/memory/quantum_coherence_manager.h
+++ b/include/memory/quantum_coherence_manager.h
@@ -44,8 +44,8 @@ class QuantumCoherenceManager {
 
     struct TierMigration {
         std::string pattern_id;
-        MemoryTierEnum from_tier{MemoryTierEnum::STM};
-        MemoryTierEnum to_tier{MemoryTierEnum::STM};
+        sep::memory::MemoryTierEnum from_tier{sep::memory::MemoryTierEnum::STM};
+        sep::memory::MemoryTierEnum to_tier{sep::memory::MemoryTierEnum::STM};
         float coherence{0.f};
         MigrationReason reason{MigrationReason::LowActivity};
     };
@@ -88,7 +88,7 @@ class QuantumCoherenceManager {
         float stability{0.f};
         std::uint32_t access_count{0};
         std::uint64_t last_access_tick{0};
-        MemoryTierEnum current_tier{MemoryTierEnum::STM};
+        sep::memory::MemoryTierEnum current_tier{sep::memory::MemoryTierEnum::STM};
         std::vector<std::string> entangled_patterns;
         float fragmentation_score{0.f};
     };

--- a/include/memory/types.h
+++ b/include/memory/types.h
@@ -7,7 +7,6 @@
 
 #include "core/types.h"
 #include "compat/shim.h"
-#include "quantum/data.hpp"  // For sep::pattern::PatternData
 
 #include <cstdint>
 #include <cstddef>

--- a/include/quantum/data.hpp
+++ b/include/quantum/data.hpp
@@ -20,7 +20,7 @@ struct PatternData {
     float entropy{0.0f};
     float mutation_rate{0.0f};
     std::uint32_t mutation_count{0};
-    MemoryTierEnum memory_tier{MemoryTierEnum::STM};
+    sep::memory::MemoryTierEnum memory_tier{sep::memory::MemoryTierEnum::STM};
     std::vector<quantum::PatternRelationship> relationships;
 };
 

--- a/include/quantum/pattern_processor.h
+++ b/include/quantum/pattern_processor.h
@@ -26,7 +26,7 @@ constexpr float MTM_COHERENCE_THRESHOLD = 0.7F;
 struct PatternProcessResult {
     QuantumState state;
     std::string pattern_id;
-    MemoryTierEnum memory_tier{MemoryTierEnum::STM};
+    sep::memory::MemoryTierEnum memory_tier{sep::memory::MemoryTierEnum::STM};
     bool tier_changed{false};
     float coherence_score{0.0F};
     float stability_score{0.0F};

--- a/src/blender/blender_integration.cpp
+++ b/src/blender/blender_integration.cpp
@@ -263,7 +263,7 @@ sep::SEPResult BlenderBridge::freePatternMemory(ObjectState& state)
     return sep::SEPResult::SUCCESS;
 }
 
-sep::SEPResult BlenderBridge::syncMemory(MemoryTierEnum tier, bool force)
+sep::SEPResult BlenderBridge::syncMemory(sep::memory::MemoryTierEnum tier, bool force)
 {
     if (!m_processing_thread_active.load())
     {
@@ -274,17 +274,17 @@ sep::SEPResult BlenderBridge::syncMemory(MemoryTierEnum tier, bool force)
 
     switch (tier)
     {
-        case MemoryTierEnum::STM:
+        case sep::memory::MemoryTierEnum::STM:
             manager.defragmentTier(sep::memory::TierType::HOST);
             break;
-        case MemoryTierEnum::MTM:
+        case sep::memory::MemoryTierEnum::MTM:
             manager.defragmentTier(sep::memory::TierType::DEVICE);
             if (force)
             {
                 manager.defragmentTier(sep::memory::TierType::HOST);
             }
             break;
-        case MemoryTierEnum::LTM:
+        case sep::memory::MemoryTierEnum::LTM:
             manager.defragmentTier(sep::memory::TierType::UNIFIED);
             break;
         default:
@@ -473,7 +473,7 @@ sep::SEPResult BlenderBridge::validatePatternCoherence(const ObjectState& state)
     return sep::SEPResult::SUCCESS;
 }
 
-sep::SEPResult BlenderBridge::promotePatterns(ObjectHandle handle, MemoryTierEnum target_tier)
+sep::SEPResult BlenderBridge::promotePatterns(ObjectHandle handle, sep::memory::MemoryTierEnum target_tier)
 {
     (void)handle;
     (void)target_tier;

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -76,11 +76,11 @@ void MemoryTierManager::deallocate(MemoryBlock* block) {
 
 MemoryTier* MemoryTierManager::getTier(TierType tier) {
     switch (tier) {
-        case static_cast<TierType>(MemoryTierEnum::STM):
+        case static_cast<TierType>(sep::memory::MemoryTierEnum::STM):
             return stm_.get();
-        case static_cast<TierType>(MemoryTierEnum::MTM):
+        case static_cast<TierType>(sep::memory::MemoryTierEnum::MTM):
             return mtm_.get();
-        case static_cast<TierType>(MemoryTierEnum::LTM):
+        case static_cast<TierType>(sep::memory::MemoryTierEnum::LTM):
             return ltm_.get();
         default:
             return nullptr;
@@ -98,16 +98,16 @@ float MemoryTierManager::getTierFragmentation(TierType tier) const {
 }
 
 float MemoryTierManager::getTotalUtilization() const {
-    float stm_util = getTierUtilization(static_cast<TierType>(MemoryTierEnum::STM));
-    float mtm_util = getTierUtilization(static_cast<TierType>(MemoryTierEnum::MTM));
-    float ltm_util = getTierUtilization(static_cast<TierType>(MemoryTierEnum::LTM));
+    float stm_util = getTierUtilization(static_cast<TierType>(sep::memory::MemoryTierEnum::STM));
+    float mtm_util = getTierUtilization(static_cast<TierType>(sep::memory::MemoryTierEnum::MTM));
+    float ltm_util = getTierUtilization(static_cast<TierType>(sep::memory::MemoryTierEnum::LTM));
     return (stm_util + mtm_util + ltm_util) / 3.0f;
 }
 
 float MemoryTierManager::getTotalFragmentation() const {
-    float stm_frag = getTierFragmentation(static_cast<TierType>(MemoryTierEnum::STM));
-    float mtm_frag = getTierFragmentation(static_cast<TierType>(MemoryTierEnum::MTM));
-    float ltm_frag = getTierFragmentation(static_cast<TierType>(MemoryTierEnum::LTM));
+    float stm_frag = getTierFragmentation(static_cast<TierType>(sep::memory::MemoryTierEnum::STM));
+    float mtm_frag = getTierFragmentation(static_cast<TierType>(sep::memory::MemoryTierEnum::MTM));
+    float ltm_frag = getTierFragmentation(static_cast<TierType>(sep::memory::MemoryTierEnum::LTM));
     return (stm_frag + mtm_frag + ltm_frag) / 3.0f;
 }
 

--- a/src/memory/quantum_coherence_manager.cpp
+++ b/src/memory/quantum_coherence_manager.cpp
@@ -95,7 +95,7 @@ public:
         // Fill in missing fields in result
         for(int i = 0; i < 3; ++i) {
             result.tier_fragmentation[i] = metrics_.tier_fragmentation[i];
-            result.tier_pattern_count[i] = countPatternsInTier(static_cast<MemoryTierEnum>(i));
+            result.tier_pattern_count[i] = countPatternsInTier(static_cast<sep::memory::MemoryTierEnum>(i));
         }
         
         return result;
@@ -201,9 +201,9 @@ public:
         }
         
         // Capture tier distributions
-        snapshot.tier_distribution[0] = countPatternsInTier(MemoryTierEnum::STM);
-        snapshot.tier_distribution[1] = countPatternsInTier(MemoryTierEnum::MTM);
-        snapshot.tier_distribution[2] = countPatternsInTier(MemoryTierEnum::LTM);
+        snapshot.tier_distribution[0] = countPatternsInTier(sep::memory::MemoryTierEnum::STM);
+        snapshot.tier_distribution[1] = countPatternsInTier(sep::memory::MemoryTierEnum::MTM);
+        snapshot.tier_distribution[2] = countPatternsInTier(sep::memory::MemoryTierEnum::LTM);
         
         return snapshot;
     }
@@ -232,7 +232,7 @@ public:
         return global_tick_.load();
     }
 
-    uint32_t getPatternCountByTier(MemoryTierEnum tier) const {
+    uint32_t getPatternCountByTier(sep::memory::MemoryTierEnum tier) const {
         return countPatternsInTier(tier);
     }
 


### PR DESCRIPTION
## Summary
- remove cyclical include in `memory/types.h`
- qualify `MemoryTierEnum` usage in pattern types and processor headers
- fix namespace references in Blender bridge and types headers
- update memory manager and coherence manager to use namespaced enums

## Testing
- `tests/blender/run_all_tests.sh` *(fails: Could not find nvcc)*
- `npm run lint` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860ac3bd86c832aa87e71452fd98da3