### PR TITLE
Disable standalone Cycles builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,15 @@ cmake_policy(SET CMP0079 NEW)
 
 # Add Cycles source directory with custom binary dir and target prefix
 set(CYCLES_TARGET_PREFIX "cycles_ext_" CACHE STRING "Prefix for Cycles targets")
+set(WITH_CYCLES_STANDALONE OFF CACHE BOOL "Disable Cycles standalone executable" FORCE)
+set(WITH_CYCLES_PRECOMPUTE OFF CACHE BOOL "Disable Cycles precompute executable" FORCE)
+set(WITH_CYCLES_CUDA_BINARIES OFF CACHE BOOL "Disable CUDA binaries" FORCE)
+set(WITH_CYCLES_HIP_BINARIES OFF CACHE BOOL "Disable HIP binaries" FORCE)
+set(WITH_CYCLES_ONEAPI_BINARIES OFF CACHE BOOL "Disable oneAPI binaries" FORCE)
+set(WITH_GTESTS OFF CACHE BOOL "Disable gtests" FORCE)
+set(BUILD_TESTING OFF CACHE BOOL "Disable tests" FORCE)
+set(WITH_CYCLES_HYDRA_RENDER_DELEGATE OFF CACHE BOOL "Disable Hydra delegate" FORCE)
+set(WITH_CYCLES_STANDALONE_GUI OFF CACHE BOOL "Disable Cycles GUI" FORCE)
 add_subdirectory(extern/cycles ${CMAKE_BINARY_DIR}/cycles-build EXCLUDE_FROM_ALL)
 
 # Use Cycles' include directories for NanoVDB and OpenImageDenoise

--- a/src/blender/CMakeLists.txt
+++ b/src/blender/CMakeLists.txt
@@ -59,9 +59,6 @@ target_include_directories(sep_blender PRIVATE
     ${CMAKE_SOURCE_DIR}/extern/oidn
 )
 
-# Build Cycles libraries
-add_subdirectory(${CMAKE_SOURCE_DIR}/extern/cycles ${CMAKE_BINARY_DIR}/extern/cycles EXCLUDE_FROM_ALL)
-
 # Set compiler flags for Cycles targets
 set_target_properties(cycles_device cycles_kernel cycles_util cycles_subd PROPERTIES
     COMPILE_FLAGS "-D_LIBCPP_HAS_NO_INCOMPLETE_FORMAT -DFMT_DEPRECATED_OSTREAM"


### PR DESCRIPTION
## Summary
- ensure Cycles subdirectory is only added once
- disable standalone executables and tests when building Cycles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6863fe6209e4832aaa5eac63ff2604de