### PR TITLE
Fix redundant OpenPGL detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,29 +177,6 @@ if(NOT OpenVDB_FOUND)
 endif()
 
 # Helper to locate optional libraries with extended search paths
-function(find_and_add_library _var)
-  set(options)
-  set(oneValueArgs)
-  set(multiValueArgs NAMES PATHS)
-  cmake_parse_arguments(_FAAL "" "" "NAMES;PATHS" ${ARGN})
-  find_library(${_var}
-    NAMES ${_FAAL_NAMES}
-    PATHS ${_FAAL_PATHS}
-    PATH_SUFFIXES lib lib64
-  )
-  if(${_var})
-    message(STATUS "[FOUND] ${_var}: ${${_var}}")
-  else()
-    message(WARNING "[MISSING] ${_var}")
-    set(${_var} "" PARENT_SCOPE)
-  endif()
-  set(${_var} ${${_var}} PARENT_SCOPE)
-endfunction()
-
-# OpenPGL (Path Guiding Library)
-find_and_add_library(OpenPGL_LIBRARY
-  NAMES pgl
-  PATHS ${CMAKE_SOURCE_DIR}/lib ${CMAKE_INSTALL_PREFIX}/lib /usr/lib64 /usr/local/lib /usr/lib)
 
 # TBB (multiple versions for compatibility)
 find_library(TBB_LIBRARY NAMES tbb)
@@ -243,24 +220,6 @@ if(NOT OPENSUBDIV_CPU_LIBRARY OR NOT OPENSUBDIV_GPU_LIBRARY)
   endforeach()
 endif()
 
-# OpenPGL (Path Guiding Library)
-find_library(OpenPGL_LIBRARY
-    NAMES openpgl pgl
-    PATHS
-        ${CMAKE_INSTALL_PREFIX}/lib
-        /usr/lib64
-        /usr/local/lib
-        /usr/lib
-)
-if(OpenPGL_LIBRARY)
-    set(SEP_HAS_OPENPGL 1)
-    message(STATUS "[FOUND] OpenPGL: ${OpenPGL_LIBRARY}")
-else()
-    set(SEP_HAS_OPENPGL 0)
-    message(WARNING "OpenPGL library not found. Path guiding disabled.")
-    set(OpenPGL_LIBRARY "")
-endif()
-add_compile_definitions(SEP_HAS_OPENPGL=${SEP_HAS_OPENPGL})
 
 # Other critical dependencies
 find_library(OPENIMAGEIO_LIBRARY OpenImageIO)
@@ -278,7 +237,7 @@ find_library(PUGIXML_LIBRARY pugixml)
 
 # Path guiding via OpenPGL
 find_library(OpenPGL_LIBRARY
-    NAMES OpenPGL pgl
+    NAMES OpenPGL openpgl pgl
     PATHS
         ${CMAKE_SOURCE_DIR}/lib
         ${CMAKE_INSTALL_PREFIX}/lib


### PR DESCRIPTION
## Summary
- remove unused `find_and_add_library` helper and initial search
- consolidate OpenPGL detection to a single search path

## Testing
- `tests/blender/run_all_tests.sh` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6860ddc4ffe0832a8cfd15de099a0733