### PR TITLE
Fix build script compiler detection and enforce Cycles target names

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,9 @@ cmake_policy(SET CMP0079 NEW)
 # The upstream Cycles build uses the standard target names (e.g. cycles_device).
 # Avoid setting a custom target prefix so the linker can locate the generated
 # libraries without additional indirection.
-set(CYCLES_TARGET_PREFIX "" CACHE STRING "Prefix for Cycles targets")
+# Ensure the Cycles libraries use their standard target names so our
+# external linkage does not need any custom prefixes.
+set(CYCLES_TARGET_PREFIX "" CACHE STRING "Prefix for Cycles targets" FORCE)
 
 if(EXISTS "${CMAKE_SOURCE_DIR}/extern/cycles/CMakeLists.txt")
   add_subdirectory(extern/cycles ${CMAKE_BINARY_DIR}/cycles-build EXCLUDE_FROM_ALL)

--- a/build.sh
+++ b/build.sh
@@ -20,7 +20,16 @@ COMPILE_COMMANDS="${BUILD_DIR}/compile_commands.json"
 SRC_DIR="${REPO_ROOT}"
 LIB_DIR="${SRC_DIR}/lib"
 CYCLES_ROOT_DIR="${SRC_DIR}/extern/cycles"
-CMAKE_C_COMPILER_ID="/usr/bin/g++-14"
+# Resolve compilers. Use GCC/G++ 14 if available, otherwise
+# fall back to the default versions installed on the system.
+C_COMPILER="/usr/bin/gcc-14"
+CXX_COMPILER="/usr/bin/g++-14"
+if [ ! -x "$C_COMPILER" ]; then
+  C_COMPILER="/usr/bin/gcc"
+fi
+if [ ! -x "$CXX_COMPILER" ]; then
+  CXX_COMPILER="/usr/bin/g++"
+fi
 
 # Create build directory
 mkdir -p "${BUILD_DIR}"
@@ -67,10 +76,11 @@ echo "Running CMake configuration..."
 cd "${BUILD_DIR}"
 
 cmake -S "${SRC_DIR}" -B "${BUILD_DIR}" \
-  -DCMAKE_C_COMPILER=/usr/bin/gcc-14 \
-  -DCMAKE_CXX_COMPILER=/usr/bin/g++-14 \
+  -DCMAKE_C_COMPILER=${C_COMPILER} \
+  -DCMAKE_CXX_COMPILER=${CXX_COMPILER} \
   -DCMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}" \
   -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+  -DCYCLES_TARGET_PREFIX="" \
   -DCMAKE_EXE_LINKER_FLAGS="-Wl,--no-as-needed" \
   ${PIPEWIRE_CMAKE_ARGS}
 


### PR DESCRIPTION
## Summary
- autodetect available GCC/G++ versions in `build.sh`
- pass `CYCLES_TARGET_PREFIX` to cmake so library names remain standard
- force empty `CYCLES_TARGET_PREFIX` in CMakeLists to avoid prefixed cycle libs

## Testing
- `./build.sh` *(fails: could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_68641d5c5970832a84610799391699b2