### PR TITLE
Fix std namespace pollution in quantum manifold optimizer

### DIFF
--- a/include/quantum/quantum_manifold_optimizer.h
+++ b/include/quantum/quantum_manifold_optimizer.h
@@ -1,8 +1,6 @@
 // quantum_manifold_optimizer.h
 #pragma once
 
-#pragma once
-
 #include "quantum/qbsa.h"
 #include "quantum/qfh.h"
 #include "quantum/types.h"
@@ -18,6 +16,15 @@
 #include <vector>
 #include <string>
 #include <cmath>
+#include <chrono>
+#include <atomic>
+#include <thread>
+#include <mutex>
+#include <condition_variable>
+#include <complex>
+#include <functional>
+#include <unordered_map>
+#include <array>
 
 namespace sep::quantum::manifold {
 
@@ -108,18 +115,6 @@ class PerformanceAnalyzer;
     } api;
 
 using sep::memory::MemoryTierEnum;
-#include <chrono>
-#include <atomic>
-#include <thread>
-#include <mutex>
-#include <condition_variable>
-#include <complex>
-#include <functional>
-#include <vector>
-#include <unordered_map>
-#include <array>
-#include <string>
-#include "compat/cufft.h"
 
 
 // Forward declarations


### PR DESCRIPTION
## Summary
- remove duplicate `#pragma once`
- move std library includes outside namespace scope in `quantum_manifold_optimizer.h`
- add missing includes for std types

## Testing
- `g++ -std=c++17 -Iinclude -Isrc -c src/quantum/quantum_manifold_optimizer.cpp -o /tmp/qmo.o` *(fails: invalid use of incomplete type)*

------
https://chatgpt.com/codex/tasks/task_e_6860b050970c832a8e5538200585bd43