### PR TITLE
Resolve namespace alias mismatch

### DIFF
--- a/include/quantum/quantum_manifold_optimizer.h
+++ b/include/quantum/quantum_manifold_optimizer.h
@@ -53,8 +53,8 @@ using ::sep::quantum::QuantumProcessorQFH;
 // import them with different casing which resulted in a large number of
 // "does not name a type" compilation errors.  Import them with the
 // correct names instead.
-using ::sep::config::CudaConfig;
-using ::sep::config::ApiConfig;
+using ::sep::config::CUDAConfig;
+using ::sep::config::APIConfig;
 using ::sep::config::LogConfig;
 using ::sep::config::AnalyticsConfig;
 


### PR DESCRIPTION
## Summary
- correct configuration alias names in `quantum_manifold_optimizer.h`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6860b8141ba4832aa8a2909ab7fbc0f5