### PR TITLE
Fix OSL detection and Python mismatch

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -73,8 +73,9 @@ variables set.
 
 The script defines variables including `OPENVDB_INCLUDE_DIR`,
 `OPENVDB_LIBRARY`, `OPENIMAGEIO_INCLUDE_DIR`, `OPENIMAGEIO_LIBRARY`,
-`OPENEXR_INCLUDE_DIR` and others. After executing it you can build Cycles from
-`/sep/cycles-build`:
+`OPENEXR_INCLUDE_DIR` and others. When no OpenShadingLanguage headers are found
+on the system it automatically clones and builds version `v1.13.12.0` under
+`/sep/extern/osl`. After executing it you can build Cycles from `/sep/cycles-build`:
 
 ```bash
 cd /sep/cycles-build

--- a/extern/cycles/CMakeLists.txt
+++ b/extern/cycles/CMakeLists.txt
@@ -127,7 +127,7 @@ set(WITH_CYCLES_NATIVE_ONLY OFF CACHE BOOL "Build Cycles with all kernels" FORCE
 set(WITH_CYCLES_STANDALONE_GUI ON CACHE BOOL "Build Cycles standalone with GUI" FORCE)
 
 # Force Python version
-set(PYTHON_VERSION "3.11" CACHE STRING "Python version" FORCE)
+set(PYTHON_VERSION "3.12" CACHE STRING "Python version" FORCE)
 string(REPLACE "." "" PYTHON_VERSION_NO_DOTS ${PYTHON_VERSION})
 set(Boost_PYTHON_VERSION ${PYTHON_VERSION})
 

--- a/scripts/build_osl.sh
+++ b/scripts/build_osl.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -e
+
+# Build OpenShadingLanguage if not installed system-wide
+OSL_ROOT=/sep/extern/osl
+OSL_VERSION_TAG=v1.13.12.0
+
+if [ ! -f "${OSL_ROOT}/install/lib/liboslcomp.so" ]; then
+  echo "--- Building OpenShadingLanguage ${OSL_VERSION_TAG} ---"
+  mkdir -p /sep/extern
+  cd /sep/extern
+  if [ ! -d "osl" ]; then
+    git clone --depth 1 --branch ${OSL_VERSION_TAG} https://github.com/AcademySoftwareFoundation/OpenShadingLanguage.git osl
+  fi
+  cd osl
+  mkdir -p build install
+  cd build
+  cmake .. -G Ninja \
+    -DCMAKE_INSTALL_PREFIX=${OSL_ROOT}/install \
+    -DBUILD_SHARED_LIBS=ON \
+    -DBUILD_TESTING=OFF \
+    -DCMAKE_CXX_STANDARD=17
+  cmake --build . --target install
+fi
+
+export OSL_ROOT_DIR=${OSL_ROOT}/install
+export OSL_INCLUDE_DIR=${OSL_ROOT_DIR}/include
+export OSL_OSLCOMP_LIBRARY=${OSL_ROOT_DIR}/lib/liboslcomp.so
+export OSL_OSLEXEC_LIBRARY=${OSL_ROOT_DIR}/lib/liboslexec.so
+export OSL_OSLQUERY_LIBRARY=${OSL_ROOT_DIR}/lib/liboslquery.so
+export OSL_OSLNOISE_LIBRARY=${OSL_ROOT_DIR}/lib/liboslnoise.so

--- a/scripts/setup_cycles_env.sh
+++ b/scripts/setup_cycles_env.sh
@@ -22,12 +22,17 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 mkdir -p /sep/cycles-build
 mkdir -p /sep/cycles-install
 
-# Set up environment variables for all dependencies (keep as is, they look mostly correct)
-export PYTHONPATH=/usr/lib/python3.11/site-packages
-export PYTHON_INCLUDE_DIR=/usr/include/python3.11
-export PYTHON_LIBRARY=/usr/lib64/libpython3.11.so
+# Set up Python paths dynamically to match the installed version
+PY_VERSION=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
+export PYTHONPATH=$(python3 - <<'EOF'
+import site
+print(":".join(site.getsitepackages()))
+EOF
+)
+export PYTHON_INCLUDE_DIR=/usr/include/python${PY_VERSION}
+export PYTHON_LIBRARY=/usr/lib64/libpython${PY_VERSION}.so
 export PYTHON_LIBPATH=/usr/lib64
-export PYTHON_INCLUDE_CONFIG_DIR=/usr/include/python3.11
+export PYTHON_INCLUDE_CONFIG_DIR=/usr/include/python${PY_VERSION}
 
 # Set up zlib
 export ZLIB_INCLUDE_DIR=/usr/include
@@ -291,6 +296,12 @@ if ! cmake --build . --target install; then
 fi
 echo "OpenVDB build and install completed."
 
+# Build OpenShadingLanguage when system headers are missing
+if [ ! -f "${OSL_INCLUDE_DIR:-/usr/include/OSL}/OSL/oslversion.h" ]; then
+  echo "--- OpenShadingLanguage headers not found, building locally ---"
+  "${REPO_ROOT}/scripts/build_osl.sh"
+fi
+
 # Verify OpenVDB library existence and name
 OPENVDB_INSTALLED_LIB="/sep/extern/openvdb/install/lib/libopenvdb.so"
 if [ -f "$OPENVDB_INSTALLED_LIB" ]; then
@@ -332,7 +343,7 @@ cmake -S "${REPO_ROOT}/extern/cycles" -B . \
   -DWITH_CYCLES_STANDALONE_GUI=OFF \
   -DWITH_PYTHON_INSTALL=ON \
   -DWITH_PYTHON_MODULE=ON \
-  -DPYTHON_VERSION=3.11 \
+  -DPYTHON_VERSION=${PY_VERSION} \
   -DPYTHON_INCLUDE_DIR=${PYTHON_INCLUDE_DIR} \
   -DPYTHON_LIBRARY=${PYTHON_LIBRARY} \
   -DPYTHON_LIBPATH=${PYTHON_LIBPATH} \


### PR DESCRIPTION
## Summary
- auto-build OpenShadingLanguage when missing
- detect python version automatically in `setup_cycles_env.sh`
- use python 3.12 in Cycles CMake
- document OSL build step in docs

## Testing
- `bash -n scripts/build_osl.sh`
- `bash -n scripts/setup_cycles_env.sh`


------
https://chatgpt.com/codex/tasks/task_e_686420ac5e18832a95ae147d657d67ed