### PR TITLE
Update tests to use new PinState fields

### DIFF
--- a/include/core/common.h
+++ b/include/core/common.h
@@ -43,8 +43,13 @@ enum class Status { Success = 0, Error = 1 };
 struct PinState {
     std::uint64_t state{0};
     std::uint32_t flags{0};
+    std::uint32_t pin_id{0};
+    float value{0.f};
+    float coherence{1.f};
     bool operator==(const PinState& other) const noexcept {
-        return state == other.state && flags == other.flags;
+        return state == other.state && flags == other.flags &&
+               pin_id == other.pin_id && value == other.value &&
+               coherence == other.coherence;
     }
 };
 #endif // SEP_PINSTATE_DEFINED

--- a/tests/core/deterministic_output_test.cpp
+++ b/tests/core/deterministic_output_test.cpp
@@ -13,6 +13,9 @@ std::vector<PinState> makeStates(size_t count) {
     for (size_t i = 0; i < count; ++i) {
         states[i].state = static_cast<uint32_t>(i);
         states[i].flags = ~0u;
+        states[i].pin_id = static_cast<std::uint32_t>(i);
+        states[i].value = static_cast<float>(i) + 1.0f;
+        states[i].coherence = 0.75f;
     }
     return states;
 }

--- a/tests/core/engine_test.cpp
+++ b/tests/core/engine_test.cpp
@@ -28,6 +28,9 @@ class EngineTest : public ::testing::Test {
     for (size_t i = 0; i < count; i++) {
       states[i].state = i;
       states[i].flags = ~0u;  // All flags set
+      states[i].pin_id = static_cast<std::uint32_t>(i);
+      states[i].value = 1.0f + static_cast<float>(i);
+      states[i].coherence = 0.5f;
     }
     return states;
   }

--- a/tests/core/types_test.cpp
+++ b/tests/core/types_test.cpp
@@ -4,10 +4,10 @@
 
 // Test PinState equality operator
 TEST(TypesTest, PinStateEquality) {
-  sep::PinState a{42ULL, 7u};
-  sep::PinState b{42ULL, 7u};
-  sep::PinState c{43ULL, 7u};
-  sep::PinState d{42ULL, 8u};
+  sep::PinState a{42ULL, 7u, 1u, 1.0f, 0.9f};
+  sep::PinState b{42ULL, 7u, 1u, 1.0f, 0.9f};
+  sep::PinState c{43ULL, 7u, 2u, 1.0f, 0.9f};
+  sep::PinState d{42ULL, 8u, 1u, 1.0f, 0.9f};
 
   EXPECT_TRUE(a == b);
   EXPECT_FALSE(a == c);


### PR DESCRIPTION
## Summary
- extend `PinState` struct with `pin_id`, `value`, and `coherence`
- populate these fields when constructing test states

## Testing
- `cmake ..` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6863d4d62e10832a995584c1b8374d1f