### PR TITLE
Fix CUDA build and minor warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ set(CMAKE_CUDA_FLAGS_INIT "-allow-unsupported-compiler")
 set(CMAKE_CUDA_COMPILER_INIT "nvcc -allow-unsupported-compiler")
 
 # Enable CUDA as a language so .cu files are compiled
-project(SEPEngine LANGUAGES CXX)
+project(SEPEngine LANGUAGES CXX CUDA)
 
 # Configure CUDA for the project
 set(SEP_CUDA_AVAILABLE ON)

--- a/include/api/types.h
+++ b/include/api/types.h
@@ -48,6 +48,7 @@ public:
     virtual std::string body() const = 0;
 
     virtual std::string getHeader(const std::string& name) const {
+        (void)name;
         return "";
     }
 };

--- a/include/memory/memory_tier.hpp
+++ b/include/memory/memory_tier.hpp
@@ -58,7 +58,7 @@ struct MemoryBlock {
 
     MemoryBlock() = default;
     MemoryBlock(void* p, std::size_t s, std::size_t off, TierType t)
-        : ptr(p), size(s), offset(off), tier(t), original_size(s) {}
+        : ptr(p), size(s), offset(off), original_size(s), tier(t) {}
 };
 
 

--- a/src/compat/CMakeLists.txt
+++ b/src/compat/CMakeLists.txt
@@ -39,6 +39,8 @@ set_target_properties(sep_compat PROPERTIES
     CUDA_RESOLVE_DEVICE_SYMBOLS ON
 )
 
+configure_cuda_target(sep_compat)
+
 # Link CUDA libraries with explicit absolute paths to ensure they're found
 target_link_libraries(sep_compat PUBLIC
     ${CUDA_LIBRARIES}


### PR DESCRIPTION
## Summary
- enable CUDA language in the main CMake project
- configure sep_compat CUDA target correctly
- silence an unused parameter warning
- fix field initialization order in MemoryBlock

## Testing
- `npm run build` *(fails: Cannot find module '@modelcontextprotocol/sdk/server')*

------
https://chatgpt.com/codex/tasks/task_e_68619e3ca63c832a9da0917d23fb19dc