### PR TITLE
Properly define feature macros

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,22 @@ find_package(fmt REQUIRED)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(PIPEWIRE REQUIRED libpipewire-0.3)
 
+# Detect optional libraries and define feature macros once
+find_path(NANOVDB_INCLUDE_DIR nanovdb/NanoVDB.h)
+if(NANOVDB_INCLUDE_DIR)
+    message(STATUS "NanoVDB found: ${NANOVDB_INCLUDE_DIR}")
+    add_compile_definitions(WITH_NANOVDB=1)
+else()
+    add_compile_definitions(WITH_NANOVDB=0)
+endif()
+
+find_package(OpenImageDenoise QUIET)
+if(OpenImageDenoise_FOUND)
+    add_compile_definitions(WITH_OPENIMAGEDENOISE=1)
+else()
+    add_compile_definitions(WITH_OPENIMAGEDENOISE=0)
+endif()
+
 # Set C++ standard
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/scripts/setup_cycles_env.sh
+++ b/scripts/setup_cycles_env.sh
@@ -199,7 +199,8 @@ export OPENIMAGEDENOISE_LIBRARY=/sep/extern/oidn/build/lib/libOpenImageDenoise.s
 export OPENIMAGEDENOISE_OPENIMAGEDENOISE_LIBRARY=/sep/extern/oidn/build/lib/libOpenImageDenoise.so
 
 # Disable OpenImageDenoise in Cycles build
-export WITH_OPENIMAGEDENOISE=ON
+# Leave feature detection to the build system
+# export WITH_OPENIMAGEDENOISE=ON
 
 # Set up Epoxy
 export Epoxy_INCLUDE_DIR=/sep/extern/libepoxy/include
@@ -305,7 +306,7 @@ rm -rf CMakeFiles/
 echo "Configuring Cycles with CMake..."
 # Add explicit find paths and library properties for OpenVDB if necessary
 cmake -S /sep/extern/cycles -B . \
-  -G Ninja -DWITH_OPENIMAGEDENOISE=ON \
+  -G Ninja \
   -DCMAKE_INSTALL_PREFIX=/sep/cycles-install \
   -DWITH_CYCLES_STANDALONE=ON \
   -DWITH_CYCLES_DEVICE_CUDA=ON \
@@ -360,7 +361,6 @@ cmake -S /sep/extern/cycles -B . \
   -DZSTD_INCLUDE_DIR=${ZSTD_INCLUDE_DIR} \
   -DZSTD_LIBRARY=${ZSTD_LIBRARY} \
   -DWITH_OPENVDB=ON \
-  -DWITH_NANOVDB=ON \
   -DWITH_CYCLES_DEVICE_OPTIX=ON \
   -DPUGIXML_INCLUDE_DIR=${PUGIXML_INCLUDE_DIR} \
   -DPUGIXML_LIBRARY=${PUGIXML_LIBRARY} \


### PR DESCRIPTION
## Summary
- detect NanoVDB and OpenImageDenoise once in CMake
- stop hardcoding feature flags in setup script

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6863d8a79704832a8a8320ad65ca11d4