### PR TITLE
Fix logging middleware crow isolation

### DIFF
--- a/include/api/logging_middleware.h
+++ b/include/api/logging_middleware.h
@@ -2,7 +2,11 @@
 
 #include "core/logging.h"
 #include "api/server.h"
+#ifdef CROW_DISABLE_RTTI
+#include "crow/crow_isolation.h"
+#else
 #include <crow.h>
+#endif
 #include <chrono>
 
 namespace sep::api {


### PR DESCRIPTION
## Summary
- include crow_isolation only when RTTI is disabled

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68632bf671e8832ab7eef6baa34165e7