### PR TITLE
Fix QuantumManifoldOptimizer forward declaration

### DIFF
--- a/include/quantum/pattern_evolution_bridge.h
+++ b/include/quantum/pattern_evolution_bridge.h
@@ -13,7 +13,9 @@
 namespace sep::quantum {
 
 // Forward declarations
+namespace manifold {
 class QuantumManifoldOptimizer;
+}
 
 enum class QuantumPhase {
     Coherent,


### PR DESCRIPTION
## Summary
- correct namespace for QuantumManifoldOptimizer forward declaration to match its definition

## Testing
- `g++ -std=c++17 -Iinclude -c src/quantum/pattern_evolution_bridge.cpp -o /tmp/peb.o` *(fails: `nlohmann/json.hpp` missing)*

------
https://chatgpt.com/codex/tasks/task_e_6860ddbf1350832aa3d5fb3b2a21fdac