### PR TITLE
Sync metrics and pattern definitions

### DIFF
--- a/include/api/types.h
+++ b/include/api/types.h
@@ -112,6 +112,9 @@ struct HealthMetrics {
     std::atomic<size_t> timeoutRequests{0};
     std::atomic<size_t> rateLimitedCount{0};
     std::atomic<double> averageResponseTime{0.0};
+    std::atomic<std::uint64_t> allocatedMemory{0};
+    std::atomic<std::uint64_t> peakMemoryUsage{0};
+    std::atomic<double> memoryFragmentation{0.0};
     std::chrono::steady_clock::time_point lastRequestTime;
     std::chrono::steady_clock::time_point startTime;
     std::chrono::milliseconds lastResponseTime{0};

--- a/src/memory/quantum_coherence_manager.cpp
+++ b/src/memory/quantum_coherence_manager.cpp
@@ -6,6 +6,7 @@
 #endif
 #include "quantum/pattern_evolution_bridge.h"
 #include "quantum/quantum_manifold_optimizer.h"
+#include "quantum/types.h" // Ensure Pattern definition includes momentum
 #include "memory/memory_tier_manager.hpp"
 #include "quantum/quantum_processor_qfh.h"
 #include "memory/types.h"


### PR DESCRIPTION
## Summary
- extend `HealthMetrics` to track memory usage
- include `quantum/types.h` in `quantum_coherence_manager.cpp`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6860b3e524ec832ab051c2df44370dd6