### PR TITLE
Add extra metadata to PinState

### DIFF
--- a/include/core/common.h
+++ b/include/core/common.h
@@ -43,8 +43,17 @@ enum class Status { Success = 0, Error = 1 };
 struct PinState {
     std::uint64_t state{0};
     std::uint32_t flags{0};
+    std::uint32_t pin_id{0};
+    float value{0.f};
+    float coherence{1.f};
+
+    PinState() = default;
+    PinState(std::uint64_t s, std::uint32_t f, std::uint32_t id = 0,
+             float v = 0.f, float c = 1.f)
+        : state(s), flags(f), pin_id(id), value(v), coherence(c) {}
     bool operator==(const PinState& other) const noexcept {
-        return state == other.state && flags == other.flags;
+        return state == other.state && flags == other.flags && pin_id == other.pin_id &&
+               value == other.value && coherence == other.coherence;
     }
 };
 #endif // SEP_PINSTATE_DEFINED


### PR DESCRIPTION
## Summary
- extend `PinState` with `pin_id`, `value` and `coherence`
- provide constructor and equality update

## Testing
- `g++ -std=c++17 -I include -c src/core/engine.cpp -o /tmp/engine.o` *(fails: `sep_cuda_process_batch` not declared)*
- `cmake -S . -B build` *(fails: could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6863d4d4217c832a887bae27eed5cb2c