### PR TITLE
Allow SEP build without Blender

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ file(MAKE_DIRECTORY ${SEP_TEST_DATA_DIR})
 option(SEP_BUILD_TESTS "Build test suite" ON)
 option(SEP_ENABLE_CUDA "Enable CUDA support" ON)
 option(SEP_HAS_CYCLES "Enable Blender Cycles integration" OFF)
+option(SEP_HAS_BLENDER "Enable Blender integration" ON)
 
 # Configure compiler flags
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
@@ -44,6 +45,10 @@ endif()
 
 if(SEP_HAS_CYCLES)
     add_compile_definitions(SEP_HAS_CYCLES)
+endif()
+
+if(SEP_HAS_BLENDER)
+    add_compile_definitions(SEP_HAS_BLENDER)
 endif()
 
 # Set output directories

--- a/config/default.json
+++ b/config/default.json
@@ -18,5 +18,18 @@
         "log_file": "sep.log",
         "console_output": true,
         "file_output": true
+    },
+    "memory": {
+        "promote_stm_to_mtm": 0.7,
+        "promote_mtm_to_ltm": 0.9,
+        "demote_threshold": 0.3,
+        "fragmentation_threshold": 0.3,
+        "stm_to_mtm_min_gen": 5,
+        "mtm_to_ltm_min_gen": 100
+    },
+    "quantum": {
+        "ltm_coherence_threshold": 0.9,
+        "mtm_coherence_threshold": 0.6,
+        "stability_threshold": 0.8
     }
 }

--- a/docs/CONFIG_OPTIONS.md
+++ b/docs/CONFIG_OPTIONS.md
@@ -1,0 +1,17 @@
+# Configuration Options
+
+The engine reads settings from `config/default.json`. New sections allow tuning
+memory promotion thresholds and quantum processing limits.
+
+## memory
+- `promote_stm_to_mtm`: coherence threshold for promoting a block from STM to MTM.
+- `promote_mtm_to_ltm`: coherence threshold for promoting MTM blocks to LTM.
+- `demote_threshold`: relationships below this value are pruned.
+- `fragmentation_threshold`: fragmentation level that triggers defragmentation.
+- `stm_to_mtm_min_gen`: minimum generations before promotion from STM.
+- `mtm_to_ltm_min_gen`: minimum generations before promotion from MTM.
+
+## quantum
+- `ltm_coherence_threshold`: coherence needed for patterns to reach LTM.
+- `mtm_coherence_threshold`: coherence needed for MTM.
+- `stability_threshold`: minimum stability for promotion.

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ This folder contains notes and references for navigating and maintaining the SEP
 - **`GAMEPLAN.md`** — Historical build issues and how they were resolved.
 - **`THESIS.md`** — Background theory behind the project.
 - **`vscodium.md`** — Notes on the development environment setup.
+- **`CONFIG_OPTIONS.md`** — Description of configurable runtime parameters.
 
 Most documentation assumes the code has already been built with CUDA support and that `sep_engine` runs. See below for a refresher on building and running.
 

--- a/include/blender/bridge.h
+++ b/include/blender/bridge.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#ifdef SEP_HAS_BLENDER
+
 #include <atomic>
 #include <condition_variable>
 #include <memory>
@@ -161,3 +163,7 @@ class BlenderBridge {
 
 }  // namespace pattern
 }  // namespace sep
+#endif // SEP_HAS_BLENDER
+#ifndef SEP_HAS_BLENDER
+namespace sep { namespace pattern { class BlenderBridge {}; } }
+#endif

--- a/include/compat/component_bridge.h
+++ b/include/compat/component_bridge.h
@@ -1,6 +1,11 @@
 #pragma once
 #include <memory>
 #include "blender/types.h"
