### PR TITLE
Fix Cycles library target names

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,8 +39,7 @@ set(WITH_CYCLES_PRECOMPUTE OFF CACHE BOOL "Disable Cycles precompute executable"
 set(WITH_CYCLES_HYDRA_RENDER_DELEGATE OFF CACHE BOOL "Disable Cycles Hydra delegate" FORCE)
 set(WITH_GTESTS OFF CACHE BOOL "Disable Cycles tests" FORCE)
 
-# Add Cycles source directory with custom binary dir and target prefix
-set(CYCLES_TARGET_PREFIX "cycles_ext_" CACHE STRING "Prefix for Cycles targets")
+# Add Cycles source directory
 
 # Disable standalone executables and heavy kernel build targets from Cycles.
 set(WITH_CYCLES_STANDALONE OFF CACHE BOOL "Disable standalone Cycles executable" FORCE)

--- a/src/blender/CMakeLists.txt
+++ b/src/blender/CMakeLists.txt
@@ -60,10 +60,10 @@ target_include_directories(sep_blender PRIVATE
 # Respect the target prefix configured at the project root so the linker
 # resolves the correct library names when a custom prefix is in use.
 target_link_libraries(sep_blender PRIVATE
-    ${CYCLES_TARGET_PREFIX}cycles_device
-    ${CYCLES_TARGET_PREFIX}cycles_kernel
-    ${CYCLES_TARGET_PREFIX}cycles_util
-    ${CYCLES_TARGET_PREFIX}cycles_subd
+    cycles_device
+    cycles_kernel
+    cycles_util
+    cycles_subd
 )
 
 # Set library properties


### PR DESCRIPTION
## Summary
- fix blender target linkage for cycles libraries
- drop unused cycles prefix variable

## Testing
- `grep -n "cannot find -lcycles" -n build.log`


------
https://chatgpt.com/codex/tasks/task_e_6864129c7fd0832a8f1ece6f3cf6b4ed