### PR TITLE
Fix ollama struct duplication

### DIFF
--- a/include/api/client.h
+++ b/include/api/client.h
@@ -2,6 +2,7 @@
 #define SEP_API_CLIENT_H
 
 #include "api/types.h"
+#include "api/ollama_types.h"
 #include "curl/curl.h"
 #include "core/common.h"
 

--- a/include/api/types.h
+++ b/include/api/types.h
@@ -131,34 +131,3 @@ struct AuthConfig {
 };
 
 } // namespace sep::api
-
-namespace sep::ollama {
-
-struct OllamaConfig {
-    std::string host{"http://127.0.0.1:11434"};
-    std::string model{"llama2"};
-};
-
-struct GenerateRequest {
-    std::string model;
-    std::string prompt;
-    std::string system;
-    bool stream{false};
-};
-
-struct GenerateResponse {
-    std::string response;
-    bool done{false};
-    std::string model;
-};
-
-struct EmbeddingRequest {
-    std::string model;
-    std::string prompt;
-};
-
-struct EmbeddingResponse {
-    std::vector<float> embedding;
-};
-
-}  // namespace sep::ollama

--- a/include/core/types.h
+++ b/include/core/types.h
@@ -10,6 +10,7 @@
 // Project headers (must come before std headers for proper isolation)
 #include "compat/cuda.h"
 #include "api/types.h"
+#include "api/ollama_types.h"
 
 // Standard C headers
 #include <cstddef>

--- a/src/api/ollama_client.cpp
+++ b/src/api/ollama_client.cpp
@@ -1,5 +1,6 @@
 #include "api/client.h"
 #include "api/types.h"
+#include "api/ollama_types.h"
 
 #include <chrono>
 #include <fstream>


### PR DESCRIPTION
## Summary
- remove duplicate Ollama structs from `types.h`
- include `ollama_types.h` where those structs are used
- add missing include in core types
- keep `createRateLimiter` implementation in rate limiter

## Testing
- `ctest --output-on-failure` *(fails: No tests were found)*
- `cmake -S . -B /tmp/build` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6860b3ed6784832a96bfc113b68eba13