### PR TITLE
Correct error enum usage

### DIFF
--- a/src/core/engine.cpp
+++ b/src/core/engine.cpp
@@ -323,7 +323,7 @@ void Engine::process_batch(const ::sep::shim::vector<::sep::PinState>& inputs, s
 
     } catch (const std::exception& e) {
         ::sep::core::ErrorHandler::instance().reportError(
-            {sep::SEPResult::INTERNAL_ERROR, e.what(), "Engine::process_batch"}
+            {sep::SEPResult::PROCESSING_ERROR, e.what(), "Engine::process_batch"}
         );
         return;
     }


### PR DESCRIPTION
## Summary
- handle runtime failure in Engine with PROCESSING_ERROR enum

## Testing
- `cmake -S . -B build -DSEP_BUILD_TESTS=ON -DSEP_ENABLE_CUDA=OFF` *(fails: Could not find nvcc)*
- `npm test` *(fails: Missing script: "test")*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863d8a2a908832aa63b78f997e3e082