### PR TITLE
Improve TBB detection and docs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,22 +201,16 @@ find_and_add_library(OpenPGL_LIBRARY
   NAMES pgl
   PATHS ${CMAKE_SOURCE_DIR}/lib ${CMAKE_INSTALL_PREFIX}/lib /usr/lib64 /usr/local/lib /usr/lib)
 
-# TBB (multiple versions for compatibility)
-find_library(TBB_LIBRARY NAMES tbb)
-find_library(TBB_MALLOC_LIBRARY NAMES tbbmalloc)
-find_library(TBB2_LIBRARY NAMES tbb.so.2 tbb2 PATHS
-  /usr/lib64
-  /usr/local/lib
-  /usr/lib
-  /lib64
-  /lib
-)
+# TBB (Threading Building Blocks) -- require a real installation
+find_package(TBB REQUIRED COMPONENTS tbb tbbmalloc)
 
-# If TBB2 isn't found, create a stub variable that won't break the build
-if(NOT TBB2_LIBRARY)
-  message(STATUS "TBB2 library not found, using stub")
-  set(TBB2_LIBRARY "")
-endif()
+# Expose library paths for legacy variables
+get_target_property(TBB_LIBRARY_PATH TBB::tbb LOCATION)
+get_target_property(TBB_MALLOC_LIBRARY_PATH TBB::tbbmalloc LOCATION)
+
+set(TBB_LIBRARY ${TBB_LIBRARY_PATH})
+set(TBB_MALLOC_LIBRARY ${TBB_MALLOC_LIBRARY_PATH})
+set(TBB2_LIBRARY ${TBB_LIBRARY_PATH})
 
 # OpenSubdiv
 find_library(OPENSUBDIV_CPU_LIBRARY NAMES osdCPU)

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,18 @@ The project uses CMake for building.
 **1. Install Dependencies:**
 Ensure you have a modern C++ compiler (GCC 12+), CMake (3.22+), and the required libraries (Boost, TBB, cURL). If GPU support is needed, the CUDA toolkit (12.x) is required.
 
+For TBB on a Debian-based system:
+
+```bash
+sudo apt-get install libtbb-dev
+```
+
+On Fedora/CentOS:
+
+```bash
+sudo dnf install tbb-devel
+```
+
 **2. Configure and Build:**
 
 ```bash


### PR DESCRIPTION
## Summary
- use `find_package(TBB REQUIRED)` in CMakeLists
- expose TBB paths for legacy variables
- document installing TBB development headers

## Testing
- `apt-get install -y libtbb-dev`
- `cmake -DTBB_DIR=/usr/lib/x86_64-linux-gnu/cmake/TBB -S tbb_example -B tbb_example/build`

------
https://chatgpt.com/codex/tasks/task_e_6860ddc84904832aab1ca256b34e840d