### PR TITLE
Enable optional Blender build and config-driven thresholds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ file(MAKE_DIRECTORY ${SEP_TEST_DATA_DIR})
 option(SEP_BUILD_TESTS "Build test suite" ON)
 option(SEP_ENABLE_CUDA "Enable CUDA support" ON)
 option(SEP_HAS_CYCLES "Enable Blender Cycles integration" OFF)
+option(SEP_HAS_BLENDER "Enable Blender integration" ON)
 
 # Configure compiler flags
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
@@ -44,6 +45,11 @@ endif()
 
 if(SEP_HAS_CYCLES)
     add_compile_definitions(SEP_HAS_CYCLES)
+endif()
+if(SEP_HAS_BLENDER)
+    add_compile_definitions(SEP_HAS_BLENDER=1)
+else()
+    add_compile_definitions(SEP_HAS_BLENDER=0)
 endif()
 
 # Set output directories

--- a/config/default.json
+++ b/config/default.json
@@ -18,5 +18,18 @@
         "log_file": "sep.log",
         "console_output": true,
         "file_output": true
+    },
+    "memory": {
+        "promote_stm_to_mtm": 0.7,
+        "promote_mtm_to_ltm": 0.9,
+        "demote_threshold": 0.3,
+        "fragmentation_threshold": 0.3,
+        "stm_to_mtm_min_gen": 5,
+        "mtm_to_ltm_min_gen": 100
+    },
+    "processor": {
+        "ltm_coherence_threshold": 0.9,
+        "mtm_coherence_threshold": 0.6,
+        "stability_threshold": 0.8
     }
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,33 @@
+# Configuration Reference
+
+The engine loads settings from `config/default.json` and overrides
+values via environment variables or command line flags. Two new
+sections expose memory manager and quantum processor thresholds.
+
+## Memory
+
+```json
+"memory": {
+    "promote_stm_to_mtm": 0.7,
+    "promote_mtm_to_ltm": 0.9,
+    "demote_threshold": 0.3,
+    "fragmentation_threshold": 0.3,
+    "stm_to_mtm_min_gen": 5,
+    "mtm_to_ltm_min_gen": 100
+}
+```
+
+These values control promotion and demotion between STM, MTM and LTM
+memory tiers.
+
+## Processor
+
+```json
+"processor": {
+    "ltm_coherence_threshold": 0.9,
+    "mtm_coherence_threshold": 0.6,
+    "stability_threshold": 0.8
+}
+```
+
+The quantum processor uses these thresholds when evolving patterns.

--- a/include/compat/component_bridge.h
+++ b/include/compat/component_bridge.h
@@ -15,8 +15,13 @@ class CyclesRenderer; // Forward declaration if header not available
 namespace compat {
 
 std::unique_ptr<audio::AudioCapture> createAudioCapture();
+#if SEP_HAS_BLENDER
 std::unique_ptr<SEPBlenderBridge> createBlenderBridge();
 std::unique_ptr<blender::CyclesRenderer> createCyclesRenderer();
+#else
+inline std::unique_ptr<SEPBlenderBridge> createBlenderBridge() { return nullptr; }
+inline std::unique_ptr<blender::CyclesRenderer> createCyclesRenderer() { return nullptr; }
+#endif
 
 } // namespace compat
 } // namespace sep

--- a/include/core/manager.h
+++ b/include/core/manager.h
@@ -2,6 +2,8 @@
 #define SEP_CONFIG_MANAGER_H
 
 #include "types.h"
+#include "memory/memory_tier_manager.hpp"
+#include "quantum/types.h"
 #include <memory>
 #include <mutex>
 #include <string>
@@ -41,11 +43,15 @@ public:
   const APIConfig &getAPIConfig() const;
   const CudaConfig &getCudaConfig() const;
   const LogConfig &getLogConfig() const;
+  const memory::MemoryTierManager::Config &getMemoryConfig() const;
+  const quantum::ProcessingConfig &getProcessorConfig() const;
 
   // Update specific components
   void updateAPIConfig(const APIConfig &config);
   void updateCudaConfig(const CudaConfig &config);
   void updateLogConfig(const LogConfig &config);
