### PR TITLE
Fix Cycles header guard

### DIFF
--- a/include/compat/cycles.h
+++ b/include/compat/cycles.h
@@ -22,8 +22,8 @@
 #define CCL_NAMESPACE_USING_DIRECTIVE using namespace ccl;
 #endif
 
-// Core Cycles headers - only include if SEP_HAS_CYCLES is defined
-#ifdef SEP_HAS_CYCLES
+// Core Cycles headers - only include if SEP_HAS_CYCLES is enabled (non-zero)
+#if defined(SEP_HAS_CYCLES) && SEP_HAS_CYCLES
 // Core Cycles headers
 #include "../extern/cycles/src/device/device.h"
 #include "../extern/cycles/src/scene/scene.h"
@@ -43,8 +43,6 @@
 #include "../extern/cycles/src/util/param.h"
 #include "../extern/cycles/src/util/string.h"
 #include "../extern/cycles/src/util/vector.h"
-#endif
-
 // No need for stub implementations when using real Cycles
 #else
 // Using stub implementations either because SEP_HAS_CYCLES is not defined


### PR DESCRIPTION
## Summary
- fix `SEP_HAS_CYCLES` logic check in `compat/cycles.h`

## Testing
- `cmake -S . -B cmake-make` *(fails: include could not find requested file: SEPConfig)*

------
https://chatgpt.com/codex/tasks/task_e_6864e4dddb0c832a906b89cba0256b4a