### PR TITLE
Fix CUDA API build guards

### DIFF
--- a/src/compat/cuda_api.cu
+++ b/src/compat/cuda_api.cu
@@ -99,7 +99,6 @@ cudaError_t launchQSHKernel(const std::uint64_t *d_chunks,
 
 
 extern "C" {
-#if !defined(__CUDACC__)
 
 // Global state
 namespace {
@@ -256,5 +255,4 @@ sep::SEPResult sep_cuda_process_symmetry(const std::uint64_t* chunks, std::uint3
     return sep::SEPResult::SUCCESS;
 }
 
-#endif
 }  // extern "C"

--- a/src/core/engine.cpp
+++ b/src/core/engine.cpp
@@ -13,6 +13,7 @@
 #include "compat/macros.h"
 #include "compat/memory.h"
 #include "compat/stream.h"
+#include "compat/cuda_api.hpp"
 #include "core/logging.h"  // This is actually the logging manager
 #include "memory/memory_tier_manager.hpp"
 #if SEP_HAS_BLENDER


### PR DESCRIPTION
## Summary
- include `compat/cuda_api.hpp` in engine
- always compile CUDA API functions by removing `__CUDACC__` guard

## Testing
- `./build.sh` *(fails: cycles directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863d4d70344832aafb29ed30fe2b331