### PR TITLE
Fix missing standard library headers

### DIFF
--- a/include/api/auth_middleware.h
+++ b/include/api/auth_middleware.h
@@ -10,6 +10,7 @@
 #include "crow/crow_isolation.h"
 #endif
 #include <vector>
+#include <string>
 
 namespace sep::api {
 

--- a/include/api/lock_free_rate_limiter.h
+++ b/include/api/lock_free_rate_limiter.h
@@ -13,6 +13,7 @@
 #include <mutex>
 #include <thread>
 #include <unordered_map>
+#include <string>
 
 namespace sep::api {
 

--- a/src/api/auth_middleware.cpp
+++ b/src/api/auth_middleware.cpp
@@ -1,5 +1,8 @@
 #include "api/auth_middleware.h"
 
+#include <string>
+#include <vector>
+
 namespace sep::api {
 
 void AuthMiddleware::set_tokens(std::vector<std::string> tokens) { tokens_ = std::move(tokens); }

--- a/src/api/client.cpp
+++ b/src/api/client.cpp
@@ -1,5 +1,7 @@
 #include "api/client.h"
 #include "curl/curl.h"
+#include <memory>
+#include <string>
 #include <stdexcept>
 #include <utility>
 

--- a/src/api/curl_http_client.cpp
+++ b/src/api/curl_http_client.cpp
@@ -1,7 +1,8 @@
 #include "api/client.h"
 #include "core/error_handler.h"
-#include <stdexcept>
 #include <chrono>
+#include <stdexcept>
+#include <string>
 
 namespace sep::api {
 

--- a/src/api/lock_free_rate_limiter.cpp
+++ b/src/api/lock_free_rate_limiter.cpp
@@ -2,6 +2,7 @@
 #include "api/background_cleanup.h"
 #include "crow/crow_isolation.h"
 #include <nlohmann/json.hpp>
+#include <string>
 
 namespace sep::api {
 

--- a/src/api/sep_engine.cpp
+++ b/src/api/sep_engine.cpp
@@ -5,6 +5,7 @@
 #include <iomanip>
 #include <iostream>
 #include <memory>
+#include <string>
 #include <sstream>
 #include <stdexcept>
 #include <thread>

--- a/src/api/server.cpp
+++ b/src/api/server.cpp
@@ -17,6 +17,7 @@
 #include <csignal>
 #include <cstdio>
 #include <memory>
+#include <string>
 #include <nlohmann/json.hpp>
 #include <spdlog/spdlog.h>
 


### PR DESCRIPTION
## Summary
- add `<string>` include to `server.cpp` and other files needing standard headers
- include `<memory>` and `<string>` where unique pointers are used

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6860b8141ba4832aa8a2909ab7fbc0f5