### PR TITLE
Fix cycles include conditional

### DIFF
--- a/include/compat/cycles.h
+++ b/include/compat/cycles.h
@@ -23,7 +23,7 @@
 #endif
 
 // Core Cycles headers - only include if SEP_HAS_CYCLES is defined
-#ifdef SEP_HAS_CYCLES
+#if defined(SEP_HAS_CYCLES) && SEP_HAS_CYCLES
 // Core Cycles headers
 #include "../extern/cycles/src/device/device.h"
 #include "../extern/cycles/src/scene/scene.h"


### PR DESCRIPTION
## Summary
- fix `SEP_HAS_CYCLES` check so stubs are used when value is 0

## Testing
- `cmake -S . -B build` *(fails: could not find SEPConfig)*
- `npm run build` *(fails: missing module '@modelcontextprotocol/sdk')*


------
https://chatgpt.com/codex/tasks/task_e_6864e4dddb0c832a906b89cba0256b4a