### PR TITLE
Fix config struct and FFT cleanup

### DIFF
--- a/include/core/types.h
+++ b/include/core/types.h
@@ -130,6 +130,9 @@ struct MemoryThresholdConfig {
     float promote_stm_to_mtm{0.7f};
     float promote_mtm_to_ltm{0.9f};
     float demote_threshold{0.3f};
+    float fragmentation_threshold{0.3f};
+    uint32_t stm_to_mtm_min_gen{5};
+    uint32_t mtm_to_ltm_min_gen{100};
 };
 
 struct QuantumThresholdConfig {
@@ -145,8 +148,6 @@ struct SystemConfig {
     MemoryThresholdConfig memory;
     QuantumThresholdConfig quantum;
     std::string data_path;
-    MemoryThresholdConfig memory;
-    QuantumThresholdConfig quantum;
 };
 
 // Backwards compatibility aliases for renamed configuration structs
@@ -326,30 +327,6 @@ inline void from_json(const nlohmann::json& j, AnalyticsConfig& c) {
     c.collect_metrics = j.value("collect_metrics", true);
     c.history_size = j.value("history_size", static_cast<size_t>(1000));
     c.sampling_rate = j.value("sampling_rate", 0.1);
-}
-
-inline void to_json(nlohmann::json& j, const MemoryThresholdConfig& c) {
-    j = nlohmann::json{{"promote_stm_to_mtm", c.promote_stm_to_mtm},
-                       {"promote_mtm_to_ltm", c.promote_mtm_to_ltm},
-                       {"demote_threshold", c.demote_threshold}};
-}
-
-inline void from_json(const nlohmann::json& j, MemoryThresholdConfig& c) {
-    c.promote_stm_to_mtm = j.value("promote_stm_to_mtm", 0.7f);
-    c.promote_mtm_to_ltm = j.value("promote_mtm_to_ltm", 0.9f);
-    c.demote_threshold = j.value("demote_threshold", 0.3f);
-}
-
-inline void to_json(nlohmann::json& j, const QuantumThresholdConfig& c) {
-    j = nlohmann::json{{"ltm_coherence_threshold", c.ltm_coherence_threshold},
-                       {"mtm_coherence_threshold", c.mtm_coherence_threshold},
-                       {"stability_threshold", c.stability_threshold}};
-}
-
-inline void from_json(const nlohmann::json& j, QuantumThresholdConfig& c) {
-    c.ltm_coherence_threshold = j.value("ltm_coherence_threshold", 0.9f);
-    c.mtm_coherence_threshold = j.value("mtm_coherence_threshold", 0.6f);
-    c.stability_threshold = j.value("stability_threshold", 0.8f);
 }
 
 }  // namespace config

--- a/src/audio/pipeline.cpp
+++ b/src/audio/pipeline.cpp
@@ -145,10 +145,6 @@ SpectralData AudioPipeline::performFFT(const std::vector<float>& samples) {
         spectral.phases[i] = std::arg(spectral.fft[i]);
     }
 
-    fftwf_destroy_plan(plan);
-    fftwf_free(out);
-#endif
-
     return spectral;
 }
 


### PR DESCRIPTION
## Summary
- fix FFTW cleanup logic in `performFFT`
- add missing fields to `MemoryThresholdConfig`
- remove duplicate config struct members and duplicate JSON helpers

## Testing
- `npm test` *(fails: Missing script)*
- `pnpm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6862b95bff94832a92b419793038e0bc