### PR TITLE
Fix QuantumManifoldOptimizer namespace conflict

### DIFF
--- a/include/quantum/pattern_evolution_bridge.h
+++ b/include/quantum/pattern_evolution_bridge.h
@@ -11,10 +11,6 @@
 #include <glm/glm.hpp>
 
 namespace sep::quantum {
-
-// Forward declarations
-class QuantumManifoldOptimizer;
-
 enum class QuantumPhase {
     Coherent,
     Superposition,


### PR DESCRIPTION
## Summary
- remove the stray forward declaration for `QuantumManifoldOptimizer`

This header declared `QuantumManifoldOptimizer` in the wrong namespace, leading to a compiler conflict when `quantum_manifold_optimizer.h` was included. Removing the declaration resolves the name clash.

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6860ddbf1350832aa3d5fb3b2a21fdac