### PR TITLE
Implement probe generation logic

### DIFF
--- a/include/core/common.h
+++ b/include/core/common.h
@@ -43,8 +43,15 @@ enum class Status { Success = 0, Error = 1 };
 struct PinState {
     std::uint64_t state{0};
     std::uint32_t flags{0};
+    std::uint32_t pin_id{0};
+    float         value{0.f};
+    float         coherence{1.f};
     bool operator==(const PinState& other) const noexcept {
-        return state == other.state && flags == other.flags;
+        return state == other.state &&
+               flags == other.flags &&
+               pin_id == other.pin_id &&
+               value == other.value &&
+               coherence == other.coherence;
     }
 };
 #endif // SEP_PINSTATE_DEFINED

--- a/src/core/engine.cpp
+++ b/src/core/engine.cpp
@@ -186,13 +186,13 @@ void Engine::generate_probes(const ::sep::shim::vector<::sep::PinState>& inputs,
         
         // Generate probe index based on pin state and current tick
         std::uint32_t probe_idx = static_cast<std::uint32_t>(
-            (pin_state.pin_id * tick) % DEFAULT_SIZE
+            (pin_state.pin_id + tick) % DEFAULT_SIZE
         );
         probe_indices.push_back(probe_idx);
         
         // Calculate expected value based on pin state and coherence
         std::uint32_t expected = static_cast<std::uint32_t>(
-            pin_state.value * pin_state.coherence * 1000.0f
+            pin_state.value * pin_state.coherence * 1000.f
         );
         expectations.push_back(expected);
     }


### PR DESCRIPTION
## Summary
- add `pin_id`, `value`, and `coherence` to `PinState`
- compute probe indices using `pin_id` and `tick`
- compute expectations using value and coherence

## Testing
- `cmake -S . -B build` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6863d4d7875c832a990247a5f22984e2