### PR TITLE
Fix struct mismatches

### DIFF
--- a/include/quantum/pattern_processor.h
+++ b/include/quantum/pattern_processor.h
@@ -30,6 +30,8 @@ struct PatternProcessResult {
     bool tier_changed{false};
     float coherence_score{0.0F};
     float stability_score{0.0F};
+    bool success{false};
+    std::string error_message;
 };
 
 // Pattern quantum processor interface

--- a/include/quantum/types.h
+++ b/include/quantum/types.h
@@ -40,6 +40,7 @@ struct PatternRelationship {
 struct Pattern {
     std::string id;
     glm::vec4 position;
+    glm::vec3 momentum{0.0f};
     QuantumState quantum_state;
     std::vector<PatternRelationship> relationships;
     std::vector<float> data;

--- a/src/quantum/pattern_processor.cpp
+++ b/src/quantum/pattern_processor.cpp
@@ -33,7 +33,8 @@ public:
         
         // Process using quantum processor
         bool success = quantum_processor_->processPattern(stateData, numericId);
-        
+        result.success = success;
+
         if (success) {
             // Update state values based on processing
             result.coherence_score = state.coherence * 1.05f; // Simulate evolution
@@ -51,6 +52,7 @@ public:
             // Handle error case
             result.coherence_score = 0.0f;
             result.stability_score = 0.0f;
+            result.error_message = "Processing failed";
         }
 
         // Determine memory tier

--- a/src/quantum/types_serialization.cpp
+++ b/src/quantum/types_serialization.cpp
@@ -47,6 +47,7 @@ void to_json(nlohmann::json& j, const Pattern& pattern) {
     j = nlohmann::json{
         {"id", pattern.id},
         {"position", {pattern.position.x, pattern.position.y, pattern.position.z, pattern.position.w}},
+        {"momentum", {pattern.momentum.x, pattern.momentum.y, pattern.momentum.z}},
         {"quantum_state", pattern.quantum_state},
         {"relationships", pattern.relationships},
         {"data", pattern.data},
@@ -61,6 +62,12 @@ void from_json(const nlohmann::json& j, Pattern& pattern) {
     j.at("id").get_to(pattern.id);
     auto pos = j.at("position").get<std::vector<float>>();
     pattern.position = glm::vec4(pos[0], pos[1], pos[2], pos[3]);
+    if (j.contains("momentum")) {
+        auto mom = j.at("momentum").get<std::vector<float>>();
+        pattern.momentum = glm::vec3(mom[0], mom[1], mom[2]);
+    } else {
+        pattern.momentum = glm::vec3(0.0f);
+    }
     j.at("relationships").get_to(pattern.relationships);
     j.at("data").get_to(pattern.data);
     j.at("parent_ids").get_to(pattern.parent_ids);


### PR DESCRIPTION
## Summary
- add `momentum` to `Pattern`
- extend `PatternProcessResult` with success info
- store success and error message in the pattern quantum processor
- support momentum in JSON serialization

## Testing
- `npm run lint` *(fails: turbo not found)*
- `npm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860b04172d4832aaa65763a038d0d47