### PR TITLE
Fix SepEngine static access and metrics

### DIFF
--- a/src/api/sep_engine.cpp
+++ b/src/api/sep_engine.cpp
@@ -426,7 +426,8 @@ nlohmann::json SepEngine::getHealthStatus()
 
 nlohmann::json SepEngine::getMemoryMetrics()
 {
-    if (!impl_->initialized) {
+    auto& instance = SepEngine::getInstance();
+    if (!instance.impl_->initialized) {
         json result;
         result["success"] = false;
         result["error"]   = "Engine not initialized";
@@ -462,7 +463,8 @@ nlohmann::json SepEngine::getMemoryMetrics()
 
 nlohmann::json SepEngine::getConfig(const sep::config::APIConfig& config)
 {
-    if (!impl_->initialized) {
+    auto& instance = SepEngine::getInstance();
+    if (!instance.impl_->initialized) {
         json result;
         result["success"] = false;
         result["error"]   = "Engine not initialized";
@@ -557,9 +559,6 @@ nlohmann::json SepEngine::getMetrics(const HealthMetrics& metrics)
         }}
     };
     
-    return result;
-    result["response_time"]  = response_time;
-    result["timestamps"]     = timestamps;
     return result;
 }
 


### PR DESCRIPTION
## Summary
- call `SepEngine::getInstance()` in static methods to access non-static members
- remove unreachable code in `getMetrics`

## Testing
- `pnpm test` *(fails: recursive turbo invocation)*
- `pnpm lint` *(fails: recursive turbo invocation)*

------
https://chatgpt.com/codex/tasks/task_e_6860b80dfc74832a98c03eb394c349b3