### PR TITLE
Fix include and namespace mismatches

### DIFF
--- a/include/quantum/data.hpp
+++ b/include/quantum/data.hpp
@@ -17,8 +17,8 @@ struct PatternData {
   glm::vec4 velocity{0.0f};
   glm::vec4 attributes{0.0f};
   std::complex<float> amplitude{0.0f};
-  ::sep::quantum::QuantumState::State state{
-      ::sep::quantum::QuantumState::State::SUPERPOSITION};
+  ::sep::quantum::QuantumState::Status state{
+      ::sep::quantum::QuantumState::Status::SUPERPOSITION};
   float phase{0.0f};
   float coherence{0.0f};
   float stability{0.0f};
@@ -26,7 +26,7 @@ struct PatternData {
   float mutation_rate{0.0f};
   std::uint32_t mutation_count{0};
   ::sep::memory::MemoryTierEnum memory_tier{::sep::memory::MemoryTierEnum::STM};
-  std::vector<quantum::PatternRelationship> relationships;
+  std::vector<::sep::quantum::PatternRelationship> relationships;
 };
 
 struct PatternConfig {

--- a/src/quantum/quantum_manifold_optimizer.cpp
+++ b/src/quantum/quantum_manifold_optimizer.cpp
@@ -1,6 +1,9 @@
 #include "quantum/quantum_manifold_optimizer.h"
 #include "quantum/quantum_processor_qfh.h"
+#include <memory>
+#include <mutex>
 #include <numeric>
+#include <vector>
 
 namespace sep::quantum::manifold {
 


### PR DESCRIPTION
## Summary
- add missing standard library includes to `quantum_manifold_optimizer.cpp`
- correct `QuantumState` enum reference and relationship type in `data.hpp`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6860bff1f8d0832abc5c856fe990cc44