### PR TITLE
Add conditional Blender support and expose thresholds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ file(MAKE_DIRECTORY ${SEP_TEST_DATA_DIR})
 option(SEP_BUILD_TESTS "Build test suite" ON)
 option(SEP_ENABLE_CUDA "Enable CUDA support" ON)
 option(SEP_HAS_CYCLES "Enable Blender Cycles integration" OFF)
+option(SEP_HAS_BLENDER "Enable Blender integration" ON)
 
 # Configure compiler flags
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
@@ -44,6 +45,12 @@ endif()
 
 if(SEP_HAS_CYCLES)
     add_compile_definitions(SEP_HAS_CYCLES)
+endif()
+
+if(SEP_HAS_BLENDER)
+    add_compile_definitions(SEP_HAS_BLENDER=1)
+else()
+    add_compile_definitions(SEP_HAS_BLENDER=0)
 endif()
 
 # Set output directories

--- a/config/default.json
+++ b/config/default.json
@@ -18,5 +18,15 @@
         "log_file": "sep.log",
         "console_output": true,
         "file_output": true
+    },
+    "memory": {
+        "promote_stm_to_mtm": 0.7,
+        "promote_mtm_to_ltm": 0.9,
+        "demote_threshold": 0.3
+    },
+    "quantum": {
+        "ltm_coherence_threshold": 0.9,
+        "mtm_coherence_threshold": 0.6,
+        "stability_threshold": 0.8
     }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,23 @@ Execute the engine from the build directory:
 
 Configuration files are located in `config`. Command‑line flags and environment variables override these defaults.
 
+### New Configuration Sections
+
+`memory` and `quantum` sections expose promotion and coherence thresholds. Example:
+
+```json
+"memory": {
+    "promote_stm_to_mtm": 0.7,
+    "promote_mtm_to_ltm": 0.9,
+    "demote_threshold": 0.3
+},
+"quantum": {
+    "ltm_coherence_threshold": 0.9,
+    "mtm_coherence_threshold": 0.6,
+    "stability_threshold": 0.8
+}
+```
+
 ## Tests
 
 The `/tests` directory contains a minimal suite. Enable it in CMake with:

--- a/include/compat/component_bridge.h
+++ b/include/compat/component_bridge.h
@@ -1,6 +1,8 @@
 #pragma once
 #include <memory>
+#if SEP_HAS_BLENDER
 #include "blender/types.h"
