### PR TITLE
Fix CudaCore constructor linkage

### DIFF
--- a/include/compat/core.h
+++ b/include/compat/core.h
@@ -69,12 +69,12 @@ class CudaCore {
                          const DeviceMemory<float>& emb_b, std::uint32_t embedding_size,
                          Stream& stream);
 
-  Error launchBlend(DeviceMemory<float>& output, const DeviceMemory<float>& embeddings,
+ Error launchBlend(DeviceMemory<float>& output, const DeviceMemory<float>& embeddings,
                     const DeviceMemory<float>& weights, std::uint32_t num_contexts,
                     std::uint32_t embedding_size, Stream& stream);
 
  private:
-  CudaCore();   // Private constructor for singleton
+  inline CudaCore() : initialized_(false), current_device_(-1) {}
   ~CudaCore() = default;  // Private destructor
 
   CudaCore(const CudaCore&) = delete;

--- a/src/compat/core.cu
+++ b/src/compat/core.cu
@@ -11,8 +11,6 @@
 
 namespace sep::cuda {
 
-CudaCore::CudaCore() : initialized_(false), current_device_(-1) {}
-
 CudaCore& CudaCore::instance() {
     static CudaCore instance;
     return instance;


### PR DESCRIPTION
## Summary
- inline `CudaCore` constructor in header so the symbol is always available
- remove out-of-line constructor in `core.cu`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6861d6659c08832a952b2fc753be9732