### PR TITLE
Fix missing atomic includes

### DIFF
--- a/src/api/sep_engine.cpp
+++ b/src/api/sep_engine.cpp
@@ -7,6 +7,7 @@
 #include <memory>
 #include <sstream>
 #include <stdexcept>
+#include <atomic>
 #include <thread>
 #include <vector>
 

--- a/src/memory/quantum_coherence_manager.cpp
+++ b/src/memory/quantum_coherence_manager.cpp
@@ -17,6 +17,7 @@ using ::sep::memory::MemoryTierEnum;
 #include <tbb/parallel_for.h>
 #include <tbb/concurrent_hash_map.h>
 #include <algorithm>
+#include <atomic>
 #include <numeric>
 #include <cmath>
 #include <array>

--- a/src/quantum/pattern_evolution_bridge.cpp
+++ b/src/quantum/pattern_evolution_bridge.cpp
@@ -17,6 +17,7 @@ namespace logging = sep::logging;
 #include <glm/gtc/quaternion.hpp>
 #include <glm/gtx/norm.hpp>
 #include <algorithm>
+#include <atomic>
 #include <execution>
 #include <thread>
 #include <future>


### PR DESCRIPTION
## Summary
- include `<atomic>` in a few cpp files that use `std::atomic`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6860b8141ba4832aa8a2909ab7fbc0f5