### PR TITLE
Align C++ standard to 17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,20 +13,20 @@ find_package(fmt REQUIRED)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(PIPEWIRE REQUIRED libpipewire-0.3)
 
-# Detect optional libraries and define feature macros once
+# Detect optional libraries and store presence flags
 find_path(NANOVDB_INCLUDE_DIR nanovdb/NanoVDB.h)
 if(NANOVDB_INCLUDE_DIR)
     message(STATUS "NanoVDB found: ${NANOVDB_INCLUDE_DIR}")
-    add_compile_definitions(WITH_NANOVDB=1)
+    set(NANOVDB_FOUND TRUE)
 else()
-    add_compile_definitions(WITH_NANOVDB=0)
+    set(NANOVDB_FOUND FALSE)
 endif()
 
 find_package(OpenImageDenoise QUIET)
 if(OpenImageDenoise_FOUND)
-    add_compile_definitions(WITH_OPENIMAGEDENOISE=1)
+    set(OPENIMAGEDENOISE_FOUND TRUE)
 else()
-    add_compile_definitions(WITH_OPENIMAGEDENOISE=0)
+    set(OPENIMAGEDENOISE_FOUND FALSE)
 endif()
 
 # Set C++ standard

--- a/cmake/cuda_compile.sh
+++ b/cmake/cuda_compile.sh
@@ -65,7 +65,7 @@ if [[ "$SOURCE_FILE" == *.cu ]]; then
         -o "$OUTPUT_FILE"
         "${INCLUDES[@]}"
         "${DEFINES[@]}"
-        -std=c++20
+        -std=c++17
         --compiler-bindir=/usr/bin/g++-14
     )
 
@@ -112,6 +112,6 @@ else # For C++ files (not .cu)
         "${INCLUDES[@]}" \
         "${DEFINES[@]}" \
         "${FLAGS[@]}" \
-        -std=c++20 \
+        -std=c++17 \
         -fPIC
 fi

--- a/scripts/setup_cycles_env.sh
+++ b/scripts/setup_cycles_env.sh
@@ -306,6 +306,7 @@ echo "Configuring Cycles with CMake..."
 # Add explicit find paths and library properties for OpenVDB if necessary
 cmake -S /sep/extern/cycles -B . \
   -G Ninja \
+  -DCMAKE_CXX_STANDARD=17 \
   -DCMAKE_INSTALL_PREFIX=/sep/cycles-install \
   -DWITH_CYCLES_STANDALONE=ON \
   -DWITH_CYCLES_DEVICE_CUDA=ON \


### PR DESCRIPTION
## Summary
- detect NanoVDB and OpenImageDenoise but only define macros once
- compile CUDA helpers with `-std=c++17`
- ensure Cycles configuration forces C++17

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_6863db6c0054832abb23b8028312ad9f