### PR TITLE
Implement real FFT and enhance pattern evolution

### DIFF
--- a/src/audio/CMakeLists.txt
+++ b/src/audio/CMakeLists.txt
@@ -68,6 +68,14 @@ if(PIPEWIRE_FOUND)
   set(PIPEWIRE_FOUND ${PIPEWIRE_FOUND} PARENT_SCOPE)
 endif()
 
+# FFTW (for CPU FFT implementation)
+pkg_check_modules(FFTW QUIET fftw3f)
+if(FFTW_FOUND)
+  message(STATUS "Found FFTW: ${FFTW_LIBRARIES}")
+  target_include_directories(sep_audio PRIVATE ${FFTW_INCLUDE_DIRS})
+  target_link_libraries(sep_audio PRIVATE ${FFTW_LIBRARIES})
+endif()
+
 target_include_directories(sep_audio
     PUBLIC
         ${CMAKE_SOURCE_DIR}/include

--- a/src/audio/pipeline.cpp
+++ b/src/audio/pipeline.cpp
@@ -5,6 +5,8 @@
 #include <memory>
 #include <glm/glm.hpp>
 #include <glm/gtc/constants.hpp>
+#include <compat/cufft.h>
+#include <fftw3.h>
 #include <queue>
 #include <vector>
 
@@ -91,18 +93,42 @@ void AudioPipeline::applyHannWindow(std::vector<float>& samples) {
 SpectralData AudioPipeline::performFFT(const std::vector<float>& samples) {
     SpectralData spectral;
 
-    // Prepare FFT input
-    std::vector<std::complex<float>> fft_input(samples.size());
-    for (size_t i = 0; i < samples.size(); ++i) {
-        fft_input[i] = std::complex<float>(samples[i], 0.0f);
+    const size_t n = samples.size();
+    spectral.fft.resize(n);
+
+#if SEP_CUDA_AVAILABLE
+    std::vector<cufftComplex> input(n);
+    std::vector<cufftComplex> output(n);
+    for (size_t i = 0; i < n; ++i) {
+        input[i].x = samples[i];
+        input[i].y = 0.0f;
     }
+    cufftHandle plan;
+    cufftPlan1d(&plan, static_cast<int>(n), CUFFT_C2C, 1);
+    cufftExecC2C(plan, input.data(), output.data(), CUFFT_FORWARD);
+    cufftDestroy(plan);
+    for (size_t i = 0; i < n; ++i) {
+        spectral.fft[i] = std::complex<float>(output[i].x, output[i].y);
+    }
+#else
+    fftwf_complex* in = reinterpret_cast<fftwf_complex*>(fftwf_malloc(sizeof(fftwf_complex) * n));
+    fftwf_complex* out = reinterpret_cast<fftwf_complex*>(fftwf_malloc(sizeof(fftwf_complex) * n));
+    for (size_t i = 0; i < n; ++i) {
+        in[i][0] = samples[i];
+        in[i][1] = 0.0f;
+    }
+    fftwf_plan plan = fftwf_plan_dft_1d(static_cast<int>(n), in, out, FFTW_FORWARD, FFTW_ESTIMATE);
+    fftwf_execute(plan);
+    fftwf_destroy_plan(plan);
+    for (size_t i = 0; i < n; ++i) {
+        spectral.fft[i] = std::complex<float>(out[i][0], out[i][1]);
+    }
+    fftwf_free(in);
+    fftwf_free(out);
+#endif
 
-    // Perform FFT (simplified for demo)
-    spectral.fft = fft_input;  // Would use actual FFT implementation
-
-    // Calculate magnitudes and phases
-    spectral.magnitudes.resize(samples.size() / 2 + 1);
-    spectral.phases.resize(samples.size() / 2 + 1);
+    spectral.magnitudes.resize(n / 2 + 1);
+    spectral.phases.resize(n / 2 + 1);
 
     for (size_t i = 0; i < spectral.magnitudes.size(); ++i) {
         auto& bin = spectral.fft[i];

--- a/src/quantum/pattern_evolution.cpp
+++ b/src/quantum/pattern_evolution.cpp
@@ -4,6 +4,7 @@
 #include <nlohmann/json.hpp>
 #include "api/sep_engine.h"
 #include "quantum/pattern_evolution_bridge.h"
+#include "compat/kernels.cuh"
 
 // Standard Library Includes
 #include <glm/glm.hpp>
@@ -75,6 +76,22 @@ sep::pattern::PatternData sep::quantum::mcp::PatternEvolution::evolvePattern(con
 std::vector<sep::pattern::PatternData> sep::quantum::mcp::PatternEvolution::getPatterns( const nlohmann::json& args)
 {
     std::vector<sep::pattern::PatternData> patterns;
+
+    float min_coherence = args.value("min_coherence", 0.0f);
+    float min_stability = args.value("min_stability", 0.0f);
+
+    if (args.contains("patterns") && args["patterns"].is_array())
+    {
+        for (const auto& j : args["patterns"])
+        {
+            auto p = fromJson(j);
+            if (p.coherence >= min_coherence && p.stability >= min_stability)
+            {
+                patterns.push_back(p);
+            }
+        }
+    }
+
     return patterns;
 }
 
@@ -87,21 +104,29 @@ sep::pattern::PatternResult sep::quantum::mcp::PatternEvolution::processPatterns
         output.clear();
         return pattern::PatternResult::SUCCESS;
     }
-    
+
     output.resize(input.size());
-    
-    // Simple CPU-based processing for now
-    // Copy input patterns and apply basic evolution
+
+#if SEP_CUDA_AVAILABLE
+    cudaError_t err = sep::cuda::launch_pattern_processing(
+        const_cast<sep::pattern::PatternData*>(input.data()),
+        output.data(), config, input.size(), nullptr, nullptr);
+    if (err != cudaSuccess)
+    {
+        return pattern::PatternResult::PROCESSING_ERROR;
+    }
+#else
+    const float up = config.update_threshold;
     for (std::size_t i = 0; i < input.size(); ++i)
     {
-        // Use assignment operator instead of constructor
         output[i] = input[i];
         output[i].generation++;
-        output[i].coherence = std::min(1.0f, output[i].coherence * 1.01f);
-        output[i].stability = std::max(0.0f, output[i].stability * 0.99f);
+        output[i].coherence = std::min(1.0f, input[i].coherence * (1.0f + up));
+        output[i].stability = std::max(0.0f, input[i].stability * (1.0f - up));
         output[i].id = shim::string(api::SepEngine::generateId("pat").c_str());
     }
-    
+#endif
+
     return pattern::PatternResult::SUCCESS;
 }
 

--- a/tests/pattern/pattern_determinism_test.cpp
+++ b/tests/pattern/pattern_determinism_test.cpp
@@ -32,3 +32,16 @@ TEST(PatternDeterminism, JsonRoundTripStable) {
     EXPECT_EQ(PatternEvolution::toJson(r1).dump(), PatternEvolution::toJson(r2).dump());
 }
 
+TEST(PatternDeterminism, ProcessPatternsUpdateThreshold) {
+    PatternData in{};
+    in.coherence = 0.5f;
+    in.stability = 0.8f;
+    std::vector<PatternData> input{in};
+    sep::pattern::PatternConfig cfg{0.2f, false, 1, 1};
+    std::vector<PatternData> output;
+    ASSERT_EQ(PatternEvolution::processPatterns(input, cfg, output), sep::pattern::PatternResult::SUCCESS);
+    ASSERT_EQ(output.size(), 1u);
+    EXPECT_GT(output[0].coherence, input[0].coherence);
+    EXPECT_LT(output[0].stability, input[0].stability);
+}
+


### PR DESCRIPTION
## Summary
- integrate FFTW/cuFFT into audio pipeline for real spectral analysis
- extend PatternEvolution filtering and processing logic
- link FFTW in audio build
- add regression test covering update threshold behavior

## Testing
- `cmake -S . -B build -DSEP_ENABLE_CUDA=OFF -DSEP_BUILD_TESTS=ON` *(fails: missing mock_blender_bridge.cpp)*

------
https://chatgpt.com/codex/tasks/task_e_6862b3bc3bf8832aa15e0051e4969f2c