### PR TITLE
Fix build conflict with Crow stub namespace

### DIFF
--- a/include/api/logging_middleware.h
+++ b/include/api/logging_middleware.h
@@ -2,11 +2,7 @@
 
 #include "core/logging.h"
 #include "api/server.h"
-#ifdef CROW_DISABLE_RTTI
 #include "crow/crow_isolation.h"
-#else
-#include <crow.h>
-#endif
 #include <chrono>
 
 namespace sep::api {

--- a/include/crow/crow_isolation.h
+++ b/include/crow/crow_isolation.h
@@ -207,8 +207,9 @@ namespace crow {
     #define CROW_CATCHALL_ROUTE(app) app.catchall_route()
     #define CROW_BP_CATCHALL_ROUTE(bp) bp.catchall_rule()
 
-    // HTTP parser stubs
-    namespace http_parser {
+    // HTTP parser stubs.  Use a unique namespace to avoid conflicts with the
+    // real http_parser definitions that may come from the system Crow headers.
+    namespace http_stub {
         enum class http_errno {
             HPE_OK,
             HPE_UNKNOWN
@@ -249,5 +250,5 @@ namespace crow {
             void* on_chunk_header;
             void* on_chunk_complete;
         };
-    }  // namespace http_parser
+    }  // namespace http_stub
 }  // namespace crow

--- a/include/crow/http_parser_fixed.h
+++ b/include/crow/http_parser_fixed.h
@@ -13,7 +13,7 @@
 #define HTTP_PARSER_VERSION_MINOR 9
 
 namespace crow {
-    namespace http_parser {
+    namespace http_stub {
         // These are already defined in crow_isolation.h, so we don't need to redefine them
         // enum class http_errno {...};
         // enum class http_parser_type {...};

--- a/tests/config/logging_middleware_test.cpp
+++ b/tests/config/logging_middleware_test.cpp
@@ -1,11 +1,7 @@
 #include "api/server.h"
 #include <logging/manager.h>
 #include <gtest/gtest.h>
-#ifdef CROW_DISABLE_RTTI
 #include "crow/crow_isolation.h"
-#else
-#include <crow.h>
-#endif
 #include <chrono>
 #include <thread>
 


### PR DESCRIPTION
## Summary
- avoid depending on external Crow headers in logging middleware
- rename Crow HTTP parser stub namespace to avoid clash with system headers
- update tests to use isolation headers

## Testing
- `cmake -S . -B build` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_68632e0b0a20832a9e11547f85a8b688