### PR TITLE
Fix missing pattern/memory headers

### DIFF
--- a/src/blender/api.cpp
+++ b/src/blender/api.cpp
@@ -3,6 +3,8 @@
 #include "blender/types.h"
 #include "blender/config.h"
 #include "blender/pattern_bridge.h"
+#include "quantum/data.hpp"          // For PatternData/PatternConfig
+#include "memory/types.h"            // For MemoryTierEnum
 #include "compat/component_bridge.h"
 #include <memory>
 #include <string>

--- a/src/blender/blender_integration.cpp
+++ b/src/blender/blender_integration.cpp
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "quantum/processor.h"  // Ensure PatternProcessor is complete
+#include "quantum/data.hpp"      // For PatternData/PatternConfig
 
 #include "blender/pattern_observer.h"
 #include "quantum/types.h"

--- a/src/quantum/pattern_evolution.cpp
+++ b/src/quantum/pattern_evolution.cpp
@@ -1,4 +1,5 @@
 #include "quantum/pattern_evolution.h"
+#include "quantum/data.hpp"  // For PatternData/PatternConfig
 #include "quantum/types.h"
 #include <nlohmann/json.hpp>
 #include "api/sep_engine.h"

--- a/src/quantum/quantum_processor_qfh.cpp
+++ b/src/quantum/quantum_processor_qfh.cpp
@@ -1,5 +1,6 @@
 #include "quantum/quantum_processor_qfh.h"
 #include "quantum/types.h"
+#include "memory/types.h"  // For MemoryTierEnum
 #include "quantum/processor.h"
 #include "compat/component_bridge.h" // For factory functions
 


### PR DESCRIPTION
## Summary
- include pattern data and memory tier headers where pattern or tier enums are used
- pull quantum data in pattern evolution implementation
- ensure memory tier enum is accessible for quantum processor QFH

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6860bc7bc2f8832ab434c4ad867b4f51