### PR TITLE
Handle missing Cycles submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,13 +50,21 @@ set(WITH_CYCLES_CUDA_BINARIES OFF CACHE BOOL "Disable precompiled CUDA kernels" 
 set(WITH_CYCLES_HIP_BINARIES OFF CACHE BOOL "Disable precompiled HIP kernels" FORCE)
 set(WITH_CYCLES_ONEAPI_BINARIES OFF CACHE BOOL "Disable precompiled oneAPI kernels" FORCE)
 
-add_subdirectory(extern/cycles ${CMAKE_BINARY_DIR}/cycles-build EXCLUDE_FROM_ALL)
+if(EXISTS "${CMAKE_SOURCE_DIR}/extern/cycles/CMakeLists.txt")
+  add_subdirectory(extern/cycles ${CMAKE_BINARY_DIR}/cycles-build EXCLUDE_FROM_ALL)
+  set(SEP_HAS_CYCLES 1)
+else()
+  message(WARNING "Cycles submodule not found, disabling Cycles integration")
+  set(SEP_HAS_CYCLES 0)
+endif()
 
 # Use Cycles' include directories for NanoVDB and OpenImageDenoise
-include_directories(
-    ${CMAKE_SOURCE_DIR}/extern/cycles/third_party/nanovdb
-    ${CMAKE_SOURCE_DIR}/extern/cycles/third_party/OpenImageDenoise/include
-)
+if(SEP_HAS_CYCLES)
+  include_directories(
+      ${CMAKE_SOURCE_DIR}/extern/cycles/third_party/nanovdb
+      ${CMAKE_SOURCE_DIR}/extern/cycles/third_party/OpenImageDenoise/include
+  )
+endif()
 
 # Set CMake module path for OpenVDB
 list(APPEND CMAKE_MODULE_PATH "/usr/lib64/cmake/OpenVDB")
@@ -108,7 +116,7 @@ set(SEP_BUILD_TESTS 1)
 set(SEP_ENABLE_CUDA 1)
 set(SEP_HAS_BLENDER 1)
 set(SEP_HAS_CUDA 1)
-set(SEP_HAS_CYCLES 1)
+# SEP_HAS_CYCLES is set above based on submodule availability
 
 # Configure Blender paths
 set(BLENDER_VERSION "5.0")
@@ -120,7 +128,7 @@ add_compile_definitions(
     SEP_ENABLE_CUDA=1
     SEP_HAS_BLENDER=1
     SEP_HAS_CUDA=1
-    SEP_HAS_CYCLES=1
+    SEP_HAS_CYCLES=${SEP_HAS_CYCLES}
     WITH_CYCLES_NANOVDB=1
     WITH_CYCLES_OPENIMAGEDENOISE=1
     WITH_CYCLES_OPENVDB=1

--- a/src/blender/CMakeLists.txt
+++ b/src/blender/CMakeLists.txt
@@ -27,21 +27,25 @@ target_link_libraries(sep_blender
         sep_compat
 )
 
-# Add cycles_renderer.cpp unconditionally
-target_sources(sep_blender PRIVATE cycles_renderer.cpp)
+# Add Cycles renderer when available
+if(SEP_HAS_CYCLES)
+  target_sources(sep_blender PRIVATE cycles_renderer.cpp)
+endif()
 
 # Link directly against Blender's Cycles
 set(BLENDER_VERSION "5.0")
 set(BLENDER_USER_CONFIG_DIR "$ENV{HOME}/.config/blender/${BLENDER_VERSION}")
 
-# Use bundled Cycles headers
-target_include_directories(sep_blender PRIVATE
-    ${CMAKE_SOURCE_DIR}/extern/cycles/src
-)
+# Use bundled Cycles headers when available
+if(SEP_HAS_CYCLES)
+  target_include_directories(sep_blender PRIVATE
+      ${CMAKE_SOURCE_DIR}/extern/cycles/src
+  )
+endif()
 
 target_compile_definitions(sep_blender
     PUBLIC
-        SEP_HAS_CYCLES=1
+        SEP_HAS_CYCLES=${SEP_HAS_CYCLES}
     PRIVATE
         WITH_CYCLES_DEVICE_CUDA
 )
@@ -53,12 +57,14 @@ target_include_directories(sep_blender PRIVATE
 )
 
 # Link against Cycles libraries
-target_link_libraries(sep_blender PRIVATE
-    cycles_device
-    cycles_kernel
-    cycles_util
-    cycles_subd
-)
+if(SEP_HAS_CYCLES)
+  target_link_libraries(sep_blender PRIVATE
+      cycles_device
+      cycles_kernel
+      cycles_util
+      cycles_subd
+  )
+endif()
 
 # Set library properties
 set_target_properties(sep_blender PROPERTIES
@@ -74,5 +80,9 @@ target_include_directories(sep_blender
         ${CMAKE_SOURCE_DIR}/extern
         ${CMAKE_SOURCE_DIR}/extern/glm
         ${CMAKE_SOURCE_DIR}/extern/eigen
-        ${CMAKE_SOURCE_DIR}/extern/cycles/src
 )
+if(SEP_HAS_CYCLES)
+  target_include_directories(sep_blender PUBLIC
+      ${CMAKE_SOURCE_DIR}/extern/cycles/src
+  )
+endif()


### PR DESCRIPTION
## Summary
- make Cycles integration optional
- skip linking to Cycles when the submodule is missing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68641052db18832a84b8d494db294d1d