### PR TITLE
Fix SEPBlenderBridge incomplete type usage

### DIFF
--- a/include/blender/api.h
+++ b/include/blender/api.h
@@ -13,7 +13,6 @@ extern "C" {
 struct GPUContext;
 struct Object;
 struct Mesh;
-struct SEPBlenderBridge;
 typedef uint64_t SEPMeshHandle;
 
 // Initialize bridge with Blender GPU context

--- a/include/compat/component_bridge.h
+++ b/include/compat/component_bridge.h
@@ -9,7 +9,6 @@ class AudioCapture;
 namespace pattern {
 class BlenderBridge;
 }  // namespace pattern
-struct SEPBlenderBridge;
 namespace blender {
 class CyclesRenderer; // Forward declaration if header not available
 }


### PR DESCRIPTION
## Summary
- remove redundant forward declaration of `SEPBlenderBridge` in `compat` header
- drop forward declaration of `SEPBlenderBridge` from `blender/api.h` so the alias from `blender/types.h` is used

## Testing
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6860b0498400832a998df4e26325562a