### PR TITLE
Implement build.advice fixes

### DIFF
--- a/include/quantum/quantum_manifold_optimizer.h
+++ b/include/quantum/quantum_manifold_optimizer.h
@@ -135,7 +135,8 @@ struct MemoryConfig {
   double hamiltonian_coupling = 0.42;
   double predictive_horizon_ms = 100.0;
   int pattern_cache_size = 10000;
-} memory;
+};
+inline MemoryConfig memory{};
 
 // Quantum processing enhancement
 struct QuantumConfig {
@@ -143,7 +144,8 @@ struct QuantumConfig {
   double coherence_modulation_factor = 0.707;
   double rupture_detection_sensitivity = 0.3;
   int qfh_hierarchy_depth = 5;
-} quantum;
+};
+inline QuantumConfig quantum{};
 
 // CUDA acceleration parameters
 struct CudaConfig {
@@ -152,7 +154,8 @@ struct CudaConfig {
   int similarity_grid_dim = 32;
   bool enable_phase_modulation = true;
   cufftHandle fft_plan{};
-} cuda;
+};
+inline CudaConfig cuda{};
 
     // API coherence modulation
     struct APIConfig {
@@ -160,7 +163,8 @@ struct CudaConfig {
         double context_weight = 0.3;
         double state_weight = 0.7;
         int superposition_states = 4;
-    } api;
+    };
+inline APIConfig api{};
 
 struct SemanticConfig {
   int embedding_dimensions = 512;

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,4 +1,14 @@
-add_library(sep_core STATIC allocation_metrics.cpp dag_graph.cpp engine.cpp error_handler.cpp manager.cpp metrics_collector.cpp prometheus_exporter.cpp tracing.cpp)
+add_library(sep_core STATIC
+    allocation_metrics.cpp
+    dag_graph.cpp
+    engine.cpp
+    error_handler.cpp
+    logging.cpp
+    manager.cpp
+    metrics_collector.cpp
+    prometheus_exporter.cpp
+    tracing.cpp
+)
 
 target_include_directories(sep_core
     PUBLIC

--- a/src/core/logging.cpp
+++ b/src/core/logging.cpp
@@ -1,5 +1,6 @@
 #include "core/logging.h"
 #include <iostream>
+#include <spdlog/spdlog.h>
 
 namespace sep {
 namespace logging {
@@ -10,8 +11,8 @@ void Manager::initialize() {
 }
 
 void Manager::shutdownLogging() {
-    // Stub implementation - just print to stderr
-    std::cerr << "Logging shutdown" << std::endl;
+    // Properly release spdlog resources
+    spdlog::shutdown();
 }
 
 } // namespace logging

--- a/src/quantum/quantum_processor.cpp
+++ b/src/quantum/quantum_processor.cpp
@@ -143,4 +143,10 @@ QuantumProcessor::Config::operator ProcessingConfig() const {
     pc.enable_cuda = enable_gpu;
     return pc;
 }
+
+std::unique_ptr<QuantumProcessor>
+createQuantumProcessor(const QuantumProcessor::Config& config) {
+    return std::make_unique<QuantumProcessor>(config);
+}
+
 } // namespace sep::quantum


### PR DESCRIPTION
## Summary
- define global optimizer configs with inline variables
- implement missing `createQuantumProcessor` factory
- improve logging shutdown to call `spdlog::shutdown`
- include `logging.cpp` in core build

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68611f6beeb8832a89d0022b5c218da2