### PR TITLE
Fix namespace usage for core types

### DIFF
--- a/include/quantum/quantum_manifold_optimizer.h
+++ b/include/quantum/quantum_manifold_optimizer.h
@@ -136,8 +136,8 @@ struct SemanticConfig {
 
 struct ManifoldConfig {
     SemanticConfig semantic;
-    CUDAConfig cuda;
-    APIConfig api;
+    CudaConfig cuda;
+    ApiConfig api;
     LogConfig log;
 };
 

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -322,7 +322,7 @@ void MemoryTierManager::loadLTMFromPersistence() {
         for (const auto& rel : data_opt->relationship_data) {
             sep::quantum::PatternRelationship pr;
             pr.targetId = std::to_string(rel.id);
-            pr.type = static_cast<quantum::RelationshipType>(rel.type);
+            pr.type = static_cast<::sep::quantum::RelationshipType>(rel.type);
             pr.strength = rel.strength;
             pat->relationships.push_back(pr);
             pattern_relationships_[id][rel.id] = rel.strength;
@@ -331,20 +331,21 @@ void MemoryTierManager::loadLTMFromPersistence() {
     }
 }
 
-void MemoryTierManager::storeLTMToPersistence(const quantum::Pattern& pattern, const persistence::PersistentPatternData& data) {
+void MemoryTierManager::storeLTMToPersistence(const ::sep::quantum::Pattern& pattern,
+                                              const persistence::PersistentPatternData& data) {
     if (!redis_manager_ || !redis_manager_->isConnected())
         return;
     std::size_t id = pattern.id.empty() ? 0 : std::stoull(pattern.id);
     redis_manager_->storePattern(id, data, "ltm");
 }
 
-quantum::Pattern* MemoryTierManager::findPattern(std::size_t id) {
+::sep::quantum::Pattern* MemoryTierManager::findPattern(std::size_t id) {
     auto it = pattern_registry_.find(id);
     if (it == pattern_registry_.end()) {
         return nullptr;
     }
     const sep::pattern::PatternData* data = it->second.get();
-    quantum::Pattern* pattern = new quantum::Pattern();
+    ::sep::quantum::Pattern* pattern = new ::sep::quantum::Pattern();
     pattern->id = data->id;
     const float values[] = {data->attributes.x, data->attributes.y, data->attributes.z, data->attributes.w};
     pattern->data.assign(values, values + 4);
@@ -355,13 +356,13 @@ quantum::Pattern* MemoryTierManager::findPattern(std::size_t id) {
     return pattern;
 }
 
-const quantum::Pattern* MemoryTierManager::findPattern(std::size_t id) const {
+const ::sep::quantum::Pattern* MemoryTierManager::findPattern(std::size_t id) const {
     auto it = pattern_registry_.find(id);
     if (it == pattern_registry_.end()) {
         return nullptr;
     }
     const sep::pattern::PatternData* data = it->second.get();
-    quantum::Pattern* pattern = new quantum::Pattern();
+    ::sep::quantum::Pattern* pattern = new ::sep::quantum::Pattern();
     pattern->id = data->id;
     const float values[] = {data->attributes.x, data->attributes.y, data->attributes.z, data->attributes.w};
     pattern->data.assign(values, values + 4);

--- a/src/memory/quantum_coherence_manager.cpp
+++ b/src/memory/quantum_coherence_manager.cpp
@@ -47,7 +47,7 @@ public:
 
     explicit Impl(const Config& config)
         : config_(config)
-        , qfh_processor_(std::make_unique<quantum::QuantumProcessorQFH>())
+        , qfh_processor_(std::make_unique<::sep::quantum::QuantumProcessorQFH>())
         , global_tick_(0) {
 
         
@@ -246,7 +246,7 @@ public:
 
 private:
     Config config_;
-    std::unique_ptr<quantum::QuantumProcessorQFH> qfh_processor_;
+    std::unique_ptr<::sep::quantum::QuantumProcessorQFH> qfh_processor_;
     cuda::CudaCore* cuda_core_ = nullptr;
     
     // Concurrent data structures

--- a/src/quantum/processor.cpp
+++ b/src/quantum/processor.cpp
@@ -20,6 +20,8 @@ inline float deterministicNoise(uint64_t& state) {
 
 namespace sep::quantum {
 
+using ::sep::memory::MemoryTierEnum;
+
 class ProcessorImpl {
 public:
     explicit ProcessorImpl(const ProcessingConfig& config)


### PR DESCRIPTION
## Summary
- qualify quantum pattern and relationship types in memory tier manager
- fix QuantumProcessorQFH pointer namespaces in coherence manager
- fix config struct casing in `ManifoldConfig`
- import `MemoryTierEnum` into quantum processor

## Testing
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860ac31dbe8832a9c65c98e257776b9