### PR TITLE
Fix QuantumManifoldOptimizer config linkage

### DIFF
--- a/include/quantum/quantum_manifold_optimizer.h
+++ b/include/quantum/quantum_manifold_optimizer.h
@@ -45,18 +45,6 @@ using QuantumPattern = ::sep::quantum::manifold::QuantumPattern;
 using ManifoldQuantumState = ::sep::quantum::manifold::QuantumState;
 using ::sep::quantum::QFHResult;
 using ::sep::quantum::QuantumProcessorQFH;
-// Configuration structures from the core configuration module use
-// capitalised names (e.g. CUDAConfig).  The original code attempted to
-// import them with different casing which resulted in a large number of
-// "does not name a type" compilation errors.  Import them with the
-// correct names instead.
-using ::sep::config::CUDAConfig;
-using ::sep::config::APIConfig;
-using ::sep::config::LogConfig;
-using ::sep::config::AnalyticsConfig;
-using ::sep::config::APIConfig;
-using ::sep::config::CUDAConfig;
-using ::sep::config::LogConfig;
 
 class QuantumManifoldOptimizer {
 public:
@@ -64,7 +52,7 @@ public:
         MemoryTierEnum tier{MemoryTierEnum::STM};
         CudaConfig cuda;
         ApiConfig api;
-        LogConfig log;
+        ::sep::config::LogConfig log;
         double base_resonance_frequency{0.42};
         double convergence_threshold{0.001};
         double step_size{0.05};
@@ -79,16 +67,20 @@ public:
         QuantumState optimized_state{};
         std::vector<float> optimized_values;
         std::string error_message;
-        QuantumState optimized_state{};
     };
 
     struct OptimizationTarget {
         float target_coherence{0.8f};
         float target_stability{0.5f};
+        std::vector<float> target_values{};
+        float coherence_threshold{0.5f};
     };
 
     QuantumManifoldOptimizer();
     explicit QuantumManifoldOptimizer(const Config& config);
+
+    static Config createManifoldConfig(
+        const ::sep::quantum::PatternEvolutionBridge::Config& cfg);
 
     OptimizationResult optimize(const QuantumState& initial_state,
                                 const OptimizationTarget& target);
@@ -151,15 +143,6 @@ struct CudaConfig {
   bool enable_phase_modulation = true;
   cufftHandle fft_plan{};
 } cuda;
-
-    // CUDA acceleration parameters
-    struct CudaConfig {
-        int warp_tile_size = 16;
-        int coherence_block_size = 256;
-        int similarity_grid_dim = 32;
-        bool enable_phase_modulation = true;
-        cufftHandle fft_plan{};
-    } cuda;
 
     // API coherence modulation
     struct ApiConfig {

--- a/src/quantum/pattern_evolution_bridge.cpp
+++ b/src/quantum/pattern_evolution_bridge.cpp
@@ -73,7 +73,8 @@ public:
     
     explicit Impl(const Config& config)
         : config_(config)
-        , manifold_optimizer_(QuantumManifoldOptimizer(createManifoldConfig(config)))
+        , manifold_optimizer_(QuantumManifoldOptimizer(
+              QuantumManifoldOptimizer::createManifoldConfig(config)))
         , evolution_state_(std::make_unique<EvolutionState>())
         , worker_threads_(config.num_threads) {
         
@@ -471,16 +472,6 @@ private:
         }
     }
     
-    QuantumManifoldOptimizer::Config createManifoldConfig(const Config& config) {
-        QuantumManifoldOptimizer::Config manifold_config;
-        manifold_config.convergence_threshold = config.convergence_threshold;
-        manifold_config.step_size = config.evolution_step_size;
-        manifold_config.neighborhood_radius = config.interaction_radius;
-        manifold_config.target_coherence = config.target_coherence;
-        manifold_config.min_coherence_threshold = COHERENCE_COLLAPSE_THRESHOLD;
-        manifold_config.base_resonance_frequency = 1.0f;
-        return manifold_config;
-    }
     
     QuantumPhase determinePhase(float energy) const {
         if (energy < 0.3f) return QuantumPhase::Coherent;

--- a/src/quantum/quantum_manifold_optimizer.cpp
+++ b/src/quantum/quantum_manifold_optimizer.cpp
@@ -1,8 +1,20 @@
 #include "quantum/quantum_manifold_optimizer.h"
 #include "quantum/quantum_processor_qfh.h"
+#include "quantum/pattern_evolution_bridge.h"
 #include <numeric>
 
 namespace sep::quantum::manifold {
+
+QuantumManifoldOptimizer::Config QuantumManifoldOptimizer::createManifoldConfig(
+    const ::sep::quantum::PatternEvolutionBridge::Config& cfg) {
+    Config mc{};
+    mc.convergence_threshold = cfg.convergence_threshold;
+    mc.step_size = cfg.evolution_step_size;
+    mc.neighborhood_radius = cfg.interaction_radius;
+    mc.target_coherence = cfg.target_coherence;
+    mc.target_stability = cfg.target_stability;
+    return mc;
+}
 
 QuantumManifoldOptimizer::QuantumManifoldOptimizer()
     : QuantumManifoldOptimizer(Config{}) {}


### PR DESCRIPTION
## Summary
- clean up QuantumManifoldOptimizer config structs
- expose `createManifoldConfig` helper
- remove duplicate config definitions
- use new helper when building PatternEvolutionBridge

## Testing
- `npm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860bfdec8a8832a9f836f899d5a623b