### PR TITLE
Fix Cycles renderer scene handling

### DIFF
--- a/extern/cycles/src/app/oiio_output_driver.h
+++ b/extern/cycles/src/app/oiio_output_driver.h
@@ -2,6 +2,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0 */
 
+#pragma once
+
 #include <functional>
 
 #include "session/output_driver.h"

--- a/include/blender/cycles_renderer.h
+++ b/include/blender/cycles_renderer.h
@@ -33,21 +33,15 @@ public:
     bool render(const std::string& filepath);
 
 private:
-#ifdef SEP_HAS_CYCLES
-    using ScenePtr = std::unique_ptr<::ccl::Scene>;
-#endif
-
     bool initialized_{false};
     int width_{0};
     int height_{0};
     std::vector<pattern::PatternData> patterns_;
     std::unique_ptr<::ccl::Scene> cycles_scene_;
 #ifdef SEP_HAS_CYCLES
-    ScenePtr cycles_scene_{nullptr};
     ::ccl::Stats cycles_stats_;
     ::ccl::Profiler cycles_profiler_;
     std::unique_ptr<::ccl::Device> cycles_device_;
-    std::unique_ptr<::ccl::Scene> cycles_scene_;
 #endif
 
 #ifdef SEP_HAS_CYCLES

--- a/src/blender/cycles_renderer.cpp
+++ b/src/blender/cycles_renderer.cpp
@@ -134,7 +134,7 @@ bool CyclesRenderer::render(const std::string& filepath) {
     session_params.threads = 0; // Auto-detect thread count
     
     ::ccl::Session *session = new ::ccl::Session(session_params, cycles_scene_->params);
-    session->scene = cycles_scene_.get();
+    session->scene.swap(cycles_scene_);
 
     session->set_output_driver(::ccl::make_unique<::ccl::OIIOOutputDriver>(
         filepath.c_str(), "Combined", [](const ::ccl::string &msg) {
@@ -145,6 +145,7 @@ bool CyclesRenderer::render(const std::string& filepath) {
     session->start();
     session->wait();
 
+    cycles_scene_.swap(session->scene);
     delete session;
     return true;
 #else


### PR DESCRIPTION
## Summary
- avoid duplicate includes for `oiio_output_driver.h`
- remove redundant declarations for `cycles_scene_`
- preserve `cycles_scene_` ownership while rendering

## Testing
- `cmake -S . -B build -DSEP_HAS_CYCLES=OFF` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_68640e395864832a8acbc872793cd3e1