### PR TITLE
Fix build failures without Cycles

### DIFF
--- a/include/blender/cycles_renderer.h
+++ b/include/blender/cycles_renderer.h
@@ -31,7 +31,7 @@ public:
     bool render(const std::string& filepath);
 
 private:
-#ifdef SEP_HAS_CYCLES
+#if SEP_HAS_CYCLES
     using ScenePtr = std::unique_ptr<::ccl::Scene>;
 #endif
 
@@ -39,14 +39,14 @@ private:
     int width_{0};
     int height_{0};
     std::vector<pattern::PatternData> patterns_;
-#ifdef SEP_HAS_CYCLES
+#if SEP_HAS_CYCLES
     ScenePtr cycles_scene_{nullptr};
     ::ccl::Stats cycles_stats_;
     ::ccl::Profiler cycles_profiler_;
     std::unique_ptr<::ccl::Device> cycles_device_;
 #endif
 
-#ifdef SEP_HAS_CYCLES
+#if SEP_HAS_CYCLES
     void createGeometryFromPattern(const pattern::PatternData& pattern);
     void convertPatternToMesh(const pattern::PatternData& pattern,
                              std::vector<::ccl::float3>& verts,

--- a/include/compat/cycles.h
+++ b/include/compat/cycles.h
@@ -25,7 +25,7 @@
 // Include real Cycles headers when SEP_HAS_CYCLES is explicitly set to 1
 // AND we're not specifically requesting stub implementations with SEP_USE_CYCLES_STUB
 // These are controlled by CMake and passed to the compiler
-#if defined(SEP_HAS_CYCLES) && (!defined(SEP_USE_CYCLES_STUB) || SEP_USE_CYCLES_STUB == 0)
+#if defined(SEP_HAS_CYCLES) && SEP_HAS_CYCLES && (!defined(SEP_USE_CYCLES_STUB) || SEP_USE_CYCLES_STUB == 0)
 // Core Cycles headers - use relative paths for portability
 #include "../extern/cycles/src/scene/scene.h"
 #include "../extern/cycles/src/session/session.h"

--- a/src/blender/CMakeLists.txt
+++ b/src/blender/CMakeLists.txt
@@ -36,18 +36,20 @@ if(SEP_HAS_CUDA)
     target_link_libraries(sep_blender PRIVATE CUDA::cudart)
 endif()
 
-# Add Cycles renderer when available
-if(SEP_HAS_CYCLES)
-  target_sources(sep_blender PRIVATE
-    cycles_renderer.cpp
-  )
-  
-  # Ensure Cycles renderer is built with CUDA support
-  set_source_files_properties(cycles_renderer.cpp
-    PROPERTIES
-    COMPILE_FLAGS "-DWITH_CYCLES_DEVICE_CUDA"
-  )
-endif()
+# Always compile the Cycles renderer.  When SEP_HAS_CYCLES is not
+# defined the implementation falls back to stub logic so we still
+# need the translation unit to satisfy symbol references.
+target_sources(sep_blender PRIVATE
+  cycles_renderer.cpp
+)
+
+# When real Cycles support is available compile with the device flag so
+# the CUDA integration paths are enabled.  The flag is harmless when
+# building the stub implementation.
+set_source_files_properties(cycles_renderer.cpp
+  PROPERTIES
+  COMPILE_FLAGS "-DWITH_CYCLES_DEVICE_CUDA"
+)
 
 # Link directly against Blender's Cycles
 set(BLENDER_VERSION "5.0")

--- a/src/blender/cycles_renderer.cpp
+++ b/src/blender/cycles_renderer.cpp
@@ -9,7 +9,7 @@
 #include "core/types.h"
 #include "quantum/data.hpp"
 
-#ifdef SEP_HAS_CYCLES
+#if SEP_HAS_CYCLES
 // Cycles core includes
 #include "device/device.h"
 #include "scene/camera.h"
@@ -37,7 +37,7 @@ namespace blender {
 namespace ccl {
 
 SEPResult CyclesRenderer::isCyclesAvailable() {
-#ifdef SEP_HAS_CYCLES
+#if SEP_HAS_CYCLES
     return SEPResult::SUCCESS;
 #else
     return SEPResult::FEATURE_UNAVAILABLE;
@@ -49,7 +49,7 @@ SEPResult CyclesRenderer::initialize() {
         return SEPResult::FEATURE_UNAVAILABLE;
     }
     try {
-#ifdef SEP_HAS_CYCLES
+#if SEP_HAS_CYCLES
         ::ccl::DeviceInfo device_info;
         cycles_device_ = ::ccl::Device::create(device_info,
                                                cycles_stats_,
@@ -76,7 +76,7 @@ SEPResult CyclesRenderer::createSceneFromPatterns(const std::vector<pattern::Pat
         return SEPResult::INVALID_ARGUMENT;
     }
     try {
-#ifdef SEP_HAS_CYCLES
+#if SEP_HAS_CYCLES
         patterns_ = patterns;
         
         // Create scene if not already created
@@ -114,7 +114,7 @@ SEPResult CyclesRenderer::renderScene(const RenderParams& params) {
         return SEPResult::INVALID_ARGUMENT;
     }
     try {
-#ifdef SEP_HAS_CYCLES
+#if SEP_HAS_CYCLES
         width_ = params.width;
         height_ = params.height;
         if (!cycles_scene_) {
@@ -198,7 +198,7 @@ bool CyclesRenderer::render(const std::string& filepath) {
         return false;
     }
 
-#ifdef SEP_HAS_CYCLES
+#if SEP_HAS_CYCLES
     // Initialize session
     ::ccl::SessionParams session_params;
     session_params.background = true;
@@ -224,7 +224,7 @@ bool CyclesRenderer::render(const std::string& filepath) {
 #endif
 }
 
-#ifdef SEP_HAS_CYCLES
+#if SEP_HAS_CYCLES
 void CyclesRenderer::createGeometryFromPattern(const pattern::PatternData& pattern) {
     // Create mesh
     ::ccl::Mesh *mesh = new ::ccl::Mesh();


### PR DESCRIPTION
## Summary
- always compile `cycles_renderer.cpp`
- guard Cycles code with `#if SEP_HAS_CYCLES`
- handle `SEP_HAS_CYCLES=0` in `compat/cycles.h`

## Testing
- `npm run build` *(fails: Cannot find module `@modelcontextprotocol/sdk/server`)*

------
https://chatgpt.com/codex/tasks/task_e_6864dbbe9b08832a8fa61f3ab0a12404