### PR TITLE
Fix build scripts to use repository paths

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -12,10 +12,11 @@ echo "==== SEP Engine Build Script with FULL Cycles and PipeWire Support ===="
 echo "Setting up build environment with real library paths - NO STUBS!"
 
 # --- Environment Setup ---
-# Using absolute paths in build scripts for reliability
-# These paths correspond to ${workspaceFolder} in VSCode settings
-BUILD_DIR="/sep/cmake-make"
-SRC_DIR="/sep"
+# Determine repository root dynamically so the script works regardless
+# of where the project directory is located on disk.
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+BUILD_DIR="${REPO_ROOT}/cmake-make"
+SRC_DIR="${REPO_ROOT}"
 LIB_DIR="${SRC_DIR}/lib"
 CYCLES_ROOT_DIR="${SRC_DIR}/extern/cycles"
 

--- a/sep-build.sh
+++ b/sep-build.sh
@@ -12,8 +12,10 @@ echo "==== SEP Engine Build Script with FULL Cycles and PipeWire Support ===="
 echo "Setting up build environment with real library paths - NO STUBS!"
 
 # --- Environment Setup ---
-BUILD_DIR="/sep/build"
-SRC_DIR="/sep"
+# Determine repository root dynamically so the script can run from any location
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+BUILD_DIR="${REPO_ROOT}/build"
+SRC_DIR="${REPO_ROOT}"
 LIB_DIR="${SRC_DIR}/lib"
 CYCLES_ROOT_DIR="${SRC_DIR}/extern/cycles"
 


### PR DESCRIPTION
## Summary
- use repo-relative `REPO_ROOT` in `build.sh` and `sep-build.sh`
- avoid hard-coding `/sep` so libraries resolve correctly

## Testing
- `git commit -m "fix build scripts to use repo-relative paths"`

------
https://chatgpt.com/codex/tasks/task_e_6860ddcc7338832a8bf0a4bcc9d3406f