### PR TITLE
Fix missing includes and constructor order

### DIFF
--- a/include/memory/memory_tier.hpp
+++ b/include/memory/memory_tier.hpp
@@ -58,7 +58,7 @@ struct MemoryBlock {
 
     MemoryBlock() = default;
     MemoryBlock(void* p, std::size_t s, std::size_t off, TierType t)
-        : ptr(p), size(s), offset(off), tier(t), original_size(s) {}
+        : ptr(p), size(s), offset(off), original_size(s), tier(t) {}
 };
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,6 +13,9 @@
 #include <string>
 #include <csignal>
 #include <nlohmann/json.hpp>
+#include "quantum/data.hpp" // For sep::pattern::PatternData
+#include <thread>
+#include <chrono>
 
 #ifndef SEP_HAS_EXCEPTIONS
 #    if defined(__cpp_exceptions) || defined(__EXCEPTIONS) || defined(_CPPUNWIND)


### PR DESCRIPTION
## Summary
- add missing includes for `PatternData`, `<thread>`, `<chrono>` in main
- fix MemoryBlock initialization order to match field order

## Testing
- `g++ -std=c++17 -Iinclude -c src/main.cpp -o /tmp/main.o` *(fails: nlohmann/json.hpp missing)*

------
https://chatgpt.com/codex/tasks/task_e_68619e3ca63c832a9da0917d23fb19dc