### PR TITLE
Fix standard library usage

### DIFF
--- a/include/quantum/quantum_manifold_optimizer.h
+++ b/include/quantum/quantum_manifold_optimizer.h
@@ -40,12 +40,13 @@
 #include "quantum/qfh.h"
 #include "quantum/quantum_processor_qfh.h"
 #include "quantum/types.h"
+#include "quantum/pattern.h"
 
 namespace sep::quantum::manifold {
 
 using ::sep::memory::MemoryTierEnum;
 using ::sep::quantum::QuantumState;
-using QuantumPattern = ::sep::quantum::Pattern;
+using QuantumPattern = ::sep::quantum::manifold::QuantumPattern;
 using ::sep::quantum::QFHResult;
 using ::sep::quantum::QuantumProcessorQFH;
 // Configuration structures from the core configuration module use
@@ -53,8 +54,8 @@ using ::sep::quantum::QuantumProcessorQFH;
 // import them with different casing which resulted in a large number of
 // "does not name a type" compilation errors.  Import them with the
 // correct names instead.
-using ::sep::config::CudaConfig;
-using ::sep::config::ApiConfig;
+using ::sep::config::CUDAConfig;
+using ::sep::config::APIConfig;
 using ::sep::config::LogConfig;
 using ::sep::config::AnalyticsConfig;
 

--- a/src/quantum/pattern_evolution_bridge.cpp
+++ b/src/quantum/pattern_evolution_bridge.cpp
@@ -24,6 +24,7 @@ namespace logging = sep::logging;
 #include <memory>
 #include <chrono>
 #include <cmath>
+#include <numeric>
 #include <mutex>
 #include <vector>
 


### PR DESCRIPTION
## Summary
- include `<numeric>` in pattern evolution bridge implementation
- correct config type aliases in `quantum_manifold_optimizer` header
- include `quantum/pattern.h` to use the proper `QuantumPattern` type

## Testing
- `git commit -m "Fix std namespace and include issues"`

------
https://chatgpt.com/codex/tasks/task_e_6860b8141ba4832aa8a2909ab7fbc0f5