### PR TITLE
Fix quantum build issues

### DIFF
--- a/include/quantum/quantum_manifold_optimizer.h
+++ b/include/quantum/quantum_manifold_optimizer.h
@@ -175,7 +175,7 @@ struct ManifoldConfig {
     sep::config::CudaConfig cuda;
     sep::config::APIConfig api;
     sep::config::LogConfig log;
-    AnalyticsConfig analytics;
+    sep::config::AnalyticsConfig analytics;
 };
 
 // 1. ADVANCED MEMORY TIER OPTIMIZATION
@@ -257,7 +257,7 @@ public:
 private:
     cudaStream_t stream_;
     cufftHandle fft_plan_;
-    ManifoldConfig::CudaConfig config_;
+    sep::config::CudaConfig config_;
     
     void* d_workspace_;
     size_t workspace_size_;
@@ -285,7 +285,7 @@ public:
                                   const std::vector<double> &weights);
 
 private:
-    ManifoldConfig::APIConfig config_;
+    sep::config::APIConfig config_;
     std::unordered_map<std::string, double> context_coherence_map_;
     
     std::vector<double> extractCoherenceFactors(const std::string& context,

--- a/src/blender/mesh_handler.cpp
+++ b/src/blender/mesh_handler.cpp
@@ -4,8 +4,6 @@
  */
 
 #include "blender/mesh_handler.h"
-
-using namespace sep::pattern;
 #include "core/common.h"  // defines sep::SEPResult
 
 using namespace sep::pattern;

--- a/src/quantum/pattern_evolution_bridge.cpp
+++ b/src/quantum/pattern_evolution_bridge.cpp
@@ -31,6 +31,7 @@ namespace logging = sep::logging;
 
 namespace sep::quantum {
 
+using manifold::QuantumManifoldOptimizer;
 
 namespace {
     // Evolution constants from quantum field theory
@@ -62,7 +63,7 @@ namespace {
 
 namespace {
 // Implementation details
-class PatternEvolutionBridgeImpl {
+class PatternEvolutionBridge::Impl {
 public:
     struct EvolutionState {
         std::vector<Pattern> active_patterns;
@@ -509,6 +510,8 @@ public:
         evolution_state_->evolution_tick++;
     }
 };
+} // anonymous namespace
+
 PatternEvolutionBridge::PatternEvolutionBridge(const Config& config)
     : impl_(std::make_unique<Impl>(config)) {}
 
@@ -520,6 +523,20 @@ void PatternEvolutionBridge::initializeEvolutionState() {
 
 void PatternEvolutionBridge::updatePatterns(const std::vector<Pattern>& patterns) {
     impl_->updatePatterns(patterns);
+}
+
+EvolutionResult PatternEvolutionBridge::evolvePatterns(std::vector<Pattern>& patterns,
+                                                       float time_step) {
+    return impl_->evolvePatterns(patterns, time_step);
+}
+
+std::vector<EntanglementPair> PatternEvolutionBridge::computeEntanglements(
+    const std::vector<Pattern>& patterns) {
+    return impl_->computeEntanglements(patterns);
+}
+
+CollapseEvent PatternEvolutionBridge::detectCollapse(const std::vector<Pattern>& patterns) {
+    return impl_->detectCollapse(patterns);
 }
 
 } // namespace sep::quantum


### PR DESCRIPTION
## Summary
- ensure manifold config uses fully namespaced config types
- clean up mesh handler namespace usage
- define PatternEvolutionBridge::Impl and add bridging methods

## Testing
- `npm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860d88b1f3c832a9c8885124ba761c5