### PR TITLE
Fix engine error enum

### DIFF
--- a/src/core/engine.cpp
+++ b/src/core/engine.cpp
@@ -323,7 +323,7 @@ void Engine::process_batch(const ::sep::shim::vector<::sep::PinState>& inputs, s
 
     } catch (const std::exception& e) {
         ::sep::core::ErrorHandler::instance().reportError(
-            {sep::SEPResult::INTERNAL_ERROR, e.what(), "Engine::process_batch"}
+            {sep::SEPResult::PROCESSING_ERROR, e.what(), "Engine::process_batch"}
         );
         return;
     }


### PR DESCRIPTION
## Summary
- fix mis-specified error enum in `Engine::process_batch`

## Testing
- `g++ -std=c++17 -c src/core/engine.cpp -Iinclude -Isrc`
- `g++ -std=c++17 /tmp/min_test.cpp src/core/engine.cpp src/core/error_handler.cpp -Iinclude -Isrc -lgtest -lgtest_main -pthread -o /tmp/min_test` *(fails: undefined references to fmt symbols)*

------
https://chatgpt.com/codex/tasks/task_e_6863d8931558832a8c31371b18dd55c5