### PR TITLE
Update outdated dependency diagrams

### DIFF
--- a/docs/diagrams/include-api.md
+++ b/docs/diagrams/include-api.md
@@ -12,7 +12,7 @@ flowchart TD
     CrowServer[Crow Server]
     Middleware[Auth/Rate Limit]
     SepEngine[SepEngine]
-    Processor[Context Processor]
+    Processor[Pattern Processor]
     HttpClient -- request --> CrowServer
     CrowServer -- wrapped request --> Middleware
     Middleware -- validated --> SepEngine
@@ -111,7 +111,7 @@ Abstract interface for rate limiter implementations.
 Defines the abstract `IRequest` base class used across adapters.
 
 ### `sep_engine.h`
-Singleton providing the main API for context validation, pattern processing, embeddings, and other high level operations.
+Singleton providing the main API for pattern processing, embeddings, and other high level operations.
 
 ### `server.h`
 Defines `SEPApiServer` which ties together the Crow server, middleware, and `SepEngine` to form the running HTTP API service.

--- a/docs/diagrams/include-crow.md
+++ b/docs/diagrams/include-crow.md
@@ -20,8 +20,8 @@ HTTP API layer that external clients interact with.
                                |                   |
                                v                   v
                        +-------+---------+  +------+------+
-                       | Memory Manager  |  | Quantum /   |
-                       | (memory)        |  | Context     |
+                       | Memory Manager  |  | Quantum     |
+                       | (memory)        |  | Module      |
                        +-----------------+  +-------------+
 ```
 
@@ -31,11 +31,11 @@ HTTP API layer that external clients interact with.
    incoming JSON, invoke `SepEngine` methods, and build responses.
 3. **Crow Adapter** – `crow_adapter.h/cpp` bridges Crow’s `request` and `response`
    objects with the internal `HttpRequest`/`HttpResponse` interfaces.
-4. **SepEngine API** – Implements the high‑level operations. It consumes context
-   or pattern data and returns JSON results. Located under `src/api` and uses
+4. **SepEngine API** – Implements the high‑level operations. It consumes pattern
+   data and returns JSON results. Located under `src/api` and uses
    headers in `include/api`.
-5. **Memory Manager / Quantum / Context** – Lower‑level modules (`src/memory`,
-   `src/quantum`, `src/context`). These modules provide data storage and algorithmic
+5. **Memory Manager / Quantum Modules** – Lower‑level modules (`src/memory`,
+   `src/quantum`). These modules provide data storage and algorithmic
    processing. The `SepEngine` API passes data from HTTP requests down to these
    subsystems and aggregates their results.
 


### PR DESCRIPTION
## Summary
- update API graph to use `Pattern Processor`
- clarify `sep_engine.h` description
- fix Crow integration diagram and notes after removing the old context module

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68642c050054832aba44fd1c7b1f1eab