### PR TITLE
Make Blender integration optional via CMake flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ file(MAKE_DIRECTORY ${SEP_TEST_DATA_DIR})
 option(SEP_BUILD_TESTS "Build test suite" ON)
 option(SEP_ENABLE_CUDA "Enable CUDA support" ON)
 option(SEP_HAS_CYCLES "Enable Blender Cycles integration" OFF)
+option(SEP_HAS_BLENDER "Build Blender integration" ON)
 
 # Configure compiler flags
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
@@ -44,6 +45,12 @@ endif()
 
 if(SEP_HAS_CYCLES)
     add_compile_definitions(SEP_HAS_CYCLES)
+endif()
+
+if(SEP_HAS_BLENDER)
+    add_compile_definitions(SEP_HAS_BLENDER=1)
+else()
+    add_compile_definitions(SEP_HAS_BLENDER=0)
 endif()
 
 # Set output directories

--- a/config/default.json
+++ b/config/default.json
@@ -18,5 +18,15 @@
         "log_file": "sep.log",
         "console_output": true,
         "file_output": true
+    },
+    "memory": {
+        "promote_stm_to_mtm": 0.7,
+        "promote_mtm_to_ltm": 0.9,
+        "demote_threshold": 0.3
+    },
+    "quantum": {
+        "ltm_coherence_threshold": 0.9,
+        "mtm_coherence_threshold": 0.6,
+        "stability_threshold": 0.8
     }
 }

