### PR TITLE
Fix linker failure by grouping cycles libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -436,10 +436,10 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
         # First link CUDA-dependent libraries
         sep_compat
         
-        # Then Cycles with whole-archive
-        -Wl,--whole-archive
+        # Then Cycles libraries grouped to resolve cross-dependencies
+        -Wl,--start-group
         ${CYCLES_LINK_ORDER}
-        -Wl,--no-whole-archive
+        -Wl,--end-group
         
         # Then remaining internal libraries
         sep_api

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -54,20 +54,20 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
         # First link CUDA implementation to resolve sep::cuda symbols
         ${CUDA_LIBRARIES}
         ${CYCLES_CUDA_LIBRARIES}
-        # Then link all Cycles components with whole-archive
-        -Wl,--whole-archive
+        # Then link all Cycles components grouped for dependency resolution
+        -Wl,--start-group
         ${CYCLES_LINK_ORDER}
         ${CYCLES_SCENE_LIBRARIES}
         ${CYCLES_KERNEL_LIBRARIES}
         ${CYCLES_DEVICE_LIBRARIES}
         ${CYCLES_RENDER_LIBRARIES}
         ${CYCLES_RENDER_LIB}
-        -Wl,--no-whole-archive
+        -Wl,--end-group
 
-        # Link OSL implementation with whole-archive
-        -Wl,--whole-archive
+        # Link OSL implementation with group to avoid duplicate symbols
+        -Wl,--start-group
         ${CYCLES_OSL_LIBRARY}
-        -Wl,--no-whole-archive
+        -Wl,--end-group
 
         # Then link system OSL libraries in correct order
         ${OSL_COMP_LIBRARY}


### PR DESCRIPTION
## Summary
- group Cycles libraries with `--start-group`/`--end-group` instead of `--whole-archive`
- apply the same grouping to `cycles_test`

This avoids duplicate object errors when linking the OSL library.


------
https://chatgpt.com/codex/tasks/task_e_68615b49cb90832aa1cbab809f894521