### PR TITLE
Fix Cycles linking by building dependencies from source

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ cmake_policy(SET CMP0079 NEW)
 # Avoid setting a custom target prefix so the linker can locate the generated
 # libraries without additional indirection.
 set(CYCLES_TARGET_PREFIX "" CACHE STRING "Prefix for Cycles targets")
+set(WITH_LIBS_PRECOMPILED OFF CACHE BOOL "Use precompiled library dependencies")
 
 if(EXISTS "${CMAKE_SOURCE_DIR}/extern/cycles/CMakeLists.txt")
   add_subdirectory(extern/cycles ${CMAKE_BINARY_DIR}/cycles-build EXCLUDE_FROM_ALL)


### PR DESCRIPTION
## Summary
- disable precompiled Cycles libraries so the build uses the locally built targets

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68641d5c5970832a84610799391699b2