### PR TITLE
Fix macro redefinitions and ensure C++17 build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,18 +67,6 @@ add_compile_definitions(
     SEP_HAS_CYCLES=1
 )
 
-if(NANOVDB_FOUND)
-    add_compile_definitions(WITH_NANOVDB=1)
-else()
-    add_compile_definitions(WITH_NANOVDB=0)
-endif()
-
-if(OPENIMAGEDENOISE_FOUND)
-    add_compile_definitions(WITH_OPENIMAGEDENOISE=1)
-else()
-    add_compile_definitions(WITH_OPENIMAGEDENOISE=0)
-endif()
-
 # Set output directories
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)


### PR DESCRIPTION
## Summary
- remove duplicate compile definitions for NanoVDB and OpenImageDenoise
- keep C++17 standard settings in the main build

## Testing
- `cmake -S . -B build` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6863db6c0054832abb23b8028312ad9f