### PR TITLE
Move ConfigManager Impl inside namespace

### DIFF
--- a/src/core/manager.cpp
+++ b/src/core/manager.cpp
@@ -6,7 +6,8 @@
 #include <fstream>
 #include <ios>
 
-namespace sep::config {
+namespace sep {
+namespace config {
 
 using namespace env_keys;
 
@@ -205,4 +206,5 @@ void ConfigManager::initialize(int argc, char **argv) {
   impl_->loadFromCommandLine(argc, argv);
 }
 
-} // namespace sep::config
+} // namespace config
+} // namespace sep


### PR DESCRIPTION
## Summary
- switch manager.cpp to nested namespace syntax

## Testing
- `g++ -std=c++17 -Isrc -Iinclude -c src/core/manager.cpp -o /tmp/manager.o` *(fails: nlohmann/json.hpp missing)*

------
https://chatgpt.com/codex/tasks/task_e_6860bc7189c4832ab39ce30f7bb699f5