### PR TITLE
Fix Python version detection in build scripts

### DIFF
--- a/scripts/local_env_paths.sh.example
+++ b/scripts/local_env_paths.sh.example
@@ -3,11 +3,12 @@
 # Copy this file to local_env_paths.sh and edit the variables as needed.
 
 # Python
-export PYTHON_VERSION="3.11"
-export PYTHON_LIBRARY="/usr/lib64/libpython3.11.so"
+PY_VER=$(python3 -c 'import sys;print(f"{sys.version_info.major}.{sys.version_info.minor}")')
+export PYTHON_VERSION="${PY_VER}"
+export PYTHON_LIBRARY="/usr/lib64/libpython${PY_VER}.so"
 export PYTHON_LIBPATH="/usr/lib64"
-export PYTHON_INCLUDE_DIR="/usr/include/python3.11"
-export PYTHON_INCLUDE_CONFIG_DIR="/usr/include/python3.11"
+export PYTHON_INCLUDE_DIR="/usr/include/python${PY_VER}"
+export PYTHON_INCLUDE_CONFIG_DIR="/usr/include/python${PY_VER}"
 
 # Zlib
 export ZLIB_INCLUDE_DIR="/usr/include"
@@ -78,7 +79,7 @@ export OPENVDB_LIBRARY="/usr/lib64/libopenvdb.so"
 # directly set needed environment variables for real libraries
 
 # Direct system paths for Python - NO STUBS!
-export PYTHON_VERSION="${PYTHON_VERSION:-3.11}"
+export PYTHON_VERSION="${PYTHON_VERSION:-$PY_VER}"
 export PYTHON_LIBRARY="${PYTHON_LIBRARY:-/usr/lib64/libpython${PYTHON_VERSION}.so}"
 export PYTHON_LIBPATH="${PYTHON_LIBPATH:-/usr/lib64}"
 export PYTHON_INCLUDE_DIR="${PYTHON_INCLUDE_DIR:-/usr/include/python${PYTHON_VERSION}}"

--- a/scripts/setup_cycles_env.sh
+++ b/scripts/setup_cycles_env.sh
@@ -23,11 +23,12 @@ mkdir -p /sep/cycles-build
 mkdir -p /sep/cycles-install
 
 # Set up environment variables for all dependencies (keep as is, they look mostly correct)
-export PYTHONPATH=/usr/lib/python3.11/site-packages
-export PYTHON_INCLUDE_DIR=/usr/include/python3.11
-export PYTHON_LIBRARY=/usr/lib64/libpython3.11.so
+PY_VER=$(python3 -c 'import sys;print(f"{sys.version_info.major}.{sys.version_info.minor}")')
+export PYTHONPATH="/usr/lib/python${PY_VER}/site-packages"
+export PYTHON_INCLUDE_DIR="/usr/include/python${PY_VER}"
+export PYTHON_LIBRARY="/usr/lib64/libpython${PY_VER}.so"
 export PYTHON_LIBPATH=/usr/lib64
-export PYTHON_INCLUDE_CONFIG_DIR=/usr/include/python3.11
+export PYTHON_INCLUDE_CONFIG_DIR="/usr/include/python${PY_VER}"
 
 # Set up zlib
 export ZLIB_INCLUDE_DIR=/usr/include
@@ -332,7 +333,7 @@ cmake -S "${REPO_ROOT}/extern/cycles" -B . \
   -DWITH_CYCLES_STANDALONE_GUI=OFF \
   -DWITH_PYTHON_INSTALL=ON \
   -DWITH_PYTHON_MODULE=ON \
-  -DPYTHON_VERSION=3.11 \
+  -DPYTHON_VERSION=${PY_VER} \
   -DPYTHON_INCLUDE_DIR=${PYTHON_INCLUDE_DIR} \
   -DPYTHON_LIBRARY=${PYTHON_LIBRARY} \
   -DPYTHON_LIBPATH=${PYTHON_LIBPATH} \


### PR DESCRIPTION
## Summary
- adjust Python environment setup to auto-detect installed version
- update sample `local_env_paths.sh` accordingly

## Testing
- `apt-get install -y libopenimageio-dev libopenexr-dev libtbb-dev libboost-all-dev cmake ninja-build git`
- `cmake .. -DCMAKE_INSTALL_PREFIX=/usr/local/osl -DCMAKE_BUILD_TYPE=Release` *(fails: OpenImageIO too old)*

------
https://chatgpt.com/codex/tasks/task_e_686420ac5e18832a95ae147d657d67ed