### PR TITLE
Implement real FFT and pattern evolution improvements

### DIFF
--- a/src/api/bridge.cpp
+++ b/src/api/bridge.cpp
@@ -9,6 +9,7 @@
 #include <string>
 #include <memory>
 #include <exception>
+#include <mutex>
 #include <unordered_map>
 #include <vector>
 #include <nlohmann/json.hpp>

--- a/src/api/bridge_c.cpp
+++ b/src/api/bridge_c.cpp
@@ -14,6 +14,7 @@
 #include <cstring>
 #include <cstdio>  // Required for snprintf
 #include <memory>
+#include <mutex>
 #include <unordered_map>
 #include <vector>
 
@@ -87,11 +88,11 @@ SEP_API int sep_process_context(const char *context_json, const char *layer,
         }
       }
 
-      // Call a method that exists on the Processor class, perhaps `processBatch` with dummy data or `processAll`.
-      // Replacing with a dummy success for now, assuming the actual processing logic will be integrated later.
       sep::quantum::BatchProcessingResult process_result;
-      process_result.success = true;
- process_result.error_code = 0; // Fix: Initialize error_code
+      {
+        std::lock_guard<std::mutex> lock(sep::api::bridge::detail::g_bridge_mutex);
+        process_result = sep::api::bridge::detail::g_context_processor_bridge->processAll();
+      }
       
       if (!process_result.success) {
         sep::api::bridge::detail::setLastError(process_result.error_message.c_str());

--- a/src/audio/CMakeLists.txt
+++ b/src/audio/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(sep_audio
 # Find PipeWire using both pkg-config and direct library find for robustness
 find_package(PkgConfig QUIET)
 set(PIPEWIRE_FOUND FALSE)
+pkg_check_modules(FFTW QUIET fftw3f)
 
 # Try using pkg-config first
 if(PKG_CONFIG_FOUND)
@@ -93,3 +94,10 @@ target_include_directories(sep_audio
         ${CMAKE_SOURCE_DIR}/extern/blender/lib/linux_x64/osl/include
         ${CMAKE_SOURCE_DIR}/extern/eigen
 )
+
+if(FFTW_FOUND)
+  target_include_directories(sep_audio PRIVATE ${FFTW_INCLUDE_DIRS})
+  target_link_libraries(sep_audio PRIVATE ${FFTW_LIBRARIES})
+  set(FFTW_LIBRARIES ${FFTW_LIBRARIES} PARENT_SCOPE)
+  set(FFTW_FOUND ${FFTW_FOUND} PARENT_SCOPE)
+endif()

--- a/src/audio/pipeline.cpp
+++ b/src/audio/pipeline.cpp
@@ -5,6 +5,11 @@
 #include <memory>
 #include <glm/glm.hpp>
 #include <glm/gtc/constants.hpp>
+#if SEP_HAS_CUDA
+#include "compat/cufft.h"
+#else
+#include <fftw3.h>
+#endif
 #include <queue>
 #include <vector>
 
@@ -91,18 +96,31 @@ void AudioPipeline::applyHannWindow(std::vector<float>& samples) {
 SpectralData AudioPipeline::performFFT(const std::vector<float>& samples) {
     SpectralData spectral;
 
-    // Prepare FFT input
-    std::vector<std::complex<float>> fft_input(samples.size());
-    for (size_t i = 0; i < samples.size(); ++i) {
-        fft_input[i] = std::complex<float>(samples[i], 0.0f);
+    const size_t n = samples.size();
+#if SEP_HAS_CUDA
+    std::vector<cufftComplex> out(n);
+    cufftHandle plan;
+    cufftPlan1d(&plan, static_cast<int>(n), CUFFT_R2C, 1);
+    cufftExecR2C(plan, const_cast<float*>(samples.data()), reinterpret_cast<cufftComplex*>(out.data()));
+    cufftDestroy(plan);
+    spectral.fft.resize(n);
+    for (size_t i = 0; i < n; ++i) {
+        spectral.fft[i] = std::complex<float>(out[i].x, out[i].y);
     }
-
-    // Perform FFT (simplified for demo)
-    spectral.fft = fft_input;  // Would use actual FFT implementation
+#else
+    std::vector<fftwf_complex> out(n);
+    fftwf_plan plan = fftwf_plan_dft_r2c_1d(static_cast<int>(n), const_cast<float*>(samples.data()), out.data(), FFTW_ESTIMATE);
+    fftwf_execute(plan);
+    fftwf_destroy_plan(plan);
+    spectral.fft.resize(n);
+    for (size_t i = 0; i < n; ++i) {
+        spectral.fft[i] = std::complex<float>(out[i][0], out[i][1]);
+    }
+#endif
 
     // Calculate magnitudes and phases
-    spectral.magnitudes.resize(samples.size() / 2 + 1);
-    spectral.phases.resize(samples.size() / 2 + 1);
+    spectral.magnitudes.resize(n / 2 + 1);
+    spectral.phases.resize(n / 2 + 1);
 
     for (size_t i = 0; i < spectral.magnitudes.size(); ++i) {
         auto& bin = spectral.fft[i];

--- a/src/quantum/pattern_evolution.cpp
+++ b/src/quantum/pattern_evolution.cpp
@@ -4,6 +4,7 @@
 #include <nlohmann/json.hpp>
 #include "api/sep_engine.h"
 #include "quantum/pattern_evolution_bridge.h"
+#include "memory/memory_tier_manager.hpp"
 
 // Standard Library Includes
 #include <glm/glm.hpp>
@@ -75,6 +76,25 @@ sep::pattern::PatternData sep::quantum::mcp::PatternEvolution::evolvePattern(con
 std::vector<sep::pattern::PatternData> sep::quantum::mcp::PatternEvolution::getPatterns( const nlohmann::json& args)
 {
     std::vector<sep::pattern::PatternData> patterns;
+    float min_coherence = args.value("min_coherence", 0.0f);
+    float min_stability = args.value("min_stability", 0.0f);
+    if (!args.contains("patterns") || !args["patterns"].is_array()) {
+        return patterns;
+    }
+
+    for (const auto& p : args["patterns"]) {
+        sep::pattern::PatternData pat{};
+        pat.coherence = p.value("coherence", 0.0f);
+        pat.stability = p.value("stability", 0.0f);
+        if (p.contains("id") && p["id"].is_string()) {
+            pat.id = shim::string(p["id"].get<std::string>().c_str());
+        } else {
+            pat.id = shim::string(api::SepEngine::generateId("pat").c_str());
+        }
+        if (pat.coherence >= min_coherence && pat.stability >= min_stability) {
+            patterns.push_back(pat);
+        }
+    }
     return patterns;
 }
 
@@ -89,19 +109,24 @@ sep::pattern::PatternResult sep::quantum::mcp::PatternEvolution::processPatterns
     }
     
     output.resize(input.size());
-    
-    // Simple CPU-based processing for now
-    // Copy input patterns and apply basic evolution
-    for (std::size_t i = 0; i < input.size(); ++i)
-    {
-        // Use assignment operator instead of constructor
+
+#ifdef SEP_USE_CUDA
+    auto res = memory::MemoryTierManager::getInstance().launch_pattern_processing(
+        const_cast<sep::pattern::PatternData*>(input.data()), output.data(), config,
+        input.size(), nullptr, nullptr);
+    if (res != sep::SEPResult::SUCCESS) {
+        return pattern::PatternResult::PROCESSING_ERROR;
+    }
+#else
+    for (std::size_t i = 0; i < input.size(); ++i) {
         output[i] = input[i];
         output[i].generation++;
-        output[i].coherence = std::min(1.0f, output[i].coherence * 1.01f);
-        output[i].stability = std::max(0.0f, output[i].stability * 0.99f);
+        output[i].coherence = std::min(1.0f, input[i].coherence + config.update_threshold);
+        output[i].stability = std::max(0.0f, input[i].stability - config.update_threshold / 2.0f);
         output[i].id = shim::string(api::SepEngine::generateId("pat").c_str());
     }
-    
+#endif
+
     return pattern::PatternResult::SUCCESS;
 }
 

--- a/tests/audio/fft_accuracy_test.cpp
+++ b/tests/audio/fft_accuracy_test.cpp
@@ -1,0 +1,21 @@
+#include <gtest/gtest.h>
+#include "audio/pipeline.h"
+#include <glm/glm.hpp>
+#include <glm/gtc/constants.hpp>
+
+using namespace sep::audio;
+
+TEST(AudioPipelineFFT, AccurateFundamental) {
+    const size_t sample_rate = 48000;
+    AudioPipeline pipeline(sample_rate, 1);
+    const float frequency = 1000.0f;
+    for(int i = 0; i < 2048; ++i) {
+        float sample = std::sin(2.0f * glm::pi<float>() * frequency * i / sample_rate);
+        pipeline.processAudioFrame(std::vector<float>{sample});
+    }
+    auto patterns = pipeline.getPatterns();
+    ASSERT_FALSE(patterns.empty());
+    float fundamental = patterns.front().x * (sample_rate / 2.0f);
+    EXPECT_NEAR(fundamental, frequency, 1.0f);
+}
+


### PR DESCRIPTION
## Summary
- use FFTW or cuFFT in `AudioPipeline::performFFT`
- filter and update patterns in `PatternEvolution`
- call real processor in bridge C API
- link FFTW in audio build and add unit test for FFT accuracy

## Testing
- `cmake -S . -B build -DSEP_BUILD_TESTS=ON -DCUDAToolkit_ROOT=/usr` *(fails: Could not find nvcc executable)*

------
https://chatgpt.com/codex/tasks/task_e_6862b3bc3bf8832aa15e0051e4969f2c