### PR TITLE
Clarify SEPBlenderBridge definition

### DIFF
--- a/docs/diagrams/include-blender.md
+++ b/docs/diagrams/include-blender.md
@@ -45,7 +45,7 @@ flowchart TD
 
 ## Objects and Outputs
 
-- **`SEPBlenderBridge`** (defined in `src/blender/api.cpp`)
+- **`SEPBlenderBridge`** (defined in `include/blender/types.h`)
   - Holds a `std::shared_ptr<sep::pattern::BlenderBridge>` instance.
   - Provides access to `SEPAudioMetrics` and `SEPPatternMetrics` produced during processing.
 - **`sep::pattern::BlenderBridge`** (declared in `bridge.h`)

--- a/include/blender/types.h
+++ b/include/blender/types.h
@@ -51,7 +51,9 @@ inline const char* sep_result_to_string(sep::SEPResult result) {
   }
 }
 
-// Bridge structure used by the C API
+// Bridge structure used by the C API.
+// This header is the canonical home of the definition so that
+// any source including it has the complete type available.
 namespace sep {
 struct SEPBlenderBridge {
     std::shared_ptr<pattern::BlenderBridge> impl;


### PR DESCRIPTION
## Summary
- highlight where `SEPBlenderBridge` is defined
- fix docs to reference the correct header

## Testing
- `cmake --version`
- `make --version | head -n 1`


------
https://chatgpt.com/codex/tasks/task_e_6860b3b5836c832aa205408665049e48