+#ifdef SEP_HAS_BLENDER
+#include "blender/bridge.h"
+#include "blender/api.h"
+#include "blender/cycles_renderer.h"
+#endif
 
 namespace sep {
 namespace audio {
@@ -15,8 +20,14 @@ class CyclesRenderer; // Forward declaration if header not available
 namespace compat {
 
 std::unique_ptr<audio::AudioCapture> createAudioCapture();
+#ifdef SEP_HAS_BLENDER
 std::unique_ptr<SEPBlenderBridge> createBlenderBridge();
 std::unique_ptr<blender::CyclesRenderer> createCyclesRenderer();
+#else
+inline std::unique_ptr<SEPBlenderBridge> createBlenderBridge() { return nullptr; }
+namespace blender { struct CyclesRenderer {}; }
+inline std::unique_ptr<blender::CyclesRenderer> createCyclesRenderer() { return nullptr; }
+#endif
 
 } // namespace compat
 } // namespace sep

--- a/include/core/manager.h
+++ b/include/core/manager.h
@@ -41,11 +41,15 @@ public:
   const APIConfig &getAPIConfig() const;
   const CudaConfig &getCudaConfig() const;
   const LogConfig &getLogConfig() const;
+  const MemoryThresholdConfig &getMemoryConfig() const;
+  const QuantumThresholdConfig &getQuantumConfig() const;
 
   // Update specific components
   void updateAPIConfig(const APIConfig &config);
   void updateCudaConfig(const CudaConfig &config);
   void updateLogConfig(const LogConfig &config);
+  void updateMemoryConfig(const MemoryThresholdConfig &config);
+  void updateQuantumConfig(const QuantumThresholdConfig &config);
 
   // Reset configuration to defaults
   void resetToDefaults();

--- a/include/core/types.h
+++ b/include/core/types.h
@@ -126,11 +126,28 @@ struct AnalyticsConfig {
     double sampling_rate{0.1};
 };
 
+struct MemoryThresholdConfig {
+    float promote_stm_to_mtm{0.7f};
+    float promote_mtm_to_ltm{0.9f};
+    float demote_threshold{0.3f};
+    float fragmentation_threshold{0.3f};
+    std::uint32_t stm_to_mtm_min_gen{5};
+    std::uint32_t mtm_to_ltm_min_gen{100};
+};
+
+struct QuantumThresholdConfig {
+    float ltm_coherence_threshold{0.9f};
+    float mtm_coherence_threshold{0.6f};
+    float stability_threshold{0.8f};
+};
+
 struct SystemConfig {
     APIConfig   api;
     CudaConfig  cuda;
     LogConfig   logging;
     std::string data_path;
+    MemoryThresholdConfig memory;
+    QuantumThresholdConfig quantum;
 };
 
 // Backwards compatibility aliases for renamed configuration structs
@@ -186,6 +203,36 @@ inline void from_json(const nlohmann::json& j, LoggingConfig& l)
     l.max_file_size = j.value("max_file_size", static_cast<size_t>(10 * 1024 * 1024));
     l.max_files     = j.value("max_files", static_cast<size_t>(5));
     l.level         = j.value("level", std::string{"info"});
+}
+
+inline void to_json(nlohmann::json& j, const MemoryThresholdConfig& c) {
+    j = nlohmann::json{{"promote_stm_to_mtm", c.promote_stm_to_mtm},
+                       {"promote_mtm_to_ltm", c.promote_mtm_to_ltm},
+                       {"demote_threshold", c.demote_threshold},
+                       {"fragmentation_threshold", c.fragmentation_threshold},
+                       {"stm_to_mtm_min_gen", c.stm_to_mtm_min_gen},
+                       {"mtm_to_ltm_min_gen", c.mtm_to_ltm_min_gen}};
+}
+
+inline void from_json(const nlohmann::json& j, MemoryThresholdConfig& c) {
+    c.promote_stm_to_mtm = j.value("promote_stm_to_mtm", 0.7f);
+    c.promote_mtm_to_ltm = j.value("promote_mtm_to_ltm", 0.9f);
+    c.demote_threshold = j.value("demote_threshold", 0.3f);
+    c.fragmentation_threshold = j.value("fragmentation_threshold", 0.3f);
+    c.stm_to_mtm_min_gen = j.value("stm_to_mtm_min_gen", 5u);
+    c.mtm_to_ltm_min_gen = j.value("mtm_to_ltm_min_gen", 100u);
+}
+
+inline void to_json(nlohmann::json& j, const QuantumThresholdConfig& c) {
+    j = nlohmann::json{{"ltm_coherence_threshold", c.ltm_coherence_threshold},
+                       {"mtm_coherence_threshold", c.mtm_coherence_threshold},
+                       {"stability_threshold", c.stability_threshold}};
+}
+
+inline void from_json(const nlohmann::json& j, QuantumThresholdConfig& c) {
+    c.ltm_coherence_threshold = j.value("ltm_coherence_threshold", 0.9f);
+    c.mtm_coherence_threshold = j.value("mtm_coherence_threshold", 0.6f);
+    c.stability_threshold = j.value("stability_threshold", 0.8f);
 }
 
 inline void to_json(nlohmann::json& j, const APIConfig& c)

--- a/include/quantum/processor.h
+++ b/include/quantum/processor.h
@@ -121,6 +121,7 @@ private:
 };
 
 std::unique_ptr<Processor> createProcessor(const ProcessingConfig& config);
