### PR TITLE
Fix static access issues in SepEngine

### DIFF
--- a/include/api/types.h
+++ b/include/api/types.h
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <atomic>
+#include <cstdint>
 #include <chrono>
 #include <map>
 #include <vector>

--- a/src/api/sep_engine.cpp
+++ b/src/api/sep_engine.cpp
@@ -428,8 +428,7 @@ nlohmann::json SepEngine::getHealthStatus()
 
 nlohmann::json SepEngine::getMemoryMetrics()
 {
-    auto& instance = SepEngine::getInstance();
-    if (!instance.impl_->initialized) {
+    if (!SepEngine::getInstance().impl_->initialized) {
         json result;
         result["success"] = false;
         result["error"]   = "Engine not initialized";
@@ -465,8 +464,7 @@ nlohmann::json SepEngine::getMemoryMetrics()
 
 nlohmann::json SepEngine::getConfig(const sep::config::APIConfig& config)
 {
-    auto& instance = SepEngine::getInstance();
-    if (!instance.impl_->initialized) {
+    if (!SepEngine::getInstance().impl_->initialized) {
         json result;
         result["success"] = false;
         result["error"]   = "Engine not initialized";


### PR DESCRIPTION
## Summary
- include cstdint for fixed-width types in HealthMetrics
- access engine singleton directly in static functions

## Testing
- `pnpm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860bfec2848832a99546d45a5f90d11