### PR TITLE
Fix compile errors in Cycles renderer

### DIFF
--- a/include/blender/cycles_renderer.h
+++ b/include/blender/cycles_renderer.h
@@ -37,6 +37,10 @@ private:
     std::vector<pattern::PatternData> patterns_;
     ::ccl::Scene* cycles_scene_{nullptr};
 #ifdef SEP_HAS_CYCLES
+    int width_{0};
+    int height_{0};
+#endif
+#ifdef SEP_HAS_CYCLES
     ::ccl::Stats cycles_stats_;
     ::ccl::Profiler cycles_profiler_;
     std::unique_ptr<::ccl::Device> cycles_device_;

--- a/src/blender/cycles_renderer.cpp
+++ b/src/blender/cycles_renderer.cpp
@@ -10,6 +10,7 @@
 #include "session/session.h"
 #include "util/math_base.h"
 #include "util/texture.h"
+#include "util/param.h"
 #endif
 
 #ifdef SEP_HAS_CYCLES
@@ -98,7 +99,7 @@ SEPResult CyclesRenderer::renderScene(const RenderParams& params) {
         ::ccl::Camera *cam = cycles_scene_->camera;
         if (cam) {
             cam->set_screen_size(params.width, params.height);
-            cam->fov = 45.0f * (M_PI_F / 180.0f);
+            cam->set_fov(45.0f * (M_PI_F / 180.0f));
         }
 
         // Create geometry from patterns
@@ -120,11 +121,10 @@ bool CyclesRenderer::render(const std::string& filepath) {
 #ifdef SEP_HAS_CYCLES
     // Initialize session
     ::ccl::SessionParams session_params;
-    session_params.progressive = true;
     session_params.background = true;
     session_params.threads = 0; // Auto-detect thread count
     
-    ccl::Session *session = new ccl::Session(session_params, cycles_scene_->params);
+    ::ccl::Session *session = new ::ccl::Session(session_params, cycles_scene_->params);
     session->scene = cycles_scene_;
 
     // Start render
@@ -132,10 +132,10 @@ bool CyclesRenderer::render(const std::string& filepath) {
     session->wait();
 
     // Save render result
-    ccl::ImageFormat format;
+    ::ccl::ImageFormat format;
     format.width = cycles_scene_->camera->get_full_width();
     format.height = cycles_scene_->camera->get_full_height();
-    format.type = ccl::IMAGE_DATA_TYPE_FLOAT;
+    format.type = ::ccl::IMAGE_DATA_TYPE_FLOAT;
     format.channels = 4;
 
     session->write_render_tile(filepath.c_str(), &format);
@@ -157,11 +157,24 @@ void CyclesRenderer::createGeometryFromPattern(const pattern::PatternData& patte
     std::vector<::ccl::float3> verts;
     std::vector<::ccl::int3> triangles;
     convertPatternToMesh(pattern, verts, triangles);
-    
+
     // Add vertices and faces to mesh
-    mesh->verts = verts;
-    mesh->triangles = triangles;
-    mesh->attributes.add(::ccl::ATTR_STD_UV, "uvmap");
+    ::ccl::array<::ccl::float3> verts_array;
+    verts_array = ::ccl::vector<::ccl::float3>(verts.begin(), verts.end());
+    mesh->set_verts(verts_array);
+
+    ::ccl::vector<int> tri_indices;
+    tri_indices.reserve(triangles.size() * 3);
+    for (const auto &tri : triangles) {
+        tri_indices.push_back(tri.x);
+        tri_indices.push_back(tri.y);
+        tri_indices.push_back(tri.z);
+    }
+    ::ccl::array<int> triangles_array;
+    triangles_array = tri_indices;
+    mesh->set_triangles(triangles_array);
+
+    mesh->attributes.add(::ccl::ATTR_STD_UV, ::ccl::ustring("uvmap"));
     
     // Add mesh to scene
     cycles_scene_->geometry.push_back(std::unique_ptr<::ccl::Geometry>(mesh));


### PR DESCRIPTION
## Summary
- add missing width_ and height_ members
- use `set_fov`, `set_verts`, and `set_triangles`
- fix namespace usage and declare image format before use
- add ustring include and correct attribute creation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6864059d7c8c832a8e7018f899731b62