### PR TITLE
Fix Blender bridge include duplication

### DIFF
--- a/include/core/engine.h
+++ b/include/core/engine.h
@@ -11,7 +11,6 @@
 #include "blender/types.h"  // Ensure SEPBlenderBridge definition available
 #include "compat/types.h"  // for QSHResult
 #include "quantum/qbsa.h"
-#include "blender/types.h"
 
 namespace sep {
 namespace cuda {


### PR DESCRIPTION
## Summary
- remove a duplicate `blender/types.h` include in `core/engine.h`

## Testing
- `g++ -std=c++17 -Iinclude -c src/compat/component_bridge.cpp -o /tmp/component.o` *(fails: spa/support/log.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6860b3b5836c832aa205408665049e48