### PR TITLE
Fix library link order for sep_engine

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -503,11 +503,11 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
         # Link sep_compat first to ensure CUDA symbols are available
         sep_compat
         sep_core
-        
+
         # Core libraries that may use CUDA through sep_compat
+        sep_memory
         sep_api
         sep_audio
-        sep_memory
         sep_blender
         sep_quantum
         


### PR DESCRIPTION
## Summary
- adjust library order so `sep_memory` links before `sep_api`

## Testing
- `cmake -DCMAKE_CXX_COMPILER=clang++ ..` *(fails: Could not find CLANG using the following names: clang++-15)*

------
https://chatgpt.com/codex/tasks/task_e_6861cca546a8832aac589cb1d15395ce