### PR TITLE
Refactor MetricsCollector init

### DIFF
--- a/include/core/metrics_collector.h
+++ b/include/core/metrics_collector.h
@@ -83,7 +83,7 @@ public:
     void resetOperation(const std::string& operation_name);
 
 private:
-    MetricsCollector() = default;
+    MetricsCollector();
     ~MetricsCollector() = default;
     MetricsCollector(const MetricsCollector&) = delete;
     MetricsCollector& operator=(const MetricsCollector&) = delete;

--- a/src/core/metrics_collector.cpp
+++ b/src/core/metrics_collector.cpp
@@ -238,12 +238,11 @@ class MetricsCollector::Impl {
 
 // MetricsCollector implementation
 
+MetricsCollector::MetricsCollector() : pImpl(std::make_unique<Impl>()) {}
+
 MetricsCollector& MetricsCollector::instance() {
     // Use a function-local static variable for thread-safe singleton initialization
-    static MetricsCollector instance; // Fix: Declare the static instance
-    if (!instance.pImpl) {
-        instance.pImpl = std::make_unique<Impl>();
-    }
+    static MetricsCollector instance;
     return instance;
 }
 


### PR DESCRIPTION
## Summary
- ensure MetricsCollector owns Impl via pImpl
- allocate pImpl on construction and simplify instance()

## Testing
- `cmake -S . -B build -DSEP_BUILD_TESTS=ON` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6860bc715cb0832a9cf27a869d7e428e