### PR TITLE
Fix build macros and bridge visibility

### DIFF
--- a/include/blender/types.h
+++ b/include/blender/types.h
@@ -62,3 +62,6 @@ struct SEPBlenderBridge {
 };
 }  // namespace sep
 
+// Make SEPBlenderBridge accessible from the global namespace for C++ code
+using SEPBlenderBridge = sep::SEPBlenderBridge;
+

--- a/include/compat/cycles.h
+++ b/include/compat/cycles.h
@@ -25,7 +25,7 @@
 // Include real Cycles headers when SEP_HAS_CYCLES is explicitly set to 1
 // AND we're not specifically requesting stub implementations with SEP_USE_CYCLES_STUB
 // These are controlled by CMake and passed to the compiler
-#if defined(SEP_HAS_CYCLES) && SEP_HAS_CYCLES == 1 && (!defined(SEP_USE_CYCLES_STUB) || SEP_USE_CYCLES_STUB == 0)
+#if defined(SEP_HAS_CYCLES) && (!defined(SEP_USE_CYCLES_STUB) || SEP_USE_CYCLES_STUB == 0)
 // Core Cycles headers - use relative paths for portability
 #include "../extern/cycles/src/scene/scene.h"
 #include "../extern/cycles/src/session/session.h"


### PR DESCRIPTION
## Summary
- fix compatibility check in `compat/cycles.h` for when `SEP_HAS_CYCLES` is defined without a value
- expose `SEPBlenderBridge` in the global namespace so API headers compile

## Testing
- `cmake ..` *(fails: include not found)*

------
https://chatgpt.com/codex/tasks/task_e_68644125c70c832ab5201b6bef554d5d