### PR TITLE
Refactor bridge API to use SEPResult

### DIFF
--- a/include/api/bridge.h
+++ b/include/api/bridge.h
@@ -2,6 +2,7 @@
 #define SEP_API_BRIDGE_H
 
 #include <cstddef> // For size_t
+#include "core/common.h"
 
 // Cross-platform API export macro
 #if defined(_WIN32)
@@ -18,16 +19,16 @@
 extern "C" {
 #endif
 
-SEP_API int sep_bridge_init(void);
-SEP_API int sep_bridge_cleanup(void);
-SEP_API int sep_process_context(const char *context_json, const char *layer,
+SEP_API sep::SEPResult sep_bridge_init(void);
+SEP_API sep::SEPResult sep_bridge_cleanup(void);
+SEP_API sep::SEPResult sep_process_context(const char *context_json, const char *layer,
                                 char *result_buffer, size_t buffer_size);
-SEP_API int sep_bridge_get_last_error(char *buffer, size_t buffer_size);
+SEP_API sep::SEPResult sep_bridge_get_last_error(char *buffer, size_t buffer_size);
 SEP_API size_t sep_get_required_buffer_size(void);
-SEP_API int sep_bridge_set_config(const char *key, const char *value);
-SEP_API int sep_bridge_get_config(const char *key, char *buffer,
+SEP_API sep::SEPResult sep_bridge_set_config(const char *key, const char *value);
+SEP_API sep::SEPResult sep_bridge_get_config(const char *key, char *buffer,
                                   size_t buffer_size);
-SEP_API int
+SEP_API sep::SEPResult
 sep_bridge_register_callback(const char *event_type,
                              void (*callback)(const char *event_data));
 

--- a/include/api/bridge.hpp
+++ b/include/api/bridge.hpp
@@ -2,6 +2,7 @@
 #define SEP_API_BRIDGE_HPP
 
 #include "api/types.h"
+#include "core/common.h"
 #include "quantum/processor.h"
 #include "quantum/types.h"
 #include "quantum/resource_predictor.h" // Provides context types
@@ -25,7 +26,7 @@ void setLastError(const std::string &error);
 std::string getLastError();
   void setRequiredBufferSize(size_t size);
   size_t getRequiredBufferSize();
-  ::sep::api::ErrorCode mapSepError(::sep::api::ErrorCode core);
+  sep::SEPResult mapSepError(::sep::api::ErrorCode core);
   void invokeCallbacks(const std::string &event_type,
                        const std::string &event_data);
 } // namespace detail
@@ -33,15 +34,15 @@ std::string getLastError();
 } // namespace sep::api::bridge
 
 extern "C" {
-SEP_API int sep_bridge_init(void);
-SEP_API int sep_bridge_cleanup(void);
-SEP_API int sep_process_context(const char *context_json, const char *layer,
+SEP_API sep::SEPResult sep_bridge_init(void);
+SEP_API sep::SEPResult sep_bridge_cleanup(void);
+SEP_API sep::SEPResult sep_process_context(const char *context_json, const char *layer,
                                 char *result_buffer, size_t buffer_size);
-SEP_API int sep_bridge_get_last_error(char *buffer, size_t buffer_size);
+SEP_API sep::SEPResult sep_bridge_get_last_error(char *buffer, size_t buffer_size);
 SEP_API size_t sep_get_required_buffer_size(void);
-SEP_API int sep_bridge_set_config(const char *key, const char *value);
-SEP_API int sep_bridge_get_config(const char *key, char *buffer, size_t buffer_size);
-SEP_API int sep_bridge_register_callback(const char *event_type,
+SEP_API sep::SEPResult sep_bridge_set_config(const char *key, const char *value);
+SEP_API sep::SEPResult sep_bridge_get_config(const char *key, char *buffer, size_t buffer_size);
+SEP_API sep::SEPResult sep_bridge_register_callback(const char *event_type,
                                          void (*callback)(const char *event_data));
 } // extern "C"
 
@@ -50,18 +51,18 @@ SEP_API int sep_bridge_register_callback(const char *event_type,
 #define SEP_BRIDGE_CATCH(core) \
   catch (const std::exception &e) { \
     sep::api::bridge::detail::setLastError(e.what()); \
-    return static_cast<int>(core); \
+    return sep::api::bridge::detail::mapSepError(core); \
   } \
   catch (...) { \
     sep::api::bridge::detail::setLastError("Unknown error"); \
-    return static_cast<int>(core); \
+    return sep::api::bridge::detail::mapSepError(core); \
   }
 #else
 #define SEP_BRIDGE_TRY if (true)
 #define SEP_BRIDGE_CATCH(core)                                                   
   {                                                                             
     sep::api::bridge::detail::setLastError("exceptions disabled");              
-    return static_cast<int>(core);                                              
+    return sep::api::bridge::detail::mapSepError(core);                                              
   }
 #endif
 

--- a/include/api/bridge_internal.hpp
+++ b/include/api/bridge_internal.hpp
@@ -24,14 +24,14 @@ class Processor;
 #define SEP_CATCH_RETURN(code) \
   catch (const std::exception &e) { \
     sep::api::bridge::detail::setLastError(e.what()); \
-    return static_cast<int>(sep::api::bridge::detail::mapSepError(code)); \
+    return sep::api::bridge::detail::mapSepError(code); \
   }
 #else
 #define SEP_TRY if (true)
-#define SEP_CATCH_RETURN(code) 
-  do { 
-    sep::api::bridge::detail::setLastError("exceptions disabled"); 
-    return static_cast<int>(code); 
+#define SEP_CATCH_RETURN(code) \
+  do { \
+    sep::api::bridge::detail::setLastError("exceptions disabled"); \
+    return code; \
   } while (0)
 #endif
 
@@ -47,6 +47,6 @@ void setLastError(const std::string& error);
 std::string getLastError();
 void setRequiredBufferSize(size_t size);
 size_t getRequiredBufferSize();
-::sep::api::ErrorCode mapSepError(::sep::api::ErrorCode code);
+sep::SEPResult mapSepError(::sep::api::ErrorCode code);
 void invokeCallbacks(const std::string& event_type, const std::string& event_data);
 } // namespace sep::api::bridge::detail

--- a/include/blender/bridge.h
+++ b/include/blender/bridge.h
@@ -123,7 +123,9 @@ class BlenderBridge {
   sep::GPUContext* gpu_context_;  // Changed to sep::GPUContext
   std::unique_ptr<sep::pattern::PatternProcessor> pattern_processor_;  // Base pattern processor from processor.h
 
+  // Access to objects_ must be guarded by objects_mutex_
   std::unordered_map<sep::pattern::ObjectHandle, ObjectState> objects_;
+  // observers_ is modified by multiple threads and protected by observers_mutex_
   ::sep::shim::vector<std::shared_ptr<sep::pattern::PatternObserver>> observers_;
 
   std::atomic<bool> initialized_{false};

--- a/include/compat/cuda_api.hpp
+++ b/include/compat/cuda_api.hpp
@@ -2,6 +2,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include "core/common.h"
 #include "compat/cuda_runtime.h"
 
 namespace sep::cuda {
@@ -30,14 +31,14 @@ cudaError_t launchQSHKernel(const std::uint64_t *d_chunks,
 // C API
 extern "C" {
 
-int sep_cuda_init(int device_id);
-int sep_cuda_cleanup(void);
+sep::SEPResult sep_cuda_init(int device_id);
+sep::SEPResult sep_cuda_cleanup(void);
 
-int sep_cuda_process_batch(const std::uint32_t* probe_indices, const std::uint32_t* expectations,
+sep::SEPResult sep_cuda_process_batch(const std::uint32_t* probe_indices, const std::uint32_t* expectations,
                           std::uint32_t num_probes, std::uint32_t* bitfield, std::uint32_t* correction_indices,
                           std::uint32_t* correction_count);
 
-int sep_cuda_process_symmetry(const std::uint64_t* chunks, std::uint32_t num_chunks,
+sep::SEPResult sep_cuda_process_symmetry(const std::uint64_t* chunks, std::uint32_t num_chunks,
                             std::uint32_t* collapse_indices, std::uint32_t* collapse_counts);
 
 } // extern "C"

--- a/include/quantum/processor.h
+++ b/include/quantum/processor.h
@@ -117,6 +117,7 @@ public:
     void updateConfig(const ProcessingConfig& config);
 
 private:
+    // All mutable state lives inside ProcessorImpl which uses a mutex internally
     std::unique_ptr<ProcessorImpl> impl_;
 };
 

--- a/src/api/bridge.cpp
+++ b/src/api/bridge.cpp
@@ -21,14 +21,14 @@
 // Use macros from bridge_internal.hpp
 #if !SEP_HAS_EXCEPTIONS
 #define SEP_TRY
-  do { sep::crow::error::set_last_error("exceptions disabled"); 
-    return static_cast<int>(core); 
+  do { sep::crow::error::set_last_error("exceptions disabled");
+    return sep::api::bridge::detail::mapSepError(core);
   } while (0)
 #endif
 #else // No exceptions
 #define SEP_TRY
-#define SEP_CATCH_RETURN(core) 
-  do { return static_cast<int>(core); } while (0)
+#define SEP_CATCH_RETURN(core)
+  do { return sep::api::bridge::detail::mapSepError(core); } while (0)
 #endif
 
 namespace sep::api::bridge::detail {
@@ -55,21 +55,30 @@ void setRequiredBufferSize(size_t size) { g_required_buffer_size = size; }
 
 size_t getRequiredBufferSize() { return g_required_buffer_size; }
 
-sep::api::ErrorCode mapSepError(sep::api::ErrorCode core) {
+sep::SEPResult mapSepError(sep::api::ErrorCode core) {
   switch (core) {
+    case sep::api::ErrorCode::Success:
+      return sep::SEPResult::SUCCESS;
     case sep::api::ErrorCode::InvalidArgument:
-      return sep::api::ErrorCode::InvalidParameter;
+    case sep::api::ErrorCode::InvalidParameter:
+      return sep::SEPResult::INVALID_ARGUMENT;
+    case sep::api::ErrorCode::ResourceNotFound:
+      return sep::SEPResult::NOT_FOUND;
+    case sep::api::ErrorCode::OutOfMemory:
+      return sep::SEPResult::OUT_OF_MEMORY;
+    case sep::api::ErrorCode::InvalidState:
+      return sep::SEPResult::INVALID_STATE;
     case sep::api::ErrorCode::CudaError:
+      return sep::SEPResult::CUDA_ERROR;
+    case sep::api::ErrorCode::ProcessingError:
     case sep::api::ErrorCode::ApiError:
     case sep::api::ErrorCode::InvalidOperation:
-    case sep::api::ErrorCode::ResourceNotFound:
-    case sep::api::ErrorCode::OutOfMemory:
-    case sep::api::ErrorCode::InvalidState:
     case sep::api::ErrorCode::SystemError:
-    case sep::api::ErrorCode::Unknown:
-      return sep::api::ErrorCode::ProcessingError;
+      return sep::SEPResult::PROCESSING_ERROR;
+    case sep::api::ErrorCode::BufferTooSmall:
+      return sep::SEPResult::BUFFER_TOO_SMALL;
     default:
-      return sep::api::ErrorCode::GeneralError;
+      return sep::SEPResult::UNKNOWN_ERROR;
   }
 }
 

--- a/src/api/bridge_c.cpp
+++ b/src/api/bridge_c.cpp
@@ -1,3 +1,10 @@
+#include <cstring>
+#include <cstdio>
+#include <memory>
+#include <mutex>
+
+#include <nlohmann/json.hpp>
+
 #include "api/bridge.h"
 #include "quantum/types.h"
 #include "api/bridge_internal.hpp"
@@ -7,20 +14,11 @@
 #include "compat/shim.h"
 #include "compat/cuda_runtime.h"  // For sep::cuda::cudaMemcpyAsync
 #include "compat/macros.h"  // For SEP_CUDA_AVAILABLE
-#include "crow/asio_isolation.h"
-#include "crow/socket_adaptors.h"
-#include <ios>
-#include <nlohmann/json.hpp>
-#include <cstring>
-#include <cstdio>  // Required for snprintf
-#include <memory>
-#include <unordered_map>
-#include <vector>
 
 
 extern "C" {
 
-SEP_API int sep_bridge_init(void) {
+SEP_API sep::SEPResult sep_bridge_init(void) {
 #ifdef SEP_HAS_EXCEPTIONS
   try {
 #endif
@@ -30,29 +28,29 @@ SEP_API int sep_bridge_init(void) {
  sep::api::bridge::detail::g_last_error.clear(); // Fix: Add semicolon
   // Fix: Initialize g_required_buffer_size to 0 here
   sep::api::bridge::detail::g_required_buffer_size = 0;
-  return 0;
+  return sep::SEPResult::SUCCESS;
 #if SEP_HAS_EXCEPTIONS
   } SEP_CATCH_RETURN(sep::api::ErrorCode::ApiError);
 #endif
 }
 
-SEP_API int sep_bridge_cleanup(void) {
+SEP_API sep::SEPResult sep_bridge_cleanup(void) {
   std::lock_guard<std::mutex> lock(sep::api::bridge::detail::g_bridge_mutex);
  sep::api::bridge::detail::g_context_processor_bridge.reset(); // Fix: Add semicolon
   sep::api::bridge::detail::g_last_error.clear();
   // Fix: Initialize g_required_buffer_size to 0 here
   sep::api::bridge::detail::g_required_buffer_size = 0;
-  return 0;
+  return sep::SEPResult::SUCCESS;
 }
 
-SEP_API int sep_process_context(const char *context_json, const char *layer,
+SEP_API sep::SEPResult sep_process_context(const char *context_json, const char *layer,
                                char *result_buffer, size_t buffer_size) {
 #if SEP_HAS_EXCEPTIONS
   try { // Fix: Use try block when exceptions are enabled
 #endif
     if (!context_json || !result_buffer || !layer || buffer_size == 0) {
       sep::api::bridge::detail::setLastError("Invalid parameters");
-      return static_cast<int>(sep::api::ErrorCode::InvalidParameter);
+      return sep::SEPResult::INVALID_ARGUMENT;
     }
 
     sep::quantum::Processor *processor = nullptr;
@@ -60,7 +58,7 @@ SEP_API int sep_process_context(const char *context_json, const char *layer,
       std::lock_guard<std::mutex> lock(sep::api::bridge::detail::g_bridge_mutex);
       if (!sep::api::bridge::detail::g_context_processor_bridge) {
         sep::api::bridge::detail::setLastError("Context processor not initialized");
-        return static_cast<int>(sep::api::ErrorCode::GeneralError);
+        return sep::SEPResult::UNKNOWN_ERROR;
       }
       processor = sep::api::bridge::detail::g_context_processor_bridge.get();
     }
@@ -69,7 +67,7 @@ SEP_API int sep_process_context(const char *context_json, const char *layer,
       nlohmann::json json_obj = nlohmann::json::parse(context_json, nullptr, false);
       if (json_obj.is_discarded()) {
         sep::api::bridge::detail::setLastError("JSON parsing error");
-        return static_cast<int>(sep::api::ErrorCode::ProcessingError);
+        return sep::SEPResult::PROCESSING_ERROR;
       }
 
       nlohmann::json test_result;
@@ -83,7 +81,7 @@ SEP_API int sep_process_context(const char *context_json, const char *layer,
  sep::api::bridge::detail::setRequiredBufferSize(test_str.size() + 1); // Fix: Add semicolon
         if (test_str.size() >= buffer_size) {
           sep::api::bridge::detail::setLastError("Result buffer too small");
-          return static_cast<int>(sep::api::ErrorCode::BufferTooSmall);
+          return sep::SEPResult::BUFFER_TOO_SMALL;
         }
       }
 
@@ -95,7 +93,7 @@ SEP_API int sep_process_context(const char *context_json, const char *layer,
       
       if (!process_result.success) {
         sep::api::bridge::detail::setLastError(process_result.error_message.c_str());
-        return static_cast<int>(process_result.error_code); // Use specific error code
+        return static_cast<sep::SEPResult>(process_result.error_code); // Use specific error code
       }
 
       nlohmann::json result_json;
@@ -117,29 +115,30 @@ SEP_API int sep_process_context(const char *context_json, const char *layer,
         sep::api::bridge::detail::setRequiredBufferSize(result_str.size() + 1);
         if (result_str.size() >= buffer_size) {
           sep::api::bridge::detail::setLastError("Result buffer too small");
-          return static_cast<int>(sep::api::ErrorCode::BufferTooSmall);
+          return sep::SEPResult::BUFFER_TOO_SMALL;
         }
       }
 
       (void)std::snprintf(result_buffer, buffer_size, "%s", result_str.c_str());
-      return 0;
+      return sep::SEPResult::SUCCESS;
     }
 #ifdef SEP_HAS_EXCEPTIONS
   } catch (const std::exception &e) {
     sep::api::bridge::detail::setLastError(e.what());
-    return static_cast<int>(sep::api::bridge::detail::mapSepError(sep::api::ErrorCode::ProcessingError));
+    return sep::api::bridge::detail::mapSepError(sep::api::ErrorCode::ProcessingError);
   }
 #endif
 }
 
-SEP_API int sep_bridge_get_last_error(char *buffer, size_t buffer_size) {
+SEP_API sep::SEPResult sep_bridge_get_last_error(char *buffer, size_t buffer_size) {
   std::lock_guard<std::mutex> lock(sep::api::bridge::detail::g_bridge_mutex);
   if (!buffer || buffer_size == 0) { // Fix: Check for null buffer or zero size
-    return static_cast<int>(sep::api::ErrorCode::InvalidParameter);
+    return sep::SEPResult::INVALID_ARGUMENT;
   }
   size_t len = std::min(sep::api::bridge::detail::g_last_error.size(), buffer_size - 1);
   (void)std::snprintf(buffer, buffer_size, "%s", sep::api::bridge::detail::g_last_error.c_str());
-  return static_cast<int>(len);
+  (void)len;
+  return sep::SEPResult::SUCCESS;
 }
 
 SEP_API size_t sep_get_required_buffer_size(void) {
@@ -147,14 +146,14 @@ SEP_API size_t sep_get_required_buffer_size(void) {
   return sep::api::bridge::detail::g_required_buffer_size;
 }
 
-SEP_API int sep_bridge_set_config(const char *key, const char *value) {
+SEP_API sep::SEPResult sep_bridge_set_config(const char *key, const char *value) {
 #if SEP_HAS_EXCEPTIONS
   try { // Fix: Use try block when exceptions are enabled
 #endif
   std::lock_guard<std::mutex> lock(sep::api::bridge::detail::g_bridge_mutex);
   if (!key || !value) {
     sep::api::bridge::detail::setLastError("Invalid parameters");
-    return static_cast<int>(sep::api::ErrorCode::GeneralError);
+    return sep::SEPResult::UNKNOWN_ERROR;
   }
   std::string k = key;
   auto &cm = sep::config::ConfigManager::getInstance();
@@ -175,28 +174,28 @@ SEP_API int sep_bridge_set_config(const char *key, const char *value) {
       cfg.keep_alive_timeout_ms = static_cast<size_t>(std::stoul(value));
     } else {
       sep::api::bridge::detail::setLastError("Config key not found");
-      return static_cast<int>(sep::api::ErrorCode::InvalidParameter);
+      return sep::SEPResult::INVALID_ARGUMENT;
     }
   } catch (...) {
     sep::api::bridge::detail::setLastError("Invalid value");
-    return static_cast<int>(sep::api::ErrorCode::GeneralError);
+    return sep::SEPResult::UNKNOWN_ERROR;
   }
   cm.updateAPIConfig(cfg);
   sep::api::bridge::detail::setLastError("");
- return 0; // Fix: Add semicolon
+ return sep::SEPResult::SUCCESS; // Fix: Add semicolon
 #if SEP_HAS_EXCEPTIONS
   } SEP_CATCH_RETURN(sep::api::ErrorCode::GeneralError);
 #endif
 }
 
-SEP_API int sep_bridge_get_config(const char *key, char *buffer, size_t buffer_size) {
+SEP_API sep::SEPResult sep_bridge_get_config(const char *key, char *buffer, size_t buffer_size) {
 #if SEP_HAS_EXCEPTIONS
   try { // Fix: Use try block when exceptions are enabled
 #endif
   std::lock_guard<std::mutex> lock(sep::api::bridge::detail::g_bridge_mutex);
   if (!key || !buffer || buffer_size == 0) {
     sep::api::bridge::detail::setLastError("Invalid parameters");
-    return static_cast<int>(sep::api::ErrorCode::GeneralError);
+    return sep::SEPResult::UNKNOWN_ERROR;
   }
   std::string k = key;
   const auto &cfg = sep::config::ConfigManager::getInstance().getAPIConfig();
@@ -216,17 +215,17 @@ SEP_API int sep_bridge_get_config(const char *key, char *buffer, size_t buffer_s
   } else {
     buffer[0] = '\0';
     sep::api::bridge::detail::setLastError("Config key not found");
-    return static_cast<int>(sep::api::ErrorCode::InvalidParameter);
+    return sep::SEPResult::INVALID_ARGUMENT;
   }
   (void)std::snprintf(buffer, buffer_size, "%s", val.c_str());
   sep::api::bridge::detail::setLastError("");
- return 0; // Fix: Add semicolon
+ return sep::SEPResult::SUCCESS; // Fix: Add semicolon
 #if SEP_HAS_EXCEPTIONS
   } SEP_CATCH_RETURN(sep::api::ErrorCode::GeneralError);
 #endif
 }
 
-SEP_API int sep_bridge_register_callback(const char *event_type,
+SEP_API sep::SEPResult sep_bridge_register_callback(const char *event_type,
                                          void (*callback)(const char *event_data)) {
 #if SEP_HAS_EXCEPTIONS
   try { // Fix: Use try block when exceptions are enabled
@@ -234,11 +233,11 @@ SEP_API int sep_bridge_register_callback(const char *event_type,
   std::lock_guard<std::mutex> lock(sep::api::bridge::detail::g_bridge_mutex);
   if (!event_type || !callback) {
     sep::api::bridge::detail::setLastError("Invalid parameters");
-    return static_cast<int>(sep::api::ErrorCode::GeneralError);
+    return sep::SEPResult::UNKNOWN_ERROR;
   } // Fix: Add closing brace
   sep::api::bridge::detail::g_callback_map[event_type].push_back(callback);
   sep::api::bridge::detail::setLastError("");
- return 0; // Fix: Add semicolon
+ return sep::SEPResult::SUCCESS; // Fix: Add semicolon
 #if SEP_HAS_EXCEPTIONS
   } SEP_CATCH_RETURN(sep::api::ErrorCode::GeneralError);
 #endif

--- a/src/compat/cuda_api.cu
+++ b/src/compat/cuda_api.cu
@@ -1,5 +1,13 @@
-#include "compat/cuda_common.h"
+#if !defined(__CUDACC__)
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <utility>
+#endif
 
+#include "core/common.h"
+
+#include "compat/cuda_common.h"
 #include "compat/cuda_unified_fix.h"
 
 // CUDA runtime must come first
@@ -9,15 +17,6 @@
 #include "compat/cuda_runtime.h"
 #include "compat/cuda_helpers.h"
 
-// Standard library includes - only for host compilation
-#if !defined(__CUDACC__)
-#include <cstddef>
-#include <cstdint>
-#include <memory>
-#include <utility>
-#endif
-
-// Project includes
 #include "compat/constants.h"
 #include "compat/cuda_wrapper.h"
 #include "compat/kernels.h"
@@ -100,9 +99,9 @@ using StreamPtr = std::unique_ptr<sep::cuda::StreamRAII>;
 static StreamPtr g_stream;
 static bool g_initialized = false;
 
-int sep_cuda_init(int device_id) {
+sep::SEPResult sep_cuda_init(int device_id) {
     if (g_initialized) {
-        return 0;
+        return sep::SEPResult::SUCCESS;
     }
 
     if (device_id >= 0) {
@@ -112,28 +111,28 @@ int sep_cuda_init(int device_id) {
     g_stream = std::make_unique<sep::cuda::StreamRAII>();
     if (!g_stream || !g_stream->valid()) {
         g_stream.reset();
-        return static_cast<int>(sep::ErrorCode::GeneralError);
+        return sep::SEPResult::UNKNOWN_ERROR;
     }
 
     g_initialized = true;
-    return 0;
+    return sep::SEPResult::SUCCESS;
 }
 
-int sep_cuda_cleanup(void) {
+sep::SEPResult sep_cuda_cleanup(void) {
     if (!g_initialized) {
-        return 0;
+        return sep::SEPResult::SUCCESS;
     }
 
     g_stream.reset();
     g_initialized = false;
-    return 0;
+    return sep::SEPResult::SUCCESS;
 }
 
-int sep_cuda_process_batch(const std::uint32_t* probe_indices, const std::uint32_t* expectations,
+sep::SEPResult sep_cuda_process_batch(const std::uint32_t* probe_indices, const std::uint32_t* expectations,
                            std::uint32_t num_probes, std::uint32_t* bitfield, std::uint32_t* correction_indices,
                            std::uint32_t* correction_count) {
     if (!g_initialized) {
-        return static_cast<int>(sep::ErrorCode::GeneralError);
+        return sep::SEPResult::UNKNOWN_ERROR;
     }
 
     // Get constants
@@ -155,7 +154,7 @@ int sep_cuda_process_batch(const std::uint32_t* probe_indices, const std::uint32
 
     if (!d_probe_indices.valid() || !d_expectations.valid() || !d_bitfield.valid() || !d_corrections.valid() ||
         !d_correction_count.valid()) {
-        return static_cast<int>(sep::ErrorCode::GeneralError);
+        return sep::SEPResult::UNKNOWN_ERROR;
     }
 
     try {
@@ -188,16 +187,16 @@ int sep_cuda_process_batch(const std::uint32_t* probe_indices, const std::uint32
 
         CUDA_CHECK(cudaStreamSynchronize(g_stream->get()));
     } catch (const sep::CudaException&) {
-        return static_cast<int>(sep::ErrorCode::GeneralError);
+        return sep::SEPResult::UNKNOWN_ERROR;
     }
 
-    return 0;
+    return sep::SEPResult::SUCCESS;
 }
 
-int sep_cuda_process_symmetry(const std::uint64_t* chunks, std::uint32_t num_chunks, std::uint32_t* collapse_indices,
+sep::SEPResult sep_cuda_process_symmetry(const std::uint64_t* chunks, std::uint32_t num_chunks, std::uint32_t* collapse_indices,
                               std::uint32_t* collapse_counts) {
     if (!g_initialized) {
-        return static_cast<int>(sep::ErrorCode::GeneralError);
+        return sep::SEPResult::UNKNOWN_ERROR;
     }
 
     // Get constants
@@ -214,7 +213,7 @@ int sep_cuda_process_symmetry(const std::uint64_t* chunks, std::uint32_t num_chu
     sep::cuda::DeviceBufferRAII<std::uint32_t> d_collapse_counts(num_chunks);
 
     if (!d_chunks.valid() || !d_collapse_indices.valid() || !d_collapse_counts.valid()) {
-        return static_cast<int>(sep::ErrorCode::GeneralError);
+        return sep::SEPResult::UNKNOWN_ERROR;
     }
 
     try {
@@ -236,10 +235,10 @@ int sep_cuda_process_symmetry(const std::uint64_t* chunks, std::uint32_t num_chu
 
         CUDA_CHECK(cudaStreamSynchronize(g_stream->get()));
     } catch (const sep::CudaException&) {
-        return static_cast<int>(sep::ErrorCode::GeneralError);
+        return sep::SEPResult::UNKNOWN_ERROR;
     }
 
-    return 0;
+    return sep::SEPResult::SUCCESS;
 }
 
 #endif

--- a/tests/api/bridge_api_test.cpp
+++ b/tests/api/bridge_api_test.cpp
@@ -3,9 +3,9 @@
 #include "api/bridge.hpp"
 
 TEST(BridgeCAPI, InitProcessCleanup) {
-    ASSERT_EQ(sep_bridge_init(), 0);
+    ASSERT_EQ(sep_bridge_init(), sep::SEPResult::SUCCESS);
     const char* ctx = "{\"type\":\"test\",\"content\":{}}";
     char buffer[256];
-    ASSERT_EQ(sep_process_context(ctx, "layer", buffer, sizeof(buffer)), 0);
-    ASSERT_EQ(sep_bridge_cleanup(), 0);
+    ASSERT_EQ(sep_process_context(ctx, "layer", buffer, sizeof(buffer)), sep::SEPResult::SUCCESS);
+    ASSERT_EQ(sep_bridge_cleanup(), sep::SEPResult::SUCCESS);
 }

--- a/tests/api/bridge_test.cpp
+++ b/tests/api/bridge_test.cpp
@@ -17,7 +17,7 @@ using json = nlohmann::json;
 
 class BridgeTest : public ::testing::Test {
  protected:
-  void SetUp() override { ASSERT_EQ(sep_bridge_init(), 0); }
+  void SetUp() override { ASSERT_EQ(sep_bridge_init(), sep::SEPResult::SUCCESS); }
 
   void TearDown() override { sep_bridge_cleanup(); }
 
@@ -76,9 +76,9 @@ TEST_F(BridgeTest, BasicContextProcessing) {
                   {"metadata", json::object()}};
 
   char result_buffer[1024];
-  int result = sep_process_context(context.dump().c_str(), "test_layer", result_buffer,
+  sep::SEPResult result = sep_process_context(context.dump().c_str(), "test_layer", result_buffer,
                                    sizeof(result_buffer));
-  EXPECT_EQ(result, 0) << "Process context failed with code " << result;
+  EXPECT_EQ(result, sep::SEPResult::SUCCESS) << "Process context failed";
 
   json result_json = json::parse(result_buffer);
   EXPECT_TRUE(result_json["success"].get<bool>());
@@ -90,7 +90,7 @@ TEST_F(BridgeTest, InvalidJsonProcessing) {
   char result_buffer[1024];
 
   EXPECT_EQ(sep_process_context(invalid_json, "test_layer", result_buffer, sizeof(result_buffer)),
-            -4);
+            sep::SEPResult::PROCESSING_ERROR);
 
   char error_buffer[1024];
   sep_bridge_get_last_error(error_buffer, sizeof(error_buffer));
@@ -108,7 +108,7 @@ TEST_F(BridgeTest, BufferSizeHandling) {
   char small_buffer[10];
   EXPECT_EQ(sep_process_context(large_context.dump().c_str(), "test_layer", small_buffer,
                                 sizeof(small_buffer)),
-            -3);
+            sep::SEPResult::BUFFER_TOO_SMALL);
 
   size_t required_size = sep_get_required_buffer_size();
   EXPECT_GT(required_size, sizeof(small_buffer));
@@ -117,19 +117,19 @@ TEST_F(BridgeTest, BufferSizeHandling) {
 // Error Handling Tests
 TEST_F(BridgeTest, NullParameterHandling) {
   char buffer[1024];
-  EXPECT_EQ(sep_process_context(nullptr, "layer", buffer, sizeof(buffer)), -2);
-  EXPECT_EQ(sep_process_context("test", nullptr, buffer, sizeof(buffer)), -2);
-  EXPECT_EQ(sep_process_context("test", "layer", nullptr, sizeof(buffer)), -2);
+  EXPECT_EQ(sep_process_context(nullptr, "layer", buffer, sizeof(buffer)), sep::SEPResult::INVALID_ARGUMENT);
+  EXPECT_EQ(sep_process_context("test", nullptr, buffer, sizeof(buffer)), sep::SEPResult::INVALID_ARGUMENT);
+  EXPECT_EQ(sep_process_context("test", "layer", nullptr, sizeof(buffer)), sep::SEPResult::INVALID_ARGUMENT);
 }
 
 TEST_F(BridgeTest, ErrorBufferHandling) {
   char error_buffer[1024];
 
   // Test with null buffer
-  EXPECT_EQ(sep_bridge_get_last_error(nullptr, 1024), 0);
+  EXPECT_EQ(sep_bridge_get_last_error(nullptr, 1024), sep::SEPResult::INVALID_ARGUMENT);
 
   // Test with zero size
-  EXPECT_EQ(sep_bridge_get_last_error(error_buffer, 0), 0);
+  EXPECT_EQ(sep_bridge_get_last_error(error_buffer, 0), sep::SEPResult::INVALID_ARGUMENT);
 
   // Test with small buffer
   detail::setLastError("Long error message for testing buffer handling");
@@ -143,18 +143,18 @@ TEST_F(BridgeTest, ConfigurationManagement) {
   char buffer[1024];
 
   // Test invalid parameters
-  EXPECT_EQ(sep_bridge_set_config(nullptr, "value"), -1);
-  EXPECT_EQ(sep_bridge_set_config("key", nullptr), -1);
-  EXPECT_EQ(sep_bridge_get_config(nullptr, buffer, sizeof(buffer)), -1);
-  EXPECT_EQ(sep_bridge_get_config("key", nullptr, sizeof(buffer)), -1);
+  EXPECT_EQ(sep_bridge_set_config(nullptr, "value"), sep::SEPResult::UNKNOWN_ERROR);
+  EXPECT_EQ(sep_bridge_set_config("key", nullptr), sep::SEPResult::UNKNOWN_ERROR);
+  EXPECT_EQ(sep_bridge_get_config(nullptr, buffer, sizeof(buffer)), sep::SEPResult::UNKNOWN_ERROR);
+  EXPECT_EQ(sep_bridge_get_config("key", nullptr, sizeof(buffer)), sep::SEPResult::UNKNOWN_ERROR);
 
   // Basic set and get using ConfigManager
-  EXPECT_EQ(sep_bridge_set_config("api.host", "example.com"), 0);
-  EXPECT_EQ(sep_bridge_get_config("api.host", buffer, sizeof(buffer)), 0);
+  EXPECT_EQ(sep_bridge_set_config("api.host", "example.com"), sep::SEPResult::SUCCESS);
+  EXPECT_EQ(sep_bridge_get_config("api.host", buffer, sizeof(buffer)), sep::SEPResult::SUCCESS);
   EXPECT_STREQ(buffer, "example.com");
 
   // Non-existent key
-  EXPECT_EQ(sep_bridge_get_config("api.missing", buffer, sizeof(buffer)), -2);
+  EXPECT_EQ(sep_bridge_get_config("api.missing", buffer, sizeof(buffer)), sep::SEPResult::INVALID_ARGUMENT);
 }
 
 // Callback Registration Tests
@@ -167,11 +167,11 @@ TEST_F(BridgeTest, CallbackRegistration) {
   };
 
   // Test invalid parameters
-  EXPECT_EQ(sep_bridge_register_callback(nullptr, callback), -1);
-  EXPECT_EQ(sep_bridge_register_callback("event", nullptr), -1);
+  EXPECT_EQ(sep_bridge_register_callback(nullptr, callback), sep::SEPResult::UNKNOWN_ERROR);
+  EXPECT_EQ(sep_bridge_register_callback("event", nullptr), sep::SEPResult::UNKNOWN_ERROR);
 
   // Successful registration and invocation
-  EXPECT_EQ(sep_bridge_register_callback("test_event", callback), 0);
+  EXPECT_EQ(sep_bridge_register_callback("test_event", callback), sep::SEPResult::SUCCESS);
   detail::invokeCallbacks("test_event", "payload");
   EXPECT_TRUE(called);
   EXPECT_EQ(data, "payload");
@@ -193,7 +193,7 @@ TEST_F(BridgeTest, ConcurrentProcessing) {
   for (int i = 0; i < num_threads; ++i) {
     threads.emplace_back([&]() {
       char buffer[1024];
-      if (sep_process_context(context_json.c_str(), "test_layer", buffer, sizeof(buffer)) == 0) {
+      if (sep_process_context(context_json.c_str(), "test_layer", buffer, sizeof(buffer)) == sep::SEPResult::SUCCESS) {
         success_count++;
       }
     });
@@ -210,8 +210,8 @@ TEST_F(BridgeTest, ConcurrentProcessing) {
 TEST_F(BridgeTest, MultipleInitCleanup) {
   // Test multiple init/cleanup cycles
   for (int i = 0; i < 5; ++i) {
-    EXPECT_EQ(sep_bridge_cleanup(), 0);
-    EXPECT_EQ(sep_bridge_init(), 0);
+  EXPECT_EQ(sep_bridge_cleanup(), sep::SEPResult::SUCCESS);
+  EXPECT_EQ(sep_bridge_init(), sep::SEPResult::SUCCESS);
   }
 }
 
@@ -219,7 +219,8 @@ TEST_F(BridgeTest, ProcessingAfterCleanup) {
   sep_bridge_cleanup();
 
   char buffer[1024];
-  EXPECT_EQ(sep_process_context(R"({"type": "test"})", "layer", buffer, sizeof(buffer)), -1);
+  EXPECT_EQ(sep_process_context(R"({"type": "test"})", "layer", buffer, sizeof(buffer)),
+            sep::SEPResult::UNKNOWN_ERROR);
 
   char error_buffer[1024];
   sep_bridge_get_last_error(error_buffer, sizeof(error_buffer));


### PR DESCRIPTION
## Summary
- change bridge C API and CUDA API functions to return `sep::SEPResult`
- update error mapping and macros
- adjust callers and unit tests
- clean up includes and document locking

## Testing
- `ctest --output-on-failure -j1` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_6862b374b278832ab13ed9b403e7c1f0