### PR TITLE
Fix ignore rules and add stub cycles renderer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,7 @@ compile_commands.json
 build.log
 assets/sep_engine
 blender
+!include/blender/
+!src/blender/
+!include/blender/cycles_renderer.h
+!src/blender/cycles_renderer.cpp

--- a/include/blender/cycles_renderer.h
+++ b/include/blender/cycles_renderer.h
@@ -1,0 +1,12 @@
+#pragma once
+#include <string>
+
+namespace sep {
+namespace blender {
+class CyclesRenderer {
+public:
+    CyclesRenderer() = default;
+    bool render(const std::string& filepath);
+};
+} // namespace blender
+} // namespace sep

--- a/src/blender/cycles_renderer.cpp
+++ b/src/blender/cycles_renderer.cpp
@@ -1,0 +1,10 @@
+#include "blender/cycles_renderer.h"
+
+namespace sep {
+namespace blender {
+bool CyclesRenderer::render(const std::string& filepath) {
+    (void)filepath;
+    return true;
+}
+} // namespace blender
+} // namespace sep


### PR DESCRIPTION
## Summary
- unignore src and include blender folders so new files are tracked
- provide a stub `CyclesRenderer` implementation for builds without Blender/Cycles

## Testing
- `cmake ..` *(fails: OSL_INCLUDE_DIR-NOTFOUND)*

------
https://chatgpt.com/codex/tasks/task_e_6860bc7f0c6c832a8d39652cc3a62c5b