### PR TITLE
Fix QuantumCoherenceManager header declarations

### DIFF
--- a/include/memory/quantum_coherence_manager.h
+++ b/include/memory/quantum_coherence_manager.h
@@ -126,22 +126,8 @@ class QuantumCoherenceManager {
     void applyCoherenceDecay(float decay_factor);
     CoherenceSnapshot createSnapshot() const;
     bool restoreFromSnapshot(const CoherenceSnapshot& snapshot);
-    const CoherenceMetrics& getMetrics() const;
-    uint64_t getGlobalTick() const;
-    uint32_t getPatternCountByTier(MemoryTierEnum tier) const;
-    float getTierFragmentation(MemoryTierEnum tier) const;
 
     // Metrics and diagnostics
-    const CoherenceMetrics& getMetrics() const;
-    uint64_t getGlobalTick() const;
-    uint32_t getPatternCountByTier(MemoryTierEnum tier) const;
-    float getTierFragmentation(MemoryTierEnum tier) const;
-
-    const CoherenceMetrics& getMetrics() const;
-    uint64_t getGlobalTick() const;
-    uint32_t getPatternCountByTier(MemoryTierEnum tier) const;
-    float getTierFragmentation(MemoryTierEnum tier) const;
-
     const CoherenceMetrics& getMetrics() const;
     uint64_t getGlobalTick() const;
     uint32_t getPatternCountByTier(::sep::memory::MemoryTierEnum tier) const;


### PR DESCRIPTION
## Summary
- remove duplicate declarations in `QuantumCoherenceManager`
- align function declarations with their definitions

## Testing
- `n/a`

------
https://chatgpt.com/codex/tasks/task_e_6860b0577274832aa3e80be0db6cd410