### PR TITLE
Add cudaMemsetAsync stub for CUDA compatibility

### DIFF
--- a/include/compat/cuda_impl.h
+++ b/include/compat/cuda_impl.h
@@ -37,6 +37,11 @@ extern "C" {
 // Memory management functions
 cudaError_t cudaMemset(void* devPtr, int value, size_t count);
 cudaError_t cudaMallocManaged(void** ptr, size_t size);
+// Async memset is not available in stub builds; provide simple wrapper
+inline cudaError_t cudaMemsetAsync(void* devPtr, int value, size_t count,
+                                   cudaStream_t /*stream*/) {
+    return cudaMemset(devPtr, value, count);
+}
 
 // Memory copy functions
 cudaError_t cudaMemcpy(void* dst, const void* src, size_t count, cudaMemcpyKind kind);


### PR DESCRIPTION
## Summary
- add a simple `cudaMemsetAsync` wrapper to the CUDA stub implementation

## Testing
- `g++ -x c++ -Iinclude -c src/compat/cuda_api.cu -DSEP_CUDA_AVAILABLE=0 -o /tmp/cuda_api.o` *(fails: `sep::ErrorCode` not declared)*

------
https://chatgpt.com/codex/tasks/task_e_6860bc7db7dc832abdb53b487305e0a8