### PR TITLE
Fix SEPBlenderBridge include issues

### DIFF
--- a/include/blender/api.h
+++ b/include/blender/api.h
@@ -13,7 +13,6 @@ extern "C" {
 struct GPUContext;
 struct Object;
 struct Mesh;
-struct SEPBlenderBridge;
 typedef uint64_t SEPMeshHandle;
 
 // Initialize bridge with Blender GPU context

--- a/include/compat/component_bridge.h
+++ b/include/compat/component_bridge.h
@@ -9,7 +9,6 @@ class AudioCapture;
 namespace pattern {
 class BlenderBridge;
 }  // namespace pattern
-struct SEPBlenderBridge;
 namespace blender {
 class CyclesRenderer; // Forward declaration if header not available
 }

--- a/include/core/engine.h
+++ b/include/core/engine.h
@@ -8,6 +8,7 @@
 #include "core/common.h"
 
 #include "core/types.h"
+#include "blender/types.h"  // Ensure SEPBlenderBridge definition available
 #include "compat/types.h"  // for QSHResult
 #include "quantum/qbsa.h"
 


### PR DESCRIPTION
## Summary
- include `blender/types.h` from `engine.h` so that SEPBlenderBridge is defined whenever the header is used
- drop redundant forward declaration in `component_bridge.h`
- remove unused forward declaration from `blender/api.h`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6860b0498400832a998df4e26325562a