### PR TITLE
Fix BlenderBridge stats field names

### DIFF
--- a/src/blender/blender_integration.cpp
+++ b/src/blender/blender_integration.cpp
@@ -423,7 +423,7 @@ sep::SEPResult BlenderBridge::processObjectPatterns(sep::pattern::ObjectHandle h
     updatePatternMetrics(state);
     validatePatternCoherence(state);
 
-    state.stats.total_updates++;
+    state.stats.update_count++;
     notifyObservers(handle, state.metrics);
 
     state.is_processing = false;
@@ -449,10 +449,10 @@ sep::SEPResult BlenderBridge::updatePatternMetrics(ObjectState& state)
 
     state.metrics.avg_coherence = pattern_count ? coherence_sum / pattern_count : 0.0f;
     state.metrics.peak_entropy  = max_entropy;
-    state.metrics.updates_processed = state.stats.total_updates;
+    state.metrics.updates_processed = state.stats.update_count;
     state.metrics.evolution.mutations = mutation_total;
     state.metrics.evolution.stability = pattern_count ? stability_sum / pattern_count : 0.0f;
-    state.metrics.performance.process_time = state.stats.last_process_time;
+    state.metrics.performance.process_time = state.stats.processing_time;
     state.metrics.performance.gpu_utilization = 0.0f;
 
     return sep::SEPResult::SUCCESS;


### PR DESCRIPTION
## Summary
- correct references to `ObjectState::stats` fields in `BlenderBridge`

## Testing
- `pnpm lint` *(fails: `turbo: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6860bfe484b8832aab59b7f6920226cc