### PR TITLE
Fix Cycles renderer compilation

### DIFF
--- a/include/blender/cycles_renderer.h
+++ b/include/blender/cycles_renderer.h
@@ -5,6 +5,7 @@
 #include "core/types.h"
 #include "core/common.h"
 #include "blender/cycles_compat.h"
+#include "compat/cycles.h"
 
 namespace sep {
 namespace blender {

--- a/include/quantum/data.hpp
+++ b/include/quantum/data.hpp
@@ -27,6 +27,7 @@ struct PatternData {
   std::uint32_t mutation_count{0};
   ::sep::memory::MemoryTierEnum memory_tier{::sep::memory::MemoryTierEnum::STM};
   std::vector<::sep::quantum::PatternRelationship> relationships;
+  std::vector<float> data;
 };
 
 struct PatternConfig {

--- a/src/blender/cycles_renderer.cpp
+++ b/src/blender/cycles_renderer.cpp
@@ -2,6 +2,8 @@
 #include "core/error_handler.h"
 #include "core/types.h"
 #include "quantum/data.hpp"
+#include "compat/cycles.h"
+#include <memory>
 
 namespace sep {
 namespace blender {
@@ -20,9 +22,12 @@ SEPResult CyclesRenderer::initialize() {
         return SEPResult::FEATURE_UNAVAILABLE;
     }
     try {
-        initialized_ = true;
 #ifdef SEP_HAS_CYCLES
-        cycles_scene_ = new ::ccl::Scene();
+        ::ccl::SceneParams scene_params;
+        initialized_ = true;
+        cycles_scene_ = new ::ccl::Scene(scene_params, nullptr);
+#else
+        initialized_ = true;
 #endif
         return SEPResult::SUCCESS;
     } catch (const std::exception& e) {
@@ -93,12 +98,12 @@ bool CyclesRenderer::render(const std::string& filepath) {
 
 #ifdef SEP_HAS_CYCLES
     // Initialize session
-    ccl::SessionParams session_params;
+    ::ccl::SessionParams session_params;
     session_params.progressive = true;
     session_params.background = true;
     session_params.threads = 0; // Auto-detect thread count
     
-    ccl::Session *session = new ccl::Session(session_params);
+    ::ccl::Session *session = new ::ccl::Session(session_params);
     session->scene = cycles_scene_;
 
     // Start render
@@ -106,10 +111,10 @@ bool CyclesRenderer::render(const std::string& filepath) {
     session->wait();
 
     // Save render result
-    ccl::ImageFormat format;
+    ::ccl::ImageFormat format;
     format.width = cycles_scene_->params.width;
     format.height = cycles_scene_->params.height;
-    format.type = ccl::IMAGE_DATA_TYPE_FLOAT;
+    format.type = ::ccl::IMAGE_DATA_TYPE_FLOAT;
     format.channels = 4;
 
     session->write_render_tile(filepath.c_str(), &format);
@@ -138,7 +143,7 @@ void CyclesRenderer::createGeometryFromPattern(const pattern::PatternData& patte
     mesh->attributes.add(::ccl::ATTR_STD_UV, "uvmap");
     
     // Add mesh to scene
-    cycles_scene_->geometry.push_back(mesh);
+    cycles_scene_->geometry.push_back(std::unique_ptr<::ccl::Geometry>(mesh));
 }
 
 void CyclesRenderer::convertPatternToMesh(const pattern::PatternData& pattern,


### PR DESCRIPTION
## Summary
- include compat/cycles headers for full Cycles type definitions
- initialize Scene with SceneParams
- push meshes using unique_ptr
- expose `data` vector in `PatternData`

## Testing
- `scripts/code_analysis_suite.sh analyze` *(fails: Compile commands file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68640213f328832a856202418f66d20d