### PR TITLE
Fix std includes and implement QuantumManifoldOptimizer stub

### DIFF
--- a/include/quantum/quantum_manifold_optimizer.h
+++ b/include/quantum/quantum_manifold_optimizer.h
@@ -13,6 +13,11 @@
 #include <thread>
 #include <unordered_map>
 #include <vector>
+#include <future>
+#include <algorithm>
+#include <numeric>
+#include <execution>
+#include <stdexcept>
 #include <cmath>
 #include <glm/glm.hpp>
 
@@ -47,8 +52,8 @@ class QuantumManifoldOptimizer {
 public:
     struct Config {
         MemoryTierEnum tier{MemoryTierEnum::STM};
-        CudaConfig cuda;
-        ApiConfig api;
+        CUDAConfig cuda;
+        APIConfig api;
         LogConfig log;
         double base_resonance_frequency{0.42};
     };
@@ -104,7 +109,7 @@ class PerformanceAnalyzer;
     } quantum;
 
     // CUDA acceleration parameters
-    struct CudaConfig {
+    struct CUDAKernelConfig {
         int warp_tile_size = 16;
         int coherence_block_size = 256;
         int similarity_grid_dim = 32;
@@ -113,26 +118,25 @@ class PerformanceAnalyzer;
     } cuda;
 
     // API coherence modulation
-    struct ApiConfig {
+    struct APIModulationConfig {
         double base_coherence = 0.5;
         double context_weight = 0.3;
         double state_weight = 0.7;
         int superposition_states = 4;
     } api;
 
-struct SemanticConfig {
-    int embedding_dimensions = 512;
-    MemoryTierEnum tier = MemoryTierEnum::STM;
-    int hierarchy_levels = 4;
-    double interference_threshold = 0.1;
-    bool enable_multimodal_fusion = true;
-};
-
 struct ManifoldConfig {
+    using SemanticConfig = ::sep::config::SemanticConfig;
+    using CudaConfig = ::sep::config::CUDAConfig;
+    using ApiConfig = ::sep::config::APIConfig;
+    using LogConfig = ::sep::config::LogConfig;
+    using AnalyticsConfig = ::sep::config::AnalyticsConfig;
+
     SemanticConfig semantic;
     CudaConfig cuda;
     ApiConfig api;
     LogConfig log;
+    AnalyticsConfig analytics;
 };
 
 // Implementation class

--- a/src/quantum/quantum_manifold_optimizer.cpp
+++ b/src/quantum/quantum_manifold_optimizer.cpp
@@ -30,7 +30,7 @@ namespace logging = sep::logging;
 #include <vector>
 #include <stdexcept>
 
-namespace sep::quantum {
+namespace sep::quantum::manifold {
 
 namespace {
     // Manifold curvature constants for quantum state optimization
@@ -96,4 +96,75 @@ std::vector<glm::vec3> QuantumManifoldOptimizer::sampleTangentSpace(const glm::v
 std::unique_ptr<QuantumManifoldOptimizer> createQuantumManifoldOptimizer(const QuantumManifoldOptimizer::Config& config) {
     return std::make_unique<QuantumManifoldOptimizer>(config);
 }
-} // namespace sep::quantum
+
+// ------------------------------------------------------------------
+// QuantumManifoldOptimizer::Impl implementation
+
+QuantumManifoldOptimizer::Impl::Impl(const Config& config)
+    : config_(config),
+      riemannian_metric_(1.0f),
+      qfh_processor_(std::make_unique<QuantumProcessorQFH>()) {
+    initializeManifold();
+}
+
+QuantumManifoldOptimizer::OptimizationResult
+QuantumManifoldOptimizer::Impl::optimize(const QuantumState& /*initial_state*/,
+                                         const OptimizationTarget& target) {
+    OptimizationResult result;
+    result.success = true;
+    result.optimized_values = target.target_values;
+    return result;
+}
+
+void QuantumManifoldOptimizer::Impl::updateManifoldGeometry(
+    const std::vector<QuantumState>& /*quantum_states*/) {
+    // Stub: real implementation would update manifold_points_
+}
+
+float QuantumManifoldOptimizer::Impl::computeManifoldCoherence(
+    const glm::vec3& /*position*/) const {
+    return 1.0f;
+}
+
+std::vector<glm::vec3> QuantumManifoldOptimizer::Impl::sampleTangentSpace(
+    const glm::vec3& position, uint32_t num_samples) const {
+    return std::vector<glm::vec3>(num_samples, position);
+}
+
+void QuantumManifoldOptimizer::Impl::initializeManifold() {}
+
+QuantumManifoldOptimizer::Impl::ManifoldPoint
+QuantumManifoldOptimizer::Impl::quantumStateToManifold(const QuantumState& /*state*/) {
+    return {};
+}
+
+QuantumState QuantumManifoldOptimizer::Impl::manifoldToQuantumState(
+    const ManifoldPoint& /*point*/) {
+    return {};
+}
+
+QuantumManifoldOptimizer::Impl::ManifoldPoint
+QuantumManifoldOptimizer::Impl::targetToManifold(const OptimizationTarget& /*target*/) {
+    return {};
+}
+
+QuantumManifoldOptimizer::Impl::GeodesicPath
+QuantumManifoldOptimizer::Impl::findOptimalGeodesic(const ManifoldPoint& /*start*/,
+                                                    const ManifoldPoint& /*target*/) {
+    return {};
+}
+
+void QuantumManifoldOptimizer::Impl::applyRicciFlow(GeodesicPath& /*path*/) {}
+void QuantumManifoldOptimizer::Impl::computeNeighborhoods() {}
+void QuantumManifoldOptimizer::Impl::updateRiemannianMetric() {}
+float QuantumManifoldOptimizer::Impl::computeLocalCurvature(const glm::vec3& /*position*/) const { return 0.0f; }
+float QuantumManifoldOptimizer::Impl::computeRicciCurvature(const ManifoldPoint& /*point*/, const ManifoldPoint& /*prev*/, const ManifoldPoint& /*next*/) const { return 0.0f; }
+glm::vec3 QuantumManifoldOptimizer::Impl::computeFlowDirection(const ManifoldPoint& /*point*/, float /*ricci_curvature*/) const { return {}; }
+float QuantumManifoldOptimizer::Impl::computePathAction(const GeodesicPath& /*path*/) const { return 0.0f; }
+float QuantumManifoldOptimizer::Impl::computePathStability(const GeodesicPath& /*path*/) const { return 0.0f; }
+float QuantumManifoldOptimizer::Impl::computeConvergenceMetric(const GeodesicPath& /*path*/) const { return 0.0f; }
+float QuantumManifoldOptimizer::Impl::computeRicciScalar(const GeodesicPath& /*path*/) const { return 0.0f; }
+float QuantumManifoldOptimizer::Impl::computeGeodesicDistance(const GeodesicPath& /*path*/) const { return 0.0f; }
+float QuantumManifoldOptimizer::Impl::computeHolonomyPhase(const GeodesicPath& /*path*/) const { return 0.0f; }
+float QuantumManifoldOptimizer::Impl::computeResonanceFromCurvature(float /*curvature*/) const { return 0.0f; }
+} // namespace sep::quantum::manifold


### PR DESCRIPTION
## Summary
- add a set of standard headers used by quantum_manifold_optimizer
- fix config casing for CUDA/API configs
- alias config types inside `ManifoldConfig`
- implement `QuantumManifoldOptimizer::Impl` as a basic stub
- place source definitions in the correct namespace

## Testing
- `g++ -std=c++17 -Iinclude -Itests -c tests/quantum/quantum_manifold_optimizer_test.cpp -o /tmp/test.o` *(fails: nlohmann/json.hpp missing)*

------
https://chatgpt.com/codex/tasks/task_e_6860b3d3531c832a9451b5999d96546f