### PR TITLE
Fix redeclarations and Cycles render path

### DIFF
--- a/include/blender/cycles_renderer.h
+++ b/include/blender/cycles_renderer.h
@@ -33,27 +33,19 @@ public:
     bool render(const std::string& filepath);
 
 private:
+#ifdef SEP_HAS_CYCLES
+    using ScenePtr = std::unique_ptr<::ccl::Scene>;
+#endif
+
     bool initialized_{false};
     int width_{0};
     int height_{0};
     std::vector<pattern::PatternData> patterns_;
-    ::ccl::Scene* cycles_scene_{nullptr};
 #ifdef SEP_HAS_CYCLES
-    int width_{0};
-    int height_{0};
-#endif
-#ifdef SEP_HAS_CYCLES
+    ScenePtr cycles_scene_{nullptr};
     ::ccl::Stats cycles_stats_;
     ::ccl::Profiler cycles_profiler_;
     std::unique_ptr<::ccl::Device> cycles_device_;
-#endif
-
-    int width_{0};
-    int height_{0};
-
-#ifdef SEP_HAS_CYCLES
-    int width_{0};
-    int height_{0};
 #endif
 
 #ifdef SEP_HAS_CYCLES

--- a/src/blender/cycles_renderer.cpp
+++ b/src/blender/cycles_renderer.cpp
@@ -24,6 +24,7 @@
 #  include "util/stats.h"
 #  include "util/profiling.h"
 #  include "device/device.h"
+#  include "app/oiio_output_driver.h"
 #  include "scene/image.h"
 #  include "util/vector.h"
 #  include "util/array.h"
@@ -57,7 +58,7 @@ SEPResult CyclesRenderer::initialize() {
             return SEPResult::INITIALIZATION_FAILED;
         }
         ::ccl::SceneParams scene_params;
-        cycles_scene_ = new ::ccl::Scene(scene_params, cycles_device_.get());
+        cycles_scene_ = std::make_unique<::ccl::Scene>(scene_params, cycles_device_.get());
 #endif
         return SEPResult::SUCCESS;
     } catch (const std::exception& e) {
@@ -128,20 +129,17 @@ bool CyclesRenderer::render(const std::string& filepath) {
     session_params.threads = 0; // Auto-detect thread count
     
     ::ccl::Session *session = new ::ccl::Session(session_params, cycles_scene_->params);
-    session->scene = cycles_scene_;
+    session->scene = cycles_scene_.get();
+
+    auto driver = ::ccl::make_unique<::ccl::OIIOOutputDriver>(
+        filepath.c_str(), "Combined",
+        [](const ::ccl::string &msg) { printf("%s\n", msg.c_str()); });
+    session->set_output_driver(std::move(driver));
 
     // Start render
     session->start();
     session->wait();
 
-    // Save render result
-    ::ccl::ImageFormat format;
-    format.width = cycles_scene_->camera->get_full_width();
-    format.height = cycles_scene_->camera->get_full_height();
-    format.type = ::ccl::IMAGE_DATA_TYPE_FLOAT;
-    format.channels = 4;
-
-    session->write_render_tile(filepath.c_str(), &format);
 
     delete session;
     return true;


### PR DESCRIPTION
## Summary
- deduplicate width and height members in `CyclesRenderer`
- store Cycles scene in a `unique_ptr`
- update initialization and session setup accordingly
- switch to `OIIOOutputDriver` for writing renders

## Testing
- `bash tests/blender/run_tests.sh` *(fails: Could not find nvcc, please set CUDAToolkit_ROOT)*
- `bash scripts/code_analysis_suite.sh analyze-all` *(fails: compile commands file not found)*

------
https://chatgpt.com/codex/tasks/task_e_686408c23d7c832a8d6883b2e6a44421