### PR TITLE
Fix QuantumState enum and adjust optimizer aliases

### DIFF
--- a/include/quantum/data.hpp
+++ b/include/quantum/data.hpp
@@ -17,8 +17,8 @@ struct PatternData {
   glm::vec4 velocity{0.0f};
   glm::vec4 attributes{0.0f};
   std::complex<float> amplitude{0.0f};
-  ::sep::quantum::QuantumState::State state{
-      ::sep::quantum::QuantumState::State::SUPERPOSITION};
+  ::sep::quantum::QuantumState::Status state{
+      ::sep::quantum::QuantumState::Status::SUPERPOSITION};
   float phase{0.0f};
   float coherence{0.0f};
   float stability{0.0f};

--- a/include/quantum/quantum_manifold_optimizer.h
+++ b/include/quantum/quantum_manifold_optimizer.h
@@ -40,23 +40,18 @@ namespace sep::quantum { class PatternEvolutionBridge; }
 namespace sep::quantum::manifold {
 
 using ::sep::memory::MemoryTierEnum;
-using ::sep::quantum::QuantumState;
+using QuantumStateStruct = ::sep::quantum::QuantumState;
 using QuantumPattern = ::sep::quantum::manifold::QuantumPattern;
 using ManifoldQuantumState = ::sep::quantum::manifold::QuantumState;
 using ::sep::quantum::QFHResult;
 using ::sep::quantum::QuantumProcessorQFH;
 // Configuration structures from the core configuration module use
-// capitalised names (e.g. CUDAConfig).  The original code attempted to
-// import them with different casing which resulted in a large number of
-// "does not name a type" compilation errors.  Import them with the
-// correct names instead.
-using ::sep::config::CUDAConfig;
-using ::sep::config::APIConfig;
-using ::sep::config::LogConfig;
-using ::sep::config::AnalyticsConfig;
-using ::sep::config::APIConfig;
-using ::sep::config::CUDAConfig;
-using ::sep::config::LogConfig;
+// capitalised names (e.g. CUDAConfig). Import them with matching
+// casing to avoid "does not name a type" errors.
+using CoreCUDAConfig = ::sep::config::CUDAConfig;
+using CoreAPIConfig = ::sep::config::APIConfig;
+using CoreLogConfig = ::sep::config::LogConfig;
+using CoreAnalyticsConfig = ::sep::config::AnalyticsConfig;
 
 class QuantumManifoldOptimizer {
 public:


### PR DESCRIPTION
## Summary
- update `PatternData` to use `QuantumState::Status`
- clean up alias definitions in `quantum_manifold_optimizer.h` to avoid namespace clashes

## Testing
- `cmake -S . -B _build` *(fails: Could not find nvcc)*
- `npm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860bff1f8d0832abc5c856fe990cc44