+#endif
 
 namespace sep {
 namespace audio {
@@ -15,8 +17,13 @@ class CyclesRenderer; // Forward declaration if header not available
 namespace compat {
 
 std::unique_ptr<audio::AudioCapture> createAudioCapture();
+#if SEP_HAS_BLENDER
 std::unique_ptr<SEPBlenderBridge> createBlenderBridge();
 std::unique_ptr<blender::CyclesRenderer> createCyclesRenderer();
+#else
+inline std::unique_ptr<SEPBlenderBridge> createBlenderBridge() { return nullptr; }
+inline std::unique_ptr<blender::CyclesRenderer> createCyclesRenderer() { return nullptr; }
+#endif
 
 } // namespace compat
 } // namespace sep

--- a/include/core/manager.h
+++ b/include/core/manager.h
@@ -41,11 +41,15 @@ public:
   const APIConfig &getAPIConfig() const;
   const CudaConfig &getCudaConfig() const;
   const LogConfig &getLogConfig() const;
+  const MemoryConfig &getMemoryConfig() const;
+  const QuantumConfig &getQuantumConfig() const;
 
   // Update specific components
   void updateAPIConfig(const APIConfig &config);
   void updateCudaConfig(const CudaConfig &config);
   void updateLogConfig(const LogConfig &config);
+  void updateMemoryConfig(const MemoryConfig &config);
+  void updateQuantumConfig(const QuantumConfig &config);
 
   // Reset configuration to defaults
   void resetToDefaults();

--- a/include/core/types.h
+++ b/include/core/types.h
@@ -126,10 +126,24 @@ struct AnalyticsConfig {
     double sampling_rate{0.1};
 };
 
+struct MemoryConfig {
+    float promote_stm_to_mtm{0.7f};
+    float promote_mtm_to_ltm{0.9f};
+    float demote_threshold{0.3f};
+};
+
+struct QuantumConfig {
+    float ltm_coherence_threshold{0.9f};
+    float mtm_coherence_threshold{0.6f};
+    float stability_threshold{0.8f};
+};
+
 struct SystemConfig {
     APIConfig   api;
     CudaConfig  cuda;
     LogConfig   logging;
+    MemoryConfig memory;
+    QuantumConfig quantum;
     std::string data_path;
 };
 
@@ -280,6 +294,30 @@ inline void from_json(const nlohmann::json& j, AnalyticsConfig& c) {
     c.collect_metrics = j.value("collect_metrics", true);
     c.history_size = j.value("history_size", static_cast<size_t>(1000));
     c.sampling_rate = j.value("sampling_rate", 0.1);
+}
+
+inline void to_json(nlohmann::json& j, const MemoryConfig& c) {
+    j = nlohmann::json{{"promote_stm_to_mtm", c.promote_stm_to_mtm},
+                       {"promote_mtm_to_ltm", c.promote_mtm_to_ltm},
+                       {"demote_threshold", c.demote_threshold}};
+}
+
+inline void from_json(const nlohmann::json& j, MemoryConfig& c) {
+    c.promote_stm_to_mtm = j.value("promote_stm_to_mtm", 0.7f);
+    c.promote_mtm_to_ltm = j.value("promote_mtm_to_ltm", 0.9f);
+    c.demote_threshold = j.value("demote_threshold", 0.3f);
+}
+
+inline void to_json(nlohmann::json& j, const QuantumConfig& c) {
+    j = nlohmann::json{{"ltm_coherence_threshold", c.ltm_coherence_threshold},
+                       {"mtm_coherence_threshold", c.mtm_coherence_threshold},
+                       {"stability_threshold", c.stability_threshold}};
+}
+
+inline void from_json(const nlohmann::json& j, QuantumConfig& c) {
+    c.ltm_coherence_threshold = j.value("ltm_coherence_threshold", 0.9f);
+    c.mtm_coherence_threshold = j.value("mtm_coherence_threshold", 0.6f);
+    c.stability_threshold = j.value("stability_threshold", 0.8f);
 }
 
 }  // namespace config

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,7 +12,9 @@ target_include_directories(sep_main PRIVATE ${SEP_INCLUDE_DIRS})
 # Add component subdirectories
 add_subdirectory(api)
 add_subdirectory(audio)
-add_subdirectory(blender)
+if(SEP_HAS_BLENDER)
+    add_subdirectory(blender)
+endif()
 add_subdirectory(compat)
 add_subdirectory(core)
 add_subdirectory(memory)
