### PR TITLE
Fix StreamRAII signature and include headers

### DIFF
--- a/include/compat/raii.h
+++ b/include/compat/raii.h
@@ -20,7 +20,7 @@ namespace cuda {
 
 class StreamRAII {
  public:
-  explicit StreamRAII(::sep::StreamFlags flags = ::sep::StreamFlags::Default);
+  explicit StreamRAII(sep::StreamFlags flags = sep::StreamFlags::Default);
   ~StreamRAII() noexcept;
 
   StreamRAII(const StreamRAII&) = delete;

--- a/src/compat/raii.cpp
+++ b/src/compat/raii.cpp
@@ -14,9 +14,11 @@
 // Include CUDA headers in the correct order
 #include "compat/raii.h"
 #include "memory/memory_tier_manager.hpp" // Include header for interface
-#include "compat/cuda_helpers.h" // Fix: Include cuda_helpers for CUDA_CHECK
+#include "compat/cuda_helpers.h"         // For CUDA_CHECK macro
 #include "compat/cuda_common.h"
-#if !SEP_CUDA_AVAILABLE
+#if SEP_CUDA_AVAILABLE
+#include <cuda_runtime.h>
+#else
 #include "compat/cuda_runtime.h"
 #endif
 
@@ -85,7 +87,7 @@ const char* cudaGetErrorString(cudaError_t /*error*/) {
 }
 #endif
 
-StreamRAII::StreamRAII(::sep::StreamFlags flags) {
+StreamRAII::StreamRAII(sep::StreamFlags flags) {
     unsigned int cuda_flags = (flags == sep::StreamFlags::NonBlocking) ? cudaStreamNonBlocking : cudaStreamDefault;
     cudaError_t err = cudaStreamCreateWithFlags(&stream_, cuda_flags);
     if (err != cudaSuccess) {


### PR DESCRIPTION
## Summary
- match constructor declaration in raii.h with implementation
- add missing CUDA runtime include

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6860bc7b15bc832a8defb7fe919c9335