### PR TITLE
Fix PipeWire detection message

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -38,20 +38,25 @@ echo "Using Cycles root: ${CYCLES_ROOT_DIR}"
 # --- Dependency Detection ---
 # Check for PipeWire using pkg-config (most reliable method)
 echo "Checking for PipeWire development headers..."
-export PKG_CONFIG_PATH=/usr/lib64/pkgconfig:$PKG_CONFIG_PATH 
-if command -v pkg-config >/dev/null && pkg-config --exists libpipewire-0.3; then
-  PIPEWIRE_INCLUDE_DIR=$(pkg-config --variable=includedir libpipewire-0.3)
-  PIPEWIRE_LIB_PATH=$(pkg-config --libs-only-L libpipewire-0.3 | sed 's/-L//g')
-  PIPEWIRE_LIB_FILE="${PIPEWIRE_LIB_PATH}/libpipewire-0.3.so"
+export PKG_CONFIG_PATH=/usr/lib64/pkgconfig:$PKG_CONFIG_PATH
+PIPEWIRE_CMAKE_ARGS=""
+if command -v pkg-config >/dev/null; then
+  if pkg-config --exists libpipewire-0.3; then
+    PIPEWIRE_INCLUDE_DIR=$(pkg-config --variable=includedir libpipewire-0.3)
+    PIPEWIRE_LIB_DIR=$(pkg-config --variable=libdir libpipewire-0.3)
+    PIPEWIRE_LIB_FILE="${PIPEWIRE_LIB_DIR}/libpipewire-0.3.so"
 
-  if [ -d "${PIPEWIRE_INCLUDE_DIR}" ] && [ -f "${PIPEWIRE_LIB_FILE}" ]; then
-    echo "PipeWire found via pkg-config: ${PIPEWIRE_LIB_FILE}"
-    PIPEWIRE_CMAKE_ARGS="-DPIPEWIRE_INCLUDE_DIR=${PIPEWIRE_INCLUDE_DIR} -DPIPEWIRE_LIBRARY=${PIPEWIRE_LIB_FILE}"
+    if [ -d "${PIPEWIRE_INCLUDE_DIR}" ] && [ -f "${PIPEWIRE_LIB_FILE}" ]; then
+      echo "PipeWire found via pkg-config: ${PIPEWIRE_LIB_FILE}"
+      PIPEWIRE_CMAKE_ARGS="-DPIPEWIRE_INCLUDE_DIR=${PIPEWIRE_INCLUDE_DIR} -DPIPEWIRE_LIBRARY=${PIPEWIRE_LIB_FILE}"
+    else
+      echo "Warning: Could not verify PipeWire installation. Falling back to CMake detection."
+    fi
   else
-    echo "Warning: PipeWire headers or library missing. PipeWire disabled."
+    echo "Warning: libpipewire-0.3 not found via pkg-config. Falling back to CMake detection."
   fi
 else
-  echo "Warning: pkg-config not found or libpipewire-0.3 is not available. Audio capture will be disabled."
+  echo "Warning: pkg-config not found. Falling back to CMake detection."
 fi
 
 # --- CMake Configuration ---


### PR DESCRIPTION
## Summary
- improve build script detection logic so PipeWire checks are accurate

## Testing
- `bash -n build.sh`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6860ddd183a0832a94ac46212cb7c3ab