### PR TITLE
Fix Cycles condition in compatibility header

### DIFF
--- a/include/compat/cycles.h
+++ b/include/compat/cycles.h
@@ -22,8 +22,8 @@
 #define CCL_NAMESPACE_USING_DIRECTIVE using namespace ccl;
 #endif
 
-// Core Cycles headers - only include if SEP_HAS_CYCLES is defined
-#ifdef SEP_HAS_CYCLES
+// Core Cycles headers - only include if SEP_HAS_CYCLES is enabled
+#if SEP_HAS_CYCLES
 // Core Cycles headers
 #include "../extern/cycles/src/device/device.h"
 #include "../extern/cycles/src/scene/scene.h"


### PR DESCRIPTION
## Summary
- correct the SEP_HAS_CYCLES guard in `compat/cycles.h`

## Testing
- `npm install`
- `npm run build` *(fails: Cannot find module '@modelcontextprotocol/sdk/server')*

------
https://chatgpt.com/codex/tasks/task_e_6864e4dddb0c832a906b89cba0256b4a