### PR TITLE
Fix optimizer headers

### DIFF
--- a/include/quantum/data.hpp
+++ b/include/quantum/data.hpp
@@ -17,8 +17,8 @@ struct PatternData {
   glm::vec4 velocity{0.0f};
   glm::vec4 attributes{0.0f};
   std::complex<float> amplitude{0.0f};
-  ::sep::quantum::QuantumState::State state{
-      ::sep::quantum::QuantumState::State::SUPERPOSITION};
+  ::sep::quantum::QuantumState::Status state{
+      ::sep::quantum::QuantumState::Status::SUPERPOSITION};
   float phase{0.0f};
   float coherence{0.0f};
   float stability{0.0f};

--- a/include/quantum/quantum_manifold_optimizer.h
+++ b/include/quantum/quantum_manifold_optimizer.h
@@ -54,16 +54,13 @@ using ::sep::config::CUDAConfig;
 using ::sep::config::APIConfig;
 using ::sep::config::LogConfig;
 using ::sep::config::AnalyticsConfig;
-using ::sep::config::APIConfig;
-using ::sep::config::CUDAConfig;
-using ::sep::config::LogConfig;
 
 class QuantumManifoldOptimizer {
 public:
     struct Config {
         MemoryTierEnum tier{MemoryTierEnum::STM};
-        CudaConfig cuda;
-        ApiConfig api;
+        CUDAConfig cuda;
+        APIConfig api;
         LogConfig log;
         double base_resonance_frequency{0.42};
         double convergence_threshold{0.001};
@@ -79,7 +76,6 @@ public:
         QuantumState optimized_state{};
         std::vector<float> optimized_values;
         std::string error_message;
-        QuantumState optimized_state{};
     };
 
     struct OptimizationTarget {


### PR DESCRIPTION
## Summary
- correct QuantumState member type for pattern data
- clean up config type names and duplicates in `quantum_manifold_optimizer.h`
- drop duplicate field in `OptimizationResult`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6860bfdec8a8832a9f836f899d5a623b