+  void updateMemoryConfig(const memory::MemoryTierManager::Config &config);
+  void updateProcessorConfig(const quantum::ProcessingConfig &config);
 
   // Reset configuration to defaults
   void resetToDefaults();

--- a/include/core/types.h
+++ b/include/core/types.h
@@ -126,11 +126,28 @@ struct AnalyticsConfig {
     double sampling_rate{0.1};
 };
 
+struct MemoryThresholdConfig {
+    float promote_stm_to_mtm{0.7f};
+    float promote_mtm_to_ltm{0.9f};
+    float demote_threshold{0.3f};
+    float fragmentation_threshold{0.3f};
+    std::uint32_t stm_to_mtm_min_gen{5};
+    std::uint32_t mtm_to_ltm_min_gen{100};
+};
+
+struct ProcessorThresholdConfig {
+    float ltm_coherence_threshold{0.9f};
+    float mtm_coherence_threshold{0.6f};
+    float stability_threshold{0.8f};
+};
+
 struct SystemConfig {
     APIConfig   api;
     CudaConfig  cuda;
     LogConfig   logging;
     std::string data_path;
+    MemoryThresholdConfig memory;
+    ProcessorThresholdConfig processor;
 };
 
 // Backwards compatibility aliases for renamed configuration structs
@@ -280,6 +297,36 @@ inline void from_json(const nlohmann::json& j, AnalyticsConfig& c) {
     c.collect_metrics = j.value("collect_metrics", true);
     c.history_size = j.value("history_size", static_cast<size_t>(1000));
     c.sampling_rate = j.value("sampling_rate", 0.1);
+}
+
+inline void to_json(nlohmann::json& j, const MemoryThresholdConfig& c) {
+    j = nlohmann::json{{"promote_stm_to_mtm", c.promote_stm_to_mtm},
+                       {"promote_mtm_to_ltm", c.promote_mtm_to_ltm},
+                       {"demote_threshold", c.demote_threshold},
+                       {"fragmentation_threshold", c.fragmentation_threshold},
+                       {"stm_to_mtm_min_gen", c.stm_to_mtm_min_gen},
+                       {"mtm_to_ltm_min_gen", c.mtm_to_ltm_min_gen}};
+}
+
+inline void from_json(const nlohmann::json& j, MemoryThresholdConfig& c) {
+    c.promote_stm_to_mtm = j.value("promote_stm_to_mtm", 0.7f);
+    c.promote_mtm_to_ltm = j.value("promote_mtm_to_ltm", 0.9f);
+    c.demote_threshold = j.value("demote_threshold", 0.3f);
+    c.fragmentation_threshold = j.value("fragmentation_threshold", 0.3f);
+    c.stm_to_mtm_min_gen = j.value("stm_to_mtm_min_gen", 5u);
+    c.mtm_to_ltm_min_gen = j.value("mtm_to_ltm_min_gen", 100u);
+}
+
+inline void to_json(nlohmann::json& j, const ProcessorThresholdConfig& c) {
+    j = nlohmann::json{{"ltm_coherence_threshold", c.ltm_coherence_threshold},
+                       {"mtm_coherence_threshold", c.mtm_coherence_threshold},
+                       {"stability_threshold", c.stability_threshold}};
+}
+
+inline void from_json(const nlohmann::json& j, ProcessorThresholdConfig& c) {
+    c.ltm_coherence_threshold = j.value("ltm_coherence_threshold", 0.9f);
+    c.mtm_coherence_threshold = j.value("mtm_coherence_threshold", 0.6f);
+    c.stability_threshold = j.value("stability_threshold", 0.8f);
 }
 
 }  // namespace config

--- a/include/memory/memory_tier_manager.hpp
+++ b/include/memory/memory_tier_manager.hpp
@@ -25,6 +25,7 @@
 #include <system_error>
 #include <unordered_map>
 #include <vector>
+#include <nlohmann/json.hpp>
 
 #include <glm/vec3.hpp>
 
@@ -151,8 +152,38 @@ private:
 
     // Pattern tier transition helpers
     bool checkTierPromotion(const ::sep::pattern::PatternData& pattern, MemoryTier target_tier) const;
