### PR TITLE
Fix SEPBlenderBridge include usage

### DIFF
--- a/include/blender/api.h
+++ b/include/blender/api.h
@@ -13,7 +13,6 @@ extern "C" {
 struct GPUContext;
 struct Object;
 struct Mesh;
-struct SEPBlenderBridge;
 typedef uint64_t SEPMeshHandle;
 
 // Initialize bridge with Blender GPU context

--- a/include/compat/component_bridge.h
+++ b/include/compat/component_bridge.h
@@ -9,7 +9,6 @@ class AudioCapture;
 namespace pattern {
 class BlenderBridge;
 }  // namespace pattern
-struct SEPBlenderBridge;
 namespace blender {
 class CyclesRenderer; // Forward declaration if header not available
 }

--- a/include/core/engine.h
+++ b/include/core/engine.h
@@ -10,6 +10,7 @@
 #include "core/types.h"
 #include "compat/types.h"  // for QSHResult
 #include "quantum/qbsa.h"
+#include "blender/types.h"
 
 namespace sep {
 namespace cuda {


### PR DESCRIPTION
## Summary
- remove redundant `SEPBlenderBridge` forward declarations
- include blender `types.h` in engine header

## Testing
- `git diff --cached --name-status`

------
https://chatgpt.com/codex/tasks/task_e_6860b0498400832a998df4e26325562a