### PR TITLE
Fix Cycles renderer build

### DIFF
--- a/include/blender/cycles_renderer.h
+++ b/include/blender/cycles_renderer.h
@@ -42,6 +42,9 @@ private:
     std::unique_ptr<::ccl::Device> cycles_device_;
 #endif
 
+    int width_{0};
+    int height_{0};
+
 #ifdef SEP_HAS_CYCLES
     void createGeometryFromPattern(const pattern::PatternData& pattern);
     void convertPatternToMesh(const pattern::PatternData& pattern,

--- a/src/blender/cycles_renderer.cpp
+++ b/src/blender/cycles_renderer.cpp
@@ -98,7 +98,7 @@ SEPResult CyclesRenderer::renderScene(const RenderParams& params) {
         ::ccl::Camera *cam = cycles_scene_->camera;
         if (cam) {
             cam->set_screen_size(params.width, params.height);
-            cam->fov = 45.0f * (M_PI_F / 180.0f);
+            cam->set_fov(45.0f * (M_PI_F / 180.0f));
         }
 
         // Create geometry from patterns
@@ -120,11 +120,10 @@ bool CyclesRenderer::render(const std::string& filepath) {
 #ifdef SEP_HAS_CYCLES
     // Initialize session
     ::ccl::SessionParams session_params;
-    session_params.progressive = true;
     session_params.background = true;
     session_params.threads = 0; // Auto-detect thread count
-    
-    ccl::Session *session = new ccl::Session(session_params, cycles_scene_->params);
+
+    ::ccl::Session *session = new ::ccl::Session(session_params, cycles_scene_->params);
     session->scene = cycles_scene_;
 
     // Start render
@@ -132,10 +131,10 @@ bool CyclesRenderer::render(const std::string& filepath) {
     session->wait();
 
     // Save render result
-    ccl::ImageFormat format;
+    ::ccl::ImageFormat format;
     format.width = cycles_scene_->camera->get_full_width();
     format.height = cycles_scene_->camera->get_full_height();
-    format.type = ccl::IMAGE_DATA_TYPE_FLOAT;
+    format.type = ::ccl::IMAGE_DATA_TYPE_FLOAT;
     format.channels = 4;
 
     session->write_render_tile(filepath.c_str(), &format);
@@ -157,11 +156,25 @@ void CyclesRenderer::createGeometryFromPattern(const pattern::PatternData& patte
     std::vector<::ccl::float3> verts;
     std::vector<::ccl::int3> triangles;
     convertPatternToMesh(pattern, verts, triangles);
-    
+
     // Add vertices and faces to mesh
-    mesh->verts = verts;
-    mesh->triangles = triangles;
-    mesh->attributes.add(::ccl::ATTR_STD_UV, "uvmap");
+    ::ccl::vector<::ccl::float3> verts_vec(verts.begin(), verts.end());
+    ::ccl::array<::ccl::float3> verts_array;
+    verts_array = verts_vec;
+
+    ::ccl::vector<int> tri_flat;
+    tri_flat.reserve(triangles.size() * 3);
+    for (const auto &t : triangles) {
+        tri_flat.push_back(t.x);
+        tri_flat.push_back(t.y);
+        tri_flat.push_back(t.z);
+    }
+    ::ccl::array<int> tri_array;
+    tri_array = tri_flat;
+
+    mesh->set_verts(verts_array);
+    mesh->set_triangles(tri_array);
+    mesh->attributes.add(::ccl::ATTR_STD_UV, ::ccl::ustring("uvmap"));
     
     // Add mesh to scene
     cycles_scene_->geometry.push_back(std::unique_ptr<::ccl::Geometry>(mesh));


### PR DESCRIPTION
## Summary
- declare width and height members in `CyclesRenderer`
- use public Cycles API for camera FOV and mesh data
- fix Cycles session initialization and output format handling
- fix attribute addition

## Testing
- `ctest --version`
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_6864059d7c8c832a8e7018f899731b62