### PR TITLE
Fix build linkage for cycles and cuda

### DIFF
--- a/src/blender/CMakeLists.txt
+++ b/src/blender/CMakeLists.txt
@@ -37,12 +37,15 @@ if(SEP_HAS_CUDA)
 endif()
 
 # Add Cycles renderer when available
+# Always compile the Cycles renderer source. It contains internal
+# compile-time guards to fall back to stub implementations when
+# `SEP_HAS_CYCLES` is not enabled, so excluding the file leads to
+# missing symbols at link time.
+target_sources(sep_blender PRIVATE cycles_renderer.cpp)
+
 if(SEP_HAS_CYCLES)
-  target_sources(sep_blender PRIVATE
-    cycles_renderer.cpp
-  )
-  
-  # Ensure Cycles renderer is built with CUDA support
+  # Ensure Cycles renderer is built with CUDA support when the real
+  # Cycles integration is enabled.
   set_source_files_properties(cycles_renderer.cpp
     PROPERTIES
     COMPILE_FLAGS "-DWITH_CYCLES_DEVICE_CUDA"

--- a/src/compat/CMakeLists.txt
+++ b/src/compat/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(sep_compat STATIC
     quantum_kernels.cu
     utils.cu
     event.cu
+    cuda_api_stub.cpp
     stream.cpp
     raii.cpp
 )

--- a/src/compat/cuda_api_stub.cpp
+++ b/src/compat/cuda_api_stub.cpp
@@ -1,0 +1,22 @@
+#ifndef SEP_USE_CUDA
+#include "compat/cuda_api.hpp"
+#include "core/common.h"
+
+extern "C" {
+
+sep::SEPResult sep_cuda_init(int /*device_id*/) { return sep::SEPResult::FEATURE_UNAVAILABLE; }
+sep::SEPResult sep_cuda_cleanup(void) { return sep::SEPResult::SUCCESS; }
+
+sep::SEPResult sep_cuda_process_batch(const std::uint32_t*, const std::uint32_t*,
+                                      std::uint32_t, std::uint32_t*, std::uint32_t*,
+                                      std::uint32_t*) {
+  return sep::SEPResult::FEATURE_UNAVAILABLE;
+}
+
+sep::SEPResult sep_cuda_process_symmetry(const std::uint64_t*, std::uint32_t,
+                                         std::uint32_t*, std::uint32_t*) {
+  return sep::SEPResult::FEATURE_UNAVAILABLE;
+}
+
+}  // extern "C"
+#endif  // SEP_USE_CUDA


### PR DESCRIPTION
## Summary
- always include cycles renderer source so stubs link correctly
- provide CUDA stub implementations used when SEP_USE_CUDA isn't defined

## Testing
- `cmake -S . -B build` *(fails: include could not find requested file: SEPConfig)*

------
https://chatgpt.com/codex/tasks/task_e_6864dbbe9b08832a8fa61f3ab0a12404