### PR TITLE
Fix namespace and config struct issues

### DIFF
--- a/include/quantum/quantum_manifold_optimizer.h
+++ b/include/quantum/quantum_manifold_optimizer.h
@@ -34,7 +34,7 @@ class QuantumManifoldOptimizer {
 public:
     struct Config {
         MemoryTierEnum tier{MemoryTierEnum::STM};
-        CUDAConfig cuda;
+        CudaConfig cuda;
         APIConfig api;
         LogConfig log;
         double base_resonance_frequency{0.42};
@@ -64,6 +64,8 @@ private:
 };
 
 } // namespace sep::quantum::manifold
+
+namespace sep::quantum::manifold {
 
 // Forward declarations
 class HamiltonianEvolver;
@@ -136,7 +138,7 @@ struct SemanticConfig {
 
 struct ManifoldConfig {
     SemanticConfig semantic;
-    CUDAConfig cuda;
+    CudaConfig cuda;
     APIConfig api;
     LogConfig log;
 };
@@ -503,3 +505,5 @@ private:
     void integrateWithExistingMemoryTiers();
     void setupQuantumProcessingPipeline();
 };
+
+} // namespace sep::quantum::manifold

--- a/src/quantum/pattern_evolution.cpp
+++ b/src/quantum/pattern_evolution.cpp
@@ -56,7 +56,7 @@ sep::pattern::PatternData sep::quantum::mcp::PatternEvolution::evolvePattern(con
     {
         for (const auto& rel_json : config["relationships"])
         {
-            PatternRelationship rel;
+            ::sep::quantum::PatternRelationship rel;
             
             std::string target_id = rel_json.value("target", "");
             if (!target_id.empty())
@@ -195,7 +195,7 @@ sep::pattern::PatternData sep::quantum::mcp::PatternEvolution::fromJson(const nl
     {
         for (const auto& rel_json : j["relationships"])
         {
-            PatternRelationship rel;
+            ::sep::quantum::PatternRelationship rel;
             
             if (rel_json.contains("target") && rel_json["target"].is_string())
             {


### PR DESCRIPTION
## Summary
- standardize QuantumManifoldOptimizer header
- reopen namespace correctly
- use `CudaConfig` type consistently
- qualify `PatternRelationship` usages

## Testing
- `git diff --color --unified=3 include/quantum/quantum_manifold_optimizer.h | head -n 40`


------
https://chatgpt.com/codex/tasks/task_e_6860ac31dbe8832a9c65c98e257776b9