### PR TITLE
Fix includes and config types in quantum optimizer

### DIFF
--- a/include/quantum/quantum_manifold_optimizer.h
+++ b/include/quantum/quantum_manifold_optimizer.h
@@ -1,15 +1,20 @@
 // quantum_manifold_optimizer.h
 #pragma once
 
+#include <algorithm>
 #include <array>
 #include <atomic>
 #include <chrono>
 #include <complex>
 #include <condition_variable>
+#include <execution>
+#include <future>
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <numeric>
 #include <string>
+#include <stdexcept>
 #include <thread>
 #include <unordered_map>
 #include <vector>
@@ -39,17 +44,17 @@ using ::sep::quantum::QuantumProcessorQFH;
 // import them with different casing which resulted in a large number of
 // "does not name a type" compilation errors.  Import them with the
 // correct names instead.
-using ::sep::config::CUDAConfig;
-using ::sep::config::APIConfig;
+using ::sep::config::CudaConfig;
+using ::sep::config::ApiConfig;
 using ::sep::config::LogConfig;
 
 class QuantumManifoldOptimizer {
 public:
     struct Config {
         MemoryTierEnum tier{MemoryTierEnum::STM};
-        CudaConfig cuda;
-        ApiConfig api;
-        LogConfig log;
+        sep::config::CudaConfig cuda;
+        sep::config::ApiConfig api;
+        sep::config::LogConfig log;
         double base_resonance_frequency{0.42};
     };
 
@@ -129,62 +134,12 @@ struct SemanticConfig {
 };
 
 struct ManifoldConfig {
-    SemanticConfig semantic;
-    CudaConfig cuda;
-    ApiConfig api;
-    LogConfig log;
+    sep::config::SemanticConfig semantic;
+    sep::config::CudaConfig cuda;
+    sep::config::ApiConfig api;
+    sep::config::LogConfig log;
 };
 
-// Implementation class
-class QuantumManifoldOptimizer::Impl {
-public:
-    struct ManifoldPoint {
-        glm::vec3 position;
-        glm::vec3 momentum;
-        float curvature;
-        float coherence;
-        uint32_t dimension_index;
-        std::vector<uint32_t> neighbor_indices;
-    };
-    
-    struct GeodesicPath {
-        std::vector<ManifoldPoint> points;
-        float total_action;
-        float stability_metric;
-        bool is_minimal;
-    };
-    
-    explicit Impl(const Config& config);
-    OptimizationResult optimize(const QuantumState& initial_state, const OptimizationTarget& target);
-    void updateManifoldGeometry(const std::vector<QuantumState>& quantum_states);
-    float computeManifoldCoherence(const glm::vec3& position) const;
-    std::vector<glm::vec3> sampleTangentSpace(const glm::vec3& position, uint32_t num_samples) const;
-
-private:
-    Config config_;
-    std::vector<ManifoldPoint> manifold_points_;
-    glm::mat4 riemannian_metric_;
-    std::unique_ptr<QuantumProcessorQFH> qfh_processor_;
-
-    void initializeManifold();
-    ManifoldPoint quantumStateToManifold(const QuantumState& state);
-    QuantumState manifoldToQuantumState(const ManifoldPoint& point);
-    ManifoldPoint targetToManifold(const OptimizationTarget& target);
-    GeodesicPath findOptimalGeodesic(const ManifoldPoint& start, const ManifoldPoint& target);
-    void applyRicciFlow(GeodesicPath& path);
-    void computeNeighborhoods();
-    void updateRiemannianMetric();
-    float computeLocalCurvature(const glm::vec3& position) const;
-    float computeRicciCurvature(const ManifoldPoint& point, const ManifoldPoint& prev, const ManifoldPoint& next) const;
-    glm::vec3 computeFlowDirection(const ManifoldPoint& point, float ricci_curvature) const;
-    float computePathAction(const GeodesicPath& path) const;
-    float computePathStability(const GeodesicPath& path) const;
-    float computeConvergenceMetric(const GeodesicPath& path) const;
-    float computeRicciScalar(const GeodesicPath& path) const;
-    float computeGeodesicDistance(const GeodesicPath& path) const;
-    float computeHolonomyPhase(const GeodesicPath& path) const;
-    float computeResonanceFromCurvature(float curvature) const;
-};
 
 // 1. ADVANCED MEMORY TIER OPTIMIZATION
 class AdvancedMemoryTierOptimizer {
@@ -243,7 +198,7 @@ private:
 // 3. CUDA ACCELERATION WITH HIERARCHICAL PARALLELIZATION
 class CUDAQuantumKernel {
 public:
-    explicit CUDAQuantumKernel(const ManifoldConfig::CudaConfig& config);
+    explicit CUDAQuantumKernel(const sep::config::CudaConfig& config);
     ~CUDAQuantumKernel();
 
     // Warp-level primitive operations
@@ -261,7 +216,7 @@ public:
 private:
     cudaStream_t stream_;
     cufftHandle fft_plan_;
-    ManifoldConfig::CudaConfig config_;
+    sep::config::CudaConfig config_;
     
     void* d_workspace_;
     size_t workspace_size_;
@@ -270,7 +225,7 @@ private:
 // 4. API COHERENCE MODULATION
 class APICoherenceModulator {
 public:
-    explicit APICoherenceModulator(const ManifoldConfig::ApiConfig& config);
+    explicit APICoherenceModulator(const sep::config::ApiConfig& config);
 
     // Dynamic response coherence synthesis
     struct CoherenceResponse {
@@ -287,7 +242,7 @@ public:
                                          const std::vector<double>& weights);
 
 private:
-    ManifoldConfig::ApiConfig config_;
+    sep::config::ApiConfig config_;
     std::unordered_map<std::string, double> context_coherence_map_;
     
     std::vector<double> extractCoherenceFactors(const std::string& context,
@@ -297,7 +252,7 @@ private:
 // 5. HIERARCHICAL SEMANTIC PROCESSING
 class SemanticProcessor {
 public:
-    explicit SemanticProcessor(const ManifoldConfig::SemanticConfig& config);
+    explicit SemanticProcessor(const sep::config::SemanticConfig& config);
 
     // Code embedding with structural awareness
     struct CodeEmbedding {
@@ -324,7 +279,7 @@ public:
         const std::vector<std::vector<SearchResult>>& modal_results);
 
 private:
-    ManifoldConfig::SemanticConfig config_;
+    sep::config::SemanticConfig config_;
     std::unique_ptr<CUDAQuantumKernel> cuda_kernel_;
     
     double calculateQuantumInterference(const CodeEmbedding& a, const CodeEmbedding& b);
@@ -334,7 +289,7 @@ private:
 // 6. REAL-TIME PERFORMANCE ANALYTICS
 class PerformanceAnalyzer {
 public:
-    explicit PerformanceAnalyzer(const ManifoldConfig::AnalyticsConfig& config);
+    explicit PerformanceAnalyzer(const sep::config::AnalyticsConfig& config);
 
     // Quantum state space analysis
     struct StateSpaceAnalysis {
@@ -367,7 +322,7 @@ public:
                                               const std::vector<double>& performance_metrics);
 
 private:
-    ManifoldConfig::AnalyticsConfig config_;
+    sep::config::AnalyticsConfig config_;
     std::vector<double> performance_history_;
     std::mutex history_mutex_;
     

--- a/src/quantum/quantum_manifold_optimizer.cpp
+++ b/src/quantum/quantum_manifold_optimizer.cpp
@@ -13,24 +13,28 @@
 
 // Define namespace alias for clarity
 namespace logging = sep::logging;
-#include <glm/glm.hpp>
+#include <algorithm>
+#include <array>
+#include <atomic>
 #include <chrono>
-#include <future>
-#include <thread>
-#include <mutex>
-#include <condition_variable>
 #include <complex>
+#include <condition_variable>
+#include <execution>
+#include <future>
+#include <glm/glm.hpp>
 #include <glm/gtc/quaternion.hpp>
 #include <glm/gtx/norm.hpp>
-#include <algorithm>
-#include <cmath>
-#include <numeric>
-#include <execution>
 #include <memory>
-#include <vector>
+#include <mutex>
+#include <numeric>
 #include <stdexcept>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+#include <cmath>
 
-namespace sep::quantum {
+namespace sep::quantum::manifold {
 
 namespace {
     // Manifold curvature constants for quantum state optimization
@@ -67,6 +71,58 @@ namespace {
     }
 }
 
+// Implementation of the optimizer internals
+
+class QuantumManifoldOptimizer::Impl {
+public:
+    struct ManifoldPoint {
+        glm::vec3 position;
+        glm::vec3 momentum;
+        float curvature;
+        float coherence;
+        uint32_t dimension_index;
+        std::vector<uint32_t> neighbor_indices;
+    };
+
+    struct GeodesicPath {
+        std::vector<ManifoldPoint> points;
+        float total_action;
+        float stability_metric;
+        bool is_minimal;
+    };
+
+    explicit Impl(const Config& config);
+    OptimizationResult optimize(const QuantumState& initial_state, const OptimizationTarget& target);
+    void updateManifoldGeometry(const std::vector<QuantumState>& quantum_states);
+    float computeManifoldCoherence(const glm::vec3& position) const;
+    std::vector<glm::vec3> sampleTangentSpace(const glm::vec3& position, uint32_t num_samples) const;
+
+private:
+    Config config_;
+    std::vector<ManifoldPoint> manifold_points_;
+    glm::mat4 riemannian_metric_;
+    std::unique_ptr<QuantumProcessorQFH> qfh_processor_;
+
+    void initializeManifold();
+    ManifoldPoint quantumStateToManifold(const QuantumState& state);
+    QuantumState manifoldToQuantumState(const ManifoldPoint& point);
+    ManifoldPoint targetToManifold(const OptimizationTarget& target);
+    GeodesicPath findOptimalGeodesic(const ManifoldPoint& start, const ManifoldPoint& target);
+    void applyRicciFlow(GeodesicPath& path);
+    void computeNeighborhoods();
+    void updateRiemannianMetric();
+    float computeLocalCurvature(const glm::vec3& position) const;
+    float computeRicciCurvature(const ManifoldPoint& point, const ManifoldPoint& prev, const ManifoldPoint& next) const;
+    glm::vec3 computeFlowDirection(const ManifoldPoint& point, float ricci_curvature) const;
+    float computePathAction(const GeodesicPath& path) const;
+    float computePathStability(const GeodesicPath& path) const;
+    float computeConvergenceMetric(const GeodesicPath& path) const;
+    float computeRicciScalar(const GeodesicPath& path) const;
+    float computeGeodesicDistance(const GeodesicPath& path) const;
+    float computeHolonomyPhase(const GeodesicPath& path) const;
+    float computeResonanceFromCurvature(float curvature) const;
+};
+
 // Public interface implementation
 QuantumManifoldOptimizer::QuantumManifoldOptimizer(const Config& config)
     : impl_(std::make_unique<Impl>(config)) {}
@@ -96,4 +152,4 @@ std::vector<glm::vec3> QuantumManifoldOptimizer::sampleTangentSpace(const glm::v
 std::unique_ptr<QuantumManifoldOptimizer> createQuantumManifoldOptimizer(const QuantumManifoldOptimizer::Config& config) {
     return std::make_unique<QuantumManifoldOptimizer>(config);
 }
-} // namespace sep::quantum
+} // namespace sep::quantum::manifold


### PR DESCRIPTION
## Summary
- expand STL includes for QuantumManifoldOptimizer
- qualify config struct names with `sep::config`
- define `QuantumManifoldOptimizer::Impl` in the cpp and fix namespace
- correct namespace for optimizer implementation

## Testing
- `pnpm test` *(fails: recursive_turbo_invocations)*

------
https://chatgpt.com/codex/tasks/task_e_6860b3db71b8832aab5f48ec9e0e18d3