### PR TITLE
Fix warnings

### DIFF
--- a/include/api/server.h
+++ b/include/api/server.h
@@ -22,8 +22,8 @@
 
 // Forward declarations for Crow request/response and application
 namespace crow {
-struct request;
-struct response;
+class request;
+class response;
 template <typename... Middlewares>
 class Crow;
 }  // namespace crow

--- a/include/api/types.h
+++ b/include/api/types.h
@@ -48,6 +48,7 @@ public:
     virtual std::string body() const = 0;
 
     virtual std::string getHeader(const std::string& name) const {
+        (void)name; // suppress unused parameter warning
         return "";
     }
 };

--- a/include/memory/memory_tier.hpp
+++ b/include/memory/memory_tier.hpp
@@ -58,7 +58,7 @@ struct MemoryBlock {
 
     MemoryBlock() = default;
     MemoryBlock(void* p, std::size_t s, std::size_t off, TierType t)
-        : ptr(p), size(s), offset(off), tier(t), original_size(s) {}
+        : ptr(p), size(s), offset(off), original_size(s), tier(t) {}
 };
 
 


### PR DESCRIPTION
## Summary
- address mismatched Crow forward declarations
- silence unused parameter warning
- fix memory tier constructor order

## Testing
- `cmake .. -DSEP_CUDA_AVAILABLE=OFF -DSEP_BUILD_TESTS=ON` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_68619e3ca63c832a9da0917d23fb19dc