### PR TITLE
Fix SEPBlenderBridge alias

### DIFF
--- a/include/blender/types.h
+++ b/include/blender/types.h
@@ -61,4 +61,4 @@ struct SEPBlenderBridge {
 }  // namespace sep
 
 // Provide global alias for C API compatibility
-using SEPBlenderBridge = sep::SEPBlenderBridge;
+typedef sep::SEPBlenderBridge SEPBlenderBridge;


### PR DESCRIPTION
## Summary
- provide `typedef` alias for `SEPBlenderBridge` for C compatibility

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6860b3b5836c832aa205408665049e48