### PR TITLE
Fix Ollama structs and add rate limiter factory

### DIFF
--- a/include/api/types.h
+++ b/include/api/types.h
@@ -131,34 +131,3 @@ struct AuthConfig {
 };
 
 } // namespace sep::api
-
-namespace sep::ollama {
-
-struct OllamaConfig {
-    std::string host{"http://127.0.0.1:11434"};
-    std::string model{"llama2"};
-};
-
-struct GenerateRequest {
-    std::string model;
-    std::string prompt;
-    std::string system;
-    bool stream{false};
-};
-
-struct GenerateResponse {
-    std::string response;
-    bool done{false};
-    std::string model;
-};
-
-struct EmbeddingRequest {
-    std::string model;
-    std::string prompt;
-};
-
-struct EmbeddingResponse {
-    std::vector<float> embedding;
-};
-
-}  // namespace sep::ollama

--- a/include/core/types.h
+++ b/include/core/types.h
@@ -10,6 +10,7 @@
 // Project headers (must come before std headers for proper isolation)
 #include "compat/cuda.h"
 #include "api/types.h"
+#include "api/ollama_types.h"
 
 // Standard C headers
 #include <cstddef>

--- a/src/api/ollama_client.cpp
+++ b/src/api/ollama_client.cpp
@@ -1,5 +1,6 @@
 #include "api/client.h"
 #include "api/types.h"
+#include "api/ollama_types.h"
 
 #include <chrono>
 #include <fstream>

--- a/tests/api/ollama_client_test.cpp
+++ b/tests/api/ollama_client_test.cpp
@@ -1,5 +1,5 @@
 #include "api/ollama_client.h"
-#include "ollama/types.h"
+#include "api/ollama_types.h"
 #include <cstdio>
 #include <fstream>
 #include <gtest/gtest.h>

--- a/tests/api/ollama_test.cpp
+++ b/tests/api/ollama_test.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 #include "api/client.h"
 #include <fstream>
+#include "api/ollama_types.h"
 // shim.h not required for this standalone test
 
 using namespace sep::api;


### PR DESCRIPTION
## Summary
- deduplicate Ollama type definitions
- include the new header in core and Ollama client
- update unit tests to use `api/ollama_types.h`
- keep a simple rate limiter factory implementation

## Testing
- `g++ -std=c++17 -c src/api/ollama_client.cpp -Iinclude` *(fails: nlohmann/json.hpp: No such file or directory)*
- `g++ -std=c++17 -c tests/api/ollama_client_test.cpp -Iinclude` *(fails: nlohmann/json.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6860b3ed6784832a96bfc113b68eba13