### PR TITLE
Fix build header references

### DIFF
--- a/include/quantum/quantum_manifold_optimizer.h
+++ b/include/quantum/quantum_manifold_optimizer.h
@@ -175,7 +175,7 @@ struct ManifoldConfig {
     sep::config::CudaConfig cuda;
     sep::config::APIConfig api;
     sep::config::LogConfig log;
-    AnalyticsConfig analytics;
+    sep::config::AnalyticsConfig analytics;
 };
 
 // 1. ADVANCED MEMORY TIER OPTIMIZATION
@@ -257,7 +257,7 @@ public:
 private:
     cudaStream_t stream_;
     cufftHandle fft_plan_;
-    ManifoldConfig::CudaConfig config_;
+    sep::config::CudaConfig config_;
     
     void* d_workspace_;
     size_t workspace_size_;
@@ -285,7 +285,7 @@ public:
                                   const std::vector<double> &weights);
 
 private:
-    ManifoldConfig::APIConfig config_;
+    sep::config::APIConfig config_;
     std::unordered_map<std::string, double> context_coherence_map_;
     
     std::vector<double> extractCoherenceFactors(const std::string& context,
@@ -369,7 +369,7 @@ public:
                         const std::vector<double> &performance_metrics);
 
 private:
-  AnalyticsConfig config_;
+  sep::config::AnalyticsConfig config_;
   std::vector<double> performance_history_;
   std::mutex history_mutex_;
 

--- a/src/blender/mesh_handler.cpp
+++ b/src/blender/mesh_handler.cpp
@@ -41,7 +41,7 @@ sep::SEPResult MeshHandler::init(Object* bl_object, Mesh* bl_mesh) {
   return sep::SEPResult::SUCCESS;
 }
 
-sep::SEPResult MeshHandler::update(const pattern::PatternData& pattern_data) {
+sep::SEPResult MeshHandler::update(const sep::pattern::PatternData& pattern_data) {
   if (!initialized_) {
     return sep::SEPResult::INITIALIZATION_FAILED;
   }
@@ -196,7 +196,7 @@ sep::SEPResult MeshHandler::applyDeformation(const DeformParams& params) {
   return notifyDepsgraph();
 }
 
-sep::SEPResult MeshHandler::generateHyperMesh(const pattern::PatternData& pattern,
+sep::SEPResult MeshHandler::generateHyperMesh(const sep::pattern::PatternData& pattern,
                                          int dimensions) {
   if (!initialized_) {
     return sep::SEPResult::INITIALIZATION_FAILED;
@@ -221,7 +221,7 @@ sep::SEPResult MeshHandler::generateHyperMesh(const pattern::PatternData& patter
 // Private helpers
 // ---------------------------------------------------------------------------
 
-sep::SEPResult MeshHandler::updateVertices(const pattern::PatternData& pattern_data) {
+sep::SEPResult MeshHandler::updateVertices(const sep::pattern::PatternData& pattern_data) {
   if (!validateMesh()) {
     return sep::SEPResult::INVALID_STATE;
   }
@@ -237,7 +237,7 @@ sep::SEPResult MeshHandler::updateVertices(const pattern::PatternData& pattern_d
   return sep::SEPResult::SUCCESS;
 }
 
-sep::SEPResult MeshHandler::updateCustomData(const pattern::PatternData& pattern_data) {
+sep::SEPResult MeshHandler::updateCustomData(const sep::pattern::PatternData& pattern_data) {
   if (custom_layers_.empty()) {
     (void)addCustomDataLayer("pattern_weight", 0);
   }
@@ -265,7 +265,7 @@ sep::SEPResult MeshHandler::notifyDepsgraph() {
 
 bool MeshHandler::validateMesh() const { return initialized_ && mesh_ != nullptr; }
 
-bool MeshHandler::validatePattern(const pattern::PatternData& pattern_data) const {
+bool MeshHandler::validatePattern(const sep::pattern::PatternData& pattern_data) const {
   return pattern_data.coherence >= 0.0f && pattern_data.coherence <= 1.0f;
 }
 
@@ -344,7 +344,7 @@ void MeshHandler::ensureCustomDataCapacity(size_t vertex_count) {
   }
 }
 
-float MeshHandler::calculateVertexInfluence(const pattern::PatternData& pattern,
+float MeshHandler::calculateVertexInfluence(const sep::pattern::PatternData& pattern,
                                            const float* vertex) const {
   float dx = vertex[0] - pattern.position.x;
   float dy = vertex[1] - pattern.position.y;
@@ -354,7 +354,7 @@ float MeshHandler::calculateVertexInfluence(const pattern::PatternData& pattern,
   return computeCoherenceWeight(weight);
 }
 
-void MeshHandler::calculateDisplacement(const pattern::PatternData& pattern,
+void MeshHandler::calculateDisplacement(const sep::pattern::PatternData& pattern,
                                        const float* vertex,
                                        float* displacement) const {
   float w = calculateVertexInfluence(pattern, vertex);

--- a/src/quantum/pattern_evolution_bridge.cpp
+++ b/src/quantum/pattern_evolution_bridge.cpp
@@ -62,7 +62,7 @@ namespace {
 
 namespace {
 // Implementation details
-class PatternEvolutionBridgeImpl {
+class PatternEvolutionBridge::Impl {
 public:
     struct EvolutionState {
         std::vector<Pattern> active_patterns;


### PR DESCRIPTION
## Summary
- correctly reference analytics and config types in QuantumManifoldOptimizer
- fix private config namespaces
- fix pattern evolution impl class name
- qualify PatternData usage in MeshHandler

## Testing
- `npm run lint` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860d88b1f3c832a9c8885124ba761c5