+std::unique_ptr<Processor> createProcessor();
 std::unique_ptr<Processor> createCPUProcessor(const ProcessingConfig& config);
 std::unique_ptr<Processor> createGPUProcessor(const ProcessingConfig& config);
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,7 +12,9 @@ target_include_directories(sep_main PRIVATE ${SEP_INCLUDE_DIRS})
 # Add component subdirectories
 add_subdirectory(api)
 add_subdirectory(audio)
-add_subdirectory(blender)
+if(SEP_HAS_BLENDER)
+    add_subdirectory(blender)
+endif()
 add_subdirectory(compat)
 add_subdirectory(core)
 add_subdirectory(memory)
@@ -22,7 +24,6 @@ add_subdirectory(quantum)
 target_link_libraries(sep_main PRIVATE
     sep_api
     sep_audio
-    sep_blender
     sep_compat
     sep_core
     sep_memory
@@ -30,6 +31,10 @@ target_link_libraries(sep_main PRIVATE
     ${PIPEWIRE_LIBRARIES}
     fmt::fmt
 )
+
+if(SEP_HAS_BLENDER)
+    target_link_libraries(sep_main PRIVATE sep_blender)
+endif()
 
 if(SEP_ENABLE_CUDA)
     target_link_libraries(sep_main PRIVATE

--- a/src/api/bridge_c.cpp
+++ b/src/api/bridge_c.cpp
@@ -21,35 +21,28 @@
 extern "C" {
 
 SEP_API int sep_bridge_init(void) {
-#ifdef SEP_HAS_EXCEPTIONS
-  try {
-#endif
-  std::lock_guard<std::mutex> lock(sep::api::bridge::detail::g_bridge_mutex); // Fix: use the global mutex
-  sep::quantum::ProcessingConfig options{};
-  sep::api::bridge::detail::g_context_processor_bridge = sep::quantum::createProcessor(options);
- sep::api::bridge::detail::g_last_error.clear(); // Fix: Add semicolon
-  // Fix: Initialize g_required_buffer_size to 0 here
-  sep::api::bridge::detail::g_required_buffer_size = 0;
-  return 0;
-#if SEP_HAS_EXCEPTIONS
+  SEP_TRY {
+    std::lock_guard<std::mutex> lock(sep::api::bridge::detail::g_bridge_mutex);
+    sep::api::bridge::detail::g_context_processor_bridge = sep::quantum::createProcessor();
+    sep::api::bridge::detail::g_last_error.clear();
+    sep::api::bridge::detail::g_required_buffer_size = 0;
+    return 0;
   } SEP_CATCH_RETURN(sep::api::ErrorCode::ApiError);
-#endif
 }
 
 SEP_API int sep_bridge_cleanup(void) {
-  std::lock_guard<std::mutex> lock(sep::api::bridge::detail::g_bridge_mutex);
- sep::api::bridge::detail::g_context_processor_bridge.reset(); // Fix: Add semicolon
-  sep::api::bridge::detail::g_last_error.clear();
-  // Fix: Initialize g_required_buffer_size to 0 here
-  sep::api::bridge::detail::g_required_buffer_size = 0;
-  return 0;
+  SEP_TRY {
+    std::lock_guard<std::mutex> lock(sep::api::bridge::detail::g_bridge_mutex);
+    sep::api::bridge::detail::g_context_processor_bridge.reset();
+    sep::api::bridge::detail::g_last_error.clear();
+    sep::api::bridge::detail::g_required_buffer_size = 0;
+    return 0;
+  } SEP_CATCH_RETURN(sep::api::ErrorCode::ApiError);
 }
 
 SEP_API int sep_process_context(const char *context_json, const char *layer,
                                char *result_buffer, size_t buffer_size) {
-#if SEP_HAS_EXCEPTIONS
-  try { // Fix: Use try block when exceptions are enabled
-#endif
+  SEP_TRY {
     if (!context_json || !result_buffer || !layer || buffer_size == 0) {
       sep::api::bridge::detail::setLastError("Invalid parameters");
       return static_cast<int>(sep::api::ErrorCode::InvalidParameter);
@@ -124,12 +117,7 @@ SEP_API int sep_process_context(const char *context_json, const char *layer,
       (void)std::snprintf(result_buffer, buffer_size, "%s", result_str.c_str());
       return 0;
     }
-#ifdef SEP_HAS_EXCEPTIONS
-  } catch (const std::exception &e) {
-    sep::api::bridge::detail::setLastError(e.what());
-    return static_cast<int>(sep::api::bridge::detail::mapSepError(sep::api::ErrorCode::ProcessingError));
-  }
-#endif
+  } SEP_CATCH_RETURN(sep::api::ErrorCode::ProcessingError);
 }
 
 SEP_API int sep_bridge_get_last_error(char *buffer, size_t buffer_size) {
@@ -148,9 +136,7 @@ SEP_API size_t sep_get_required_buffer_size(void) {
 }
 
 SEP_API int sep_bridge_set_config(const char *key, const char *value) {
-#if SEP_HAS_EXCEPTIONS
-  try { // Fix: Use try block when exceptions are enabled
-#endif
+  SEP_TRY {
   std::lock_guard<std::mutex> lock(sep::api::bridge::detail::g_bridge_mutex);
   if (!key || !value) {
     sep::api::bridge::detail::setLastError("Invalid parameters");
@@ -183,16 +169,12 @@ SEP_API int sep_bridge_set_config(const char *key, const char *value) {
   }
   cm.updateAPIConfig(cfg);
   sep::api::bridge::detail::setLastError("");
- return 0; // Fix: Add semicolon
-#if SEP_HAS_EXCEPTIONS
+  return 0;
   } SEP_CATCH_RETURN(sep::api::ErrorCode::GeneralError);
-#endif
 }
 
 SEP_API int sep_bridge_get_config(const char *key, char *buffer, size_t buffer_size) {
-#if SEP_HAS_EXCEPTIONS
-  try { // Fix: Use try block when exceptions are enabled
-#endif
+  SEP_TRY {
   std::lock_guard<std::mutex> lock(sep::api::bridge::detail::g_bridge_mutex);
   if (!key || !buffer || buffer_size == 0) {
     sep::api::bridge::detail::setLastError("Invalid parameters");
@@ -220,17 +202,13 @@ SEP_API int sep_bridge_get_config(const char *key, char *buffer, size_t buffer_s
   }
   (void)std::snprintf(buffer, buffer_size, "%s", val.c_str());
   sep::api::bridge::detail::setLastError("");
- return 0; // Fix: Add semicolon
-#if SEP_HAS_EXCEPTIONS
+  return 0;
   } SEP_CATCH_RETURN(sep::api::ErrorCode::GeneralError);
-#endif
 }
 
 SEP_API int sep_bridge_register_callback(const char *event_type,
                                          void (*callback)(const char *event_data)) {
-#if SEP_HAS_EXCEPTIONS
-  try { // Fix: Use try block when exceptions are enabled
-#endif
+  SEP_TRY {
   std::lock_guard<std::mutex> lock(sep::api::bridge::detail::g_bridge_mutex);
   if (!event_type || !callback) {
     sep::api::bridge::detail::setLastError("Invalid parameters");
@@ -238,10 +216,8 @@ SEP_API int sep_bridge_register_callback(const char *event_type,
   } // Fix: Add closing brace
   sep::api::bridge::detail::g_callback_map[event_type].push_back(callback);
   sep::api::bridge::detail::setLastError("");
- return 0; // Fix: Add semicolon
-#if SEP_HAS_EXCEPTIONS
+  return 0;
   } SEP_CATCH_RETURN(sep::api::ErrorCode::GeneralError);
-#endif
 }
 
 } // extern "C"

--- a/src/compat/component_bridge.cpp
+++ b/src/compat/component_bridge.cpp
@@ -1,9 +1,11 @@
 #include "blender/types.h"  // Must come first for SEPBlenderBridge definition
 #include "compat/component_bridge.h"
 #include "audio/pipewire_capture.h"
+#ifdef SEP_HAS_BLENDER
 #include "blender/bridge.h"
 #include "blender/api.h"
 #include "blender/cycles_renderer.h"
+#endif
 
 namespace sep {
 namespace compat {
@@ -12,6 +14,7 @@ namespace compat {
 std::unique_ptr<audio::AudioCapture> createAudioCapture() {
     return std::make_unique<audio::PipeWireCapture>();
 }
+#ifdef SEP_HAS_BLENDER
 std::unique_ptr<SEPBlenderBridge> createBlenderBridge() {
     auto bridge = std::make_unique<SEPBlenderBridge>();
     bridge->impl = std::make_shared<pattern::BlenderBridge>();
@@ -21,5 +24,14 @@ std::unique_ptr<SEPBlenderBridge> createBlenderBridge() {
 std::unique_ptr<blender::CyclesRenderer> createCyclesRenderer() {
     return std::make_unique<blender::CyclesRenderer>();
 }
+#else
+std::unique_ptr<SEPBlenderBridge> createBlenderBridge() {
+    return nullptr;
+}
+
+std::unique_ptr<blender::CyclesRenderer> createCyclesRenderer() {
+    return nullptr;
+}
+#endif
 } // namespace compat
 } // namespace sep

--- a/src/core/manager.cpp
+++ b/src/core/manager.cpp
@@ -92,6 +92,14 @@ public:
         config.logging.file_output = logging.value("file_output", true);
       }
 
+      if (json.contains("memory")) {
+        json.at("memory").get_to(config.memory);
+      }
+
+      if (json.contains("quantum")) {
+        json.at("quantum").get_to(config.quantum);
+      }
+
       return true;
   }
 
@@ -179,6 +187,16 @@ const LogConfig &ConfigManager::getLogConfig() const {
   return impl_->config.logging;
 }
 
+const MemoryThresholdConfig &ConfigManager::getMemoryConfig() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return impl_->config.memory;
+}
+
+const QuantumThresholdConfig &ConfigManager::getQuantumConfig() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return impl_->config.quantum;
+}
+
 void ConfigManager::updateAPIConfig(const APIConfig &config) {
   std::lock_guard<std::mutex> lock(mutex_);
   impl_->config.api = config;
@@ -192,6 +210,16 @@ void ConfigManager::updateCudaConfig(const CudaConfig &config) {
 void ConfigManager::updateLogConfig(const LogConfig &config) {
   std::lock_guard<std::mutex> lock(mutex_);
   impl_->config.logging = config;
+}
+
+void ConfigManager::updateMemoryConfig(const MemoryThresholdConfig &config) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  impl_->config.memory = config;
+}
+
+void ConfigManager::updateQuantumConfig(const QuantumThresholdConfig &config) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  impl_->config.quantum = config;
 }
 
 void ConfigManager::resetToDefaults() {

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -40,7 +40,18 @@ MemoryTierManager::MemoryTierManager(const MemoryTierManager::Config& cfg) : con
     init(cfg);
 }
 
-MemoryTierManager::MemoryTierManager() : MemoryTierManager(Config{}) {}
+MemoryTierManager::MemoryTierManager()
+    : MemoryTierManager([]{
+        Config cfg;
+        const auto& mcfg = sep::config::ConfigManager::getInstance().getMemoryConfig();
+        cfg.promote_stm_to_mtm = mcfg.promote_stm_to_mtm;
+        cfg.promote_mtm_to_ltm = mcfg.promote_mtm_to_ltm;
+        cfg.demote_threshold = mcfg.demote_threshold;
+        cfg.fragmentation_threshold = mcfg.fragmentation_threshold;
+        cfg.stm_to_mtm_min_gen = mcfg.stm_to_mtm_min_gen;
+        cfg.mtm_to_ltm_min_gen = mcfg.mtm_to_ltm_min_gen;
+        return cfg;
+    }()) {}
 
 MemoryTierManager::~MemoryTierManager() {
     shutdown();

--- a/src/quantum/processor.cpp
+++ b/src/quantum/processor.cpp
@@ -5,6 +5,7 @@
 #include <glm/glm.hpp>
 #include "memory/types.h"
 #include "core/common.h"  // defines sep::SEPResult
+#include "core/manager.h"
 
 using ::sep::memory::MemoryTierEnum;
 #include <mutex>
@@ -395,6 +396,15 @@ void Processor::updateConfig(const ProcessingConfig& config) { impl_->updateConf
 
 std::unique_ptr<Processor> createProcessor(const ProcessingConfig& config) {
     return std::make_unique<Processor>(config); // Fix: Use make_unique // Fix: Added comment
+}
+
+std::unique_ptr<Processor> createProcessor() {
+    const auto& cfg = sep::config::ConfigManager::getInstance().getQuantumConfig();
+    ProcessingConfig pc;
+    pc.ltm_coherence_threshold = cfg.ltm_coherence_threshold;
+    pc.mtm_coherence_threshold = cfg.mtm_coherence_threshold;
+    pc.stability_threshold = cfg.stability_threshold;
+    return std::make_unique<Processor>(pc);
 }
 
 std::unique_ptr<Processor> createCPUProcessor(const ProcessingConfig& config) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,7 +24,9 @@ include_directories(
 )
 
 # Add test subdirectories
-add_subdirectory(blender)
+if(SEP_HAS_BLENDER)
+    add_subdirectory(blender)
+endif()
 
 # Configure test discovery
 include(CTest)


### PR DESCRIPTION
## Summary
- make Blender integration optional via `SEP_HAS_BLENDER`
- add stub implementations when Blender is disabled
- expose memory and quantum thresholds through `ConfigManager`
- add configuration accessors and defaults
- document new settings

## Testing
- `cmake .. -DSEP_BUILD_TESTS=OFF -DSEP_HAS_BLENDER=OFF` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6862b3b40b7c832a99f892923208cacf