### PR TITLE
Fix API server and memory tier manager build issues

### DIFF
--- a/src/api/server.cpp
+++ b/src/api/server.cpp
@@ -146,7 +146,7 @@ std::unique_ptr<HttpResponse> SEPApiServer::makeJsonResponse(int code, const std
   return std::make_unique<SimpleHttpResponse>(code, response.dump());
 }
 
-std::string SEPApiServer::handleError(const std::string& message, int code, const std::string& body) {
+std::string SEPApiServer::handleError(const std::string& message, int code) {
   nlohmann::json error_response{};
   error_response["error"] = true;
   error_response["message"] = message;

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -36,23 +36,17 @@ std::once_flag MemoryTierManager::once_flag_;
 
 MemoryTierManager& MemoryTierManager::getInstance() {
     std::call_once(once_flag_, []() {
-        const auto& cfg = sep::config::ConfigManager::getInstance().getMemoryConfig();
+        const auto& mc = sep::config::ConfigManager::getInstance().getMemoryConfig();
+        Config cfg{};
+        cfg.promote_stm_to_mtm = mc.promote_stm_to_mtm;
+        cfg.promote_mtm_to_ltm = mc.promote_mtm_to_ltm;
+        cfg.demote_threshold = mc.demote_threshold;
+        cfg.fragmentation_threshold = mc.fragmentation_threshold;
+        cfg.stm_to_mtm_min_gen = mc.stm_to_mtm_min_gen;
+        cfg.mtm_to_ltm_min_gen = mc.mtm_to_ltm_min_gen;
         instance_ = std::make_unique<MemoryTierManager>(cfg);
     });
     return *instance_;
-}
-
-MemoryTierManager::MemoryTierManager(const sep::config::MemoryThresholdConfig& mc) {
-    Config cfg{};
-    cfg.promote_stm_to_mtm = mc.promote_stm_to_mtm;
-    cfg.promote_mtm_to_ltm = mc.promote_mtm_to_ltm;
-    cfg.demote_threshold = mc.demote_threshold;
-    cfg.stm_size = mc.stm_size;
-    cfg.mtm_size = mc.mtm_size;
-    cfg.ltm_size = mc.ltm_size;
-    cfg.stm_to_mtm_min_gen = mc.stm_to_mtm_min_gen;
-    cfg.mtm_to_ltm_min_gen = mc.mtm_to_ltm_min_gen;
-    init(cfg);
 }
 
 MemoryTierManager::MemoryTierManager() {
@@ -62,11 +56,13 @@ MemoryTierManager::MemoryTierManager() {
     cfg.promote_stm_to_mtm = mc.promote_stm_to_mtm;
     cfg.promote_mtm_to_ltm = mc.promote_mtm_to_ltm;
     cfg.demote_threshold = mc.demote_threshold;
-    cfg.stm_size = mc.stm_size;
-    cfg.mtm_size = mc.mtm_size;
-    cfg.ltm_size = mc.ltm_size;
+    cfg.fragmentation_threshold = mc.fragmentation_threshold;
     cfg.stm_to_mtm_min_gen = mc.stm_to_mtm_min_gen;
     cfg.mtm_to_ltm_min_gen = mc.mtm_to_ltm_min_gen;
+    init(cfg);
+}
+
+MemoryTierManager::MemoryTierManager(const Config& cfg) {
     init(cfg);
 }
 


### PR DESCRIPTION
## Summary
- correct `SEPApiServer::handleError` signature to match header
- rebuild `MemoryTierManager` initialization logic using thresholds

## Testing
- `cmake -S . -B build` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6862e35a9aec832a837e0c37118a3265