### PR TITLE
Update API server includes and start function

### DIFF
--- a/include/api/server.h
+++ b/include/api/server.h
@@ -8,6 +8,8 @@
 #include "api/rate_limit_middleware.h"
 #include "api/types.h"
 #include "api/auth_middleware.h"
+#include "api/ollama_client.h"
+#include "core/types.h"
 #include <atomic>
 #include <memory>
 #include <mutex>
@@ -26,9 +28,7 @@ template <typename... Middlewares>
 class Crow;
 }  // namespace crow
 
-namespace sep::ollama {
-class OllamaClient;
-}
+
 
 namespace sep::api {
 class CrowRequest;
@@ -77,7 +77,7 @@ class SEPApiServer : public Server {
   /**
    * @brief Start the server
    */
-  bool start();
+  void start();
 
   /**
    * @brief Register routes and start the server

--- a/src/api/server.cpp
+++ b/src/api/server.cpp
@@ -5,6 +5,7 @@
 #include "api/json_helpers.h"
 #include "api/types.h"
 #include "api/ollama_client.h"
+#include "core/types.h"
 #include "api/rate_limit_middleware.h"
 #include "api/request_interface.h"
 #include "api/sep_engine.h"
@@ -63,22 +64,21 @@ ServerMetrics &SEPApiServer::getModifiableMetrics() {
   return server_metrics_;
 }
 
-bool SEPApiServer::start() {
-    if (!app_) return false;
+void SEPApiServer::start() {
+    if (!app_) return;
 
     app_->port(config_.port);
     app_->multithreaded();
 
     setup_middleware();
     setup_routes();
-
-    return true;
 }
 
 bool SEPApiServer::run() {
   // Ensure routes are registered just before starting
   setup_routes();
-  return start();
+  start();
+  return true;
 }
 
 


### PR DESCRIPTION
## Summary
- include Ollama client and config headers in `SEPApiServer`
- make `SEPApiServer::start` return `void`
- adjust `run` to accommodate signature change

## Testing
- `npm test` *(fails: `turbo` not found)*
- `npm run lint` *(fails: `turbo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860bc7a74e4832aaf355f667150094c