@@ -22,7 +24,7 @@ add_subdirectory(quantum)
 target_link_libraries(sep_main PRIVATE
     sep_api
     sep_audio
-    sep_blender
+    $<IF:$<BOOL:${SEP_HAS_BLENDER}>,sep_blender,>
     sep_compat
     sep_core
     sep_memory

--- a/src/api/bridge.cpp
+++ b/src/api/bridge.cpp
@@ -44,16 +44,26 @@ std::unordered_map<std::string, std::vector<void (*)(const char *)>>
 namespace sep::api::bridge::detail {
 
 void setLastError(const std::string& error) {
+  std::lock_guard<std::mutex> lock(g_bridge_mutex);
   g_last_error = error;
 #if !SEP_HAS_EXCEPTIONS
   sep::crow::error::set_last_error(error.c_str());
 #endif
 }
-std::string getLastError() { return g_last_error; }
+std::string getLastError() {
+  std::lock_guard<std::mutex> lock(g_bridge_mutex);
+  return g_last_error;
+}
 
-void setRequiredBufferSize(size_t size) { g_required_buffer_size = size; }
+void setRequiredBufferSize(size_t size) {
+  std::lock_guard<std::mutex> lock(g_bridge_mutex);
+  g_required_buffer_size = size;
+}
 
-size_t getRequiredBufferSize() { return g_required_buffer_size; }
+size_t getRequiredBufferSize() {
+  std::lock_guard<std::mutex> lock(g_bridge_mutex);
+  return g_required_buffer_size;
+}
 
 sep::api::ErrorCode mapSepError(sep::api::ErrorCode core) {
   switch (core) {

--- a/src/api/bridge_c.cpp
+++ b/src/api/bridge_c.cpp
@@ -37,12 +37,17 @@ SEP_API int sep_bridge_init(void) {
 }
 
 SEP_API int sep_bridge_cleanup(void) {
+#if SEP_HAS_EXCEPTIONS
+  try {
+#endif
   std::lock_guard<std::mutex> lock(sep::api::bridge::detail::g_bridge_mutex);
- sep::api::bridge::detail::g_context_processor_bridge.reset(); // Fix: Add semicolon
+  sep::api::bridge::detail::g_context_processor_bridge.reset();
   sep::api::bridge::detail::g_last_error.clear();
-  // Fix: Initialize g_required_buffer_size to 0 here
   sep::api::bridge::detail::g_required_buffer_size = 0;
   return 0;
+#if SEP_HAS_EXCEPTIONS
+  } SEP_CATCH_RETURN(sep::api::ErrorCode::ApiError);
+#endif
 }
 
 SEP_API int sep_process_context(const char *context_json, const char *layer,
@@ -133,18 +138,30 @@ SEP_API int sep_process_context(const char *context_json, const char *layer,
 }
 
 SEP_API int sep_bridge_get_last_error(char *buffer, size_t buffer_size) {
+#if SEP_HAS_EXCEPTIONS
+  try {
+#endif
   std::lock_guard<std::mutex> lock(sep::api::bridge::detail::g_bridge_mutex);
-  if (!buffer || buffer_size == 0) { // Fix: Check for null buffer or zero size
+  if (!buffer || buffer_size == 0) {
     return static_cast<int>(sep::api::ErrorCode::InvalidParameter);
   }
   size_t len = std::min(sep::api::bridge::detail::g_last_error.size(), buffer_size - 1);
   (void)std::snprintf(buffer, buffer_size, "%s", sep::api::bridge::detail::g_last_error.c_str());
   return static_cast<int>(len);
+#if SEP_HAS_EXCEPTIONS
+  } SEP_CATCH_RETURN(sep::api::ErrorCode::GeneralError);
+#endif
 }
 
 SEP_API size_t sep_get_required_buffer_size(void) {
+#if SEP_HAS_EXCEPTIONS
+  try {
+#endif
   std::lock_guard<std::mutex> lock(sep::api::bridge::detail::g_bridge_mutex);
   return sep::api::bridge::detail::g_required_buffer_size;
+#if SEP_HAS_EXCEPTIONS
+  } SEP_CATCH_RETURN(sep::api::ErrorCode::GeneralError);
+#endif
 }
 
 SEP_API int sep_bridge_set_config(const char *key, const char *value) {

--- a/src/compat/component_bridge.cpp
+++ b/src/compat/component_bridge.cpp
@@ -1,9 +1,13 @@
+#if SEP_HAS_BLENDER
 #include "blender/types.h"  // Must come first for SEPBlenderBridge definition
+#endif
 #include "compat/component_bridge.h"
 #include "audio/pipewire_capture.h"
+#if SEP_HAS_BLENDER
 #include "blender/bridge.h"
 #include "blender/api.h"
 #include "blender/cycles_renderer.h"
+#endif
 
 namespace sep {
 namespace compat {
@@ -12,6 +16,7 @@ namespace compat {
 std::unique_ptr<audio::AudioCapture> createAudioCapture() {
     return std::make_unique<audio::PipeWireCapture>();
 }
+#if SEP_HAS_BLENDER
 std::unique_ptr<SEPBlenderBridge> createBlenderBridge() {
     auto bridge = std::make_unique<SEPBlenderBridge>();
     bridge->impl = std::make_shared<pattern::BlenderBridge>();
@@ -21,5 +26,9 @@ std::unique_ptr<SEPBlenderBridge> createBlenderBridge() {
 std::unique_ptr<blender::CyclesRenderer> createCyclesRenderer() {
     return std::make_unique<blender::CyclesRenderer>();
 }
+#else
+std::unique_ptr<SEPBlenderBridge> createBlenderBridge() { return nullptr; }
+std::unique_ptr<blender::CyclesRenderer> createCyclesRenderer() { return nullptr; }
+#endif
 } // namespace compat
 } // namespace sep

--- a/src/core/manager.cpp
+++ b/src/core/manager.cpp
@@ -92,6 +92,14 @@ public:
         config.logging.file_output = logging.value("file_output", true);
       }
 
+      if (json.contains("memory")) {
+        json.at("memory").get_to(config.memory);
+      }
+
+      if (json.contains("quantum")) {
+        json.at("quantum").get_to(config.quantum);
+      }
+
       return true;
   }
 
@@ -179,6 +187,16 @@ const LogConfig &ConfigManager::getLogConfig() const {
   return impl_->config.logging;
 }
 
+const MemoryConfig &ConfigManager::getMemoryConfig() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return impl_->config.memory;
+}
+
+const QuantumConfig &ConfigManager::getQuantumConfig() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return impl_->config.quantum;
+}
+
 void ConfigManager::updateAPIConfig(const APIConfig &config) {
   std::lock_guard<std::mutex> lock(mutex_);
   impl_->config.api = config;
@@ -192,6 +210,16 @@ void ConfigManager::updateCudaConfig(const CudaConfig &config) {
 void ConfigManager::updateLogConfig(const LogConfig &config) {
   std::lock_guard<std::mutex> lock(mutex_);
   impl_->config.logging = config;
+}
+
+void ConfigManager::updateMemoryConfig(const MemoryConfig &config) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  impl_->config.memory = config;
+}
+
+void ConfigManager::updateQuantumConfig(const QuantumConfig &config) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  impl_->config.quantum = config;
 }
 
 void ConfigManager::resetToDefaults() {

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -2,6 +2,7 @@
 #include "core/common.h"  // defines sep::SEPResult
 #include "memory/types.h"
 #include "memory/redis_manager.h"
+#include "core/manager.h"
 
 #include "quantum/types.h"        // For ::sep::quantum::Pattern
 #include "quantum/data.hpp"       // For ::sep::pattern::PatternData
@@ -259,9 +260,10 @@ MemoryBlock* MemoryTierManager::findBlockByPtr(void* ptr) {
 }
 
 MemoryTier* MemoryTierManager::determineTier(float coherence, float stability, int generation_count) {
-    if (coherence >= config_.promote_mtm_to_ltm && generation_count >= static_cast<int>(config_.mtm_to_ltm_min_gen))
+    auto cfg = sep::config::ConfigManager::getInstance().getMemoryConfig();
+    if (coherence >= cfg.promote_mtm_to_ltm && generation_count >= static_cast<int>(config_.mtm_to_ltm_min_gen))
         return ltm_.get();
-    if (coherence >= config_.promote_stm_to_mtm && generation_count >= static_cast<int>(config_.stm_to_mtm_min_gen))
+    if (coherence >= cfg.promote_stm_to_mtm && generation_count >= static_cast<int>(config_.stm_to_mtm_min_gen))
         return mtm_.get();
     return stm_.get();
 }
@@ -286,12 +288,14 @@ void MemoryTierManager::removePattern(std::size_t id) {
 }
 
 void MemoryTierManager::pruneWeakRelationships() {
+    auto cfg = sep::config::ConfigManager::getInstance().getMemoryConfig();
     for (auto& map : pattern_relationships_)
-        for (auto it = map.second.begin(); it != map.second.end();)
-            if (it->second < config_.demote_threshold)
+        for (auto it = map.second.begin(); it != map.second.end();) {
+            if (it->second < cfg.demote_threshold)
                 it = map.second.erase(it);
             else
                 ++it;
+        }
 }
 
 void MemoryTierManager::calculateRelationshipCoherence() {
@@ -384,8 +388,9 @@ const ::sep::quantum::Pattern* MemoryTierManager::findPattern(std::size_t id) co
 
 void MemoryTierManager::cleanupExpiredPatterns() {
     std::vector<std::size_t> to_remove;
+    auto cfg = sep::config::ConfigManager::getInstance().getMemoryConfig();
     for (const auto& p : pattern_registry_) {
-        if (p.second->coherence < static_cast<double>(config_.demote_threshold))
+        if (p.second->coherence < static_cast<double>(cfg.demote_threshold))
             to_remove.push_back(p.first);
     }
     for (std::size_t id : to_remove)

--- a/src/quantum/processor.cpp
+++ b/src/quantum/processor.cpp
@@ -4,6 +4,7 @@
 #include "quantum/quantum_processor_qfh.h"
 #include <glm/glm.hpp>
 #include "memory/types.h"
+#include "core/manager.h"
 #include "core/common.h"  // defines sep::SEPResult
 
 using ::sep::memory::MemoryTierEnum;
@@ -211,9 +212,10 @@ public:
     void demotePatterns() {
         std::lock_guard<std::mutex> lock(mutex_);
         for (auto& pattern : patterns_) {
-            if (pattern.quantum_state.coherence < config_.mtm_coherence_threshold) {
+            auto qcfg = sep::config::ConfigManager::getInstance().getQuantumConfig();
+            if (pattern.quantum_state.coherence < qcfg.mtm_coherence_threshold) {
                 pattern.quantum_state.memory_tier = ::sep::memory::MemoryTierEnum::STM;
-            } else if (pattern.quantum_state.coherence < config_.ltm_coherence_threshold) {
+            } else if (pattern.quantum_state.coherence < qcfg.ltm_coherence_threshold) {
                 pattern.quantum_state.memory_tier = ::sep::memory::MemoryTierEnum::MTM;
             }
         }
@@ -223,7 +225,8 @@ public:
         std::lock_guard<std::mutex> lock(mutex_);
         patterns_.erase(std::remove_if(patterns_.begin(), patterns_.end(),
             [this](const Pattern& p) {
-                return p.quantum_state.coherence < config_.mtm_coherence_threshold / 2;
+                auto qcfg = sep::config::ConfigManager::getInstance().getQuantumConfig();
+                return p.quantum_state.coherence < qcfg.mtm_coherence_threshold / 2;
             }), patterns_.end());
         rebuildPatternMap();
     }
@@ -311,9 +314,10 @@ private:
     void updateMemoryTier(Pattern& pattern) {
         auto& state = pattern.quantum_state;
         ::sep::memory::MemoryTierEnum previous_tier = state.memory_tier;
-        if (state.coherence >= config_.ltm_coherence_threshold && state.stability >= config_.stability_threshold) {
+        auto qcfg = sep::config::ConfigManager::getInstance().getQuantumConfig();
+        if (state.coherence >= qcfg.ltm_coherence_threshold && state.stability >= qcfg.stability_threshold) {
             state.memory_tier = ::sep::memory::MemoryTierEnum::LTM;
-        } else if (state.coherence >= config_.mtm_coherence_threshold) {
+        } else if (state.coherence >= qcfg.mtm_coherence_threshold) {
             state.memory_tier = ::sep::memory::MemoryTierEnum::MTM;
         } else {
             state.memory_tier = ::sep::memory::MemoryTierEnum::STM;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,7 +24,9 @@ include_directories(
 )
 
 # Add test subdirectories
-add_subdirectory(blender)
+if(SEP_HAS_BLENDER)
+    add_subdirectory(blender)
+endif()
 
 # Configure test discovery
 include(CTest)


### PR DESCRIPTION
## Summary
- make Blender integration optional via `SEP_HAS_BLENDER`
- provide stub implementations when Blender is disabled
- guard global bridge state with a mutex and clean up error buffers
- expose memory and quantum thresholds through `ConfigManager`
- document new configuration sections in the docs

## Testing
- `cmake ..` *(fails: Could not find nvcc, please set CUDAToolkit_ROOT)*

------
https://chatgpt.com/codex/tasks/task_e_6862b3b40b7c832a99f892923208cacf