### PR TITLE
Fix build errors in QuantumManifoldOptimizer

### DIFF
--- a/include/quantum/quantum_manifold_optimizer.h
+++ b/include/quantum/quantum_manifold_optimizer.h
@@ -13,6 +13,11 @@
 #include <thread>
 #include <unordered_map>
 #include <vector>
+#include <future>
+#include <algorithm>
+#include <numeric>
+#include <execution>
+#include <stdexcept>
 #include <cmath>
 #include <glm/glm.hpp>
 
@@ -47,8 +52,8 @@ class QuantumManifoldOptimizer {
 public:
     struct Config {
         MemoryTierEnum tier{MemoryTierEnum::STM};
-        CudaConfig cuda;
-        ApiConfig api;
+        CUDAConfig cuda;
+        APIConfig api;
         LogConfig log;
         double base_resonance_frequency{0.42};
     };
@@ -130,8 +135,8 @@ struct SemanticConfig {
 
 struct ManifoldConfig {
     SemanticConfig semantic;
-    CudaConfig cuda;
-    ApiConfig api;
+    CUDAConfig cuda;
+    APIConfig api;
     LogConfig log;
 };
 
@@ -243,7 +248,7 @@ private:
 // 3. CUDA ACCELERATION WITH HIERARCHICAL PARALLELIZATION
 class CUDAQuantumKernel {
 public:
-    explicit CUDAQuantumKernel(const ManifoldConfig::CudaConfig& config);
+    explicit CUDAQuantumKernel(const ManifoldConfig::CUDAConfig& config);
     ~CUDAQuantumKernel();
 
     // Warp-level primitive operations
@@ -261,7 +266,7 @@ public:
 private:
     cudaStream_t stream_;
     cufftHandle fft_plan_;
-    ManifoldConfig::CudaConfig config_;
+    ManifoldConfig::CUDAConfig config_;
     
     void* d_workspace_;
     size_t workspace_size_;
@@ -270,7 +275,7 @@ private:
 // 4. API COHERENCE MODULATION
 class APICoherenceModulator {
 public:
-    explicit APICoherenceModulator(const ManifoldConfig::ApiConfig& config);
+    explicit APICoherenceModulator(const ManifoldConfig::APIConfig& config);
 
     // Dynamic response coherence synthesis
     struct CoherenceResponse {
@@ -287,7 +292,7 @@ public:
                                          const std::vector<double>& weights);
 
 private:
-    ManifoldConfig::ApiConfig config_;
+    ManifoldConfig::APIConfig config_;
     std::unordered_map<std::string, double> context_coherence_map_;
     
     std::vector<double> extractCoherenceFactors(const std::string& context,

--- a/src/quantum/quantum_manifold_optimizer.cpp
+++ b/src/quantum/quantum_manifold_optimizer.cpp
@@ -28,9 +28,13 @@ namespace logging = sep::logging;
 #include <execution>
 #include <memory>
 #include <vector>
+#include <string>
+#include <array>
+#include <unordered_map>
+#include <atomic>
 #include <stdexcept>
 
-namespace sep::quantum {
+namespace sep::quantum::manifold {
 
 namespace {
     // Manifold curvature constants for quantum state optimization
@@ -96,4 +100,4 @@ std::vector<glm::vec3> QuantumManifoldOptimizer::sampleTangentSpace(const glm::v
 std::unique_ptr<QuantumManifoldOptimizer> createQuantumManifoldOptimizer(const QuantumManifoldOptimizer::Config& config) {
     return std::make_unique<QuantumManifoldOptimizer>(config);
 }
-} // namespace sep::quantum
+} // namespace sep::quantum::manifold


### PR DESCRIPTION
## Summary
- add missing STL includes for optimizer
- update configuration struct names to match sep::config definitions
- include additional STL headers in implementation
- correct implementation namespace for `QuantumManifoldOptimizer`

## Testing
- `g++ -std=c++20 -Iinclude -c src/quantum/quantum_manifold_optimizer.cpp -o /tmp/qmo.o` *(fails: nlohmann/json.hpp missing)*

------
https://chatgpt.com/codex/tasks/task_e_6860b3db71b8832aab5f48ec9e0e18d3