### PR TITLE
Implement createRateLimiter factory

### DIFF
--- a/src/api/lock_free_rate_limiter.cpp
+++ b/src/api/lock_free_rate_limiter.cpp
@@ -1,4 +1,5 @@
 #include "api/lock_free_rate_limiter.h"
+#include "api/rate_limiter.h" // for factory declaration
 #include "api/background_cleanup.h"
 #include "crow/crow_isolation.h"
 #include <nlohmann/json.hpp>


### PR DESCRIPTION
## Summary
- ensure lock-free rate limiter exports `createRateLimiter`
- include `api/rate_limiter.h` in `lock_free_rate_limiter.cpp`

## Testing
- `cmake ..` *(fails: Could not find nvcc)*
- `ctest -j$(nproc) --output-on-failure` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6860bff81c98832abc8d79338c7d9884