### PR TITLE
Fix Cycles renderer integration

### DIFF
--- a/include/blender/cycles_renderer.h
+++ b/include/blender/cycles_renderer.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <string>
 #include <vector>
+#include <memory>
 #include "quantum/data.hpp"
 #include "core/types.h"
 #include "core/common.h"
@@ -33,6 +34,8 @@ private:
     bool initialized_{false};
     std::vector<pattern::PatternData> patterns_;
     ::ccl::Scene* cycles_scene_{nullptr};
+    std::unique_ptr<::ccl::Device> device_;
+    RenderParams last_render_params_{};
 
 #ifdef SEP_HAS_CYCLES
     void createGeometryFromPattern(const pattern::PatternData& pattern);

--- a/src/blender/cycles_renderer.cpp
+++ b/src/blender/cycles_renderer.cpp
@@ -2,6 +2,14 @@
 #include "core/error_handler.h"
 #include "core/types.h"
 #include "quantum/data.hpp"
+#ifdef SEP_HAS_CYCLES
+#  include "scene/camera.h"
+#  include "scene/mesh.h"
+#  include "session/session.h"
+#  include "session/session_params.h"
+#  include "util/stats.h"
+#  include "util/profiling.h"
+#endif
 
 namespace sep {
 namespace blender {
@@ -22,7 +30,12 @@ SEPResult CyclesRenderer::initialize() {
     try {
         initialized_ = true;
 #ifdef SEP_HAS_CYCLES
-        cycles_scene_ = new ::ccl::Scene();
+        ::ccl::SceneParams scene_params;
+        ::ccl::Stats stats;
+        ::ccl::Profiler profiler;
+        ::ccl::DeviceInfo device_info = ::ccl::Device::dummy_device();
+        device_ = ::ccl::Device::create(device_info, stats, profiler, true);
+        cycles_scene_ = new ::ccl::Scene(scene_params, device_.get());
 #endif
         return SEPResult::SUCCESS;
     } catch (const std::exception& e) {
@@ -61,17 +74,11 @@ SEPResult CyclesRenderer::renderScene(const RenderParams& params) {
             return SEPResult::NOT_INITIALIZED;
         }
 
-        // Update scene parameters
-        cycles_scene_->params.width = params.width;
-        cycles_scene_->params.height = params.height;
-        cycles_scene_->params.samples = params.samples;
-        cycles_scene_->params.background = true;
-        cycles_scene_->params.progressive = true;
+        last_render_params_ = params;
 
         // Create camera
         ::ccl::Camera *cam = new ::ccl::Camera();
-        cam->width = params.width;
-        cam->height = params.height;
+        cam->set_screen_size(params.width, params.height);
         cam->fov = 45.0f;
         cycles_scene_->camera = cam;
 
@@ -93,12 +100,13 @@ bool CyclesRenderer::render(const std::string& filepath) {
 
 #ifdef SEP_HAS_CYCLES
     // Initialize session
-    ccl::SessionParams session_params;
+    ::ccl::SessionParams session_params;
     session_params.progressive = true;
     session_params.background = true;
     session_params.threads = 0; // Auto-detect thread count
-    
-    ccl::Session *session = new ccl::Session(session_params);
+    session_params.samples = static_cast<int>(last_render_params_.samples);
+
+    ::ccl::Session *session = new ::ccl::Session(session_params, cycles_scene_->params);
     session->scene = cycles_scene_;
 
     // Start render
@@ -106,10 +114,10 @@ bool CyclesRenderer::render(const std::string& filepath) {
     session->wait();
 
     // Save render result
-    ccl::ImageFormat format;
-    format.width = cycles_scene_->params.width;
-    format.height = cycles_scene_->params.height;
-    format.type = ccl::IMAGE_DATA_TYPE_FLOAT;
+    ::ccl::ImageFormat format;
+    format.width = last_render_params_.width;
+    format.height = last_render_params_.height;
+    format.type = ::ccl::IMAGE_DATA_TYPE_FLOAT;
     format.channels = 4;
 
     session->write_render_tile(filepath.c_str(), &format);
@@ -138,7 +146,7 @@ void CyclesRenderer::createGeometryFromPattern(const pattern::PatternData& patte
     mesh->attributes.add(::ccl::ATTR_STD_UV, "uvmap");
     
     // Add mesh to scene
-    cycles_scene_->geometry.push_back(mesh);
+    cycles_scene_->geometry.push_back(std::unique_ptr<::ccl::Geometry>(mesh));
 }
 
 void CyclesRenderer::convertPatternToMesh(const pattern::PatternData& pattern,
@@ -147,18 +155,19 @@ void CyclesRenderer::convertPatternToMesh(const pattern::PatternData& pattern,
     // Convert pattern data into mesh vertices and triangles
     // This is a simple example - you'll want to implement your own conversion logic
     float scale = 0.1f;
-    for (size_t i = 0; i < pattern.data.size(); i++) {
-        float x = scale * static_cast<float>(i % 10);
-        float y = scale * static_cast<float>(i / 10);
-        float z = scale * pattern.data[i];
+    float z = scale * pattern.amplitude.real();
+    const size_t grid = 10;
+    for (size_t i = 0; i < grid * grid; ++i) {
+        float x = scale * static_cast<float>(i % grid);
+        float y = scale * static_cast<float>(i / grid);
         verts.push_back(::ccl::make_float3(x, y, z));
     }
 
     // Create triangles from vertices
-    for (size_t i = 0; i < verts.size() - 11; i++) {
-        if ((i + 1) % 10 != 0) {
-            triangles.push_back(::ccl::make_int3(i, i + 1, i + 10));
-            triangles.push_back(::ccl::make_int3(i + 1, i + 11, i + 10));
+    for (size_t i = 0; i < verts.size() - grid - 1; i++) {
+        if ((i + 1) % grid != 0) {
+            triangles.push_back(::ccl::make_int3(i, i + 1, i + grid));
+            triangles.push_back(::ccl::make_int3(i + 1, i + grid + 1, i + grid));
         }
     }
 }


### PR DESCRIPTION
## Summary
- fix incomplete Cycles types by including needed headers
- create a dummy Cycles device and keep it alive for the scene
- keep last render parameters for output format
- store camera dimensions via `set_screen_size`
- push meshes into the scene using `unique_ptr`
- simplify pattern mesh conversion using `amplitude` value

## Testing
- `git commit -m "Fix Cycles renderer integration"`


------
https://chatgpt.com/codex/tasks/task_e_68640213f328832a856202418f66d20d