### PR TITLE
Add wrapper comment for rate limiter factory

### DIFF
--- a/src/api/lock_free_rate_limiter.cpp
+++ b/src/api/lock_free_rate_limiter.cpp
@@ -310,6 +310,8 @@ createLockFreeRateLimiter(unsigned int requests_per_minute) {
   return std::make_unique<LockFreeRateLimiter>(requests_per_minute);
 }
 
+// Wrapper factory that currently returns the lock-free implementation.
+// This indirection allows swapping implementations without touching callers.
 std::unique_ptr<IRateLimiter>
 createRateLimiter(unsigned int requests_per_minute) {
   return createLockFreeRateLimiter(requests_per_minute);


### PR DESCRIPTION
## Summary
- clarify that `createRateLimiter` is a wrapper around the lock free implementation

## Testing
- `pnpm lint` *(fails: turbo not found)*
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_6860b8197c28832aadc5805fe081349d