### PR TITLE
Fix conditional feature macros

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,21 @@ find_package(fmt REQUIRED)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(PIPEWIRE REQUIRED libpipewire-0.3)
 
+# Detect NanoVDB and OpenImageDenoise support
+find_path(NANOVDB_INCLUDE_DIR nanovdb/NanoVDB.h)
+if(NANOVDB_INCLUDE_DIR)
+    add_compile_definitions(WITH_NANOVDB=1)
+else()
+    add_compile_definitions(WITH_NANOVDB=0)
+endif()
+
+find_package(OpenImageDenoise QUIET)
+if(OpenImageDenoise_FOUND)
+    add_compile_definitions(WITH_OPENIMAGEDENOISE=1)
+else()
+    add_compile_definitions(WITH_OPENIMAGEDENOISE=0)
+endif()
+
 # Set C++ standard
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/scripts/setup_cycles_env.sh
+++ b/scripts/setup_cycles_env.sh
@@ -199,7 +199,6 @@ export OPENIMAGEDENOISE_LIBRARY=/sep/extern/oidn/build/lib/libOpenImageDenoise.s
 export OPENIMAGEDENOISE_OPENIMAGEDENOISE_LIBRARY=/sep/extern/oidn/build/lib/libOpenImageDenoise.so
 
 # Disable OpenImageDenoise in Cycles build
-export WITH_OPENIMAGEDENOISE=ON
 
 # Set up Epoxy
 export Epoxy_INCLUDE_DIR=/sep/extern/libepoxy/include
@@ -304,8 +303,8 @@ rm -rf CMakeFiles/
 
 echo "Configuring Cycles with CMake..."
 # Add explicit find paths and library properties for OpenVDB if necessary
-cmake -S /sep/extern/cycles -B . \
-  -G Ninja -DWITH_OPENIMAGEDENOISE=ON \
+  cmake -S /sep/extern/cycles -B . \
+    -G Ninja \
   -DCMAKE_INSTALL_PREFIX=/sep/cycles-install \
   -DWITH_CYCLES_STANDALONE=ON \
   -DWITH_CYCLES_DEVICE_CUDA=ON \
@@ -360,7 +359,6 @@ cmake -S /sep/extern/cycles -B . \
   -DZSTD_INCLUDE_DIR=${ZSTD_INCLUDE_DIR} \
   -DZSTD_LIBRARY=${ZSTD_LIBRARY} \
   -DWITH_OPENVDB=ON \
-  -DWITH_NANOVDB=ON \
   -DWITH_CYCLES_DEVICE_OPTIX=ON \
   -DPUGIXML_INCLUDE_DIR=${PUGIXML_INCLUDE_DIR} \
   -DPUGIXML_LIBRARY=${PUGIXML_LIBRARY} \

--- a/scripts/setup_cycles_env_fixed.sh
+++ b/scripts/setup_cycles_env_fixed.sh
@@ -201,7 +201,6 @@ export OPENIMAGEDENOISE_LIBRARY=/sep/extern/oidn/build/lib/libOpenImageDenoise.s
 export OPENIMAGEDENOISE_OPENIMAGEDENOISE_LIBRARY=/sep/extern/oidn/build/lib/libOpenImageDenoise.so
 
 # Disable OpenImageDenoise in Cycles build
-export WITH_OPENIMAGEDENOISE=OFF
 
 # Set up Epoxy
 export Epoxy_INCLUDE_DIR=/sep/extern/libepoxy/include
@@ -972,7 +971,6 @@ cmake -DCMAKE_INSTALL_PREFIX=/sep/cycles-install \
       -DWITH_CYCLES_DEVICE_HIP=OFF \
       -DWITH_CYCLES_DEVICE_METAL=OFF \
       -DWITH_CYCLES_DEVICE_ONEAPI=OFF \
-      -DWITH_OPENIMAGEDENOISE=OFF \
       -DWITH_OPENVDB=ON \
       -DSEP_CUDACC_DISABLE_EXCEPTION_SPEC_CHECKS=1 \
       -DCUDA_NVCC_FLAGS="--allow-unsupported-compiler;-D__CUDACC_DISABLE_EXCEPTION_SPEC_CONFLICTS=1;-Xcompiler;-fno-exceptions;--diag-suppress;20012;--diag-suppress;541;--diag-suppress;177" \

--- a/src/blender/CMakeLists.txt
+++ b/src/blender/CMakeLists.txt
@@ -50,8 +50,6 @@ set(WITH_CYCLES_DEVICE_CUDA ON CACHE BOOL "Enable CUDA support")
 set(WITH_CYCLES_DEVICE_OPTIX ON CACHE BOOL "Enable OptiX support")
 set(WITH_CYCLES_HYDRA_RENDER_DELEGATE OFF CACHE BOOL "Disable Hydra delegate")
 set(WITH_BLENDER OFF CACHE BOOL "Disable Blender integration")
-set(WITH_NANOVDB OFF CACHE BOOL "Disable NanoVDB")
-set(WITH_OPENIMAGEDENOISE OFF CACHE BOOL "Disable OpenImageDenoise")
 
 # Build Cycles libraries
 add_subdirectory(${CMAKE_SOURCE_DIR}/extern/cycles ${CMAKE_BINARY_DIR}/extern/cycles EXCLUDE_FROM_ALL)


### PR DESCRIPTION
## Summary
- detect NanoVDB and OpenImageDenoise once in root CMakeLists
- stop forcing these macros in `src/blender/CMakeLists.txt`
- drop explicit definitions from setup scripts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6863d8a79704832a8a8320ad65ca11d4