### PR TITLE
Fix Cycles library link names

### DIFF
--- a/src/blender/CMakeLists.txt
+++ b/src/blender/CMakeLists.txt
@@ -53,11 +53,14 @@ target_include_directories(sep_blender PRIVATE
 )
 
 # Link against Cycles libraries
+# Link against Cycles libraries built in the extern/cycles subdirectory.
+# Respect the target prefix configured at the project root so the linker
+# resolves the correct library names when a custom prefix is in use.
 target_link_libraries(sep_blender PRIVATE
-    cycles_device
-    cycles_kernel
-    cycles_util
-    cycles_subd
+    ${CYCLES_TARGET_PREFIX}cycles_device
+    ${CYCLES_TARGET_PREFIX}cycles_kernel
+    ${CYCLES_TARGET_PREFIX}cycles_util
+    ${CYCLES_TARGET_PREFIX}cycles_subd
 )
 
 # Set library properties


### PR DESCRIPTION
## Summary
- link the sep_blender target to the correct Cycles library names
- respect `CYCLES_TARGET_PREFIX` when referencing Cycles targets

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68641052db18832a84b8d494db294d1d