### PR TITLE
Resolve macro redefinition warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,6 @@ find_path(NANOVDB_INCLUDE_DIR nanovdb/NanoVDB.h)
 if(NANOVDB_INCLUDE_DIR)
     message(STATUS "NanoVDB found: ${NANOVDB_INCLUDE_DIR}")
 endif()
-add_compile_definitions(WITH_NANOVDB=${WITH_NANOVDB})
 
 find_package(OpenImageDenoise QUIET)
 

--- a/include/api/crow_adapter_impl.h
+++ b/include/api/crow_adapter_impl.h
@@ -9,7 +9,7 @@
 #pragma once
 
 // Include Crow headers with correct path
-#include "../extern/crow/crow_isolation.h"
+#include "crow/crow_isolation.h"
 
 #include <string>
 #include <memory>


### PR DESCRIPTION
## Summary
- clean up `WITH_NANOVDB` handling in the root `CMakeLists.txt`
- fix Crow adapter header include path

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6863ddd6a070832aa6b966214fb5d9e8