### PR TITLE
Implement real FFT and pattern evolution features

### DIFF
--- a/src/api/bridge.cpp
+++ b/src/api/bridge.cpp
@@ -1,11 +1,11 @@
 #include "api/bridge.h"
 #include "api/bridge.hpp"
-#include "api/bridge_internal.hpp" // Fix: Include internal header
+#include "api/bridge_internal.hpp"
 #include "quantum/processor.h"
 
-#include "api/types.h" // Fix: Include api/types.h
+#include "api/types.h"
 
-#include <atomic> // Fix: Add atomic for thread safety
+#include <atomic>
 #include <string>
 #include <memory>
 #include <exception>
@@ -32,7 +32,7 @@
 #endif
 
 namespace sep::api::bridge::detail {
-std::unique_ptr<sep::quantum::Processor> g_context_processor_bridge; // Fix: Use unique_ptr for memory management
+std::unique_ptr<sep::quantum::Processor> g_context_processor_bridge;
 std::string g_last_error;
 size_t g_required_buffer_size = 0;
 // Global mutex protects shared bridge state
@@ -147,7 +147,6 @@ void invokeCallbacks(const std::string &event_type,
                      const std::string &event_data) {
   std::lock_guard<std::mutex> lock(g_bridge_mutex);
   auto it = g_callback_map.find(event_type);
-  // Fix: check for end() iterator before dereferencing
   if (it == g_callback_map.end()) {
     return;
   }

--- a/src/api/bridge_c.cpp
+++ b/src/api/bridge_c.cpp
@@ -24,11 +24,11 @@ SEP_API int sep_bridge_init(void) {
 #ifdef SEP_HAS_EXCEPTIONS
   try {
 #endif
-  std::lock_guard<std::mutex> lock(sep::api::bridge::detail::g_bridge_mutex); // Fix: use the global mutex
+  std::lock_guard<std::mutex> lock(sep::api::bridge::detail::g_bridge_mutex);
   sep::quantum::ProcessingConfig options{};
   sep::api::bridge::detail::g_context_processor_bridge = sep::quantum::createProcessor(options);
- sep::api::bridge::detail::g_last_error.clear(); // Fix: Add semicolon
-  // Fix: Initialize g_required_buffer_size to 0 here
+  sep::api::bridge::detail::g_last_error.clear();
+  // Initialize g_required_buffer_size to 0 here
   sep::api::bridge::detail::g_required_buffer_size = 0;
   return 0;
 #if SEP_HAS_EXCEPTIONS
@@ -38,9 +38,9 @@ SEP_API int sep_bridge_init(void) {
 
 SEP_API int sep_bridge_cleanup(void) {
   std::lock_guard<std::mutex> lock(sep::api::bridge::detail::g_bridge_mutex);
- sep::api::bridge::detail::g_context_processor_bridge.reset(); // Fix: Add semicolon
+  sep::api::bridge::detail::g_context_processor_bridge.reset();
   sep::api::bridge::detail::g_last_error.clear();
-  // Fix: Initialize g_required_buffer_size to 0 here
+  // Initialize g_required_buffer_size to 0 here
   sep::api::bridge::detail::g_required_buffer_size = 0;
   return 0;
 }
@@ -48,7 +48,7 @@ SEP_API int sep_bridge_cleanup(void) {
 SEP_API int sep_process_context(const char *context_json, const char *layer,
                                char *result_buffer, size_t buffer_size) {
 #if SEP_HAS_EXCEPTIONS
-  try { // Fix: Use try block when exceptions are enabled
+  try {
 #endif
     if (!context_json || !result_buffer || !layer || buffer_size == 0) {
       sep::api::bridge::detail::setLastError("Invalid parameters");
@@ -80,7 +80,7 @@ SEP_API int sep_process_context(const char *context_json, const char *layer,
       std::string test_str = test_result.dump();
       {
         std::lock_guard<std::mutex> lock(sep::api::bridge::detail::g_bridge_mutex);
- sep::api::bridge::detail::setRequiredBufferSize(test_str.size() + 1); // Fix: Add semicolon
+        sep::api::bridge::detail::setRequiredBufferSize(test_str.size() + 1);
         if (test_str.size() >= buffer_size) {
           sep::api::bridge::detail::setLastError("Result buffer too small");
           return static_cast<int>(sep::api::ErrorCode::BufferTooSmall);
@@ -91,7 +91,7 @@ SEP_API int sep_process_context(const char *context_json, const char *layer,
       // Replacing with a dummy success for now, assuming the actual processing logic will be integrated later.
       sep::quantum::BatchProcessingResult process_result;
       process_result.success = true;
- process_result.error_code = 0; // Fix: Initialize error_code
+      process_result.error_code = 0;
       
       if (!process_result.success) {
         sep::api::bridge::detail::setLastError(process_result.error_message.c_str());
@@ -112,9 +112,9 @@ SEP_API int sep_process_context(const char *context_json, const char *layer,
       }
 
       std::string result_str = result_json.dump();
-      {
- std::lock_guard<std::mutex> lock(sep::api::bridge::detail::g_bridge_mutex); // Fix: Add semicolon
-        sep::api::bridge::detail::setRequiredBufferSize(result_str.size() + 1);
+        {
+          std::lock_guard<std::mutex> lock(sep::api::bridge::detail::g_bridge_mutex);
+          sep::api::bridge::detail::setRequiredBufferSize(result_str.size() + 1);
         if (result_str.size() >= buffer_size) {
           sep::api::bridge::detail::setLastError("Result buffer too small");
           return static_cast<int>(sep::api::ErrorCode::BufferTooSmall);
@@ -134,7 +134,7 @@ SEP_API int sep_process_context(const char *context_json, const char *layer,
 
 SEP_API int sep_bridge_get_last_error(char *buffer, size_t buffer_size) {
   std::lock_guard<std::mutex> lock(sep::api::bridge::detail::g_bridge_mutex);
-  if (!buffer || buffer_size == 0) { // Fix: Check for null buffer or zero size
+  if (!buffer || buffer_size == 0) {
     return static_cast<int>(sep::api::ErrorCode::InvalidParameter);
   }
   size_t len = std::min(sep::api::bridge::detail::g_last_error.size(), buffer_size - 1);
@@ -149,7 +149,7 @@ SEP_API size_t sep_get_required_buffer_size(void) {
 
 SEP_API int sep_bridge_set_config(const char *key, const char *value) {
 #if SEP_HAS_EXCEPTIONS
-  try { // Fix: Use try block when exceptions are enabled
+  try {
 #endif
   std::lock_guard<std::mutex> lock(sep::api::bridge::detail::g_bridge_mutex);
   if (!key || !value) {
@@ -183,7 +183,7 @@ SEP_API int sep_bridge_set_config(const char *key, const char *value) {
   }
   cm.updateAPIConfig(cfg);
   sep::api::bridge::detail::setLastError("");
- return 0; // Fix: Add semicolon
+  return 0;
 #if SEP_HAS_EXCEPTIONS
   } SEP_CATCH_RETURN(sep::api::ErrorCode::GeneralError);
 #endif
@@ -191,7 +191,7 @@ SEP_API int sep_bridge_set_config(const char *key, const char *value) {
 
 SEP_API int sep_bridge_get_config(const char *key, char *buffer, size_t buffer_size) {
 #if SEP_HAS_EXCEPTIONS
-  try { // Fix: Use try block when exceptions are enabled
+  try {
 #endif
   std::lock_guard<std::mutex> lock(sep::api::bridge::detail::g_bridge_mutex);
   if (!key || !buffer || buffer_size == 0) {
@@ -220,7 +220,7 @@ SEP_API int sep_bridge_get_config(const char *key, char *buffer, size_t buffer_s
   }
   (void)std::snprintf(buffer, buffer_size, "%s", val.c_str());
   sep::api::bridge::detail::setLastError("");
- return 0; // Fix: Add semicolon
+  return 0;
 #if SEP_HAS_EXCEPTIONS
   } SEP_CATCH_RETURN(sep::api::ErrorCode::GeneralError);
 #endif
@@ -229,16 +229,16 @@ SEP_API int sep_bridge_get_config(const char *key, char *buffer, size_t buffer_s
 SEP_API int sep_bridge_register_callback(const char *event_type,
                                          void (*callback)(const char *event_data)) {
 #if SEP_HAS_EXCEPTIONS
-  try { // Fix: Use try block when exceptions are enabled
+  try {
 #endif
   std::lock_guard<std::mutex> lock(sep::api::bridge::detail::g_bridge_mutex);
   if (!event_type || !callback) {
     sep::api::bridge::detail::setLastError("Invalid parameters");
     return static_cast<int>(sep::api::ErrorCode::GeneralError);
-  } // Fix: Add closing brace
+  }
   sep::api::bridge::detail::g_callback_map[event_type].push_back(callback);
   sep::api::bridge::detail::setLastError("");
- return 0; // Fix: Add semicolon
+  return 0;
 #if SEP_HAS_EXCEPTIONS
   } SEP_CATCH_RETURN(sep::api::ErrorCode::GeneralError);
 #endif

--- a/src/audio/pipeline.cpp
+++ b/src/audio/pipeline.cpp
@@ -7,6 +7,10 @@
 #include <glm/gtc/constants.hpp>
 #include <queue>
 #include <vector>
+#include "compat/cufft.h"
+#ifdef SEP_USE_FFTW
+#include <fftw3.h>
+#endif
 
 namespace sep {
 namespace audio {
@@ -90,24 +94,53 @@ void AudioPipeline::applyHannWindow(std::vector<float>& samples) {
 
 SpectralData AudioPipeline::performFFT(const std::vector<float>& samples) {
     SpectralData spectral;
+    const size_t N = samples.size();
 
-    // Prepare FFT input
-    std::vector<std::complex<float>> fft_input(samples.size());
-    for (size_t i = 0; i < samples.size(); ++i) {
-        fft_input[i] = std::complex<float>(samples[i], 0.0f);
+#if SEP_CUDA_AVAILABLE
+    cufftHandle plan;
+    cufftPlan1d(&plan, static_cast<int>(N), CUFFT_R2C, 1);
+    std::vector<cufftReal> input(samples.begin(), samples.end());
+    std::vector<cufftComplex> output(N / 2 + 1);
+    cufftExecR2C(plan, input.data(), output.data());
+    cufftDestroy(plan);
+
+    spectral.fft.resize(output.size());
+    for (size_t i = 0; i < output.size(); ++i) {
+        spectral.fft[i] = std::complex<float>(output[i].x, output[i].y);
     }
+#elif defined(SEP_USE_FFTW)
+    fftwf_complex* out = reinterpret_cast<fftwf_complex*>(
+        fftwf_malloc(sizeof(fftwf_complex) * (N / 2 + 1)));
+    fftwf_plan plan = fftwf_plan_dft_r2c_1d(static_cast<int>(N),
+                                           const_cast<float*>(samples.data()),
+                                           out, FFTW_ESTIMATE);
+    fftwf_execute(plan);
+    fftwf_destroy_plan(plan);
 
-    // Perform FFT (simplified for demo)
-    spectral.fft = fft_input;  // Would use actual FFT implementation
+    spectral.fft.resize(N / 2 + 1);
+    for (size_t i = 0; i < spectral.fft.size(); ++i) {
+        spectral.fft[i] = std::complex<float>(out[i][0], out[i][1]);
+    }
+    fftwf_free(out);
+#else
+    spectral.fft.resize(N);
+    for (size_t k = 0; k < N; ++k) {
+        std::complex<float> sum(0.0f, 0.0f);
+        for (size_t n = 0; n < N; ++n) {
+            float angle = -2.0f * glm::pi<float>() * static_cast<float>(n * k) /
+                          static_cast<float>(N);
+            sum += std::complex<float>(samples[n] * std::cos(angle),
+                                      samples[n] * std::sin(angle));
+        }
+        spectral.fft[k] = sum;
+    }
+#endif
 
-    // Calculate magnitudes and phases
-    spectral.magnitudes.resize(samples.size() / 2 + 1);
-    spectral.phases.resize(samples.size() / 2 + 1);
-
-    for (size_t i = 0; i < spectral.magnitudes.size(); ++i) {
-        auto& bin = spectral.fft[i];
-        spectral.magnitudes[i] = std::abs(bin);
-        spectral.phases[i] = std::arg(bin);
+    spectral.magnitudes.resize(spectral.fft.size());
+    spectral.phases.resize(spectral.fft.size());
+    for (size_t i = 0; i < spectral.fft.size(); ++i) {
+        spectral.magnitudes[i] = std::abs(spectral.fft[i]);
+        spectral.phases[i] = std::arg(spectral.fft[i]);
     }
 
     return spectral;

--- a/src/quantum/pattern_evolution.cpp
+++ b/src/quantum/pattern_evolution.cpp
@@ -4,6 +4,7 @@
 #include <nlohmann/json.hpp>
 #include "api/sep_engine.h"
 #include "quantum/pattern_evolution_bridge.h"
+#include "quantum/quantum_processor_qfh.h"
 
 // Standard Library Includes
 #include <glm/glm.hpp>
@@ -75,6 +76,23 @@ sep::pattern::PatternData sep::quantum::mcp::PatternEvolution::evolvePattern(con
 std::vector<sep::pattern::PatternData> sep::quantum::mcp::PatternEvolution::getPatterns( const nlohmann::json& args)
 {
     std::vector<sep::pattern::PatternData> patterns;
+    auto json_patterns = args.value("patterns", nlohmann::json::array());
+    float min_coherence = args.value("min_coherence", 0.0f);
+    float min_stability = args.value("min_stability", 0.0f);
+
+    for (const auto& jp : json_patterns)
+    {
+        auto p = fromJson(jp);
+        if (p.id.empty())
+        {
+            p.id = shim::string(api::SepEngine::generateId("pat").c_str());
+        }
+        if (p.coherence >= min_coherence && p.stability >= min_stability)
+        {
+            patterns.push_back(p);
+        }
+    }
+
     return patterns;
 }
 
@@ -87,21 +105,25 @@ sep::pattern::PatternResult sep::quantum::mcp::PatternEvolution::processPatterns
         output.clear();
         return pattern::PatternResult::SUCCESS;
     }
-    
+
     output.resize(input.size());
-    
-    // Simple CPU-based processing for now
-    // Copy input patterns and apply basic evolution
+
+    ::sep::quantum::QuantumProcessorQFH tier_helper;
+
     for (std::size_t i = 0; i < input.size(); ++i)
     {
-        // Use assignment operator instead of constructor
         output[i] = input[i];
         output[i].generation++;
-        output[i].coherence = std::min(1.0f, output[i].coherence * 1.01f);
-        output[i].stability = std::max(0.0f, output[i].stability * 0.99f);
+        output[i].coherence = std::clamp(input[i].coherence * (1.0f + config.update_threshold), 0.0f, 1.0f);
+        output[i].stability = std::clamp(input[i].stability * (1.0f - config.update_threshold / 2.0f), 0.0f, 1.0f);
+        output[i].entropy = std::clamp(input[i].entropy + 0.01f, 0.0f, 1.0f);
+        output[i].mutation_count += config.enable_mutations ? 1u : 0u;
+        output[i].memory_tier = tier_helper.determineMemoryTier(output[i].coherence,
+                                                                output[i].stability,
+                                                                output[i].generation);
         output[i].id = shim::string(api::SepEngine::generateId("pat").c_str());
     }
-    
+
     return pattern::PatternResult::SUCCESS;
 }
 

--- a/tests/audio/fft_accuracy_test.cpp
+++ b/tests/audio/fft_accuracy_test.cpp
@@ -1,0 +1,19 @@
+#include <gtest/gtest.h>
+#include "audio/pipeline.h"
+#include <glm/gtc/constants.hpp>
+
+using namespace sep::audio;
+
+TEST(AudioPipelineFFT, AccurateSineFrequency) {
+    const size_t sample_rate = 48000;
+    AudioPipeline pipeline(sample_rate, 1);
+    const float freq = 440.0f;
+    for (int i = 0; i < 2048; ++i) {
+        float sample = std::sin(2.0f * glm::pi<float>() * freq * i / sample_rate);
+        pipeline.processAudioFrame(std::vector<float>{sample});
+    }
+    auto patterns = pipeline.getPatterns();
+    ASSERT_FALSE(patterns.empty());
+    float fundamental = patterns.front().x * (sample_rate / 2.0f);
+    EXPECT_NEAR(fundamental, freq, 1.0f);
+}

--- a/tests/quantum/pattern_memory_tier_test.cpp
+++ b/tests/quantum/pattern_memory_tier_test.cpp
@@ -1,0 +1,17 @@
+#include <gtest/gtest.h>
+#include "quantum/pattern_evolution.h"
+#include "quantum/types.h"
+
+using namespace sep::quantum::mcp;
+
+TEST(PatternEvolution, MemoryTierAssignment) {
+    sep::pattern::PatternData in;
+    in.coherence = 0.95f;
+    in.stability = 0.9f;
+    in.generation = 100;
+    std::vector<sep::pattern::PatternData> out;
+    sep::pattern::PatternConfig cfg{};
+    ASSERT_EQ(PatternEvolution::processPatterns({in}, cfg, out), sep::pattern::PatternResult::SUCCESS);
+    ASSERT_EQ(out.size(), 1u);
+    EXPECT_EQ(out[0].memory_tier, sep::memory::MemoryTierEnum::LTM);
+}


### PR DESCRIPTION
## Summary
- integrate real FFT backends with cuFFT/FFTW fallbacks
- implement pattern filtering and deterministic updates
- clean up API bridge source comments
- add accuracy tests for FFT and memory tier logic

## Testing
- `ctest -V` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_6862b3bc3bf8832aa15e0051e4969f2c