### PR TITLE
Fix Cycles renderer build errors

### DIFF
--- a/include/blender/cycles_renderer.h
+++ b/include/blender/cycles_renderer.h
@@ -37,23 +37,11 @@ private:
     int width_{0};
     int height_{0};
     std::vector<pattern::PatternData> patterns_;
-    ::ccl::Scene* cycles_scene_{nullptr};
-#ifdef SEP_HAS_CYCLES
-    int width_{0};
-    int height_{0};
-#endif
+    std::unique_ptr<::ccl::Scene> cycles_scene_;
 #ifdef SEP_HAS_CYCLES
     ::ccl::Stats cycles_stats_;
     ::ccl::Profiler cycles_profiler_;
     std::unique_ptr<::ccl::Device> cycles_device_;
-#endif
-
-    int width_{0};
-    int height_{0};
-
-#ifdef SEP_HAS_CYCLES
-    int width_{0};
-    int height_{0};
 #endif
 
 #ifdef SEP_HAS_CYCLES

--- a/src/blender/cycles_renderer.cpp
+++ b/src/blender/cycles_renderer.cpp
@@ -25,6 +25,7 @@
 #  include "util/profiling.h"
 #  include "device/device.h"
 #  include "scene/image.h"
+#  include "app/oiio_output_driver.h"
 #  include "util/vector.h"
 #  include "util/array.h"
 #  include "util/string.h"
@@ -57,7 +58,7 @@ SEPResult CyclesRenderer::initialize() {
             return SEPResult::INITIALIZATION_FAILED;
         }
         ::ccl::SceneParams scene_params;
-        cycles_scene_ = new ::ccl::Scene(scene_params, cycles_device_.get());
+        cycles_scene_ = std::make_unique<::ccl::Scene>(scene_params, cycles_device_.get());
 #endif
         return SEPResult::SUCCESS;
     } catch (const std::exception& e) {
@@ -128,21 +129,14 @@ bool CyclesRenderer::render(const std::string& filepath) {
     session_params.threads = 0; // Auto-detect thread count
     
     ::ccl::Session *session = new ::ccl::Session(session_params, cycles_scene_->params);
-    session->scene = cycles_scene_;
+    session->scene = cycles_scene_.get();
+
+    session->set_output_driver(::ccl::make_unique<::ccl::OIIOOutputDriver>(
+        filepath.c_str(), "combined", [](const ::ccl::string &) {}));
 
     // Start render
     session->start();
     session->wait();
-
-    // Save render result
-    ::ccl::ImageFormat format;
-    format.width = cycles_scene_->camera->get_full_width();
-    format.height = cycles_scene_->camera->get_full_height();
-    format.type = ::ccl::IMAGE_DATA_TYPE_FLOAT;
-    format.channels = 4;
-
-    session->write_render_tile(filepath.c_str(), &format);
-
     delete session;
     return true;
 #else


### PR DESCRIPTION
## Summary
- deduplicate width/height members in `CyclesRenderer`
- manage `cycles_scene_` with `unique_ptr`
- initialize scene using `std::make_unique`
- hook up `OIIOOutputDriver` and drop obsolete `ImageFormat` logic

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686408c23d7c832a8d6883b2e6a44421