### PR TITLE
Fix Pimpl class name in PatternEvolutionBridge

### DIFF
--- a/src/quantum/pattern_evolution_bridge.cpp
+++ b/src/quantum/pattern_evolution_bridge.cpp
@@ -61,8 +61,8 @@ namespace {
 }
 
 namespace {
-// Implementation details
-class PatternEvolutionBridgeImpl {
+// Implementation details for PatternEvolutionBridge hidden behind Pimpl
+class PatternEvolutionBridge::Impl {
 public:
     struct EvolutionState {
         std::vector<Pattern> active_patterns;


### PR DESCRIPTION
## Summary
- fix the internal class name used for the Pimpl of `PatternEvolutionBridge`

## Testing
- `cmake ..` *(fails: Could not find nvcc, please set CUDAToolkit_ROOT)*

------
https://chatgpt.com/codex/tasks/task_e_6860d88b1f3c832a9c8885124ba761c5