### PR TITLE
Unify API return types

### DIFF
--- a/include/api/bridge.h
+++ b/include/api/bridge.h
@@ -18,16 +18,16 @@
 extern "C" {
 #endif
 
-SEP_API int sep_bridge_init(void);
-SEP_API int sep_bridge_cleanup(void);
-SEP_API int sep_process_context(const char *context_json, const char *layer,
+SEP_API sep::SEPResult sep_bridge_init(void);
+SEP_API sep::SEPResult sep_bridge_cleanup(void);
+SEP_API sep::SEPResult sep_process_context(const char *context_json, const char *layer,
                                 char *result_buffer, size_t buffer_size);
-SEP_API int sep_bridge_get_last_error(char *buffer, size_t buffer_size);
+SEP_API sep::SEPResult sep_bridge_get_last_error(char *buffer, size_t buffer_size);
 SEP_API size_t sep_get_required_buffer_size(void);
-SEP_API int sep_bridge_set_config(const char *key, const char *value);
-SEP_API int sep_bridge_get_config(const char *key, char *buffer,
+SEP_API sep::SEPResult sep_bridge_set_config(const char *key, const char *value);
+SEP_API sep::SEPResult sep_bridge_get_config(const char *key, char *buffer,
                                   size_t buffer_size);
-SEP_API int
+SEP_API sep::SEPResult
 sep_bridge_register_callback(const char *event_type,
                              void (*callback)(const char *event_data));
 

--- a/include/api/bridge.hpp
+++ b/include/api/bridge.hpp
@@ -33,15 +33,15 @@ std::string getLastError();
 } // namespace sep::api::bridge
 
 extern "C" {
-SEP_API int sep_bridge_init(void);
-SEP_API int sep_bridge_cleanup(void);
-SEP_API int sep_process_context(const char *context_json, const char *layer,
+SEP_API sep::SEPResult sep_bridge_init(void);
+SEP_API sep::SEPResult sep_bridge_cleanup(void);
+SEP_API sep::SEPResult sep_process_context(const char *context_json, const char *layer,
                                 char *result_buffer, size_t buffer_size);
-SEP_API int sep_bridge_get_last_error(char *buffer, size_t buffer_size);
+SEP_API sep::SEPResult sep_bridge_get_last_error(char *buffer, size_t buffer_size);
 SEP_API size_t sep_get_required_buffer_size(void);
-SEP_API int sep_bridge_set_config(const char *key, const char *value);
-SEP_API int sep_bridge_get_config(const char *key, char *buffer, size_t buffer_size);
-SEP_API int sep_bridge_register_callback(const char *event_type,
+SEP_API sep::SEPResult sep_bridge_set_config(const char *key, const char *value);
+SEP_API sep::SEPResult sep_bridge_get_config(const char *key, char *buffer, size_t buffer_size);
+SEP_API sep::SEPResult sep_bridge_register_callback(const char *event_type,
                                          void (*callback)(const char *event_data));
 } // extern "C"
 

--- a/include/blender/bridge.h
+++ b/include/blender/bridge.h
@@ -34,6 +34,8 @@ struct PatternLimits {
 // Forward declarations
 class PatternObserver;
 
+// Thread-safe bridge for coordinating Blender objects with the quantum processor.
+// Access to internal maps and observer lists is protected by mutexes.
 class BlenderBridge {
  public:
   BlenderBridge();
@@ -130,7 +132,9 @@ class BlenderBridge {
   std::atomic<bool> processing_{false};
   std::atomic<sep::pattern::ObjectHandle> next_handle_{1};
 
+  // guards access to objects_ map
   mutable std::mutex objects_mutex_;
+  // guards observers_ list
   mutable std::mutex observers_mutex_;
   std::mutex processing_mutex_;
   std::condition_variable processing_cv_;

--- a/include/compat/cuda_api.hpp
+++ b/include/compat/cuda_api.hpp
@@ -30,14 +30,14 @@ cudaError_t launchQSHKernel(const std::uint64_t *d_chunks,
 // C API
 extern "C" {
 
-int sep_cuda_init(int device_id);
-int sep_cuda_cleanup(void);
+sep::SEPResult sep_cuda_init(int device_id);
+sep::SEPResult sep_cuda_cleanup(void);
 
-int sep_cuda_process_batch(const std::uint32_t* probe_indices, const std::uint32_t* expectations,
+sep::SEPResult sep_cuda_process_batch(const std::uint32_t* probe_indices, const std::uint32_t* expectations,
                           std::uint32_t num_probes, std::uint32_t* bitfield, std::uint32_t* correction_indices,
                           std::uint32_t* correction_count);
 
-int sep_cuda_process_symmetry(const std::uint64_t* chunks, std::uint32_t num_chunks,
+sep::SEPResult sep_cuda_process_symmetry(const std::uint64_t* chunks, std::uint32_t num_chunks,
                             std::uint32_t* collapse_indices, std::uint32_t* collapse_counts);
 
 } // extern "C"

--- a/include/memory/manager.h
+++ b/include/memory/manager.h
@@ -20,10 +20,10 @@
 #include <spdlog/spdlog.h>
 #endif
 
-#include "api/server.h"
 namespace sep {
 namespace api {
 class HttpRequest;
+class Server;
 std::unique_ptr<HttpRequest> makeRequest(::crow::request &req);
 }  // namespace api
 }  // namespace sep

--- a/include/quantum/processor.h
+++ b/include/quantum/processor.h
@@ -77,6 +77,7 @@ namespace core { class SystemHooks; }
 
 class ProcessorImpl;
 
+// Processor is thread-safe. All access to internal state is guarded by a mutex.
 class Processor {
 public:
     explicit Processor(const ProcessingConfig& config);

--- a/src/api/bridge_c.cpp
+++ b/src/api/bridge_c.cpp
@@ -20,7 +20,7 @@
 
 extern "C" {
 
-SEP_API int sep_bridge_init(void) {
+SEP_API sep::SEPResult sep_bridge_init(void) {
 #ifdef SEP_HAS_EXCEPTIONS
   try {
 #endif
@@ -30,29 +30,29 @@ SEP_API int sep_bridge_init(void) {
  sep::api::bridge::detail::g_last_error.clear(); // Fix: Add semicolon
   // Fix: Initialize g_required_buffer_size to 0 here
   sep::api::bridge::detail::g_required_buffer_size = 0;
-  return 0;
+  return sep::SEPResult::SUCCESS;
 #if SEP_HAS_EXCEPTIONS
   } SEP_CATCH_RETURN(sep::api::ErrorCode::ApiError);
 #endif
 }
 
-SEP_API int sep_bridge_cleanup(void) {
+SEP_API sep::SEPResult sep_bridge_cleanup(void) {
   std::lock_guard<std::mutex> lock(sep::api::bridge::detail::g_bridge_mutex);
  sep::api::bridge::detail::g_context_processor_bridge.reset(); // Fix: Add semicolon
   sep::api::bridge::detail::g_last_error.clear();
   // Fix: Initialize g_required_buffer_size to 0 here
   sep::api::bridge::detail::g_required_buffer_size = 0;
-  return 0;
+  return sep::SEPResult::SUCCESS;
 }
 
-SEP_API int sep_process_context(const char *context_json, const char *layer,
+SEP_API sep::SEPResult sep_process_context(const char *context_json, const char *layer,
                                char *result_buffer, size_t buffer_size) {
 #if SEP_HAS_EXCEPTIONS
   try { // Fix: Use try block when exceptions are enabled
 #endif
     if (!context_json || !result_buffer || !layer || buffer_size == 0) {
       sep::api::bridge::detail::setLastError("Invalid parameters");
-      return static_cast<int>(sep::api::ErrorCode::InvalidParameter);
+      return sep::SEPResult::INVALID_ARGUMENT;
     }
 
     sep::quantum::Processor *processor = nullptr;
@@ -60,7 +60,7 @@ SEP_API int sep_process_context(const char *context_json, const char *layer,
       std::lock_guard<std::mutex> lock(sep::api::bridge::detail::g_bridge_mutex);
       if (!sep::api::bridge::detail::g_context_processor_bridge) {
         sep::api::bridge::detail::setLastError("Context processor not initialized");
-        return static_cast<int>(sep::api::ErrorCode::GeneralError);
+        return sep::SEPResult::UNKNOWN_ERROR;
       }
       processor = sep::api::bridge::detail::g_context_processor_bridge.get();
     }
@@ -69,7 +69,7 @@ SEP_API int sep_process_context(const char *context_json, const char *layer,
       nlohmann::json json_obj = nlohmann::json::parse(context_json, nullptr, false);
       if (json_obj.is_discarded()) {
         sep::api::bridge::detail::setLastError("JSON parsing error");
-        return static_cast<int>(sep::api::ErrorCode::ProcessingError);
+        return sep::SEPResult::PROCESSING_ERROR;
       }
 
       nlohmann::json test_result;
@@ -83,7 +83,7 @@ SEP_API int sep_process_context(const char *context_json, const char *layer,
  sep::api::bridge::detail::setRequiredBufferSize(test_str.size() + 1); // Fix: Add semicolon
         if (test_str.size() >= buffer_size) {
           sep::api::bridge::detail::setLastError("Result buffer too small");
-          return static_cast<int>(sep::api::ErrorCode::BufferTooSmall);
+          return sep::SEPResult::BUFFER_TOO_SMALL;
         }
       }
 
@@ -95,7 +95,7 @@ SEP_API int sep_process_context(const char *context_json, const char *layer,
       
       if (!process_result.success) {
         sep::api::bridge::detail::setLastError(process_result.error_message.c_str());
-        return static_cast<int>(process_result.error_code); // Use specific error code
+        return static_cast<sep::SEPResult>(process_result.error_code); // Use specific error code
       }
 
       nlohmann::json result_json;
@@ -117,29 +117,29 @@ SEP_API int sep_process_context(const char *context_json, const char *layer,
         sep::api::bridge::detail::setRequiredBufferSize(result_str.size() + 1);
         if (result_str.size() >= buffer_size) {
           sep::api::bridge::detail::setLastError("Result buffer too small");
-          return static_cast<int>(sep::api::ErrorCode::BufferTooSmall);
+          return sep::SEPResult::BUFFER_TOO_SMALL;
         }
       }
 
       (void)std::snprintf(result_buffer, buffer_size, "%s", result_str.c_str());
-      return 0;
+      return sep::SEPResult::SUCCESS;
     }
 #ifdef SEP_HAS_EXCEPTIONS
   } catch (const std::exception &e) {
     sep::api::bridge::detail::setLastError(e.what());
-    return static_cast<int>(sep::api::bridge::detail::mapSepError(sep::api::ErrorCode::ProcessingError));
+    return sep::SEPResult::PROCESSING_ERROR;
   }
 #endif
 }
 
-SEP_API int sep_bridge_get_last_error(char *buffer, size_t buffer_size) {
+SEP_API sep::SEPResult sep_bridge_get_last_error(char *buffer, size_t buffer_size) {
   std::lock_guard<std::mutex> lock(sep::api::bridge::detail::g_bridge_mutex);
   if (!buffer || buffer_size == 0) { // Fix: Check for null buffer or zero size
-    return static_cast<int>(sep::api::ErrorCode::InvalidParameter);
+    return sep::SEPResult::INVALID_ARGUMENT;
   }
   size_t len = std::min(sep::api::bridge::detail::g_last_error.size(), buffer_size - 1);
   (void)std::snprintf(buffer, buffer_size, "%s", sep::api::bridge::detail::g_last_error.c_str());
-  return static_cast<int>(len);
+  return static_cast<sep::SEPResult>(len);
 }
 
 SEP_API size_t sep_get_required_buffer_size(void) {
@@ -147,14 +147,14 @@ SEP_API size_t sep_get_required_buffer_size(void) {
   return sep::api::bridge::detail::g_required_buffer_size;
 }
 
-SEP_API int sep_bridge_set_config(const char *key, const char *value) {
+SEP_API sep::SEPResult sep_bridge_set_config(const char *key, const char *value) {
 #if SEP_HAS_EXCEPTIONS
   try { // Fix: Use try block when exceptions are enabled
 #endif
   std::lock_guard<std::mutex> lock(sep::api::bridge::detail::g_bridge_mutex);
   if (!key || !value) {
     sep::api::bridge::detail::setLastError("Invalid parameters");
-    return static_cast<int>(sep::api::ErrorCode::GeneralError);
+    return sep::SEPResult::UNKNOWN_ERROR;
   }
   std::string k = key;
   auto &cm = sep::config::ConfigManager::getInstance();
@@ -175,28 +175,28 @@ SEP_API int sep_bridge_set_config(const char *key, const char *value) {
       cfg.keep_alive_timeout_ms = static_cast<size_t>(std::stoul(value));
     } else {
       sep::api::bridge::detail::setLastError("Config key not found");
-      return static_cast<int>(sep::api::ErrorCode::InvalidParameter);
+      return sep::SEPResult::INVALID_ARGUMENT;
     }
   } catch (...) {
     sep::api::bridge::detail::setLastError("Invalid value");
-    return static_cast<int>(sep::api::ErrorCode::GeneralError);
+    return sep::SEPResult::UNKNOWN_ERROR;
   }
   cm.updateAPIConfig(cfg);
   sep::api::bridge::detail::setLastError("");
- return 0; // Fix: Add semicolon
+ return sep::SEPResult::SUCCESS; // Fix: Add semicolon
 #if SEP_HAS_EXCEPTIONS
   } SEP_CATCH_RETURN(sep::api::ErrorCode::GeneralError);
 #endif
 }
 
-SEP_API int sep_bridge_get_config(const char *key, char *buffer, size_t buffer_size) {
+SEP_API sep::SEPResult sep_bridge_get_config(const char *key, char *buffer, size_t buffer_size) {
 #if SEP_HAS_EXCEPTIONS
   try { // Fix: Use try block when exceptions are enabled
 #endif
   std::lock_guard<std::mutex> lock(sep::api::bridge::detail::g_bridge_mutex);
   if (!key || !buffer || buffer_size == 0) {
     sep::api::bridge::detail::setLastError("Invalid parameters");
-    return static_cast<int>(sep::api::ErrorCode::GeneralError);
+    return sep::SEPResult::UNKNOWN_ERROR;
   }
   std::string k = key;
   const auto &cfg = sep::config::ConfigManager::getInstance().getAPIConfig();
@@ -216,17 +216,17 @@ SEP_API int sep_bridge_get_config(const char *key, char *buffer, size_t buffer_s
   } else {
     buffer[0] = '\0';
     sep::api::bridge::detail::setLastError("Config key not found");
-    return static_cast<int>(sep::api::ErrorCode::InvalidParameter);
+    return sep::SEPResult::INVALID_ARGUMENT;
   }
   (void)std::snprintf(buffer, buffer_size, "%s", val.c_str());
   sep::api::bridge::detail::setLastError("");
- return 0; // Fix: Add semicolon
+  return sep::SEPResult::SUCCESS; // Fix: Add semicolon
 #if SEP_HAS_EXCEPTIONS
   } SEP_CATCH_RETURN(sep::api::ErrorCode::GeneralError);
 #endif
 }
 
-SEP_API int sep_bridge_register_callback(const char *event_type,
+SEP_API sep::SEPResult sep_bridge_register_callback(const char *event_type,
                                          void (*callback)(const char *event_data)) {
 #if SEP_HAS_EXCEPTIONS
   try { // Fix: Use try block when exceptions are enabled
@@ -234,11 +234,11 @@ SEP_API int sep_bridge_register_callback(const char *event_type,
   std::lock_guard<std::mutex> lock(sep::api::bridge::detail::g_bridge_mutex);
   if (!event_type || !callback) {
     sep::api::bridge::detail::setLastError("Invalid parameters");
-    return static_cast<int>(sep::api::ErrorCode::GeneralError);
+    return sep::SEPResult::UNKNOWN_ERROR;
   } // Fix: Add closing brace
   sep::api::bridge::detail::g_callback_map[event_type].push_back(callback);
   sep::api::bridge::detail::setLastError("");
- return 0; // Fix: Add semicolon
+  return sep::SEPResult::SUCCESS; // Fix: Add semicolon
 #if SEP_HAS_EXCEPTIONS
   } SEP_CATCH_RETURN(sep::api::ErrorCode::GeneralError);
 #endif

--- a/src/compat/cuda_api.cu
+++ b/src/compat/cuda_api.cu
@@ -100,9 +100,9 @@ using StreamPtr = std::unique_ptr<sep::cuda::StreamRAII>;
 static StreamPtr g_stream;
 static bool g_initialized = false;
 
-int sep_cuda_init(int device_id) {
+sep::SEPResult sep_cuda_init(int device_id) {
     if (g_initialized) {
-        return 0;
+        return sep::SEPResult::SUCCESS;
     }
 
     if (device_id >= 0) {
@@ -112,28 +112,28 @@ int sep_cuda_init(int device_id) {
     g_stream = std::make_unique<sep::cuda::StreamRAII>();
     if (!g_stream || !g_stream->valid()) {
         g_stream.reset();
-        return static_cast<int>(sep::ErrorCode::GeneralError);
+        return sep::SEPResult::UNKNOWN_ERROR;
     }
 
     g_initialized = true;
-    return 0;
+    return sep::SEPResult::SUCCESS;
 }
 
-int sep_cuda_cleanup(void) {
+sep::SEPResult sep_cuda_cleanup(void) {
     if (!g_initialized) {
-        return 0;
+        return sep::SEPResult::SUCCESS;
     }
 
     g_stream.reset();
     g_initialized = false;
-    return 0;
+    return sep::SEPResult::SUCCESS;
 }
 
-int sep_cuda_process_batch(const std::uint32_t* probe_indices, const std::uint32_t* expectations,
+sep::SEPResult sep_cuda_process_batch(const std::uint32_t* probe_indices, const std::uint32_t* expectations,
                            std::uint32_t num_probes, std::uint32_t* bitfield, std::uint32_t* correction_indices,
                            std::uint32_t* correction_count) {
     if (!g_initialized) {
-        return static_cast<int>(sep::ErrorCode::GeneralError);
+        return sep::SEPResult::UNKNOWN_ERROR;
     }
 
     // Get constants
@@ -155,7 +155,7 @@ int sep_cuda_process_batch(const std::uint32_t* probe_indices, const std::uint32
 
     if (!d_probe_indices.valid() || !d_expectations.valid() || !d_bitfield.valid() || !d_corrections.valid() ||
         !d_correction_count.valid()) {
-        return static_cast<int>(sep::ErrorCode::GeneralError);
+        return sep::SEPResult::UNKNOWN_ERROR;
     }
 
     try {
@@ -188,16 +188,16 @@ int sep_cuda_process_batch(const std::uint32_t* probe_indices, const std::uint32
 
         CUDA_CHECK(cudaStreamSynchronize(g_stream->get()));
     } catch (const sep::CudaException&) {
-        return static_cast<int>(sep::ErrorCode::GeneralError);
+        return sep::SEPResult::UNKNOWN_ERROR;
     }
 
-    return 0;
+    return sep::SEPResult::SUCCESS;
 }
 
-int sep_cuda_process_symmetry(const std::uint64_t* chunks, std::uint32_t num_chunks, std::uint32_t* collapse_indices,
+sep::SEPResult sep_cuda_process_symmetry(const std::uint64_t* chunks, std::uint32_t num_chunks, std::uint32_t* collapse_indices,
                               std::uint32_t* collapse_counts) {
     if (!g_initialized) {
-        return static_cast<int>(sep::ErrorCode::GeneralError);
+        return sep::SEPResult::UNKNOWN_ERROR;
     }
 
     // Get constants
@@ -214,7 +214,7 @@ int sep_cuda_process_symmetry(const std::uint64_t* chunks, std::uint32_t num_chu
     sep::cuda::DeviceBufferRAII<std::uint32_t> d_collapse_counts(num_chunks);
 
     if (!d_chunks.valid() || !d_collapse_indices.valid() || !d_collapse_counts.valid()) {
-        return static_cast<int>(sep::ErrorCode::GeneralError);
+        return sep::SEPResult::UNKNOWN_ERROR;
     }
 
     try {
@@ -236,10 +236,10 @@ int sep_cuda_process_symmetry(const std::uint64_t* chunks, std::uint32_t num_chu
 
         CUDA_CHECK(cudaStreamSynchronize(g_stream->get()));
     } catch (const sep::CudaException&) {
-        return static_cast<int>(sep::ErrorCode::GeneralError);
+        return sep::SEPResult::UNKNOWN_ERROR;
     }
 
-    return 0;
+    return sep::SEPResult::SUCCESS;
 }
 
 #endif

--- a/src/memory/manager.cpp
+++ b/src/memory/manager.cpp
@@ -1,24 +1,22 @@
-#include "api/types.h"
-#include "api/server.h"
-#include "api/crow_adapter.h" // Fix: Include crow_adapter for LoggingMiddleware
-#include "core/common.h" // Fix: Include common
-#include "memory/memory_tier_manager.hpp"
-#include "quantum/quantum_processor_qfh.h"
-#include "memory/manager.h"
+#include <atomic>
 
-// Debug logging for OpenTelemetry headers
 #ifdef SEP_HAS_OPENTELEMETRY
 #include <opentelemetry/trace/provider.h>
 #endif
-// CROW_DISABLE_RTTI is defined globally via CMake
+
 #include <spdlog/sinks/rotating_file_sink.h>
-#include <spdlog/sinks/basic_file_sink.h> // Fix: Include basic file sink
-#include <spdlog/sinks/daily_file_sink.h> // Fix: Include daily file sink
-#include <spdlog/sinks/dist_sink.h> // Fix: Include distributed sink
-#include <spdlog/sinks/null_sink.h> // Fix: Include null sink
+#include <spdlog/sinks/basic_file_sink.h>
+#include <spdlog/sinks/daily_file_sink.h>
+#include <spdlog/sinks/dist_sink.h>
+#include <spdlog/sinks/null_sink.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/spdlog.h>
-#include <atomic>
+
+#include "api/types.h"
+#include "api/server.h"
+#include "api/crow_adapter.h"
+#include "core/common.h"
+#include "memory/manager.h"
 
 namespace sep::logging {
 

--- a/src/memory/memory_tier.cpp
+++ b/src/memory/memory_tier.cpp
@@ -1,13 +1,13 @@
-// Standard library headers FIRST to ensure proper namespace resolution
-#include "memory/memory_tier.hpp"
-#include "core/common.h"  // defines sep::SEPResult
-
+// Standard library headers
 #include <algorithm>
 #include <cassert>
 #include <cstdlib>
 #include <cstring>
 #include <stdexcept>
 #include <vector>
+
+// Project headers
+#include "core/common.h"  // defines sep::SEPResult
 
 #ifndef SEP_HAS_EXCEPTIONS
 #if defined(__cpp_exceptions) || defined(__EXCEPTIONS) || defined(_CPPUNWIND)
@@ -19,14 +19,14 @@
 
 // CUDA headers after standard library
 #include "compat/cuda_common.h"
-#include "compat/cuda_runtime.h" // for sep::cuda::cudaMemcpy // Fix: Add comment // Fix: Added comment
+#include "compat/cuda_runtime.h"  // for sep::cuda::cudaMemcpy
 #include "compat/macros.h"
 
 #include "compat/math_common.h"
+#include "core/allocation_metrics.h"
 #include "memory/logger.hpp"
 #include "memory/manager.h"
 #include "memory/memory_tier_manager.hpp"
-#include "core/allocation_metrics.h"
 #include "memory/types.h"
 
 namespace sep::memory {

--- a/tests/api/bridge_api_test.cpp
+++ b/tests/api/bridge_api_test.cpp
@@ -3,9 +3,9 @@
 #include "api/bridge.hpp"
 
 TEST(BridgeCAPI, InitProcessCleanup) {
-    ASSERT_EQ(sep_bridge_init(), 0);
+    ASSERT_EQ(sep_bridge_init(), sep::SEPResult::SUCCESS);
     const char* ctx = "{\"type\":\"test\",\"content\":{}}";
     char buffer[256];
-    ASSERT_EQ(sep_process_context(ctx, "layer", buffer, sizeof(buffer)), 0);
-    ASSERT_EQ(sep_bridge_cleanup(), 0);
+    ASSERT_EQ(sep_process_context(ctx, "layer", buffer, sizeof(buffer)), sep::SEPResult::SUCCESS);
+    ASSERT_EQ(sep_bridge_cleanup(), sep::SEPResult::SUCCESS);
 }

--- a/tests/api/bridge_test.cpp
+++ b/tests/api/bridge_test.cpp
@@ -17,7 +17,7 @@ using json = nlohmann::json;
 
 class BridgeTest : public ::testing::Test {
  protected:
-  void SetUp() override { ASSERT_EQ(sep_bridge_init(), 0); }
+  void SetUp() override { ASSERT_EQ(sep_bridge_init(), sep::SEPResult::SUCCESS); }
 
   void TearDown() override { sep_bridge_cleanup(); }
 
@@ -76,9 +76,9 @@ TEST_F(BridgeTest, BasicContextProcessing) {
                   {"metadata", json::object()}};
 
   char result_buffer[1024];
-  int result = sep_process_context(context.dump().c_str(), "test_layer", result_buffer,
+  sep::SEPResult result = sep_process_context(context.dump().c_str(), "test_layer", result_buffer,
                                    sizeof(result_buffer));
-  EXPECT_EQ(result, 0) << "Process context failed with code " << result;
+  EXPECT_EQ(result, sep::SEPResult::SUCCESS) << "Process context failed with code " << static_cast<int>(result);
 
   json result_json = json::parse(result_buffer);
   EXPECT_TRUE(result_json["success"].get<bool>());
@@ -90,7 +90,7 @@ TEST_F(BridgeTest, InvalidJsonProcessing) {
   char result_buffer[1024];
 
   EXPECT_EQ(sep_process_context(invalid_json, "test_layer", result_buffer, sizeof(result_buffer)),
-            -4);
+            sep::SEPResult::PROCESSING_ERROR);
 
   char error_buffer[1024];
   sep_bridge_get_last_error(error_buffer, sizeof(error_buffer));
@@ -108,7 +108,7 @@ TEST_F(BridgeTest, BufferSizeHandling) {
   char small_buffer[10];
   EXPECT_EQ(sep_process_context(large_context.dump().c_str(), "test_layer", small_buffer,
                                 sizeof(small_buffer)),
-            -3);
+            sep::SEPResult::BUFFER_TOO_SMALL);
 
   size_t required_size = sep_get_required_buffer_size();
   EXPECT_GT(required_size, sizeof(small_buffer));
@@ -117,19 +117,19 @@ TEST_F(BridgeTest, BufferSizeHandling) {
 // Error Handling Tests
 TEST_F(BridgeTest, NullParameterHandling) {
   char buffer[1024];
-  EXPECT_EQ(sep_process_context(nullptr, "layer", buffer, sizeof(buffer)), -2);
-  EXPECT_EQ(sep_process_context("test", nullptr, buffer, sizeof(buffer)), -2);
-  EXPECT_EQ(sep_process_context("test", "layer", nullptr, sizeof(buffer)), -2);
+  EXPECT_EQ(sep_process_context(nullptr, "layer", buffer, sizeof(buffer)), sep::SEPResult::INVALID_ARGUMENT);
+  EXPECT_EQ(sep_process_context("test", nullptr, buffer, sizeof(buffer)), sep::SEPResult::INVALID_ARGUMENT);
+  EXPECT_EQ(sep_process_context("test", "layer", nullptr, sizeof(buffer)), sep::SEPResult::INVALID_ARGUMENT);
 }
 
 TEST_F(BridgeTest, ErrorBufferHandling) {
   char error_buffer[1024];
 
   // Test with null buffer
-  EXPECT_EQ(sep_bridge_get_last_error(nullptr, 1024), 0);
+  EXPECT_EQ(sep_bridge_get_last_error(nullptr, 1024), sep::SEPResult::SUCCESS);
 
   // Test with zero size
-  EXPECT_EQ(sep_bridge_get_last_error(error_buffer, 0), 0);
+  EXPECT_EQ(sep_bridge_get_last_error(error_buffer, 0), sep::SEPResult::SUCCESS);
 
   // Test with small buffer
   detail::setLastError("Long error message for testing buffer handling");
@@ -143,18 +143,18 @@ TEST_F(BridgeTest, ConfigurationManagement) {
   char buffer[1024];
 
   // Test invalid parameters
-  EXPECT_EQ(sep_bridge_set_config(nullptr, "value"), -1);
-  EXPECT_EQ(sep_bridge_set_config("key", nullptr), -1);
-  EXPECT_EQ(sep_bridge_get_config(nullptr, buffer, sizeof(buffer)), -1);
-  EXPECT_EQ(sep_bridge_get_config("key", nullptr, sizeof(buffer)), -1);
+  EXPECT_EQ(sep_bridge_set_config(nullptr, "value"), sep::SEPResult::UNKNOWN_ERROR);
+  EXPECT_EQ(sep_bridge_set_config("key", nullptr), sep::SEPResult::UNKNOWN_ERROR);
+  EXPECT_EQ(sep_bridge_get_config(nullptr, buffer, sizeof(buffer)), sep::SEPResult::UNKNOWN_ERROR);
+  EXPECT_EQ(sep_bridge_get_config("key", nullptr, sizeof(buffer)), sep::SEPResult::UNKNOWN_ERROR);
 
   // Basic set and get using ConfigManager
-  EXPECT_EQ(sep_bridge_set_config("api.host", "example.com"), 0);
-  EXPECT_EQ(sep_bridge_get_config("api.host", buffer, sizeof(buffer)), 0);
+  EXPECT_EQ(sep_bridge_set_config("api.host", "example.com"), sep::SEPResult::SUCCESS);
+  EXPECT_EQ(sep_bridge_get_config("api.host", buffer, sizeof(buffer)), sep::SEPResult::SUCCESS);
   EXPECT_STREQ(buffer, "example.com");
 
   // Non-existent key
-  EXPECT_EQ(sep_bridge_get_config("api.missing", buffer, sizeof(buffer)), -2);
+  EXPECT_EQ(sep_bridge_get_config("api.missing", buffer, sizeof(buffer)), sep::SEPResult::INVALID_ARGUMENT);
 }
 
 // Callback Registration Tests
@@ -167,11 +167,11 @@ TEST_F(BridgeTest, CallbackRegistration) {
   };
 
   // Test invalid parameters
-  EXPECT_EQ(sep_bridge_register_callback(nullptr, callback), -1);
-  EXPECT_EQ(sep_bridge_register_callback("event", nullptr), -1);
+  EXPECT_EQ(sep_bridge_register_callback(nullptr, callback), sep::SEPResult::UNKNOWN_ERROR);
+  EXPECT_EQ(sep_bridge_register_callback("event", nullptr), sep::SEPResult::UNKNOWN_ERROR);
 
   // Successful registration and invocation
-  EXPECT_EQ(sep_bridge_register_callback("test_event", callback), 0);
+  EXPECT_EQ(sep_bridge_register_callback("test_event", callback), sep::SEPResult::SUCCESS);
   detail::invokeCallbacks("test_event", "payload");
   EXPECT_TRUE(called);
   EXPECT_EQ(data, "payload");
@@ -193,7 +193,7 @@ TEST_F(BridgeTest, ConcurrentProcessing) {
   for (int i = 0; i < num_threads; ++i) {
     threads.emplace_back([&]() {
       char buffer[1024];
-      if (sep_process_context(context_json.c_str(), "test_layer", buffer, sizeof(buffer)) == 0) {
+      if (sep_process_context(context_json.c_str(), "test_layer", buffer, sizeof(buffer)) == sep::SEPResult::SUCCESS) {
         success_count++;
       }
     });
@@ -210,8 +210,8 @@ TEST_F(BridgeTest, ConcurrentProcessing) {
 TEST_F(BridgeTest, MultipleInitCleanup) {
   // Test multiple init/cleanup cycles
   for (int i = 0; i < 5; ++i) {
-    EXPECT_EQ(sep_bridge_cleanup(), 0);
-    EXPECT_EQ(sep_bridge_init(), 0);
+    EXPECT_EQ(sep_bridge_cleanup(), sep::SEPResult::SUCCESS);
+    EXPECT_EQ(sep_bridge_init(), sep::SEPResult::SUCCESS);
   }
 }
 
@@ -219,7 +219,8 @@ TEST_F(BridgeTest, ProcessingAfterCleanup) {
   sep_bridge_cleanup();
 
   char buffer[1024];
-  EXPECT_EQ(sep_process_context(R"({"type": "test"})", "layer", buffer, sizeof(buffer)), -1);
+  EXPECT_EQ(sep_process_context(R"({"type": "test"})", "layer", buffer, sizeof(buffer)),
+            sep::SEPResult::UNKNOWN_ERROR);
 
   char error_buffer[1024];
   sep_bridge_get_last_error(error_buffer, sizeof(error_buffer));

--- a/tests/api/mock_bridge.cpp
+++ b/tests/api/mock_bridge.cpp
@@ -18,25 +18,25 @@ bool g_should_resize = false;
 
 extern "C" {
 
-int sep_process_context(const char *context_json, const char *layer,
+sep::SEPResult sep_process_context(const char *context_json, const char *layer,
                         char *result_buffer, size_t buffer_size) {
   sep::test::MockGuard guard;
   (void)context_json;
   (void)layer;
   if (sep::test::g_should_fail) {
-    return static_cast<int>(sep::ErrorCode::GeneralError);
+    return sep::SEPResult::UNKNOWN_ERROR;
   }
 
   if (sep::test::g_should_resize) {
-    return static_cast<int>(sep::ErrorCode::BufferTooSmall);
+    return sep::SEPResult::BUFFER_TOO_SMALL;
   }
 
   if (buffer_size < sep::test::g_mock_result.size() + 1) {
-    return static_cast<int>(sep::ErrorCode::BufferTooSmall);
+    return sep::SEPResult::BUFFER_TOO_SMALL;
   }
 
   (void)std::snprintf(result_buffer, buffer_size, "%s", sep::test::g_mock_result.c_str());
-  return 0;
+  return sep::SEPResult::SUCCESS;
 }
 
 size_t sep_get_required_buffer_size() {
@@ -44,10 +44,10 @@ size_t sep_get_required_buffer_size() {
   return sep::test::g_mock_required_size;
 }
 
-int sep_bridge_get_last_error(char *error_buffer, size_t buffer_size) {
+sep::SEPResult sep_bridge_get_last_error(char *error_buffer, size_t buffer_size) {
   sep::test::MockGuard guard;
   (void)std::snprintf(error_buffer, buffer_size, "%s", sep::test::g_mock_error.c_str());
-  return static_cast<int>(
+  return static_cast<sep::SEPResult>(
       std::min(buffer_size - 1, sep::test::g_mock_error.length()));
 }
 


### PR DESCRIPTION
## Summary
- refactor C bridge and CUDA API to return `sep::SEPResult`
- adjust tests and mock bridge for new result values
- clean up include order in memory components
- document locking for Blender bridge and quantum processor
- forward declare Server in logging header

## Testing
- `cmake ..` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6862b374b278832ab13ed9b403e7c1f0