### PR TITLE
Fix build issues per advice

### DIFF
--- a/include/quantum/quantum_manifold_optimizer.h
+++ b/include/quantum/quantum_manifold_optimizer.h
@@ -135,7 +135,9 @@ struct MemoryConfig {
   double hamiltonian_coupling = 0.42;
   double predictive_horizon_ms = 100.0;
   int pattern_cache_size = 10000;
-} memory;
+};
+
+inline MemoryConfig memory{};
 
 // Quantum processing enhancement
 struct QuantumConfig {
@@ -143,7 +145,9 @@ struct QuantumConfig {
   double coherence_modulation_factor = 0.707;
   double rupture_detection_sensitivity = 0.3;
   int qfh_hierarchy_depth = 5;
-} quantum;
+};
+
+inline QuantumConfig quantum{};
 
 // CUDA acceleration parameters
 struct CudaConfig {
@@ -152,7 +156,9 @@ struct CudaConfig {
   int similarity_grid_dim = 32;
   bool enable_phase_modulation = true;
   cufftHandle fft_plan{};
-} cuda;
+};
+
+inline CudaConfig cuda{};
 
     // API coherence modulation
     struct APIConfig {
@@ -160,7 +166,9 @@ struct CudaConfig {
         double context_weight = 0.3;
         double state_weight = 0.7;
         int superposition_states = 4;
-    } api;
+    };
+
+inline APIConfig api{};
 
 struct SemanticConfig {
   int embedding_dimensions = 512;

--- a/src/quantum/quantum_processor.cpp
+++ b/src/quantum/quantum_processor.cpp
@@ -143,4 +143,9 @@ QuantumProcessor::Config::operator ProcessingConfig() const {
     pc.enable_cuda = enable_gpu;
     return pc;
 }
+
+std::unique_ptr<QuantumProcessor> createQuantumProcessor(
+    const QuantumProcessor::Config& config) {
+    return std::make_unique<QuantumProcessor>(config);
+}
 } // namespace sep::quantum


### PR DESCRIPTION
## Summary
- mark manifold optimizer globals as inline to avoid multiple definition
- implement missing `createQuantumProcessor` factory

## Testing
- `cmake -S . -B build_test` *(fails: could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_68611f6beeb8832a89d0022b5c218da2