### PR TITLE
Fix crow include for LoggingMiddleware

### DIFF
--- a/include/api/logging_middleware.h
+++ b/include/api/logging_middleware.h
@@ -2,7 +2,7 @@
 
 #include "core/logging.h"
 #include "api/server.h"
-#include <crow.h>
+#include "crow/crow_isolation.h"
 #include <chrono>
 
 namespace sep::api {

--- a/tests/config/logging_middleware_test.cpp
+++ b/tests/config/logging_middleware_test.cpp
@@ -1,7 +1,7 @@
 #include "api/server.h"
 #include <logging/manager.h>
 #include <gtest/gtest.h>
-#include <crow.h>
+#include "crow/crow_isolation.h"
 #include <chrono>
 #include <thread>
 


### PR DESCRIPTION
## Summary
- use crow stub isolation header instead of system crow.h
- update logging middleware test to include stub

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68632bf671e8832ab7eef6baa34165e7