### PR TITLE
Fix QuantumCoherenceManager signature duplicates

### DIFF
--- a/include/memory/quantum_coherence_manager.h
+++ b/include/memory/quantum_coherence_manager.h
@@ -126,26 +126,12 @@ class QuantumCoherenceManager {
     void applyCoherenceDecay(float decay_factor);
     CoherenceSnapshot createSnapshot() const;
     bool restoreFromSnapshot(const CoherenceSnapshot& snapshot);
-    const CoherenceMetrics& getMetrics() const;
-    uint64_t getGlobalTick() const;
-    uint32_t getPatternCountByTier(MemoryTierEnum tier) const;
-    float getTierFragmentation(MemoryTierEnum tier) const;
 
     // Metrics and diagnostics
     const CoherenceMetrics& getMetrics() const;
     uint64_t getGlobalTick() const;
     uint32_t getPatternCountByTier(MemoryTierEnum tier) const;
     float getTierFragmentation(MemoryTierEnum tier) const;
-
-    const CoherenceMetrics& getMetrics() const;
-    uint64_t getGlobalTick() const;
-    uint32_t getPatternCountByTier(MemoryTierEnum tier) const;
-    float getTierFragmentation(MemoryTierEnum tier) const;
-
-    const CoherenceMetrics& getMetrics() const;
-    uint64_t getGlobalTick() const;
-    uint32_t getPatternCountByTier(::sep::memory::MemoryTierEnum tier) const;
-    float getTierFragmentation(::sep::memory::MemoryTierEnum tier) const;
 
   private:
     class Impl;

--- a/src/memory/quantum_coherence_manager.cpp
+++ b/src/memory/quantum_coherence_manager.cpp
@@ -758,11 +758,11 @@ uint64_t QuantumCoherenceManager::getGlobalTick() const {
     return impl_->getGlobalTick();
 }
 
-uint32_t QuantumCoherenceManager::getPatternCountByTier(::sep::memory::MemoryTierEnum tier) const {
+uint32_t QuantumCoherenceManager::getPatternCountByTier(MemoryTierEnum tier) const {
     return impl_->getPatternCountByTier(tier);
 }
 
-float QuantumCoherenceManager::getTierFragmentation(::sep::memory::MemoryTierEnum tier) const {
+float QuantumCoherenceManager::getTierFragmentation(MemoryTierEnum tier) const {
     return impl_->getTierFragmentation(tier);
 }
 


### PR DESCRIPTION
## Summary
- remove duplicate declarations for QuantumCoherenceManager metrics helpers
- align function signatures in cpp file with the header

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6860b0577274832aa3e80be0db6cd410