### PR TITLE
Remove unused PipeWire arguments from build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -42,11 +42,10 @@ echo "Checking for PipeWire development headers..."
 export PKG_CONFIG_PATH=/usr/lib64/pkgconfig:$PKG_CONFIG_PATH
 PIPEWIRE_CMAKE_ARGS=""
 if command -v pkg-config >/dev/null && pkg-config --exists libpipewire-0.3; then
-  PIPEWIRE_INCLUDE_DIR=$(pkg-config --variable=includedir libpipewire-0.3)
-  PIPEWIRE_LIB_DIR=$(pkg-config --variable=libdir libpipewire-0.3)
-  PIPEWIRE_LIB_FILE="${PIPEWIRE_LIB_DIR}/libpipewire-0.3.so"
-  echo "PipeWire found via pkg-config: ${PIPEWIRE_LIB_FILE}"
-  PIPEWIRE_CMAKE_ARGS="-DPIPEWIRE_INCLUDE_DIR=${PIPEWIRE_INCLUDE_DIR} -DPIPEWIRE_LIBRARY=${PIPEWIRE_LIB_FILE}"
+  # Rely on pkg-config to locate PipeWire; avoid manually setting unused variables
+  echo "PipeWire found via pkg-config"
+  # PIPEWIRE_CMAKE_ARGS can remain empty because the CMake scripts handle
+  # discovery internally via pkg-config.
 else
   echo "PipeWire not found via pkg-config. Audio capture will be disabled."
 fi


### PR DESCRIPTION
## Summary
- cleanup the PipeWire detection in `build.sh`
- remove unused CMake arguments for `PIPEWIRE_INCLUDE_DIR` and `PIPEWIRE_LIBRARY`

## Testing
- `cmake ..` *(fails: could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6863d893b008832a823a61d3a3d70f7b