### PR TITLE
Ensure C++17 without extensions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ pkg_check_modules(PIPEWIRE REQUIRED libpipewire-0.3)
 # Set C++ standard
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Add subdirectories for main project components
 add_subdirectory(src)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Common test configuration
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Configure test output directory
 set(TEST_OUTPUT_DIR ${CMAKE_BINARY_DIR}/tests)


### PR DESCRIPTION
## Summary
- disable compiler extensions in main and test CMake files

## Testing
- `cmake -S . -B build` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6863d4d387e4832a9a1b403e8fcb59c9