### PR TITLE
Specify C++17 standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,8 @@ find_package(PkgConfig REQUIRED)
 pkg_check_modules(PIPEWIRE REQUIRED libpipewire-0.3)
 
 # Set C++ standard
-set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Add subdirectories for main project components


### PR DESCRIPTION
## Summary
- reorder `CMAKE_CXX_STANDARD` so it follows `CMAKE_CXX_STANDARD_REQUIRED ON`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6863d89c91c0832a80097ec8f03a3f32