### PR TITLE
Fix build macros for Cycles

### DIFF
--- a/include/compat/macros.h
+++ b/include/compat/macros.h
@@ -15,6 +15,15 @@
 #endif
 #endif
 
+// -----------------------------------------------------------------------------
+// Cycles renderer availability
+// -----------------------------------------------------------------------------
+// Default to disabled when not explicitly specified. This avoids undefined macro
+// errors when building without Cycles integration.
+#ifndef SEP_HAS_CYCLES
+#define SEP_HAS_CYCLES 0
+#endif
+
 // Backwards compatibility for legacy macros used across the code base.
 #ifndef SEP_HAS_CUDA_RUNTIME
 #define SEP_HAS_CUDA_RUNTIME SEP_CUDA_AVAILABLE

--- a/src/blender/cycles_renderer.cpp
+++ b/src/blender/cycles_renderer.cpp
@@ -194,11 +194,11 @@ SEPResult CyclesRenderer::renderScene(const RenderParams& params) {
 }
 
 bool CyclesRenderer::render(const std::string& filepath) {
+#if SEP_HAS_CYCLES
     if (!initialized_ || patterns_.empty() || !cycles_scene_) {
         return false;
     }
 
-#if SEP_HAS_CYCLES
     // Initialize session
     ::ccl::SessionParams session_params;
     session_params.background = true;
@@ -220,6 +220,8 @@ bool CyclesRenderer::render(const std::string& filepath) {
     return true;
 #else
     (void)filepath;
+    (void)initialized_;
+    (void)patterns_;
     return false;
 #endif
 }


### PR DESCRIPTION
## Summary
- avoid undefined SEP_HAS_CYCLES macro
- guard Cycles renderer pointer usage under macro

## Testing
- `bash tests/blender/run_tests.sh` *(fails: include could not find requested file 'SEPConfig')*

------
https://chatgpt.com/codex/tasks/task_e_6864e802f84c832aaea152ac3664784d