### PR TITLE
Fix pattern struct mismatches

### DIFF
--- a/include/quantum/data.hpp
+++ b/include/quantum/data.hpp
@@ -5,6 +5,8 @@
 #include "memory/types.h"
 #include <glm/glm.hpp>
 #include <vector>
+#include <complex>
+#include "quantum/pattern.h"
 
 namespace sep {
 namespace pattern {
@@ -20,6 +22,9 @@ struct PatternData {
     float entropy{0.0f};
     float mutation_rate{0.0f};
     std::uint32_t mutation_count{0};
+    std::complex<float> amplitude{1.0f, 0.0f};
+    ::sep::quantum::manifold::QuantumState state{::sep::quantum::manifold::QuantumState::SUPERPOSITION};
+    float phase{0.0f};
     ::sep::memory::MemoryTierEnum memory_tier{::sep::memory::MemoryTierEnum::STM};
     std::vector<quantum::PatternRelationship> relationships;
 };

--- a/include/quantum/pattern_processor.h
+++ b/include/quantum/pattern_processor.h
@@ -30,6 +30,9 @@ struct PatternProcessResult {
     bool tier_changed{false};
     float coherence_score{0.0F};
     float stability_score{0.0F};
+    int generation{0};
+    bool success{false};
+    std::string error_message;
 };
 
 // Pattern quantum processor interface

--- a/include/quantum/types.h
+++ b/include/quantum/types.h
@@ -27,6 +27,8 @@ struct QuantumState {
     float mutation_rate{0.0f};
     int generation{0};
     int mutation_count{0};
+    std::vector<double> amplitudes;
+    std::vector<std::uint32_t> basis_states;
     sep::memory::MemoryTierEnum memory_tier{sep::memory::MemoryTierEnum::STM};
     float access_frequency{0.0f};
 };
@@ -40,6 +42,7 @@ struct PatternRelationship {
 struct Pattern {
     std::string id;
     glm::vec4 position;
+    glm::vec3 momentum{0.0f};
     QuantumState quantum_state;
     std::vector<PatternRelationship> relationships;
     std::vector<float> data;

--- a/src/quantum/pattern_processor.cpp
+++ b/src/quantum/pattern_processor.cpp
@@ -22,7 +22,7 @@ public:
     PatternProcessResult processPattern(
         const QuantumState& state,
         const std::string& pattern_id) override {
-        PatternProcessResult result;
+        PatternProcessResult result{};
         result.state = state;
         result.pattern_id = pattern_id;
         result.memory_tier = ::sep::memory::MemoryTierEnum::STM; // Default to Short-Term Memory
@@ -33,6 +33,8 @@ public:
         
         // Process using quantum processor
         bool success = quantum_processor_->processPattern(stateData, numericId);
+        result.success = success;
+        result.error_message.clear();
         
         if (success) {
             // Update state values based on processing
@@ -51,6 +53,7 @@ public:
             // Handle error case
             result.coherence_score = 0.0f;
             result.stability_score = 0.0f;
+            result.error_message = "processing_failed";
         }
 
         // Determine memory tier
@@ -60,6 +63,10 @@ public:
         } else if (result.coherence_score >= constants::MTM_COHERENCE_THRESHOLD) {
             result.memory_tier = ::sep::memory::MemoryTierEnum::MTM;
         }
+
+        result.tier_changed = (result.memory_tier != state.memory_tier);
+        result.state.memory_tier = result.memory_tier;
+        result.generation = result.state.generation;
 
         return result;
     }

--- a/src/quantum/types_serialization.cpp
+++ b/src/quantum/types_serialization.cpp
@@ -13,6 +13,8 @@ void to_json(nlohmann::json& j, const QuantumState& state) {
         {"mutation_rate", state.mutation_rate},
         {"generation", state.generation},
         {"mutation_count", state.mutation_count},
+        {"amplitudes", state.amplitudes},
+        {"basis_states", state.basis_states},
         {"memory_tier", static_cast<int>(state.memory_tier)}, // Fix: serialize memory_tier as int
         {"access_frequency", state.access_frequency}
     };
@@ -25,6 +27,8 @@ void from_json(const nlohmann::json& j, QuantumState& state) {
     j.at("mutation_rate").get_to(state.mutation_rate);
     j.at("generation").get_to(state.generation);
     j.at("mutation_count").get_to(state.mutation_count);
+    if (j.contains("amplitudes")) j.at("amplitudes").get_to(state.amplitudes);
+    if (j.contains("basis_states")) j.at("basis_states").get_to(state.basis_states);
     state.memory_tier = static_cast<sep::memory::MemoryTierEnum>(j.value("memory_tier", 0)); // Fix: default value for memory_tier
     j.at("access_frequency").get_to(state.access_frequency);
 }
@@ -48,6 +52,7 @@ void to_json(nlohmann::json& j, const Pattern& pattern) {
         {"id", pattern.id},
         {"position", {pattern.position.x, pattern.position.y, pattern.position.z, pattern.position.w}},
         {"quantum_state", pattern.quantum_state},
+        {"momentum", {pattern.momentum.x, pattern.momentum.y, pattern.momentum.z}},
         {"relationships", pattern.relationships},
         {"data", pattern.data},
         {"parent_ids", pattern.parent_ids},
@@ -61,6 +66,12 @@ void from_json(const nlohmann::json& j, Pattern& pattern) {
     j.at("id").get_to(pattern.id);
     auto pos = j.at("position").get<std::vector<float>>();
     pattern.position = glm::vec4(pos[0], pos[1], pos[2], pos[3]);
+    if (j.contains("momentum")) {
+        auto mom = j.at("momentum").get<std::vector<float>>();
+        if (mom.size() >= 3) {
+            pattern.momentum = glm::vec3(mom[0], mom[1], mom[2]);
+        }
+    }
     j.at("relationships").get_to(pattern.relationships);
     j.at("data").get_to(pattern.data);
     j.at("parent_ids").get_to(pattern.parent_ids);


### PR DESCRIPTION
## Summary
- sync struct definitions for pattern processing
- add amplitude, state, and phase to PatternData
- expand QuantumState with amplitude and basis state vectors
- add momentum to Pattern
- extend PatternProcessResult with generation and status fields
- serialize new fields
- update pattern processor logic

## Testing
- `ctest --output-on-failure` *(fails: No tests were found)*
- `npm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860b04172d4832aaa65763a038d0d47