### PR TITLE
Specify system OSL paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,15 @@ find_package(fmt REQUIRED)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(PIPEWIRE REQUIRED libpipewire-0.3)
 
+# Provide explicit OpenShadingLanguage paths when available on the system.
+# These help the bundled Cycles build link against the real OSL libraries
+# instead of relying on stub versions.
+set(OSL_INCLUDE_DIR "/usr/include/OSL" CACHE PATH "OSL include directory")
+set(OSL_OSLCOMP_LIBRARY "/usr/lib64/liboslcomp.so" CACHE FILEPATH "OSL compiler library")
+set(OSL_OSLEXEC_LIBRARY "/usr/lib64/liboslexec.so" CACHE FILEPATH "OSL execution library")
+set(OSL_OSLQUERY_LIBRARY "/usr/lib64/liboslquery.so" CACHE FILEPATH "OSL query library")
+set(OSL_OSLNOISE_LIBRARY "/usr/lib64/liboslnoise.so" CACHE FILEPATH "OSL noise library")
+
 # Set CMake policies for Cycles build
 cmake_policy(SET CMP0002 NEW)
 cmake_policy(SET CMP0079 NEW)

--- a/scripts/local_env_paths.sh.example
+++ b/scripts/local_env_paths.sh.example
@@ -144,3 +144,10 @@ export TBB_LIBRARY="${TBB_LIBRARY:-/usr/lib64/libtbb.so}"
 export OPENVDB_ROOT_DIR="${OPENVDB_ROOT_DIR:-/usr}"
 export OPENVDB_INCLUDE_DIR="${OPENVDB_INCLUDE_DIR:-/usr/include}"
 export OPENVDB_LIBRARY="${OPENVDB_LIBRARY:-/usr/lib64/libopenvdb.so}"
+
+# OpenShadingLanguage
+export OSL_INCLUDE_DIR="${OSL_INCLUDE_DIR:-/usr/include/OSL}"
+export OSL_OSLCOMP_LIBRARY="${OSL_OSLCOMP_LIBRARY:-/usr/lib64/liboslcomp.so}"
+export OSL_OSLEXEC_LIBRARY="${OSL_OSLEXEC_LIBRARY:-/usr/lib64/liboslexec.so}"
+export OSL_OSLQUERY_LIBRARY="${OSL_OSLQUERY_LIBRARY:-/usr/lib64/liboslquery.so}"
+export OSL_OSLNOISE_LIBRARY="${OSL_OSLNOISE_LIBRARY:-/usr/lib64/liboslnoise.so}"


### PR DESCRIPTION
## Summary
- configure system OpenShadingLanguage include and library paths in `CMakeLists.txt`
- extend example environment script with matching OSL variables

## Testing
- `cmake .. -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_68641d5c5970832a84610799391699b2