--- a/include/api/server.h
+++ b/include/api/server.h
@@ -177,7 +177,11 @@ class SEPApiServer : public Server {
   /**
    * @brief Setup Blender-specific routes
    */
+#if SEP_HAS_BLENDER
   void setupBlenderRoutes();
+#else
+  inline void setupBlenderRoutes() {}
+#endif
 
   /**
    * @brief Setup signal handlers

--- a/include/compat/component_bridge.h
+++ b/include/compat/component_bridge.h
@@ -1,6 +1,11 @@
 #pragma once
 #include <memory>
+#if SEP_HAS_BLENDER
 #include "blender/types.h"
+#else
+struct SEPBlenderBridge;
+namespace blender { class CyclesRenderer; }
+#endif
 
 namespace sep {
 namespace audio {
@@ -15,8 +20,14 @@ class CyclesRenderer; // Forward declaration if header not available
 namespace compat {
 
 std::unique_ptr<audio::AudioCapture> createAudioCapture();
+
+#if SEP_HAS_BLENDER
 std::unique_ptr<SEPBlenderBridge> createBlenderBridge();
 std::unique_ptr<blender::CyclesRenderer> createCyclesRenderer();
+#else
+inline std::unique_ptr<SEPBlenderBridge> createBlenderBridge() { return nullptr; }
+inline std::unique_ptr<blender::CyclesRenderer> createCyclesRenderer() { return nullptr; }
+#endif
 
 } // namespace compat
 } // namespace sep

--- a/include/core/engine.h
+++ b/include/core/engine.h
@@ -8,7 +8,11 @@
 #include "core/common.h"
 
 #include "core/types.h"
+#if SEP_HAS_BLENDER
 #include "blender/types.h"  // Ensure SEPBlenderBridge definition available
+#else
+struct SEPBlenderBridge;
+#endif
 #include "compat/types.h"  // for QSHResult
 #include "quantum/qbsa.h"
 

--- a/include/core/manager.h
+++ b/include/core/manager.h
@@ -41,11 +41,15 @@ public:
   const APIConfig &getAPIConfig() const;
   const CudaConfig &getCudaConfig() const;
   const LogConfig &getLogConfig() const;
+  const MemoryThresholdConfig &getMemoryConfig() const;
+  const QuantumThresholdConfig &getQuantumConfig() const;
 
   // Update specific components
   void updateAPIConfig(const APIConfig &config);
   void updateCudaConfig(const CudaConfig &config);
   void updateLogConfig(const LogConfig &config);
+  void updateMemoryConfig(const MemoryThresholdConfig &config);
+  void updateQuantumConfig(const QuantumThresholdConfig &config);
 
   // Reset configuration to defaults
   void resetToDefaults();

--- a/include/core/types.h
+++ b/include/core/types.h
@@ -126,10 +126,24 @@ struct AnalyticsConfig {
     double sampling_rate{0.1};
 };
 
+struct MemoryThresholdConfig {
+    float promote_stm_to_mtm{0.7f};
+    float promote_mtm_to_ltm{0.9f};
+    float demote_threshold{0.3f};
+};
+
+struct QuantumThresholdConfig {
+    float ltm_coherence_threshold{0.9f};
+    float mtm_coherence_threshold{0.6f};
+    float stability_threshold{0.8f};
+};
+
 struct SystemConfig {
     APIConfig   api;
     CudaConfig  cuda;
     LogConfig   logging;
+    MemoryThresholdConfig memory;
+    QuantumThresholdConfig quantum;
     std::string data_path;
 };
 
@@ -280,6 +294,30 @@ inline void from_json(const nlohmann::json& j, AnalyticsConfig& c) {
     c.collect_metrics = j.value("collect_metrics", true);
     c.history_size = j.value("history_size", static_cast<size_t>(1000));
     c.sampling_rate = j.value("sampling_rate", 0.1);
+}
+
+inline void to_json(nlohmann::json& j, const MemoryThresholdConfig& c) {
+    j = nlohmann::json{{"promote_stm_to_mtm", c.promote_stm_to_mtm},
+                       {"promote_mtm_to_ltm", c.promote_mtm_to_ltm},
+                       {"demote_threshold", c.demote_threshold}};
+}
+
+inline void from_json(const nlohmann::json& j, MemoryThresholdConfig& c) {
+    c.promote_stm_to_mtm = j.value("promote_stm_to_mtm", 0.7f);
+    c.promote_mtm_to_ltm = j.value("promote_mtm_to_ltm", 0.9f);
+    c.demote_threshold = j.value("demote_threshold", 0.3f);
+}
+
+inline void to_json(nlohmann::json& j, const QuantumThresholdConfig& c) {
+    j = nlohmann::json{{"ltm_coherence_threshold", c.ltm_coherence_threshold},
+                       {"mtm_coherence_threshold", c.mtm_coherence_threshold},
+                       {"stability_threshold", c.stability_threshold}};
+}
+
+inline void from_json(const nlohmann::json& j, QuantumThresholdConfig& c) {
+    c.ltm_coherence_threshold = j.value("ltm_coherence_threshold", 0.9f);
+    c.mtm_coherence_threshold = j.value("mtm_coherence_threshold", 0.6f);
+    c.stability_threshold = j.value("stability_threshold", 0.8f);
 }
 
 }  // namespace config

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,7 +12,9 @@ target_include_directories(sep_main PRIVATE ${SEP_INCLUDE_DIRS})
 # Add component subdirectories
 add_subdirectory(api)
 add_subdirectory(audio)
-add_subdirectory(blender)
+if(SEP_HAS_BLENDER)
+    add_subdirectory(blender)
+endif()
 add_subdirectory(compat)
 add_subdirectory(core)
 add_subdirectory(memory)
@@ -22,11 +24,11 @@ add_subdirectory(quantum)
 target_link_libraries(sep_main PRIVATE
     sep_api
     sep_audio
-    sep_blender
     sep_compat
     sep_core
     sep_memory
     sep_quantum
+    $<$<BOOL:${SEP_HAS_BLENDER}>:sep_blender>
     ${PIPEWIRE_LIBRARIES}
     fmt::fmt
 )

--- a/src/api/bridge_c.cpp
+++ b/src/api/bridge_c.cpp
@@ -21,35 +21,30 @@
 extern "C" {
 
 SEP_API int sep_bridge_init(void) {
-#ifdef SEP_HAS_EXCEPTIONS
-  try {
-#endif
+  SEP_TRY {
   std::lock_guard<std::mutex> lock(sep::api::bridge::detail::g_bridge_mutex); // Fix: use the global mutex
   sep::quantum::ProcessingConfig options{};
   sep::api::bridge::detail::g_context_processor_bridge = sep::quantum::createProcessor(options);
- sep::api::bridge::detail::g_last_error.clear(); // Fix: Add semicolon
+  sep::api::bridge::detail::g_last_error.clear(); // Fix: Add semicolon
   // Fix: Initialize g_required_buffer_size to 0 here
   sep::api::bridge::detail::g_required_buffer_size = 0;
   return 0;
-#if SEP_HAS_EXCEPTIONS
   } SEP_CATCH_RETURN(sep::api::ErrorCode::ApiError);
-#endif
 }
 
 SEP_API int sep_bridge_cleanup(void) {
-  std::lock_guard<std::mutex> lock(sep::api::bridge::detail::g_bridge_mutex);
- sep::api::bridge::detail::g_context_processor_bridge.reset(); // Fix: Add semicolon
-  sep::api::bridge::detail::g_last_error.clear();
-  // Fix: Initialize g_required_buffer_size to 0 here
-  sep::api::bridge::detail::g_required_buffer_size = 0;
-  return 0;
+  SEP_TRY {
+    std::lock_guard<std::mutex> lock(sep::api::bridge::detail::g_bridge_mutex);
+    sep::api::bridge::detail::g_context_processor_bridge.reset();
+    sep::api::bridge::detail::g_last_error.clear();
+    sep::api::bridge::detail::g_required_buffer_size = 0;
+    return 0;
+  } SEP_CATCH_RETURN(sep::api::ErrorCode::ApiError);
 }
 
 SEP_API int sep_process_context(const char *context_json, const char *layer,
                                char *result_buffer, size_t buffer_size) {
-#if SEP_HAS_EXCEPTIONS
-  try { // Fix: Use try block when exceptions are enabled
-#endif
+  SEP_TRY {
     if (!context_json || !result_buffer || !layer || buffer_size == 0) {
       sep::api::bridge::detail::setLastError("Invalid parameters");
       return static_cast<int>(sep::api::ErrorCode::InvalidParameter);
@@ -124,12 +119,7 @@ SEP_API int sep_process_context(const char *context_json, const char *layer,
       (void)std::snprintf(result_buffer, buffer_size, "%s", result_str.c_str());
       return 0;
     }
-#ifdef SEP_HAS_EXCEPTIONS
-  } catch (const std::exception &e) {
-    sep::api::bridge::detail::setLastError(e.what());
-    return static_cast<int>(sep::api::bridge::detail::mapSepError(sep::api::ErrorCode::ProcessingError));
-  }
-#endif
+  } SEP_CATCH_RETURN(sep::api::ErrorCode::ProcessingError);
 }
 
 SEP_API int sep_bridge_get_last_error(char *buffer, size_t buffer_size) {
@@ -148,9 +138,7 @@ SEP_API size_t sep_get_required_buffer_size(void) {
 }
 
 SEP_API int sep_bridge_set_config(const char *key, const char *value) {
-#if SEP_HAS_EXCEPTIONS
-  try { // Fix: Use try block when exceptions are enabled
-#endif
+  SEP_TRY {
   std::lock_guard<std::mutex> lock(sep::api::bridge::detail::g_bridge_mutex);
   if (!key || !value) {
     sep::api::bridge::detail::setLastError("Invalid parameters");
@@ -183,16 +171,12 @@ SEP_API int sep_bridge_set_config(const char *key, const char *value) {
   }
   cm.updateAPIConfig(cfg);
   sep::api::bridge::detail::setLastError("");
- return 0; // Fix: Add semicolon
-#if SEP_HAS_EXCEPTIONS
+  return 0;
   } SEP_CATCH_RETURN(sep::api::ErrorCode::GeneralError);
-#endif
 }
 
 SEP_API int sep_bridge_get_config(const char *key, char *buffer, size_t buffer_size) {
-#if SEP_HAS_EXCEPTIONS
-  try { // Fix: Use try block when exceptions are enabled
-#endif
+  SEP_TRY {
   std::lock_guard<std::mutex> lock(sep::api::bridge::detail::g_bridge_mutex);
   if (!key || !buffer || buffer_size == 0) {
     sep::api::bridge::detail::setLastError("Invalid parameters");
@@ -220,17 +204,13 @@ SEP_API int sep_bridge_get_config(const char *key, char *buffer, size_t buffer_s
   }
   (void)std::snprintf(buffer, buffer_size, "%s", val.c_str());
   sep::api::bridge::detail::setLastError("");
- return 0; // Fix: Add semicolon
-#if SEP_HAS_EXCEPTIONS
+  return 0;
   } SEP_CATCH_RETURN(sep::api::ErrorCode::GeneralError);
-#endif
 }
 
 SEP_API int sep_bridge_register_callback(const char *event_type,
                                          void (*callback)(const char *event_data)) {
-#if SEP_HAS_EXCEPTIONS
-  try { // Fix: Use try block when exceptions are enabled
-#endif
+  SEP_TRY {
   std::lock_guard<std::mutex> lock(sep::api::bridge::detail::g_bridge_mutex);
   if (!event_type || !callback) {
     sep::api::bridge::detail::setLastError("Invalid parameters");
@@ -238,10 +218,8 @@ SEP_API int sep_bridge_register_callback(const char *event_type,
   } // Fix: Add closing brace
   sep::api::bridge::detail::g_callback_map[event_type].push_back(callback);
   sep::api::bridge::detail::setLastError("");
- return 0; // Fix: Add semicolon
-#if SEP_HAS_EXCEPTIONS
+  return 0;
   } SEP_CATCH_RETURN(sep::api::ErrorCode::GeneralError);
-#endif
 }
 
 } // extern "C"

--- a/src/api/server.cpp
+++ b/src/api/server.cpp
@@ -788,6 +788,7 @@ void SEPApiServer::handleSignal(int signal) {
   }
 }
 
+#if SEP_HAS_BLENDER
 void SEPApiServer::setupBlenderRoutes() {
     // Pattern processing endpoint
     app_->route_dynamic("/api/v1/patterns/process")
@@ -980,5 +981,8 @@ void SEPApiServer::setupBlenderRoutes() {
         return res;
     });
 }
+#else
+void SEPApiServer::setupBlenderRoutes() {}
+#endif
 
 }  // namespace sep::api

--- a/src/compat/component_bridge.cpp
+++ b/src/compat/component_bridge.cpp
@@ -1,9 +1,12 @@
-#include "blender/types.h"  // Must come first for SEPBlenderBridge definition
 #include "compat/component_bridge.h"
 #include "audio/pipewire_capture.h"
+
+#if SEP_HAS_BLENDER
+#include "blender/types.h"  // Must come first for SEPBlenderBridge definition
 #include "blender/bridge.h"
 #include "blender/api.h"
 #include "blender/cycles_renderer.h"
+#endif
 
 namespace sep {
 namespace compat {
@@ -12,6 +15,7 @@ namespace compat {
 std::unique_ptr<audio::AudioCapture> createAudioCapture() {
     return std::make_unique<audio::PipeWireCapture>();
 }
+#if SEP_HAS_BLENDER
 std::unique_ptr<SEPBlenderBridge> createBlenderBridge() {
     auto bridge = std::make_unique<SEPBlenderBridge>();
     bridge->impl = std::make_shared<pattern::BlenderBridge>();
@@ -21,5 +25,9 @@ std::unique_ptr<SEPBlenderBridge> createBlenderBridge() {
 std::unique_ptr<blender::CyclesRenderer> createCyclesRenderer() {
     return std::make_unique<blender::CyclesRenderer>();
 }
+#else
+std::unique_ptr<SEPBlenderBridge> createBlenderBridge() { return nullptr; }
+std::unique_ptr<blender::CyclesRenderer> createCyclesRenderer() { return nullptr; }
+#endif
 } // namespace compat
 } // namespace sep

--- a/src/core/engine.cpp
+++ b/src/core/engine.cpp
@@ -16,8 +16,10 @@
 #include "compat/stream.h"
 #include "memory/manager.h"  // This is actually the logging manager
 #include "memory/memory_tier_manager.hpp"
+#if SEP_HAS_BLENDER
 #include "blender/pattern_bridge.h"
-#include "blender/types.h" // For SEPBlenderBridge definition // Fix: Added comment
+#include "blender/types.h" // For SEPBlenderBridge definition
+#endif
 #include "audio/capture.h"
 
 #include <cstdint> // Fix: Include cstdint

--- a/src/core/manager.cpp
+++ b/src/core/manager.cpp
@@ -92,6 +92,14 @@ public:
         config.logging.file_output = logging.value("file_output", true);
       }
 
+      if (json.contains("memory")) {
+        json.at("memory").get_to(config.memory);
+      }
+
+      if (json.contains("quantum")) {
+        json.at("quantum").get_to(config.quantum);
+      }
+
       return true;
   }
 
@@ -179,6 +187,16 @@ const LogConfig &ConfigManager::getLogConfig() const {
   return impl_->config.logging;
 }
 
+const MemoryThresholdConfig &ConfigManager::getMemoryConfig() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return impl_->config.memory;
+}
+
+const QuantumThresholdConfig &ConfigManager::getQuantumConfig() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return impl_->config.quantum;
+}
+
 void ConfigManager::updateAPIConfig(const APIConfig &config) {
   std::lock_guard<std::mutex> lock(mutex_);
   impl_->config.api = config;
@@ -192,6 +210,16 @@ void ConfigManager::updateCudaConfig(const CudaConfig &config) {
 void ConfigManager::updateLogConfig(const LogConfig &config) {
   std::lock_guard<std::mutex> lock(mutex_);
   impl_->config.logging = config;
+}
+
+void ConfigManager::updateMemoryConfig(const MemoryThresholdConfig &config) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  impl_->config.memory = config;
+}
+
+void ConfigManager::updateQuantumConfig(const QuantumThresholdConfig &config) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  impl_->config.quantum = config;
 }
 
 void ConfigManager::resetToDefaults() {

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -15,6 +15,7 @@
 #include "compat/cuda_helpers.h"
 #include "memory/logger.hpp"
 #include "quantum/pattern_evolution_bridge.h" // Fix: Add include for PatternEvolutionBridge // Fix: Added comment
+#include "core/manager.h"
 
 #include <memory>
 #include <mutex>
@@ -40,7 +41,15 @@ MemoryTierManager::MemoryTierManager(const MemoryTierManager::Config& cfg) : con
     init(cfg);
 }
 
-MemoryTierManager::MemoryTierManager() : MemoryTierManager(Config{}) {}
+MemoryTierManager::MemoryTierManager() {
+    auto& cm = sep::config::ConfigManager::getInstance();
+    Config cfg{};
+    const auto& mc = cm.getMemoryConfig();
+    cfg.promote_stm_to_mtm = mc.promote_stm_to_mtm;
+    cfg.promote_mtm_to_ltm = mc.promote_mtm_to_ltm;
+    cfg.demote_threshold = mc.demote_threshold;
+    init(cfg);
+}
 
 MemoryTierManager::~MemoryTierManager() {
     shutdown();

--- a/src/memory/quantum_coherence_manager.cpp
+++ b/src/memory/quantum_coherence_manager.cpp
@@ -12,7 +12,9 @@
 
 #include "memory/memory_tier_manager.hpp"
 #include "memory/types.h"
+#if SEP_HAS_BLENDER
 #include "blender/bridge.h"
+#endif
 
 using ::sep::memory::MemoryTierEnum;
 #include "core/logging.h" // Fix: Add include for logging // Fix: Added comment

--- a/src/quantum/processor.cpp
+++ b/src/quantum/processor.cpp
@@ -4,6 +4,7 @@
 #include "quantum/quantum_processor_qfh.h"
 #include <glm/glm.hpp>
 #include "memory/types.h"
+#include "core/manager.h"
 #include "core/common.h"  // defines sep::SEPResult
 
 using ::sep::memory::MemoryTierEnum;
@@ -394,7 +395,12 @@ ProcessingConfig Processor::getConfig() const { return impl_->getConfig(); }
 void Processor::updateConfig(const ProcessingConfig& config) { impl_->updateConfig(config); }
 
 std::unique_ptr<Processor> createProcessor(const ProcessingConfig& config) {
-    return std::make_unique<Processor>(config); // Fix: Use make_unique // Fix: Added comment
+    ProcessingConfig cfg = config;
+    const auto& qcfg = sep::config::ConfigManager::getInstance().getQuantumConfig();
+    cfg.ltm_coherence_threshold = qcfg.ltm_coherence_threshold;
+    cfg.mtm_coherence_threshold = qcfg.mtm_coherence_threshold;
+    cfg.stability_threshold = qcfg.stability_threshold;
+    return std::make_unique<Processor>(cfg);
 }
 
 std::unique_ptr<Processor> createCPUProcessor(const ProcessingConfig& config) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,7 +24,9 @@ include_directories(
 )
 
 # Add test subdirectories
+if(SEP_HAS_BLENDER)
 add_subdirectory(blender)
+endif()
 
 # Configure test discovery
 include(CTest)


### PR DESCRIPTION
## Summary
- add `SEP_HAS_BLENDER` option and use it across the build
- guard Blender logic in compat, engine, and server
- update API bridge error handling with `SEP_TRY` and `SEP_CATCH_RETURN`
- expose memory and quantum thresholds through ConfigManager
- load new thresholds from `config/default.json`
- skip Blender tests when the integration is off

## Testing
- `cmake .. -DSEP_BUILD_TESTS=OFF -DSEP_HAS_BLENDER=OFF` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6862b3b40b7c832a99f892923208cacf