### PR TITLE
Add memory metrics and include Pattern types

### DIFF
--- a/include/api/types.h
+++ b/include/api/types.h
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <atomic>
+#include <cstdint>
 #include <chrono>
 #include <map>
 #include <vector>
@@ -118,6 +119,9 @@ struct HealthMetrics {
     std::chrono::system_clock::time_point lastSuccessTime;
     std::chrono::system_clock::time_point lastErrorTime;
     int lastErrorCode{0};
+    std::atomic<std::uint64_t> allocatedMemory{0};
+    std::atomic<std::uint64_t> peakMemoryUsage{0};
+    std::atomic<float> memoryFragmentation{0.0f};
 };
 
 struct RateLimitConfig {

--- a/src/memory/quantum_coherence_manager.cpp
+++ b/src/memory/quantum_coherence_manager.cpp
@@ -6,6 +6,7 @@
 #endif
 #include "quantum/pattern_evolution_bridge.h"
 #include "quantum/quantum_manifold_optimizer.h"
+#include "quantum/types.h"
 #include "memory/memory_tier_manager.hpp"
 #include "quantum/quantum_processor_qfh.h"
 #include "memory/types.h"


### PR DESCRIPTION
## Summary
- extend `HealthMetrics` to track memory stats
- include `quantum/types.h` in `quantum_coherence_manager.cpp`

## Testing
- `pnpm install`
- `npm test` *(fails: recursive turbo invocation)*

------
https://chatgpt.com/codex/tasks/task_e_6860b3e524ec832ab051c2df44370dd6