### PR TITLE
Fix duplicate Cycles scene and add header guard

### DIFF
--- a/extern/cycles/src/app/oiio_output_driver.h
+++ b/extern/cycles/src/app/oiio_output_driver.h
@@ -1,6 +1,7 @@
 /* SPDX-FileCopyrightText: 2021-2022 Blender Foundation
  *
  * SPDX-License-Identifier: Apache-2.0 */
+#pragma once
 
 #include <functional>
 

--- a/include/blender/cycles_renderer.h
+++ b/include/blender/cycles_renderer.h
@@ -41,13 +41,11 @@ private:
     int width_{0};
     int height_{0};
     std::vector<pattern::PatternData> patterns_;
-    std::unique_ptr<::ccl::Scene> cycles_scene_;
 #ifdef SEP_HAS_CYCLES
     ScenePtr cycles_scene_{nullptr};
     ::ccl::Stats cycles_stats_;
     ::ccl::Profiler cycles_profiler_;
     std::unique_ptr<::ccl::Device> cycles_device_;
-    std::unique_ptr<::ccl::Scene> cycles_scene_;
 #endif
 
 #ifdef SEP_HAS_CYCLES

--- a/src/blender/cycles_renderer.cpp
+++ b/src/blender/cycles_renderer.cpp
@@ -3,6 +3,7 @@
 #include "core/error_handler.h"
 #include "core/types.h"
 #include "quantum/data.hpp"
+#include <utility>
 #ifdef SEP_HAS_CYCLES
 #include "device/device.h"
 #include "scene/camera.h"
@@ -134,7 +135,7 @@ bool CyclesRenderer::render(const std::string& filepath) {
     session_params.threads = 0; // Auto-detect thread count
     
     ::ccl::Session *session = new ::ccl::Session(session_params, cycles_scene_->params);
-    session->scene = cycles_scene_.get();
+    session->scene = std::move(cycles_scene_);
 
     session->set_output_driver(::ccl::make_unique<::ccl::OIIOOutputDriver>(
         filepath.c_str(), "Combined", [](const ::ccl::string &msg) {


### PR DESCRIPTION
## Summary
- remove duplicate `cycles_scene_` definitions in `CyclesRenderer`
- protect `OIIOOutputDriver` header with `#pragma once`
- move Cycles scene ownership when starting a session

## Testing
- `bash tests/blender/run_tests.sh` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_68640e395864832a8acbc872793cd3e1