### PR TITLE
Fix macro definitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,22 @@ find_package(fmt REQUIRED)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(PIPEWIRE REQUIRED libpipewire-0.3)
 
+# Detect NanoVDB
+find_path(NANOVDB_INCLUDE_DIR nanovdb/NanoVDB.h)
+find_library(NANOVDB_LIBRARY nanovdb)
+set(NANOVDB_FOUND FALSE)
+if(NANOVDB_INCLUDE_DIR AND NANOVDB_LIBRARY)
+    set(NANOVDB_FOUND TRUE)
+endif()
+
+# Detect OpenImageDenoise
+find_path(OPENIMAGEDENOISE_INCLUDE_DIR OpenImageDenoise/config.h)
+find_library(OPENIMAGEDENOISE_LIBRARY OpenImageDenoise)
+set(OPENIMAGEDENOISE_FOUND FALSE)
+if(OPENIMAGEDENOISE_INCLUDE_DIR AND OPENIMAGEDENOISE_LIBRARY)
+    set(OPENIMAGEDENOISE_FOUND TRUE)
+endif()
+
 # Set C++ standard
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -50,6 +66,18 @@ add_compile_definitions(
     SEP_HAS_BLENDER=1
     SEP_HAS_CYCLES=1
 )
+
+if(NANOVDB_FOUND)
+    add_compile_definitions(WITH_NANOVDB=1)
+else()
+    add_compile_definitions(WITH_NANOVDB=0)
+endif()
+
+if(OPENIMAGEDENOISE_FOUND)
+    add_compile_definitions(WITH_OPENIMAGEDENOISE=1)
+else()
+    add_compile_definitions(WITH_OPENIMAGEDENOISE=0)
+endif()
 
 # Set output directories
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)

--- a/scripts/setup_cycles_env.sh
+++ b/scripts/setup_cycles_env.sh
@@ -199,7 +199,7 @@ export OPENIMAGEDENOISE_LIBRARY=/sep/extern/oidn/build/lib/libOpenImageDenoise.s
 export OPENIMAGEDENOISE_OPENIMAGEDENOISE_LIBRARY=/sep/extern/oidn/build/lib/libOpenImageDenoise.so
 
 # Disable OpenImageDenoise in Cycles build
-export WITH_OPENIMAGEDENOISE=ON
+# OIDN is optional; allow CMake detection to decide
 
 # Set up Epoxy
 export Epoxy_INCLUDE_DIR=/sep/extern/libepoxy/include
@@ -305,7 +305,7 @@ rm -rf CMakeFiles/
 echo "Configuring Cycles with CMake..."
 # Add explicit find paths and library properties for OpenVDB if necessary
 cmake -S /sep/extern/cycles -B . \
-  -G Ninja -DWITH_OPENIMAGEDENOISE=ON \
+  -G Ninja \
   -DCMAKE_INSTALL_PREFIX=/sep/cycles-install \
   -DWITH_CYCLES_STANDALONE=ON \
   -DWITH_CYCLES_DEVICE_CUDA=ON \
@@ -360,7 +360,6 @@ cmake -S /sep/extern/cycles -B . \
   -DZSTD_INCLUDE_DIR=${ZSTD_INCLUDE_DIR} \
   -DZSTD_LIBRARY=${ZSTD_LIBRARY} \
   -DWITH_OPENVDB=ON \
-  -DWITH_NANOVDB=ON \
   -DWITH_CYCLES_DEVICE_OPTIX=ON \
   -DPUGIXML_INCLUDE_DIR=${PUGIXML_INCLUDE_DIR} \
   -DPUGIXML_LIBRARY=${PUGIXML_LIBRARY} \

--- a/scripts/setup_cycles_env_fixed.sh
+++ b/scripts/setup_cycles_env_fixed.sh
@@ -201,7 +201,7 @@ export OPENIMAGEDENOISE_LIBRARY=/sep/extern/oidn/build/lib/libOpenImageDenoise.s
 export OPENIMAGEDENOISE_OPENIMAGEDENOISE_LIBRARY=/sep/extern/oidn/build/lib/libOpenImageDenoise.so
 
 # Disable OpenImageDenoise in Cycles build
-export WITH_OPENIMAGEDENOISE=OFF
+# Let CMake decide whether OpenImageDenoise is enabled
 
 # Set up Epoxy
 export Epoxy_INCLUDE_DIR=/sep/extern/libepoxy/include
@@ -972,7 +972,6 @@ cmake -DCMAKE_INSTALL_PREFIX=/sep/cycles-install \
       -DWITH_CYCLES_DEVICE_HIP=OFF \
       -DWITH_CYCLES_DEVICE_METAL=OFF \
       -DWITH_CYCLES_DEVICE_ONEAPI=OFF \
-      -DWITH_OPENIMAGEDENOISE=OFF \
       -DWITH_OPENVDB=ON \
       -DSEP_CUDACC_DISABLE_EXCEPTION_SPEC_CHECKS=1 \
       -DCUDA_NVCC_FLAGS="--allow-unsupported-compiler;-D__CUDACC_DISABLE_EXCEPTION_SPEC_CONFLICTS=1;-Xcompiler;-fno-exceptions;--diag-suppress;20012;--diag-suppress;541;--diag-suppress;177" \


### PR DESCRIPTION
## Summary
- detect NanoVDB and OpenImageDenoise in `CMakeLists.txt`
- define `WITH_NANOVDB` and `WITH_OPENIMAGEDENOISE` once based on detection
- remove command line defines from setup scripts

## Testing
- `bash -n scripts/setup_cycles_env.sh`
- `bash -n scripts/setup_cycles_env_fixed.sh`


------
https://chatgpt.com/codex/tasks/task_e_6863d8a79704832a8a8320ad65ca11d4