### PR TITLE
Fix header includes for SEPResult and incomplete type

### DIFF
--- a/src/api/ollama_client.cpp
+++ b/src/api/ollama_client.cpp
@@ -1,6 +1,7 @@
 #include "api/client.h"
 #include "api/types.h"
 #include "api/ollama_types.h"
+#include "core/common.h"  // defines sep::SEPResult
 
 #include <chrono>
 #include <fstream>

--- a/src/blender/api.cpp
+++ b/src/blender/api.cpp
@@ -4,6 +4,7 @@
 #include "blender/config.h"
 #include "blender/pattern_bridge.h"
 #include "compat/component_bridge.h"
+#include "core/common.h"  // defines sep::SEPResult
 #include <memory>
 #include <string>
 

--- a/src/blender/mesh_handler.cpp
+++ b/src/blender/mesh_handler.cpp
@@ -4,7 +4,7 @@
  */
 
 #include "blender/mesh_handler.h"
-#include "core/types.h"  // for sep::SEPResult
+#include "core/common.h"  // defines sep::SEPResult
 
 
 // Minimal stand-ins for Blender API functions. These are no-ops here but allow

--- a/src/blender/pattern_visualization_pipeline.cpp
+++ b/src/blender/pattern_visualization_pipeline.cpp
@@ -1,5 +1,6 @@
 #include "blender/pattern_visualization_pipeline.h"
 #include "compat/shim.h"
+#include "core/common.h"  // defines sep::SEPResult
 #include <algorithm>
 #include <numeric>
 

--- a/src/compat/core.cu
+++ b/src/compat/core.cu
@@ -5,6 +5,8 @@
 #include "compat/constants.h"
 #include "compat/raii.h"
 
+#include "core/common.h"  // defines sep::SEPResult
+
 #include "compat/cuda_helpers.h"
 
 namespace sep::cuda {

--- a/src/compat/core_stub.cpp
+++ b/src/compat/core_stub.cpp
@@ -1,6 +1,7 @@
 #if !SEP_CUDA_AVAILABLE
 #include "compat/core.h"
 #include "compat/cuda_runtime.h"
+#include "core/common.h"  // defines sep::SEPResult
 #include <cstring>
 #include <cstdlib>
 

--- a/src/core/engine.cpp
+++ b/src/core/engine.cpp
@@ -5,6 +5,7 @@
 #include "blender/pattern_bridge.h"
 #include "memory/memory_tier_manager.hpp"
 #include "compat/component_bridge.h"
+#include "core/common.h"  // defines sep::SEPResult
 
 #include "memory/manager.h"  // This is actually the logging manager
 #include "compat/shim.h"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,6 @@
 #include "core/manager.h"
 #include "core/engine.h"
+#include "core/common.h"  // defines sep::SEPResult
 #include <curl/curl.h>
 #include <exception>
 #include <iostream>

--- a/src/memory/memory_tier.cpp
+++ b/src/memory/memory_tier.cpp
@@ -1,5 +1,6 @@
 // Standard library headers FIRST to ensure proper namespace resolution
 #include "memory/memory_tier.hpp"
+#include "core/common.h"  // defines sep::SEPResult
 
 #include <algorithm>
 #include <cassert>

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -1,4 +1,5 @@
 #include "memory/memory_tier_manager.hpp"
+#include "core/common.h"  // defines sep::SEPResult
 #include "memory/types.h"
 #include "quantum/types.h"        // For MemoryTierEnum definition
 

--- a/src/quantum/pattern_processor.cpp
+++ b/src/quantum/pattern_processor.cpp
@@ -3,6 +3,7 @@
 #include "quantum/types.h"
 #include "memory/types.h"
 #include "compat/math_common.h"
+#include "core/common.h"  // defines sep::SEPResult
 
 using ::sep::memory::MemoryTierEnum;
 

--- a/src/quantum/pattern_processor_interface.cpp
+++ b/src/quantum/pattern_processor_interface.cpp
@@ -3,6 +3,7 @@
 #include "quantum/quantum_processor_qfh.h"
 #include "quantum/quantum_processor.h"
 #include "quantum/types.h"
+#include "core/common.h"  // defines sep::SEPResult
 #include "compat/core.h"
 #include "memory/memory_tier_manager.hpp"
 #include "memory/manager.h"  // This is actually the logging manager

--- a/src/quantum/processor.cpp
+++ b/src/quantum/processor.cpp
@@ -4,6 +4,7 @@
 #include "quantum/quantum_processor_qfh.h"
 #include <glm/glm.hpp>
 #include "memory/types.h"
+#include "core/common.h"  // defines sep::SEPResult
 
 using ::sep::memory::MemoryTierEnum;
 #include <mutex>


### PR DESCRIPTION
## Summary
- include `core/common.h` in files using `sep::SEPResult`
- ensure compatibility sources include the SEP result enum
- tidy mesh_handler include usage

## Testing
- `./build.sh` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_6860bc6ff72c832a841b6c815f4d7c41