### PR TITLE
Fix HealthMetrics and ensure Pattern momentum

### DIFF
--- a/include/api/types.h
+++ b/include/api/types.h
@@ -112,6 +112,9 @@ struct HealthMetrics {
     std::atomic<size_t> timeoutRequests{0};
     std::atomic<size_t> rateLimitedCount{0};
     std::atomic<double> averageResponseTime{0.0};
+    std::atomic<uint64_t> allocatedMemory{0};
+    std::atomic<uint64_t> peakMemoryUsage{0};
+    std::atomic<double> memoryFragmentation{0.0};
     std::chrono::steady_clock::time_point lastRequestTime;
     std::chrono::steady_clock::time_point startTime;
     std::chrono::milliseconds lastResponseTime{0};

--- a/src/api/sep_engine.cpp
+++ b/src/api/sep_engine.cpp
@@ -56,6 +56,9 @@ struct SepEngine::Impl
         health_metrics.timeoutRequests     = 0;
         health_metrics.rateLimitedCount    = 0;
         health_metrics.averageResponseTime = 0.0;
+        health_metrics.allocatedMemory     = 0;
+        health_metrics.peakMemoryUsage    = 0;
+        health_metrics.memoryFragmentation = 0.0;
         health_metrics.lastResponseTime    = std::chrono::milliseconds{0};
         health_metrics.lastErrorCode       = 0;
     }

--- a/src/memory/quantum_coherence_manager.cpp
+++ b/src/memory/quantum_coherence_manager.cpp
@@ -5,6 +5,7 @@
 #include "compat/cuda_runtime.h"
 #endif
 #include "quantum/pattern_evolution_bridge.h"
+#include "quantum/types.h" // Ensure Pattern definition with momentum
 #include "quantum/quantum_manifold_optimizer.h"
 #include "memory/memory_tier_manager.hpp"
 #include "quantum/quantum_processor_qfh.h"


### PR DESCRIPTION
## Summary
- track memory metrics in HealthMetrics
- initialize memory metric fields when SepEngine starts
- include Pattern definition explicitly in QuantumCoherenceManager

## Testing
- `npm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860b3e524ec832ab051c2df44370dd6