### PR TITLE
Fix duplicate cycles inclusion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,13 @@ pkg_check_modules(PIPEWIRE REQUIRED libpipewire-0.3)
 cmake_policy(SET CMP0002 NEW)
 cmake_policy(SET CMP0079 NEW)
 
+# Disable standalone Cycles executables and tests
+set(WITH_CYCLES_STANDALONE OFF CACHE BOOL "Disable Cycles standalone executable" FORCE)
+set(WITH_CYCLES_STANDALONE_GUI OFF CACHE BOOL "Disable Cycles standalone GUI" FORCE)
+set(WITH_CYCLES_PRECOMPUTE OFF CACHE BOOL "Disable Cycles precompute executable" FORCE)
+set(WITH_CYCLES_HYDRA_RENDER_DELEGATE OFF CACHE BOOL "Disable Cycles Hydra delegate" FORCE)
+set(WITH_GTESTS OFF CACHE BOOL "Disable Cycles tests" FORCE)
+
 # Add Cycles source directory with custom binary dir and target prefix
 set(CYCLES_TARGET_PREFIX "cycles_ext_" CACHE STRING "Prefix for Cycles targets")
 add_subdirectory(extern/cycles ${CMAKE_BINARY_DIR}/cycles-build EXCLUDE_FROM_ALL)

--- a/src/blender/CMakeLists.txt
+++ b/src/blender/CMakeLists.txt
@@ -46,21 +46,11 @@ target_compile_definitions(sep_blender
         WITH_CYCLES_DEVICE_CUDA
 )
 
-# Configure Cycles build options - all features enabled
-set(WITH_CYCLES_STANDALONE ON)
-set(WITH_CYCLES_DEVICE_CUDA ON)
-set(WITH_CYCLES_DEVICE_OPTIX ON)
-set(WITH_CYCLES_HYDRA_RENDER_DELEGATE OFF)
-set(WITH_BLENDER OFF)
-
 # Use bundled dependencies
 target_include_directories(sep_blender PRIVATE
     ${CMAKE_SOURCE_DIR}/extern/nanovdb
     ${CMAKE_SOURCE_DIR}/extern/oidn
 )
-
-# Build Cycles libraries
-add_subdirectory(${CMAKE_SOURCE_DIR}/extern/cycles ${CMAKE_BINARY_DIR}/extern/cycles EXCLUDE_FROM_ALL)
 
 # Set compiler flags for Cycles targets
 set_target_properties(cycles_device cycles_kernel cycles_util cycles_subd PROPERTIES


### PR DESCRIPTION
## Summary
- remove Blender's copy of add_subdirectory for cycles
- disable cycles standalone executables and tests before adding the external project

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6863fe6209e4832aaa5eac63ff2604de