### PR TITLE
Fix CUDA macro usage and logging request creation

### DIFF
--- a/src/core/engine.cpp
+++ b/src/core/engine.cpp
@@ -1,3 +1,6 @@
+#if defined(SEP_HAS_CUDA) && !defined(SEP_USE_CUDA)
+#define SEP_USE_CUDA 1
+#endif
 #include "compat/cuda_runtime.h"  // for sep::cuda::cudaMemcpyAsync
 #include "api/types.h"
 #include "core/common.h"  // defines sep::SEPResult

--- a/src/memory/manager.cpp
+++ b/src/memory/manager.cpp
@@ -161,7 +161,7 @@ void LoggingMiddleware::after_handle(::crow::request &req, ::crow::response &res
     return;
   }
 
-  auto req_ptr = sep::api::makeRequest(req);
+  auto req_ptr = std::make_unique<sep::api::CrowRequestAdapter>(req);
 
   if (ctx.start != std::chrono::high_resolution_clock::time_point{}) {
     auto end = std::chrono::high_resolution_clock::now();


### PR DESCRIPTION
## Summary
- enable CUDA runtime types in core engine
- avoid dependency on sep_api when logging requests

## Testing
- `cmake .. -DSEP_BUILD_TESTS=ON` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6861cca546a8832aac589cb1d15395ce