### PR TITLE
Fix http_parser conflict

### DIFF
--- a/include/crow/crow_isolation.h
+++ b/include/crow/crow_isolation.h
@@ -208,7 +208,7 @@ namespace crow {
     #define CROW_BP_CATCHALL_ROUTE(bp) bp.catchall_rule()
 
     // HTTP parser stubs
-    namespace http_parser {
+    namespace http_parser_stub {
         enum class http_errno {
             HPE_OK,
             HPE_UNKNOWN
@@ -249,5 +249,5 @@ namespace crow {
             void* on_chunk_header;
             void* on_chunk_complete;
         };
-    }  // namespace http_parser
+    }  // namespace http_parser_stub
 }  // namespace crow

--- a/include/crow/http_parser_fixed.h
+++ b/include/crow/http_parser_fixed.h
@@ -13,7 +13,7 @@
 #define HTTP_PARSER_VERSION_MINOR 9
 
 namespace crow {
-    namespace http_parser {
+    namespace http_parser_stub {
         // These are already defined in crow_isolation.h, so we don't need to redefine them
         // enum class http_errno {...};
         // enum class http_parser_type {...};
@@ -84,5 +84,5 @@ namespace crow {
         inline const char* http_method_str(unsigned int method) {
             return "GET";
         }
-    }
-}
+    }  // namespace http_parser_stub
+}  // namespace crow


### PR DESCRIPTION
## Summary
- rename stub namespace `http_parser` to avoid collision with the system Crow headers

## Testing
- `bash -x build.sh` *(fails: Cycles directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_68632e0b0a20832a9e11547f85a8b688