### PR TITLE
Fix Cycles feature guards

### DIFF
--- a/include/compat/cycles.h
+++ b/include/compat/cycles.h
@@ -4,6 +4,12 @@
 // It defines the CCL_NAMESPACE_BEGIN and CCL_NAMESPACE_END macros
 // that are used throughout the Cycles codebase
 
+// Ensure SEP_HAS_CYCLES is defined to either 0 or 1. When not provided
+// by the build system we default to the stub implementation path.
+#ifndef SEP_HAS_CYCLES
+#define SEP_HAS_CYCLES 0
+#endif
+
 #ifdef __cplusplus
 // Include standard headers
 #include <memory>
@@ -22,8 +28,8 @@
 #define CCL_NAMESPACE_USING_DIRECTIVE using namespace ccl;
 #endif
 
-// Core Cycles headers - only include if SEP_HAS_CYCLES is defined
-#if defined(SEP_HAS_CYCLES) && SEP_HAS_CYCLES
+// Core Cycles headers - only include if SEP_HAS_CYCLES evaluates to true
+#if SEP_HAS_CYCLES
 // Core Cycles headers
 #include "device/device.h"
 #include "scene/scene.h"

--- a/src/blender/cycles_renderer.cpp
+++ b/src/blender/cycles_renderer.cpp
@@ -194,11 +194,11 @@ SEPResult CyclesRenderer::renderScene(const RenderParams& params) {
 }
 
 bool CyclesRenderer::render(const std::string& filepath) {
+#if SEP_HAS_CYCLES
     if (!initialized_ || patterns_.empty() || !cycles_scene_) {
         return false;
     }
 
-#if SEP_HAS_CYCLES
     // Initialize session
     ::ccl::SessionParams session_params;
     session_params.background = true;


### PR DESCRIPTION
## Summary
- ensure `SEP_HAS_CYCLES` defaults to 0 when not provided
- guard Cycles renderer logic with `#if SEP_HAS_CYCLES`

## Testing
- `bash ./tests/blender/run_tests.sh` *(fails: could not find `SEPConfig` cmake module)*

------
https://chatgpt.com/codex/tasks/task_e_6864e802f84c832aaea152ac3664784d