### PR TITLE
Fix Cycles build guards

### DIFF
--- a/include/blender/cycles_renderer.h
+++ b/include/blender/cycles_renderer.h
@@ -7,6 +7,12 @@
 #include "core/common.h"
 #include "compat/cycles.h"
 
+// Ensure SEP_HAS_CYCLES has a sensible default if the build system did not
+// define it. This keeps conditional compilation sections well-formed.
+#ifndef SEP_HAS_CYCLES
+#define SEP_HAS_CYCLES 0
+#endif
+
 namespace sep {
 namespace blender {
 namespace ccl {

--- a/include/compat/cycles.h
+++ b/include/compat/cycles.h
@@ -8,6 +8,13 @@
 // Include standard headers
 #include <memory>
 
+// Provide a default value for SEP_HAS_CYCLES so that headers can be parsed even
+// when the build system does not define it. This avoids preprocessor errors in
+// files that use `#if SEP_HAS_CYCLES`.
+#ifndef SEP_HAS_CYCLES
+#define SEP_HAS_CYCLES 0
+#endif
+
 // Define CCL namespace macros for compatibility
 // These are also defined at the compiler level with -D flags
 #ifndef CCL_NAMESPACE_BEGIN

--- a/src/blender/cycles_renderer.cpp
+++ b/src/blender/cycles_renderer.cpp
@@ -9,6 +9,13 @@
 #include "core/types.h"
 #include "quantum/data.hpp"
 
+// If SEP_HAS_CYCLES was not provided by the build system, fall back to the
+// default defined in the header. This allows compilation of stub versions
+// without special build flags.
+#ifndef SEP_HAS_CYCLES
+#define SEP_HAS_CYCLES 0
+#endif
+
 #if SEP_HAS_CYCLES
 // Cycles core includes
 #include "device/device.h"
@@ -194,11 +201,11 @@ SEPResult CyclesRenderer::renderScene(const RenderParams& params) {
 }
 
 bool CyclesRenderer::render(const std::string& filepath) {
+#if SEP_HAS_CYCLES
     if (!initialized_ || patterns_.empty() || !cycles_scene_) {
         return false;
     }
 
-#if SEP_HAS_CYCLES
     // Initialize session
     ::ccl::SessionParams session_params;
     session_params.background = true;


### PR DESCRIPTION
## Summary
- provide default value for `SEP_HAS_CYCLES`
- guard Cycles usage in `CyclesRenderer::render`

## Testing
- `npm run build` *(fails: Cannot find module `@modelcontextprotocol/sdk/server`)*

------
https://chatgpt.com/codex/tasks/task_e_6864e802f84c832aaea152ac3664784d