### PR TITLE
Fix namespace and config definitions

### DIFF
--- a/include/quantum/data.hpp
+++ b/include/quantum/data.hpp
@@ -17,8 +17,8 @@ struct PatternData {
   glm::vec4 velocity{0.0f};
   glm::vec4 attributes{0.0f};
   std::complex<float> amplitude{0.0f};
-  ::sep::quantum::QuantumState::State state{
-      ::sep::quantum::QuantumState::State::SUPERPOSITION};
+  ::sep::quantum::QuantumState::Status state{
+      ::sep::quantum::QuantumState::Status::SUPERPOSITION};
   float phase{0.0f};
   float coherence{0.0f};
   float stability{0.0f};

--- a/include/quantum/pattern.h
+++ b/include/quantum/pattern.h
@@ -7,7 +7,7 @@
 
 namespace sep::quantum::manifold {
 
-enum class QuantumState {
+enum class ManifoldQuantumState {
     SUPERPOSITION,
     COHERENT,
     COLLAPSED
@@ -18,7 +18,7 @@ struct QuantumPattern {
     double coherence;
     double stability;
     int generation;
-    QuantumState state;
+    ManifoldQuantumState state;
     double phase;
     std::complex<double> amplitude;
 };

--- a/include/quantum/quantum_manifold_optimizer.h
+++ b/include/quantum/quantum_manifold_optimizer.h
@@ -42,7 +42,7 @@ namespace sep::quantum::manifold {
 using ::sep::memory::MemoryTierEnum;
 using ::sep::quantum::QuantumState;
 using QuantumPattern = ::sep::quantum::manifold::QuantumPattern;
-using ManifoldQuantumState = ::sep::quantum::manifold::QuantumState;
+using ManifoldQuantumState = ::sep::quantum::manifold::ManifoldQuantumState;
 using ::sep::quantum::QFHResult;
 using ::sep::quantum::QuantumProcessorQFH;
 // Configuration structures from the core configuration module use
@@ -54,9 +54,10 @@ using ::sep::config::CUDAConfig;
 using ::sep::config::APIConfig;
 using ::sep::config::LogConfig;
 using ::sep::config::AnalyticsConfig;
-using ::sep::config::APIConfig;
-using ::sep::config::CUDAConfig;
-using ::sep::config::LogConfig;
+
+// Forward declare configuration structs used by QuantumManifoldOptimizer
+struct CudaConfig;
+struct ApiConfig;
 
 class QuantumManifoldOptimizer {
 public:
@@ -79,7 +80,6 @@ public:
         QuantumState optimized_state{};
         std::vector<float> optimized_values;
         std::string error_message;
-        QuantumState optimized_state{};
     };
 
     struct OptimizationTarget {
@@ -151,15 +151,6 @@ struct CudaConfig {
   bool enable_phase_modulation = true;
   cufftHandle fft_plan{};
 } cuda;
-
-    // CUDA acceleration parameters
-    struct CudaConfig {
-        int warp_tile_size = 16;
-        int coherence_block_size = 256;
-        int similarity_grid_dim = 32;
-        bool enable_phase_modulation = true;
-        cufftHandle fft_plan{};
-    } cuda;
 
     // API coherence modulation
     struct ApiConfig {


### PR DESCRIPTION
## Summary
- rename `QuantumState` enum in `pattern.h` to `ManifoldQuantumState`
- update `PatternData` to use `QuantumState::Status`
- fix aliasing and forward declarations in `quantum_manifold_optimizer.h`
- remove duplicated definitions and fields

## Testing
- `npm test` *(fails: `turbo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860bff1f8d0832abc5c856fe990cc44