### PR TITLE
Fix pattern struct defs and processor result

### DIFF
--- a/include/quantum/pattern_processor.h
+++ b/include/quantum/pattern_processor.h
@@ -30,6 +30,8 @@ struct PatternProcessResult {
     bool tier_changed{false};
     float coherence_score{0.0F};
     float stability_score{0.0F};
+    bool success{false};
+    std::string error_message;
 };
 
 // Pattern quantum processor interface

--- a/include/quantum/types.h
+++ b/include/quantum/types.h
@@ -40,6 +40,7 @@ struct PatternRelationship {
 struct Pattern {
     std::string id;
     glm::vec4 position;
+    glm::vec3 momentum{0.0f};
     QuantumState quantum_state;
     std::vector<PatternRelationship> relationships;
     std::vector<float> data;

--- a/src/quantum/pattern_processor.cpp
+++ b/src/quantum/pattern_processor.cpp
@@ -26,6 +26,8 @@ public:
         result.state = state;
         result.pattern_id = pattern_id;
         result.memory_tier = ::sep::memory::MemoryTierEnum::STM; // Default to Short-Term Memory
+        result.success = false;
+        result.error_message.clear();
         
         // Convert state to a format the quantum processor can use
         glm::vec3 stateData(state.coherence, state.stability, state.entropy);
@@ -34,6 +36,7 @@ public:
         // Process using quantum processor
         bool success = quantum_processor_->processPattern(stateData, numericId);
         
+        result.success = success;
         if (success) {
             // Update state values based on processing
             result.coherence_score = state.coherence * 1.05f; // Simulate evolution
@@ -51,15 +54,18 @@ public:
             // Handle error case
             result.coherence_score = 0.0f;
             result.stability_score = 0.0f;
+            result.error_message = "QuantumProcessor failed";
         }
 
         // Determine memory tier
+        ::sep::memory::MemoryTierEnum previous_tier = result.memory_tier;
         if (result.coherence_score >= constants::LTM_COHERENCE_THRESHOLD &&
             result.stability_score >= pattern::STABILITY_THRESHOLD) {
             result.memory_tier = ::sep::memory::MemoryTierEnum::LTM;
         } else if (result.coherence_score >= constants::MTM_COHERENCE_THRESHOLD) {
             result.memory_tier = ::sep::memory::MemoryTierEnum::MTM;
         }
+        result.tier_changed = result.memory_tier != previous_tier;
 
         return result;
     }

--- a/src/quantum/types_serialization.cpp
+++ b/src/quantum/types_serialization.cpp
@@ -47,6 +47,7 @@ void to_json(nlohmann::json& j, const Pattern& pattern) {
     j = nlohmann::json{
         {"id", pattern.id},
         {"position", {pattern.position.x, pattern.position.y, pattern.position.z, pattern.position.w}},
+        {"momentum", {pattern.momentum.x, pattern.momentum.y, pattern.momentum.z}},
         {"quantum_state", pattern.quantum_state},
         {"relationships", pattern.relationships},
         {"data", pattern.data},
@@ -61,6 +62,12 @@ void from_json(const nlohmann::json& j, Pattern& pattern) {
     j.at("id").get_to(pattern.id);
     auto pos = j.at("position").get<std::vector<float>>();
     pattern.position = glm::vec4(pos[0], pos[1], pos[2], pos[3]);
+    if (j.contains("momentum")) {
+        auto mom = j.at("momentum").get<std::vector<float>>();
+        pattern.momentum = glm::vec3(mom[0], mom[1], mom[2]);
+    } else {
+        pattern.momentum = glm::vec3(0.0f);
+    }
     j.at("relationships").get_to(pattern.relationships);
     j.at("data").get_to(pattern.data);
     j.at("parent_ids").get_to(pattern.parent_ids);


### PR DESCRIPTION
## Summary
- add `momentum` vector to `sep::quantum::Pattern`
- extend `PatternProcessResult` with success and error message fields
- update `PatternQuantumProcessorImpl::processPattern` to populate new fields
- serialize/deserialize the new momentum member of Pattern

## Testing
- `pnpm lint` *(fails: recursive turbo invocations)*
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_6860b04172d4832aaa65763a038d0d47