### PR TITLE
Add feature flag test for Blender

### DIFF
--- a/tests/blender/CMakeLists.txt
+++ b/tests/blender/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(blender_tests STATIC
     mesh_handler_perf_test.cpp
     mesh_handler_stress_test.cpp
     mesh_handler_test.cpp
+    feature_flags_test.cpp
     pattern_data_test.cpp
     scene_load_test.cpp
     shader_test.cpp

--- a/tests/blender/feature_flags_test.cpp
+++ b/tests/blender/feature_flags_test.cpp
@@ -1,0 +1,30 @@
+#include <gtest/gtest.h>
+
+#ifndef WITH_NANOVDB
+#error "WITH_NANOVDB not defined"
+#endif
+
+#ifndef WITH_OPENIMAGEDENOISE
+#error "WITH_OPENIMAGEDENOISE not defined"
+#endif
+
+static_assert(WITH_NANOVDB == 0 || WITH_NANOVDB == 1,
+              "WITH_NANOVDB must be 0 or 1");
+static_assert(WITH_OPENIMAGEDENOISE == 0 || WITH_OPENIMAGEDENOISE == 1,
+              "WITH_OPENIMAGEDENOISE must be 0 or 1");
+
+TEST(FeatureFlagsTest, NanoVDBValue) {
+#if WITH_NANOVDB == 1
+    EXPECT_EQ(1, WITH_NANOVDB);
+#else
+    EXPECT_EQ(0, WITH_NANOVDB);
+#endif
+}
+
+TEST(FeatureFlagsTest, OpenImageDenoiseValue) {
+#if WITH_OPENIMAGEDENOISE == 1
+    EXPECT_EQ(1, WITH_OPENIMAGEDENOISE);
+#else
+    EXPECT_EQ(0, WITH_OPENIMAGEDENOISE);
+#endif
+}


### PR DESCRIPTION
## Summary
- add compile-time check for WITH_NANOVDB and WITH_OPENIMAGEDENOISE
- hook new test into Blender test suite

## Testing
- `cmake -S . -B build -DBUILD_TESTING=ON` *(fails: Could not find nvcc, please set CUDAToolkit_ROOT)*

------
https://chatgpt.com/codex/tasks/task_e_6863e010f554832aaf69729c1740a520