-    bool checkTierDemotion(const ::sep::pattern::PatternData& pattern) const;
+  bool checkTierDemotion(const ::sep::pattern::PatternData& pattern) const;
 };
+
+inline void to_json(nlohmann::json& j, const MemoryTierManager::Config& c) {
+    j = nlohmann::json{
+        {"stm_size", c.stm_size},
+        {"mtm_size", c.mtm_size},
+        {"ltm_size", c.ltm_size},
+        {"promote_stm_to_mtm", c.promote_stm_to_mtm},
+        {"promote_mtm_to_ltm", c.promote_mtm_to_ltm},
+        {"demote_threshold", c.demote_threshold},
+        {"fragmentation_threshold", c.fragmentation_threshold},
+        {"use_unified_memory", c.use_unified_memory},
+        {"enable_compression", c.enable_compression},
+        {"stm_to_mtm_min_gen", c.stm_to_mtm_min_gen},
+        {"mtm_to_ltm_min_gen", c.mtm_to_ltm_min_gen}
+    };
+}
+
+inline void from_json(const nlohmann::json& j, MemoryTierManager::Config& c) {
+    c.stm_size = j.value("stm_size", static_cast<std::size_t>(1 << 20));
+    c.mtm_size = j.value("mtm_size", static_cast<std::size_t>(4 << 20));
+    c.ltm_size = j.value("ltm_size", static_cast<std::size_t>(16 << 20));
+    c.promote_stm_to_mtm = j.value("promote_stm_to_mtm", 0.7f);
+    c.promote_mtm_to_ltm = j.value("promote_mtm_to_ltm", 0.9f);
+    c.demote_threshold = j.value("demote_threshold", 0.3f);
+    c.fragmentation_threshold = j.value("fragmentation_threshold", 0.3f);
+    c.use_unified_memory = j.value("use_unified_memory", true);
+    c.enable_compression = j.value("enable_compression", true);
+    c.stm_to_mtm_min_gen = j.value("stm_to_mtm_min_gen", 5u);
+    c.mtm_to_ltm_min_gen = j.value("mtm_to_ltm_min_gen", 100u);
+}
 
 }  // namespace memory
 }  // namespace sep

--- a/include/quantum/types.h
+++ b/include/quantum/types.h
@@ -5,6 +5,7 @@
 #include <glm/glm.hpp>
 #include <string>
 #include <vector>
