### PR TITLE
Fix Cycles inclusion and disable extra builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,15 @@ cmake_policy(SET CMP0079 NEW)
 
 # Add Cycles source directory with custom binary dir and target prefix
 set(CYCLES_TARGET_PREFIX "cycles_ext_" CACHE STRING "Prefix for Cycles targets")
+
+# Disable standalone executables and heavy kernel build targets from Cycles.
+set(WITH_CYCLES_STANDALONE OFF CACHE BOOL "Disable standalone Cycles executable" FORCE)
+set(WITH_CYCLES_STANDALONE_GUI OFF CACHE BOOL "Disable Cycles standalone GUI" FORCE)
+set(WITH_CYCLES_PRECOMPUTE OFF CACHE BOOL "Disable Cycles precompute executable" FORCE)
+set(WITH_CYCLES_CUDA_BINARIES OFF CACHE BOOL "Disable precompiled CUDA kernels" FORCE)
+set(WITH_CYCLES_HIP_BINARIES OFF CACHE BOOL "Disable precompiled HIP kernels" FORCE)
+set(WITH_CYCLES_ONEAPI_BINARIES OFF CACHE BOOL "Disable precompiled oneAPI kernels" FORCE)
+
 add_subdirectory(extern/cycles ${CMAKE_BINARY_DIR}/cycles-build EXCLUDE_FROM_ALL)
 
 # Use Cycles' include directories for NanoVDB and OpenImageDenoise

--- a/src/blender/CMakeLists.txt
+++ b/src/blender/CMakeLists.txt
@@ -59,10 +59,7 @@ target_include_directories(sep_blender PRIVATE
     ${CMAKE_SOURCE_DIR}/extern/oidn
 )
 
-# Build Cycles libraries
-add_subdirectory(${CMAKE_SOURCE_DIR}/extern/cycles ${CMAKE_BINARY_DIR}/extern/cycles EXCLUDE_FROM_ALL)
-
-# Set compiler flags for Cycles targets
+# Cycles is added at the top-level CMake. Only adjust properties here.
 set_target_properties(cycles_device cycles_kernel cycles_util cycles_subd PROPERTIES
     COMPILE_FLAGS "-D_LIBCPP_HAS_NO_INCOMPLETE_FORMAT -DFMT_DEPRECATED_OSTREAM"
 )


### PR DESCRIPTION
## Summary
- avoid including `extern/cycles` twice
- disable standalone Cycles executables and precompiled kernels when adding the external project

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6863fe6209e4832aaa5eac63ff2604de