### PR TITLE
Fix namespace issues for core types

### DIFF
--- a/include/quantum/data.hpp
+++ b/include/quantum/data.hpp
@@ -20,8 +20,8 @@ struct PatternData {
     float entropy{0.0f};
     float mutation_rate{0.0f};
     std::uint32_t mutation_count{0};
-    MemoryTierEnum memory_tier{MemoryTierEnum::STM};
-    std::vector<quantum::PatternRelationship> relationships;
+    sep::memory::MemoryTierEnum memory_tier{sep::memory::MemoryTierEnum::STM};
+    std::vector<sep::quantum::PatternRelationship> relationships;
 };
 
 struct PatternConfig {

--- a/include/quantum/pattern_processor.h
+++ b/include/quantum/pattern_processor.h
@@ -26,7 +26,7 @@ constexpr float MTM_COHERENCE_THRESHOLD = 0.7F;
 struct PatternProcessResult {
     QuantumState state;
     std::string pattern_id;
-    MemoryTierEnum memory_tier{MemoryTierEnum::STM};
+    sep::memory::MemoryTierEnum memory_tier{sep::memory::MemoryTierEnum::STM};
     bool tier_changed{false};
     float coherence_score{0.0F};
     float stability_score{0.0F};

--- a/include/quantum/quantum_manifold_optimizer.h
+++ b/include/quantum/quantum_manifold_optimizer.h
@@ -26,16 +26,16 @@ using ::sep::quantum::QuantumState;
 using QuantumPattern = ::sep::quantum::Pattern;
 using ::sep::quantum::QFHResult;
 using ::sep::quantum::QuantumProcessorQFH;
-using ::sep::config::CUDAConfig;
-using ::sep::config::APIConfig;
+using sep::config::CudaConfig;
+using sep::config::ApiConfig;
 using ::sep::config::LogConfig;
 
 class QuantumManifoldOptimizer {
 public:
     struct Config {
         MemoryTierEnum tier{MemoryTierEnum::STM};
-        CUDAConfig cuda;
-        APIConfig api;
+        CudaConfig cuda;
+        ApiConfig api;
         LogConfig log;
         double base_resonance_frequency{0.42};
     };
@@ -136,8 +136,8 @@ struct SemanticConfig {
 
 struct ManifoldConfig {
     SemanticConfig semantic;
-    CUDAConfig cuda;
-    APIConfig api;
+    CudaConfig cuda;
+    ApiConfig api;
     LogConfig log;
 };
 

--- a/src/memory/quantum_coherence_manager.cpp
+++ b/src/memory/quantum_coherence_manager.cpp
@@ -95,7 +95,7 @@ public:
         // Fill in missing fields in result
         for(int i = 0; i < 3; ++i) {
             result.tier_fragmentation[i] = metrics_.tier_fragmentation[i];
-            result.tier_pattern_count[i] = countPatternsInTier(static_cast<MemoryTierEnum>(i));
+            result.tier_pattern_count[i] = countPatternsInTier(static_cast<sep::memory::MemoryTierEnum>(i));
         }
         
         return result;
@@ -201,9 +201,9 @@ public:
         }
         
         // Capture tier distributions
-        snapshot.tier_distribution[0] = countPatternsInTier(MemoryTierEnum::STM);
-        snapshot.tier_distribution[1] = countPatternsInTier(MemoryTierEnum::MTM);
-        snapshot.tier_distribution[2] = countPatternsInTier(MemoryTierEnum::LTM);
+        snapshot.tier_distribution[0] = countPatternsInTier(sep::memory::MemoryTierEnum::STM);
+        snapshot.tier_distribution[1] = countPatternsInTier(sep::memory::MemoryTierEnum::MTM);
+        snapshot.tier_distribution[2] = countPatternsInTier(sep::memory::MemoryTierEnum::LTM);
         
         return snapshot;
     }
@@ -232,7 +232,7 @@ public:
         return global_tick_.load();
     }
 
-    uint32_t getPatternCountByTier(MemoryTierEnum tier) const {
+    uint32_t getPatternCountByTier(sep::memory::MemoryTierEnum tier) const {
         return countPatternsInTier(tier);
     }
 

--- a/src/quantum/pattern_evolution.cpp
+++ b/src/quantum/pattern_evolution.cpp
@@ -56,7 +56,7 @@ sep::pattern::PatternData sep::quantum::mcp::PatternEvolution::evolvePattern(con
     {
         for (const auto& rel_json : config["relationships"])
         {
-            PatternRelationship rel;
+            sep::quantum::PatternRelationship rel;
             
             std::string target_id = rel_json.value("target", "");
             if (!target_id.empty())
@@ -195,7 +195,7 @@ sep::pattern::PatternData sep::quantum::mcp::PatternEvolution::fromJson(const nl
     {
         for (const auto& rel_json : j["relationships"])
         {
-            PatternRelationship rel;
+            sep::quantum::PatternRelationship rel;
             
             if (rel_json.contains("target") && rel_json["target"].is_string())
             {

--- a/src/quantum/processor.cpp
+++ b/src/quantum/processor.cpp
@@ -81,7 +81,7 @@ public:
         return patterns_;
     }
 
-    std::vector<Pattern> getPatternsByTier(MemoryTierEnum tier) const {
+    std::vector<Pattern> getPatternsByTier(sep::memory::MemoryTierEnum tier) const {
         std::lock_guard<std::mutex> lock(mutex_);
         std::vector<Pattern> result;
         for (const auto& pattern : patterns_) {
@@ -205,9 +205,9 @@ public:
         std::lock_guard<std::mutex> lock(mutex_);
         for (auto& pattern : patterns_) {
             if (pattern.quantum_state.coherence < config_.mtm_coherence_threshold) {
-                pattern.quantum_state.memory_tier = MemoryTierEnum::STM;
+                pattern.quantum_state.memory_tier = sep::memory::MemoryTierEnum::STM;
             } else if (pattern.quantum_state.coherence < config_.ltm_coherence_threshold) {
-                pattern.quantum_state.memory_tier = MemoryTierEnum::MTM;
+                pattern.quantum_state.memory_tier = sep::memory::MemoryTierEnum::MTM;
             }
         }
     }
@@ -260,9 +260,9 @@ public:
         size_t stm_count = 0, mtm_count = 0, ltm_count = 0;
         for (const auto& pattern : patterns_) {
             switch (pattern.quantum_state.memory_tier) {
-                case MemoryTierEnum::STM: stm_count++; break;
-                case MemoryTierEnum::MTM: mtm_count++; break;
-                case MemoryTierEnum::LTM: ltm_count++; break;
+                case sep::memory::MemoryTierEnum::STM: stm_count++; break;
+                case sep::memory::MemoryTierEnum::MTM: mtm_count++; break;
+                case sep::memory::MemoryTierEnum::LTM: ltm_count++; break;
             }
         }
         status += "  STM patterns: " + std::to_string(stm_count) + "\n";
@@ -303,13 +303,13 @@ private:
 
     void updateMemoryTier(Pattern& pattern) {
         auto& state = pattern.quantum_state;
-        MemoryTierEnum previous_tier = state.memory_tier;
+        sep::memory::MemoryTierEnum previous_tier = state.memory_tier;
         if (state.coherence >= config_.ltm_coherence_threshold && state.stability >= config_.stability_threshold) {
-            state.memory_tier = MemoryTierEnum::LTM;
+            state.memory_tier = sep::memory::MemoryTierEnum::LTM;
         } else if (state.coherence >= config_.mtm_coherence_threshold) {
-            state.memory_tier = MemoryTierEnum::MTM;
+            state.memory_tier = sep::memory::MemoryTierEnum::MTM;
         } else {
-            state.memory_tier = MemoryTierEnum::STM;
+            state.memory_tier = sep::memory::MemoryTierEnum::STM;
         }
         if (state.memory_tier != previous_tier) {
             state.access_frequency = 1.0f;
@@ -361,7 +361,7 @@ sep::SEPResult Processor::updatePattern(const std::string& pattern_id, const Pat
 Pattern Processor::getPattern(const std::string& pattern_id) const { return impl_->getPattern(pattern_id); }
 
 std::vector<Pattern> Processor::getPatterns() const { return impl_->getPatterns(); }
-std::vector<Pattern> Processor::getPatternsByTier(MemoryTierEnum tier) const { return impl_->getPatternsByTier(tier); }
+std::vector<Pattern> Processor::getPatternsByTier(sep::memory::MemoryTierEnum tier) const { return impl_->getPatternsByTier(tier); }
 size_t Processor::getPatternCount() const { return impl_->getPatternCount(); }
 ProcessingResult Processor::processPattern(const std::string& pattern_id) { return impl_->processPattern(pattern_id); }
 

--- a/src/quantum/types_serialization.cpp
+++ b/src/quantum/types_serialization.cpp
@@ -29,7 +29,7 @@ void from_json(const nlohmann::json& j, QuantumState& state) {
     j.at("access_frequency").get_to(state.access_frequency);
 }
 
-void to_json(nlohmann::json& j, const PatternRelationship& rel) {
+void to_json(nlohmann::json& j, const sep::quantum::PatternRelationship& rel) {
     j = nlohmann::json{
         {"targetId", rel.targetId},
         {"strength", rel.strength},
@@ -37,7 +37,7 @@ void to_json(nlohmann::json& j, const PatternRelationship& rel) {
     };
 }
 
-void from_json(const nlohmann::json& j, PatternRelationship& rel) {
+void from_json(const nlohmann::json& j, sep::quantum::PatternRelationship& rel) {
     j.at("targetId").get_to(rel.targetId);
     j.at("strength").get_to(rel.strength);
     rel.type = static_cast<RelationshipType>(j.value("type", 0)); // Fix: default value for type


### PR DESCRIPTION
## Summary
- qualify core types with `sep` namespaces
- correct config struct names in QuantumManifoldOptimizer
- update serialization and pattern evolution helpers
- use qualified memory tier enums in QuantumCoherenceManager and Processor

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6860ac31dbe8832a9c65c98e257776b9