### PR TITLE
Fix Ollama structs duplication

### DIFF
--- a/include/api/client.h
+++ b/include/api/client.h
@@ -2,6 +2,7 @@
 #define SEP_API_CLIENT_H
 
 #include "api/types.h"
+#include "api/ollama_types.h"
 #include "curl/curl.h"
 #include "core/common.h"
 

--- a/include/api/types.h
+++ b/include/api/types.h
@@ -131,34 +131,3 @@ struct AuthConfig {
 };
 
 } // namespace sep::api
-
-namespace sep::ollama {
-
-struct OllamaConfig {
-    std::string host{"http://127.0.0.1:11434"};
-    std::string model{"llama2"};
-};
-
-struct GenerateRequest {
-    std::string model;
-    std::string prompt;
-    std::string system;
-    bool stream{false};
-};
-
-struct GenerateResponse {
-    std::string response;
-    bool done{false};
-    std::string model;
-};
-
-struct EmbeddingRequest {
-    std::string model;
-    std::string prompt;
-};
-
-struct EmbeddingResponse {
-    std::vector<float> embedding;
-};
-
-}  // namespace sep::ollama

--- a/include/core/types.h
+++ b/include/core/types.h
@@ -10,6 +10,7 @@
 // Project headers (must come before std headers for proper isolation)
 #include "compat/cuda.h"
 #include "api/types.h"
+#include "api/ollama_types.h"
 
 // Standard C headers
 #include <cstddef>

--- a/src/api/ollama_client.cpp
+++ b/src/api/ollama_client.cpp
@@ -1,5 +1,6 @@
 #include "api/client.h"
 #include "api/types.h"
+#include "api/ollama_types.h"
 
 #include <chrono>
 #include <fstream>

--- a/tests/api/ollama_test.cpp
+++ b/tests/api/ollama_test.cpp
@@ -1,5 +1,5 @@
 #include <gtest/gtest.h>
-#include "api/client.h"
+#include "api/ollama_client.h"
 #include <fstream>
 // shim.h not required for this standalone test
 


### PR DESCRIPTION
## Summary
- centralize Ollama-related types in `ollama_types.h`
- include new header wherever those types are used
- fix tests to include `api/ollama_client.h`

## Testing
- `g++ -std=c++17 -Iinclude -I./include -c src/api/ollama_client.cpp -o /tmp/ollama_client.o` *(fails: <missing nlohmann/json.hpp>)*

------
https://chatgpt.com/codex/tasks/task_e_6860b3ed6784832a96bfc113b68eba13