+#include <nlohmann/json.hpp>
 
 namespace sep::quantum {
 
@@ -54,6 +55,26 @@ struct ProcessingConfig {
   float stability_threshold{0.8f};
   bool enable_cuda{false};
 };
+
+inline void to_json(nlohmann::json& j, const ProcessingConfig& c) {
+    j = nlohmann::json{
+        {"max_patterns", c.max_patterns},
+        {"mutation_rate", c.mutation_rate},
+        {"ltm_coherence_threshold", c.ltm_coherence_threshold},
+        {"mtm_coherence_threshold", c.mtm_coherence_threshold},
+        {"stability_threshold", c.stability_threshold},
+        {"enable_cuda", c.enable_cuda}
+    };
+}
+
+inline void from_json(const nlohmann::json& j, ProcessingConfig& c) {
+    c.max_patterns = j.value("max_patterns", static_cast<size_t>(10000));
+    c.mutation_rate = j.value("mutation_rate", 0.01f);
+    c.ltm_coherence_threshold = j.value("ltm_coherence_threshold", 0.9f);
+    c.mtm_coherence_threshold = j.value("mtm_coherence_threshold", 0.6f);
+    c.stability_threshold = j.value("stability_threshold", 0.8f);
+    c.enable_cuda = j.value("enable_cuda", false);
+}
 
 struct ProcessingResult {
   bool success{false};

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,7 +12,9 @@ target_include_directories(sep_main PRIVATE ${SEP_INCLUDE_DIRS})
 # Add component subdirectories
 add_subdirectory(api)
 add_subdirectory(audio)
-add_subdirectory(blender)
+if(SEP_HAS_BLENDER)
+    add_subdirectory(blender)
+endif()
 add_subdirectory(compat)
 add_subdirectory(core)
 add_subdirectory(memory)
@@ -22,7 +24,7 @@ add_subdirectory(quantum)
 target_link_libraries(sep_main PRIVATE
     sep_api
     sep_audio
-    sep_blender
+    $<IF:$<BOOL:${SEP_HAS_BLENDER}>,sep_blender,>
     sep_compat
     sep_core
     sep_memory

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -19,16 +19,16 @@ target_include_directories(sep_api
         ${CMAKE_SOURCE_DIR}/include
         ${CMAKE_SOURCE_DIR}/include/api
         ${CMAKE_SOURCE_DIR}/include/audio
-        ${CMAKE_SOURCE_DIR}/include/blender
+        $<IF:$<BOOL:${SEP_HAS_BLENDER}>,${CMAKE_SOURCE_DIR}/include/blender,>
         ${CMAKE_SOURCE_DIR}/include/compat
         ${CMAKE_SOURCE_DIR}/include/core
         ${CMAKE_SOURCE_DIR}/include/crow
         ${CMAKE_SOURCE_DIR}/include/memory
         ${CMAKE_SOURCE_DIR}/include/quantum
-        ${CMAKE_SOURCE_DIR}/cycles/src
+        $<IF:$<BOOL:${SEP_HAS_BLENDER}>,${CMAKE_SOURCE_DIR}/cycles/src,>
         ${CMAKE_SOURCE_DIR}/extern
-        ${CMAKE_SOURCE_DIR}/extern/cycles/src
-        ${CMAKE_SOURCE_DIR}/extern/blender/lib/linux_x64/osl/include
+        $<IF:$<BOOL:${SEP_HAS_BLENDER}>,${CMAKE_SOURCE_DIR}/extern/cycles/src,>
+        $<IF:$<BOOL:${SEP_HAS_BLENDER}>,${CMAKE_SOURCE_DIR}/extern/blender/lib/linux_x64/osl/include,>
         ${CMAKE_SOURCE_DIR}/extern/eigen
 )
 
@@ -40,6 +40,7 @@ target_link_libraries(sep_api
     PRIVATE
         ${CURL_LIBRARIES}
         sep_core
+        $<IF:$<BOOL:${SEP_HAS_BLENDER}>,sep_blender,>
 )
 
 if(HIREDIS_FOUND)

--- a/src/api/bridge_c.cpp
+++ b/src/api/bridge_c.cpp
@@ -37,12 +37,17 @@ SEP_API int sep_bridge_init(void) {
 }
 
 SEP_API int sep_bridge_cleanup(void) {
+#if SEP_HAS_EXCEPTIONS
+  try {
+#endif
   std::lock_guard<std::mutex> lock(sep::api::bridge::detail::g_bridge_mutex);
- sep::api::bridge::detail::g_context_processor_bridge.reset(); // Fix: Add semicolon
+  sep::api::bridge::detail::g_context_processor_bridge.reset();
   sep::api::bridge::detail::g_last_error.clear();
-  // Fix: Initialize g_required_buffer_size to 0 here
   sep::api::bridge::detail::g_required_buffer_size = 0;
   return 0;
+#if SEP_HAS_EXCEPTIONS
+  } SEP_CATCH_RETURN(sep::api::ErrorCode::ApiError);
+#endif
 }
 
 SEP_API int sep_process_context(const char *context_json, const char *layer,
@@ -133,18 +138,30 @@ SEP_API int sep_process_context(const char *context_json, const char *layer,
 }
 
 SEP_API int sep_bridge_get_last_error(char *buffer, size_t buffer_size) {
+#if SEP_HAS_EXCEPTIONS
+  try {
+#endif
   std::lock_guard<std::mutex> lock(sep::api::bridge::detail::g_bridge_mutex);
-  if (!buffer || buffer_size == 0) { // Fix: Check for null buffer or zero size
+  if (!buffer || buffer_size == 0) {
     return static_cast<int>(sep::api::ErrorCode::InvalidParameter);
   }
   size_t len = std::min(sep::api::bridge::detail::g_last_error.size(), buffer_size - 1);
   (void)std::snprintf(buffer, buffer_size, "%s", sep::api::bridge::detail::g_last_error.c_str());
   return static_cast<int>(len);
+#if SEP_HAS_EXCEPTIONS
+  } SEP_CATCH_RETURN(sep::api::ErrorCode::GeneralError);
+#endif
 }
 
 SEP_API size_t sep_get_required_buffer_size(void) {
+#if SEP_HAS_EXCEPTIONS
+  try {
+#endif
   std::lock_guard<std::mutex> lock(sep::api::bridge::detail::g_bridge_mutex);
   return sep::api::bridge::detail::g_required_buffer_size;
+#if SEP_HAS_EXCEPTIONS
+  } SEP_CATCH_RETURN(static_cast<size_t>(0));
+#endif
 }
 
 SEP_API int sep_bridge_set_config(const char *key, const char *value) {

--- a/src/api/server.cpp
+++ b/src/api/server.cpp
@@ -788,6 +788,7 @@ void SEPApiServer::handleSignal(int signal) {
   }
 }
 
+#if SEP_HAS_BLENDER
 void SEPApiServer::setupBlenderRoutes() {
     // Pattern processing endpoint
     app_->route_dynamic("/api/v1/patterns/process")
@@ -980,5 +981,8 @@ void SEPApiServer::setupBlenderRoutes() {
         return res;
     });
 }
+#else
+void SEPApiServer::setupBlenderRoutes() {}
+#endif
 
 }  // namespace sep::api

--- a/src/blender/CMakeLists.txt
+++ b/src/blender/CMakeLists.txt
@@ -1,3 +1,7 @@
+if(NOT SEP_HAS_BLENDER)
+    return()
+endif()
+
 add_library(sep_blender STATIC
     compression_utils.cpp
     gpu_context.cpp

--- a/src/compat/component_bridge.cpp
+++ b/src/compat/component_bridge.cpp
@@ -1,9 +1,11 @@
 #include "blender/types.h"  // Must come first for SEPBlenderBridge definition
 #include "compat/component_bridge.h"
 #include "audio/pipewire_capture.h"
+#if SEP_HAS_BLENDER
 #include "blender/bridge.h"
 #include "blender/api.h"
 #include "blender/cycles_renderer.h"
+#endif
 
 namespace sep {
 namespace compat {
@@ -12,6 +14,8 @@ namespace compat {
 std::unique_ptr<audio::AudioCapture> createAudioCapture() {
     return std::make_unique<audio::PipeWireCapture>();
 }
+
+#if SEP_HAS_BLENDER
 std::unique_ptr<SEPBlenderBridge> createBlenderBridge() {
     auto bridge = std::make_unique<SEPBlenderBridge>();
     bridge->impl = std::make_shared<pattern::BlenderBridge>();
@@ -21,5 +25,14 @@ std::unique_ptr<SEPBlenderBridge> createBlenderBridge() {
 std::unique_ptr<blender::CyclesRenderer> createCyclesRenderer() {
     return std::make_unique<blender::CyclesRenderer>();
 }
+#else
+std::unique_ptr<SEPBlenderBridge> createBlenderBridge() {
+    return nullptr;
+}
+
+std::unique_ptr<blender::CyclesRenderer> createCyclesRenderer() {
+    return nullptr;
+}
+#endif
 } // namespace compat
 } // namespace sep

--- a/src/core/manager.cpp
+++ b/src/core/manager.cpp
@@ -92,6 +92,14 @@ public:
         config.logging.file_output = logging.value("file_output", true);
       }
 
+      if (json.contains("memory")) {
+        json.at("memory").get_to(config.memory);
+      }
+
+      if (json.contains("processor")) {
+        json.at("processor").get_to(config.processor);
+      }
+
       return true;
   }
 
@@ -179,6 +187,16 @@ const LogConfig &ConfigManager::getLogConfig() const {
   return impl_->config.logging;
 }
 
+const memory::MemoryTierManager::Config &ConfigManager::getMemoryConfig() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return impl_->config.memory;
+}
+
+const quantum::ProcessingConfig &ConfigManager::getProcessorConfig() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return impl_->config.processor;
+}
+
 void ConfigManager::updateAPIConfig(const APIConfig &config) {
   std::lock_guard<std::mutex> lock(mutex_);
   impl_->config.api = config;
@@ -192,6 +210,16 @@ void ConfigManager::updateCudaConfig(const CudaConfig &config) {
 void ConfigManager::updateLogConfig(const LogConfig &config) {
   std::lock_guard<std::mutex> lock(mutex_);
   impl_->config.logging = config;
+}
+
+void ConfigManager::updateMemoryConfig(const memory::MemoryTierManager::Config &config) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  impl_->config.memory = config;
+}
+
+void ConfigManager::updateProcessorConfig(const quantum::ProcessingConfig &config) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  impl_->config.processor = config;
 }
 
 void ConfigManager::resetToDefaults() {

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -1,5 +1,6 @@
 #include "memory/memory_tier_manager.hpp"
 #include "core/common.h"  // defines sep::SEPResult
+#include "core/manager.h"
 #include "memory/types.h"
 #include "memory/redis_manager.h"
 
@@ -32,7 +33,10 @@ std::unique_ptr<MemoryTierManager> MemoryTierManager::instance_;
 std::once_flag MemoryTierManager::once_flag_;
 
 MemoryTierManager& MemoryTierManager::getInstance() {
-    std::call_once(once_flag_, []() { instance_ = std::make_unique<MemoryTierManager>(); });
+    std::call_once(once_flag_, []() {
+        const auto& cfg = sep::config::ConfigManager::getInstance().getMemoryConfig();
+        instance_ = std::make_unique<MemoryTierManager>(cfg);
+    });
     return *instance_;
 }
 

--- a/src/quantum/processor.cpp
+++ b/src/quantum/processor.cpp
@@ -1,5 +1,6 @@
 #include "quantum/processor.h"
 #include "quantum/types.h"
+#include "core/manager.h"
 #include "quantum/pattern_evolution_bridge.h"
 #include "quantum/quantum_processor_qfh.h"
 #include <glm/glm.hpp>
@@ -394,19 +395,24 @@ ProcessingConfig Processor::getConfig() const { return impl_->getConfig(); }
 void Processor::updateConfig(const ProcessingConfig& config) { impl_->updateConfig(config); }
 
 std::unique_ptr<Processor> createProcessor(const ProcessingConfig& config) {
-    return std::make_unique<Processor>(config); // Fix: Use make_unique // Fix: Added comment
+    ProcessingConfig merged = config;
+    const auto& global_cfg = sep::config::ConfigManager::getInstance().getProcessorConfig();
+    merged.ltm_coherence_threshold = global_cfg.ltm_coherence_threshold;
+    merged.mtm_coherence_threshold = global_cfg.mtm_coherence_threshold;
+    merged.stability_threshold = global_cfg.stability_threshold;
+    return std::make_unique<Processor>(merged);
 }
 
 std::unique_ptr<Processor> createCPUProcessor(const ProcessingConfig& config) {
     ProcessingConfig cpu_config = config;
     cpu_config.enable_cuda = false;
-    return std::make_unique<Processor>(cpu_config);
+    return createProcessor(cpu_config);
 }
 
 std::unique_ptr<Processor> createGPUProcessor(const ProcessingConfig& config) {
     ProcessingConfig gpu_config = config;
     gpu_config.enable_cuda = true;
-    return std::make_unique<Processor>(gpu_config);
+    return createProcessor(gpu_config);
 }
 
 } // namespace sep::quantum

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,7 +24,9 @@ include_directories(
 )
 
 # Add test subdirectories
-add_subdirectory(blender)
+if(SEP_HAS_BLENDER)
+    add_subdirectory(blender)
+endif()
 
 # Configure test discovery
 include(CTest)


### PR DESCRIPTION
## Summary
- wrap Blender integration behind `SEP_HAS_BLENDER`
- expose memory/processor thresholds through `ConfigManager`
- add config defaults and documentation
- guard global bridge state with mutex and consistent try/catch

## Testing
- `cmake -S . -B build -DSEP_HAS_BLENDER=OFF -DSEP_ENABLE_CUDA=OFF -DSEP_BUILD_TESTS=OFF` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6862b3b40b7c832a99f892923208cacf