### PR TITLE
Unify cmake build dir

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -16,6 +16,7 @@ echo "Setting up build environment with real library paths - NO STUBS!"
 # of where the project directory is located on disk.
 REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
 BUILD_DIR="${REPO_ROOT}/cmake-make"
+COMPILE_COMMANDS="${BUILD_DIR}/compile_commands.json"
 SRC_DIR="${REPO_ROOT}"
 LIB_DIR="${SRC_DIR}/lib"
 CYCLES_ROOT_DIR="${SRC_DIR}/extern/cycles"
@@ -71,6 +72,9 @@ cmake -S "${SRC_DIR}" -B "${BUILD_DIR}" \
   -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
   -DCMAKE_EXE_LINKER_FLAGS="-Wl,--no-as-needed" \
   ${PIPEWIRE_CMAKE_ARGS}
+
+# Link compile_commands.json to the repository root for tool integration
+ln -sf "${COMPILE_COMMANDS}" "${REPO_ROOT}/compile_commands.json"
 
 # --- Build and Install ---
 echo "Building SEP Engine..."

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,17 +14,17 @@ Most documentation assumes the code has already been built with CUDA support and
 ## Build Recap
 
 ```bash
-mkdir build
-cd build
+mkdir cmake-make
+cd cmake-make
 cmake ..
 make -j$(nproc)
 ```
 
-The resulting executable lives in `build/sep_engine`. Additional static libraries for each module are produced in the same directory.
+The resulting executable lives in `cmake-make/sep_engine`. Additional static libraries for each module are produced in the same directory.
 
 ## Running the Engine
 
-Execute the engine from the build directory:
+Execute the engine from the build directory (`cmake-make`):
 
 ```bash
 ./sep_engine

--- a/docs/vscodium.md
+++ b/docs/vscodium.md
@@ -2,13 +2,13 @@
 
 1. **Build Directory Inconsistency**:
    - MCP config: `/sep/cmake-make`
-   - build.sh: `/sep/build`
+   - build.sh: `/sep/cmake-make`
    - VSCode: `${workspaceFolder}/cmake-make`
-   - CodeChecker helper: `$PWD/build/compile_commands.json`
+   - CodeChecker helper: `$PWD/cmake-make/compile_commands.json`
 
 2. **Compile Commands Location**:
-   - VSCode settings: `${workspaceFolder}/compile_commands.json`
-   - CodeChecker expects: `build/compile_commands.json`
+   - VSCode settings: `${workspaceFolder}/compile_commands.json` (symlink)
+   - CodeChecker expects: `cmake-make/compile_commands.json`
    - CMake generates: in the build directory
 
 3. **Path References**: Mix of absolute (`/sep`) and relative paths
@@ -214,8 +214,8 @@ graph TD
 
 ### 1. **Standardize Build Directory**
    - Use `/sep/cmake-make` consistently across all tools
-   - Update build.sh to use `cmake-make` instead of `build`
-   - Ensure compile_commands.json is generated in the build directory
+   - `build.sh` outputs to `cmake-make` and symlinks `compile_commands.json` to the repo root
+   - Analysis scripts read `cmake-make/compile_commands.json`
 
 ### 2. **Update Configuration Files**
    - Synchronize paths in all configuration files

--- a/scripts/code_analysis_suite.sh
+++ b/scripts/code_analysis_suite.sh
@@ -5,7 +5,7 @@ set -e
 CODECHECKER_PORT=8001
 CODECHECKER_WORKSPACE="$PWD/.codechecker"
 REPORTS_DIR="$CODECHECKER_WORKSPACE/reports"
-COMPILE_COMMANDS="$PWD/build/compile_commands.json"
+COMPILE_COMMANDS="$PWD/cmake-make/compile_commands.json"
 OLLAMA_URL="http://localhost:11434"
 OLLAMA_MODEL="${OLLAMA_MODEL:-mxbai-embed-large}"
 EMBEDDINGS_DIR="$PWD/.embeddings"

--- a/tests/blender/run_all_tests.sh
+++ b/tests/blender/run_all_tests.sh
@@ -4,7 +4,7 @@
 set -e
 
 # Build directory
-BUILD_DIR="build"
+BUILD_DIR="cmake-make"
 
 # Colors for output
 GREEN='\033[0;32m'

--- a/tests/blender/run_tests.sh
+++ b/tests/blender/run_tests.sh
@@ -4,7 +4,7 @@
 set -e
 
 # Build directory
-BUILD_DIR="build"
+BUILD_DIR="cmake-make"
 
 # Colors for output
 GREEN='\033[0;32m'


### PR DESCRIPTION
## Summary
- ensure build scripts output to `cmake-make`
- link generated compile_commands.json to repo root
- fix analysis script and test runners to use `cmake-make`
- document unified build directory in docs

## Testing
- `bash -n build.sh`
- `bash -n scripts/code_analysis_suite.sh`
- `bash -n tests/blender/run_tests.sh`
- `bash -n tests/blender/run_all_tests.sh`
- `npm run build` *(fails: Cannot find module '@modelcontextprotocol/sdk/server')*
- `bash tests/blender/run_tests.sh` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6863dff40990832abbb93963d12e62bb