### PR TITLE
Add memory metrics and include quantum types

### DIFF
--- a/include/api/types.h
+++ b/include/api/types.h
@@ -112,6 +112,10 @@ struct HealthMetrics {
     std::atomic<size_t> timeoutRequests{0};
     std::atomic<size_t> rateLimitedCount{0};
     std::atomic<double> averageResponseTime{0.0};
+    // Track memory usage statistics
+    std::atomic<uint64_t> allocatedMemory{0};
+    std::atomic<uint64_t> peakMemoryUsage{0};
+    std::atomic<float> memoryFragmentation{0.0f};
     std::chrono::steady_clock::time_point lastRequestTime;
     std::chrono::steady_clock::time_point startTime;
     std::chrono::milliseconds lastResponseTime{0};

--- a/src/memory/quantum_coherence_manager.cpp
+++ b/src/memory/quantum_coherence_manager.cpp
@@ -8,6 +8,7 @@
 #include "quantum/quantum_manifold_optimizer.h"
 #include "memory/memory_tier_manager.hpp"
 #include "quantum/quantum_processor_qfh.h"
+#include "quantum/types.h"
 #include "memory/types.h"
 
 using ::sep::memory::MemoryTierEnum;


### PR DESCRIPTION
## Summary
- track allocated memory, peak usage, and fragmentation in `HealthMetrics`
- include `quantum/types.h` in `quantum_coherence_manager.cpp` to ensure Pattern definition

## Testing
- `npm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860b3e524ec832ab051c2df44370dd6