### PR TITLE
Fix logging middleware header for RTTI flag

### DIFF
--- a/include/api/logging_middleware.h
+++ b/include/api/logging_middleware.h
@@ -2,7 +2,11 @@
 
 #include "core/logging.h"
 #include "api/server.h"
+#ifdef CROW_DISABLE_RTTI
+#include "crow/crow_isolation.h"
+#else
 #include <crow.h>
+#endif
 #include <chrono>
 
 namespace sep::api {

--- a/tests/config/logging_middleware_test.cpp
+++ b/tests/config/logging_middleware_test.cpp
@@ -1,7 +1,11 @@
 #include "api/server.h"
 #include <logging/manager.h>
 #include <gtest/gtest.h>
+#ifdef CROW_DISABLE_RTTI
+#include "crow/crow_isolation.h"
+#else
 #include <crow.h>
+#endif
 #include <chrono>
 #include <thread>
 


### PR DESCRIPTION
## Summary
- include `crow_isolation.h` when `CROW_DISABLE_RTTI` is set
- adjust unit test to use the same conditional include

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_68632bf671e8832ab7eef6baa34165e7