### PR TITLE
Fix QuantumManifoldOptimizer config types

### DIFF
--- a/include/quantum/quantum_manifold_optimizer.h
+++ b/include/quantum/quantum_manifold_optimizer.h
@@ -47,8 +47,8 @@ class QuantumManifoldOptimizer {
 public:
     struct Config {
         MemoryTierEnum tier{MemoryTierEnum::STM};
-        CudaConfig cuda;
-        ApiConfig api;
+        CUDAConfig cuda;
+        APIConfig api;
         LogConfig log;
         double base_resonance_frequency{0.42};
     };
@@ -130,8 +130,8 @@ struct SemanticConfig {
 
 struct ManifoldConfig {
     SemanticConfig semantic;
-    CudaConfig cuda;
-    ApiConfig api;
+    CUDAConfig cuda;
+    APIConfig api;
     LogConfig log;
 };
 


### PR DESCRIPTION
## Summary
- fix incorrect config type names in `QuantumManifoldOptimizer` header

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6860b3d3531c832a9451b5999d96546f