### PR TITLE
Fix build linking errors for Cycles stubs

### DIFF
--- a/include/compat/cycles.h
+++ b/include/compat/cycles.h
@@ -173,6 +173,29 @@ namespace ccl {
         int width = 0;
         int height = 0;
     };
+
+    /* Minimal profiler and statistics stubs used when Cycles is not available. */
+    class Profiler {
+    public:
+        Profiler() = default;
+        ~Profiler() = default;
+
+        void reset(int /*num_shaders*/, int /*num_objects*/) {}
+        void start() {}
+        void stop() {}
+    };
+
+    class Stats {
+    public:
+        size_t mem_used = 0;
+        size_t mem_peak = 0;
+
+        Stats() = default;
+        explicit Stats(int /*static_init*/) {}
+
+        void mem_alloc(size_t /*size*/) {}
+        void mem_free(size_t /*size*/) {}
+    };
 }
 #endif // SEP_HAS_CYCLES
 

--- a/src/blender/CMakeLists.txt
+++ b/src/blender/CMakeLists.txt
@@ -36,13 +36,13 @@ if(SEP_HAS_CUDA)
     target_link_libraries(sep_blender PRIVATE CUDA::cudart)
 endif()
 
-# Add Cycles renderer when available
+# Always build the Cycles renderer. When real Cycles is unavailable the
+# implementation relies on stub types provided in `compat/cycles.h`.
+target_sources(sep_blender PRIVATE cycles_renderer.cpp)
+
+# Extra compiler flags are only needed when linking against the real Cycles
+# libraries.
 if(SEP_HAS_CYCLES)
-  target_sources(sep_blender PRIVATE
-    cycles_renderer.cpp
-  )
-  
-  # Ensure Cycles renderer is built with CUDA support
   set_source_files_properties(cycles_renderer.cpp
     PROPERTIES
     COMPILE_FLAGS "-DWITH_CYCLES_DEVICE_CUDA"


### PR DESCRIPTION
## Summary
- provide stub definitions for `ccl::Profiler` and `ccl::Stats` when Cycles is not available
- always compile `cycles_renderer.cpp` so stub implementations link correctly

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6864dbbe9b08832a8fa61f3ab0a12404