### PR TITLE
Fix minor compile warnings

### DIFF
--- a/include/api/types.h
+++ b/include/api/types.h
@@ -48,6 +48,7 @@ public:
     virtual std::string body() const = 0;
 
     virtual std::string getHeader(const std::string& name) const {
+        (void)name;
         return "";
     }
 };

--- a/include/memory/memory_tier.hpp
+++ b/include/memory/memory_tier.hpp
@@ -58,7 +58,7 @@ struct MemoryBlock {
 
     MemoryBlock() = default;
     MemoryBlock(void* p, std::size_t s, std::size_t off, TierType t)
-        : ptr(p), size(s), offset(off), tier(t), original_size(s) {}
+        : ptr(p), size(s), offset(off), original_size(s), tier(t) {}
 };
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,6 +9,7 @@
 #include <spdlog/spdlog.h>
 #include "api/server.h" // Include server header
 #include "blender/cycles_renderer.h" // Include cycles renderer header
+#include "quantum/data.hpp"
 #include <atomic>
 #include <string>
 #include <csignal>


### PR DESCRIPTION
## Summary
- silence unused parameter warning in `HttpRequest::getHeader`
- fix constructor initialization order in `MemoryBlock`
- include PatternData header in `main.cpp`

## Testing
- `bash tests/blender/run_tests.sh` *(fails: Could not find nvcc, please set CUDAToolkit_ROOT)*

------
https://chatgpt.com/codex/tasks/task_e_68619e3ca63c832a9da0917d23fb19dc