### PR TITLE
Fix build errors in compatibility and API headers

### DIFF
--- a/include/blender/api.h
+++ b/include/blender/api.h
@@ -6,6 +6,10 @@
 #include <cstddef>
 
 #ifdef __cplusplus
+namespace sep {
+struct SEPBlenderBridge;
+}
+using SEPBlenderBridge = sep::SEPBlenderBridge;
 extern "C" {
 #endif
 

--- a/include/blender/cycles_renderer.h
+++ b/include/blender/cycles_renderer.h
@@ -5,8 +5,6 @@
 #include "quantum/data.hpp"
 #include "core/types.h"
 #include "core/common.h"
-#include "blender/cycles_compat.h"
-#include <memory>
 #include "compat/cycles.h"
 
 namespace sep {

--- a/include/compat/cycles.h
+++ b/include/compat/cycles.h
@@ -22,10 +22,18 @@
 #define CCL_NAMESPACE_USING_DIRECTIVE using namespace ccl;
 #endif
 
-// Include real Cycles headers when SEP_HAS_CYCLES is explicitly set to 1
-// AND we're not specifically requesting stub implementations with SEP_USE_CYCLES_STUB
-// These are controlled by CMake and passed to the compiler
-#if defined(SEP_HAS_CYCLES) && SEP_HAS_CYCLES == 1 && (!defined(SEP_USE_CYCLES_STUB) || SEP_USE_CYCLES_STUB == 0)
+// Ensure feature toggles have numeric defaults so conditional logic is robust
+#ifndef SEP_HAS_CYCLES
+#define SEP_HAS_CYCLES 0
+#endif
+#ifndef SEP_USE_CYCLES_STUB
+#define SEP_USE_CYCLES_STUB 0
+#endif
+
+// Include real Cycles headers when SEP_HAS_CYCLES is enabled and we are not
+// forcing stub implementations via SEP_USE_CYCLES_STUB. These macros are
+// typically defined through the build system but default to 0 when absent.
+#if SEP_HAS_CYCLES && !SEP_USE_CYCLES_STUB
 // Core Cycles headers - use relative paths for portability
 #include "../extern/cycles/src/scene/scene.h"
 #include "../extern/cycles/src/session/session.h"

--- a/src/blender/api.cpp
+++ b/src/blender/api.cpp
@@ -5,13 +5,8 @@
 #include "blender/pattern_bridge.h"
 #include <memory>
 #include <string>
-// Bridge implementation structure
-struct SEPBlenderBridge
-{
-    std::shared_ptr<sep::pattern::BlenderBridge> impl;
-    SEPAudioMetrics                              audio_metrics{};    // last computed audio metrics
-    SEPPatternMetrics                            pattern_metrics{};  // last collected pattern metrics
-};
+
+using sep::SEPBlenderBridge;
 
 namespace {
 // Version information


### PR DESCRIPTION
## Summary
- ensure SEP_HAS_CYCLES defaults and check logic to avoid empty macro expansion
- alias `SEPBlenderBridge` from the C++ namespace for C API use
- drop duplicate Cycles include and alias usage in renderer
- rely on shared struct definition in blender API implementation

## Testing
- `cmake` configuration *(fails: could not find SEPConfig)*

------
https://chatgpt.com/codex/tasks/task_e_68644125c70c832ab5201b6bef554d5d