### PR TITLE
Fix Cycles link names

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,8 +39,10 @@ set(WITH_CYCLES_PRECOMPUTE OFF CACHE BOOL "Disable Cycles precompute executable"
 set(WITH_CYCLES_HYDRA_RENDER_DELEGATE OFF CACHE BOOL "Disable Cycles Hydra delegate" FORCE)
 set(WITH_GTESTS OFF CACHE BOOL "Disable Cycles tests" FORCE)
 
-# Add Cycles source directory with custom binary dir and target prefix
-set(CYCLES_TARGET_PREFIX "cycles_ext_" CACHE STRING "Prefix for Cycles targets")
+# Add Cycles source directory. Disable target prefixing so that the
+# library names match the upstream Cycles build which expects targets
+# like `cycles_device` and `cycles_kernel`.
+set(CYCLES_TARGET_PREFIX "" CACHE STRING "Prefix for Cycles targets")
 
 # Disable standalone executables and heavy kernel build targets from Cycles.
 set(WITH_CYCLES_STANDALONE OFF CACHE BOOL "Disable standalone Cycles executable" FORCE)


### PR DESCRIPTION
## Summary
- disable the custom Cycles target prefix so the linker looks for the default `cycles_*` libraries

## Testing
- `cmake -S . -B build_test -DCMAKE_C_COMPILER=/usr/bin/gcc -DCMAKE_CXX_COMPILER=/usr/bin/g++` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6864129c7fd0832a8f1ece6f3cf6b4ed