### PR TITLE
Fix config aliases in quantum_manifold_optimizer

### DIFF
--- a/include/quantum/quantum_manifold_optimizer.h
+++ b/include/quantum/quantum_manifold_optimizer.h
@@ -26,8 +26,13 @@ using ::sep::quantum::QuantumState;
 using QuantumPattern = ::sep::quantum::Pattern;
 using ::sep::quantum::QFHResult;
 using ::sep::quantum::QuantumProcessorQFH;
-using ::sep::config::CudaConfig;
-using ::sep::config::ApiConfig;
+// Configuration structures from the core configuration module use
+// capitalised names (e.g. CUDAConfig).  The original code attempted to
+// import them with different casing which resulted in a large number of
+// "does not name a type" compilation errors.  Import them with the
+// correct names instead.
+using ::sep::config::CUDAConfig;
+using ::sep::config::APIConfig;
 using ::sep::config::LogConfig;
 
 class QuantumManifoldOptimizer {


### PR DESCRIPTION
## Summary
- correct casing for configuration type aliases in `quantum_manifold_optimizer.h`

## Testing
- `g++ -std=c++17 -Iinclude -I. -c src/quantum/quantum_manifold_optimizer.cpp -o /tmp/test.o` *(fails: `nlohmann/json.hpp` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860b050970c832a8e5538200585bd43