### PR TITLE
Fix missing CudaCore constructor definition

### DIFF
--- a/include/compat/core.h
+++ b/include/compat/core.h
@@ -70,8 +70,8 @@ class CudaCore {
                          Stream& stream);
 
   Error launchBlend(DeviceMemory<float>& output, const DeviceMemory<float>& embeddings,
-                    const DeviceMemory<float>& weights, std::uint32_t num_contexts,
-                    std::uint32_t embedding_size, Stream& stream);
+                      const DeviceMemory<float>& weights, std::uint32_t num_contexts,
+                      std::uint32_t embedding_size, Stream& stream);
 
  private:
   CudaCore();   // Private constructor for singleton
@@ -88,6 +88,8 @@ class CudaCore {
   Error initializeDevice(int device);
   Error queryDeviceProperties();
 };
+
+inline CudaCore::CudaCore() : initialized_{false}, current_device_{-1} {}
 
 }  // namespace sep::cuda
 


### PR DESCRIPTION
## Summary
- define `CudaCore` default constructor inline in header to satisfy linker

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6861d6659c08832a952b2fc753be9732