### PR TITLE
Fix pipewire check

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -41,7 +41,7 @@ echo "Checking for PipeWire development headers..."
 export PKG_CONFIG_PATH=/usr/lib64/pkgconfig:$PKG_CONFIG_PATH 
 if command -v pkg-config >/dev/null && pkg-config --exists libpipewire-0.3; then
   PIPEWIRE_INCLUDE_DIR=$(pkg-config --variable=includedir libpipewire-0.3)
-  PIPEWIRE_LIB_PATH=$(pkg-config --libs-only-L libpipewire-0.3 | sed 's/-L//g')
+  PIPEWIRE_LIB_PATH=$(pkg-config --variable=libdir libpipewire-0.3)
   PIPEWIRE_LIB_FILE="${PIPEWIRE_LIB_PATH}/libpipewire-0.3.so"
 
   if [ -d "${PIPEWIRE_INCLUDE_DIR}" ] && [ -f "${PIPEWIRE_LIB_FILE}" ]; then

--- a/sep-build.sh
+++ b/sep-build.sh
@@ -53,7 +53,7 @@ echo "Checking for PipeWire development headers..."
 PIPEWIRE_CMAKE_ARGS="-DSEP_HAS_PIPEWIRE=OFF"
 if command -v pkg-config >/dev/null && pkg-config --exists libpipewire-0.3; then
   PIPEWIRE_INCLUDE_DIR=$(pkg-config --variable=includedir libpipewire-0.3)
-  PIPEWIRE_LIB_PATH=$(pkg-config --libs-only-L libpipewire-0.3 | sed 's/-L//g')
+  PIPEWIRE_LIB_PATH=$(pkg-config --variable=libdir libpipewire-0.3)
   if [ -z "${PIPEWIRE_LIB_PATH}" ]; then
     echo "Warning: pkg-config returned empty PipeWire library path. Audio module disabled."
   else


### PR DESCRIPTION
## Summary
- fix pkg-config logic for detecting PipeWire

## Testing
- `shellcheck build.sh`
- `shellcheck sep-build.sh`


------
https://chatgpt.com/codex/tasks/task_e_6860ddd183a0832a94ac46212cb7c3ab