### PR TITLE
Fix build log issues

### DIFF
--- a/include/memory/memory_tier_manager.hpp
+++ b/include/memory/memory_tier_manager.hpp
@@ -67,6 +67,7 @@ public:
 
     MemoryTierManager();
     MemoryTierManager(const Config& cfg);
+    MemoryTierManager(const ::sep::config::MemoryThresholdConfig& cfg);
     ~MemoryTierManager();
 
     void init(const Config& config);

--- a/src/api/server.cpp
+++ b/src/api/server.cpp
@@ -146,11 +146,11 @@ std::unique_ptr<HttpResponse> SEPApiServer::makeJsonResponse(int code, const std
   return std::make_unique<SimpleHttpResponse>(code, response.dump());
 }
 
-std::string SEPApiServer::handleError(const std::string& message, int code, const std::string& body) {
-  nlohmann::json error_response{};
-  error_response["error"] = true;
-  error_response["message"] = message;
-  error_response["code"] = code;
+std::string SEPApiServer::handleError(const std::string& message, int code) {
+    nlohmann::json error_response{};
+    error_response["error"] = true;
+    error_response["message"] = message;
+    error_response["code"] = code;
   error_response["timestamp"] = std::chrono::duration_cast<std::chrono::seconds>(
                                     std::chrono::system_clock::now().time_since_epoch())
                                     .count();

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -47,9 +47,7 @@ MemoryTierManager::MemoryTierManager(const sep::config::MemoryThresholdConfig& m
     cfg.promote_stm_to_mtm = mc.promote_stm_to_mtm;
     cfg.promote_mtm_to_ltm = mc.promote_mtm_to_ltm;
     cfg.demote_threshold = mc.demote_threshold;
-    cfg.stm_size = mc.stm_size;
-    cfg.mtm_size = mc.mtm_size;
-    cfg.ltm_size = mc.ltm_size;
+    cfg.fragmentation_threshold = mc.fragmentation_threshold;
     cfg.stm_to_mtm_min_gen = mc.stm_to_mtm_min_gen;
     cfg.mtm_to_ltm_min_gen = mc.mtm_to_ltm_min_gen;
     init(cfg);
@@ -62,9 +60,7 @@ MemoryTierManager::MemoryTierManager() {
     cfg.promote_stm_to_mtm = mc.promote_stm_to_mtm;
     cfg.promote_mtm_to_ltm = mc.promote_mtm_to_ltm;
     cfg.demote_threshold = mc.demote_threshold;
-    cfg.stm_size = mc.stm_size;
-    cfg.mtm_size = mc.mtm_size;
-    cfg.ltm_size = mc.ltm_size;
+    cfg.fragmentation_threshold = mc.fragmentation_threshold;
     cfg.stm_to_mtm_min_gen = mc.stm_to_mtm_min_gen;
     cfg.mtm_to_ltm_min_gen = mc.mtm_to_ltm_min_gen;
     init(cfg);


### PR DESCRIPTION
## Summary
- added constructor overload for `MemoryTierManager` to accept `MemoryThresholdConfig`
- removed unused parameters and fields referencing removed config
- corrected `handleError` signature in API server implementation

## Testing
- `n/a`

------
https://chatgpt.com/codex/tasks/task_e_6862e35a9aec832a837e0c37118a3265