### PR TITLE
Add centralized C++17 CMake helper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,10 +21,11 @@ endif()
 
 find_package(OpenImageDenoise QUIET)
 
+# Make custom CMake modules available
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
+
 # Set C++ standard
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_EXTENSIONS OFF)
+include(SetCXXStandard)
 
 # Add subdirectories for main project components
 add_subdirectory(src)

--- a/cmake/SetCXXStandard.cmake
+++ b/cmake/SetCXXStandard.cmake
@@ -1,0 +1,4 @@
+# Helper to set global C++ standard
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Configure C++ standard
+include(SetCXXStandard)
+
 # Configure include paths for all targets
 set(SEP_INCLUDE_DIRS
     ${CMAKE_SOURCE_DIR}/include

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,5 @@
 # Common test configuration
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
+include(SetCXXStandard)
 
 # Configure test output directory
 set(TEST_OUTPUT_DIR ${CMAKE_BINARY_DIR}/tests)


### PR DESCRIPTION
## Summary
- create `SetCXXStandard.cmake` for common C++17 settings
- include helper in root, `src`, and `tests` build files
- remove duplicate `CMAKE_CXX_STANDARD` lines

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: missing nlohmann/json.hpp)*

------
https://chatgpt.com/codex/tasks/task_e_6863e01c84d0832aae11ec460972373d