### PR TITLE
Enforce C++17 in setup scripts

### DIFF
--- a/docs/CONFIG_OPTIONS.md
+++ b/docs/CONFIG_OPTIONS.md
@@ -15,3 +15,8 @@ memory promotion thresholds and quantum processing limits.
 - `ltm_coherence_threshold`: coherence needed for patterns to reach LTM.
 - `mtm_coherence_threshold`: coherence needed for MTM.
 - `stability_threshold`: minimum stability for promotion.
+
+## build scripts
+Both `scripts/setup_cycles_env.sh` and `scripts/setup_cycles_env_fixed.sh` require
+the environment variable `CMAKE_CXX_STANDARD` to be set to `17`. The scripts will
+abort before running CMake if this variable differs from `17`.

--- a/scripts/setup_cycles_env.sh
+++ b/scripts/setup_cycles_env.sh
@@ -6,6 +6,12 @@
 
 # Script to set up environment for building Cycles
 
+# Validate C++ standard
+if [ "${CMAKE_CXX_STANDARD:-}" != "17" ]; then
+  echo "Error: CMAKE_CXX_STANDARD must be set to 17 before running this script." >&2
+  exit 1
+fi
+
 # Create build and install directories
 mkdir -p /sep/cycles-build
 mkdir -p /sep/cycles-install

--- a/scripts/setup_cycles_env_fixed.sh
+++ b/scripts/setup_cycles_env_fixed.sh
@@ -6,6 +6,12 @@
 
 # Script to set up environment for building Cycles
 
+# Validate C++ standard
+if [ "${CMAKE_CXX_STANDARD:-}" != "17" ]; then
+  echo "Error: CMAKE_CXX_STANDARD must be set to 17 before running this script." >&2
+  exit 1
+fi
+
 # Create build and install directories
 mkdir -p /sep/cycles-build
 mkdir -p /sep/cycles-install


### PR DESCRIPTION
## Summary
- add C++ standard validation to setup scripts
- document required CMAKE_CXX_STANDARD in config options

## Testing
- `shellcheck scripts/setup_cycles_env.sh`
- `shellcheck scripts/setup_cycles_env_fixed.sh`
- `CMAKE_CXX_STANDARD=20 bash scripts/setup_cycles_env.sh`
- `CMAKE_CXX_STANDARD=20 bash scripts/setup_cycles_env_fixed.sh`


------
https://chatgpt.com/codex/tasks/task_e_6863e019390c832ab619155f52d6097d