### PR TITLE
Fix CUDA library path

### DIFF
--- a/src/compat/CMakeLists.txt
+++ b/src/compat/CMakeLists.txt
@@ -67,5 +67,5 @@ target_link_libraries(sep_compat
         sep_core
     PRIVATE
         ${CUDA_LIBRARIES}
-        ${CUDAToolkit_LIBRARY_DIR}/libcudart.so
+        ${CUDA_CUDART_LIBRARY}
 )


### PR DESCRIPTION
## Summary
- update CUDA runtime library path in compat build configuration

## Testing
- `cmake -S . -B cmake-make` *(fails: include could not find SEPConfig)*

------
https://chatgpt.com/codex/tasks/task_e_686468eeab80832abed8405831055fd7