### PR TITLE
Fix constructor signatures

### DIFF
--- a/include/memory/memory_tier_manager.hpp
+++ b/include/memory/memory_tier_manager.hpp
@@ -9,6 +9,7 @@
 
 // Project includes
 #include "core/common.h"
+#include "core/types.h"
 #include "core/dag_graph.h"
 #include "memory/memory_tier.hpp"
 #include "memory/types.h"
@@ -66,7 +67,8 @@ public:
     static MemoryTierManager& getInstance();
 
     MemoryTierManager();
-    MemoryTierManager(const Config& cfg);
+    explicit MemoryTierManager(const Config& cfg);
+    explicit MemoryTierManager(const sep::config::MemoryThresholdConfig& cfg);
     ~MemoryTierManager();
 
     void init(const Config& config);

--- a/src/api/server.cpp
+++ b/src/api/server.cpp
@@ -146,7 +146,7 @@ std::unique_ptr<HttpResponse> SEPApiServer::makeJsonResponse(int code, const std
   return std::make_unique<SimpleHttpResponse>(code, response.dump());
 }
 
-std::string SEPApiServer::handleError(const std::string& message, int code, const std::string& body) {
+std::string SEPApiServer::handleError(const std::string& message, int code) {
   nlohmann::json error_response{};
   error_response["error"] = true;
   error_response["message"] = message;

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -47,11 +47,13 @@ MemoryTierManager::MemoryTierManager(const sep::config::MemoryThresholdConfig& m
     cfg.promote_stm_to_mtm = mc.promote_stm_to_mtm;
     cfg.promote_mtm_to_ltm = mc.promote_mtm_to_ltm;
     cfg.demote_threshold = mc.demote_threshold;
-    cfg.stm_size = mc.stm_size;
-    cfg.mtm_size = mc.mtm_size;
-    cfg.ltm_size = mc.ltm_size;
+    cfg.fragmentation_threshold = mc.fragmentation_threshold;
     cfg.stm_to_mtm_min_gen = mc.stm_to_mtm_min_gen;
     cfg.mtm_to_ltm_min_gen = mc.mtm_to_ltm_min_gen;
+    init(cfg);
+}
+
+MemoryTierManager::MemoryTierManager(const Config& cfg) {
     init(cfg);
 }
 
@@ -62,9 +64,7 @@ MemoryTierManager::MemoryTierManager() {
     cfg.promote_stm_to_mtm = mc.promote_stm_to_mtm;
     cfg.promote_mtm_to_ltm = mc.promote_mtm_to_ltm;
     cfg.demote_threshold = mc.demote_threshold;
-    cfg.stm_size = mc.stm_size;
-    cfg.mtm_size = mc.mtm_size;
-    cfg.ltm_size = mc.ltm_size;
+    cfg.fragmentation_threshold = mc.fragmentation_threshold;
     cfg.stm_to_mtm_min_gen = mc.stm_to_mtm_min_gen;
     cfg.mtm_to_ltm_min_gen = mc.mtm_to_ltm_min_gen;
     init(cfg);


### PR DESCRIPTION
## Summary
- fix SEPApiServer::handleError signature
- support constructing MemoryTierManager using MemoryThresholdConfig
- add Config constructor to MemoryTierManager
- include core/types in header

## Testing
- `cmake ..` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6862e35a9aec832a837e0c37118a3265