### PR TITLE
Fix cycles library prefix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,8 +39,9 @@ set(WITH_CYCLES_PRECOMPUTE OFF CACHE BOOL "Disable Cycles precompute executable"
 set(WITH_CYCLES_HYDRA_RENDER_DELEGATE OFF CACHE BOOL "Disable Cycles Hydra delegate" FORCE)
 set(WITH_GTESTS OFF CACHE BOOL "Disable Cycles tests" FORCE)
 
-# Add Cycles source directory with custom binary dir and target prefix
-set(CYCLES_TARGET_PREFIX "cycles_ext_" CACHE STRING "Prefix for Cycles targets")
+# Add Cycles source directory. Use the default target names for Cycles
+# libraries so linking works without additional prefixes.
+set(CYCLES_TARGET_PREFIX "" CACHE STRING "Prefix for Cycles targets")
 
 # Disable standalone executables and heavy kernel build targets from Cycles.
 set(WITH_CYCLES_STANDALONE OFF CACHE BOOL "Disable standalone Cycles executable" FORCE)

--- a/src/blender/CMakeLists.txt
+++ b/src/blender/CMakeLists.txt
@@ -57,8 +57,9 @@ target_include_directories(sep_blender PRIVATE
 )
 
 # Link against Cycles libraries built in the extern/cycles subdirectory.
-# Respect the target prefix configured at the project root so the linker
-# resolves the correct library names when a custom prefix is in use.
+# Link against the Cycles libraries built in the extern/cycles directory.
+# The CYCLES_TARGET_PREFIX is empty by default but can be overridden if
+# custom target names are desired.
 target_link_libraries(sep_blender PRIVATE
     ${CYCLES_TARGET_PREFIX}cycles_device
     ${CYCLES_TARGET_PREFIX}cycles_kernel


### PR DESCRIPTION
## Summary
- use default target names for cycles libraries
- document optional cycles prefix handling

## Testing
- `cmake ..` *(fails: Could not find nvcc; dnf5 not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864129c7fd0832a8f1ece6f3cf6b4ed