### PR TITLE
Fix default feature macros for Cycles and Blender

### DIFF
--- a/include/blender/cycles_renderer.h
+++ b/include/blender/cycles_renderer.h
@@ -31,7 +31,7 @@ public:
     bool render(const std::string& filepath);
 
 private:
-#if SEP_HAS_CYCLES
+#ifdef SEP_HAS_CYCLES
     using ScenePtr = std::unique_ptr<::ccl::Scene>;
 #endif
 
@@ -39,14 +39,14 @@ private:
     int width_{0};
     int height_{0};
     std::vector<pattern::PatternData> patterns_;
-#if SEP_HAS_CYCLES
+#ifdef SEP_HAS_CYCLES
     ScenePtr cycles_scene_{nullptr};
     ::ccl::Stats cycles_stats_;
     ::ccl::Profiler cycles_profiler_;
     std::unique_ptr<::ccl::Device> cycles_device_;
 #endif
 
-#if SEP_HAS_CYCLES
+#ifdef SEP_HAS_CYCLES
     void createGeometryFromPattern(const pattern::PatternData& pattern);
     void convertPatternToMesh(const pattern::PatternData& pattern,
                              std::vector<::ccl::float3>& verts,

--- a/include/compat/cycles.h
+++ b/include/compat/cycles.h
@@ -22,8 +22,13 @@
 #define CCL_NAMESPACE_USING_DIRECTIVE using namespace ccl;
 #endif
 
-// Core Cycles headers - only include if SEP_HAS_CYCLES is defined
-#if defined(SEP_HAS_CYCLES) && SEP_HAS_CYCLES
+// Define default for SEP_HAS_CYCLES when not provided by the build system.
+#ifndef SEP_HAS_CYCLES
+#define SEP_HAS_CYCLES 0
+#endif
+
+// Core Cycles headers - only include if SEP_HAS_CYCLES evaluates to true
+#if SEP_HAS_CYCLES
 // Core Cycles headers
 #include "device/device.h"
 #include "scene/scene.h"

--- a/include/core/engine.h
+++ b/include/core/engine.h
@@ -83,7 +83,7 @@ class Engine {
 
   // Managed components
   std::unique_ptr<::sep::audio::AudioCapture> audio_capture_;
-#if SEP_HAS_BLENDER
+#ifdef SEP_HAS_BLENDER
   std::unique_ptr<SEPBlenderBridge> blender_bridge_;
 #endif
 };

--- a/src/api/server.cpp
+++ b/src/api/server.cpp
@@ -17,7 +17,7 @@
 
 #include "compat/types.h"
 
-#if SEP_HAS_BLENDER
+#ifdef SEP_HAS_BLENDER
 #include "blender/api.h"
 #include "blender/cycles_renderer.h"
 #endif
@@ -69,7 +69,7 @@ SEPApiServer::SEPApiServer(const ::sep::config::APIConfig& config)
     if (pattern_processor_) {
         (void)pattern_processor_->init(nullptr);
     }
-#if SEP_HAS_BLENDER
+#ifdef SEP_HAS_BLENDER
     if (cycles_renderer_) {
         (void)cycles_renderer_->initialize();
     }
@@ -811,7 +811,7 @@ void SEPApiServer::handleSignal(int signal) {
 }
 
 void SEPApiServer::setupBlenderRoutes() {
-#if SEP_HAS_BLENDER
+#ifdef SEP_HAS_BLENDER
     // Pattern processing endpoint
     app_->route_dynamic("/api/v1/patterns/process")
     .methods(::crow::HTTPMethod::POST)([this](const ::crow::request& req) {

--- a/src/blender/cycles_renderer.cpp
+++ b/src/blender/cycles_renderer.cpp
@@ -9,7 +9,7 @@
 #include "core/types.h"
 #include "quantum/data.hpp"
 
-#if SEP_HAS_CYCLES
+#ifdef SEP_HAS_CYCLES
 // Cycles core includes
 #include "device/device.h"
 #include "scene/camera.h"
@@ -37,7 +37,7 @@ namespace blender {
 namespace ccl {
 
 SEPResult CyclesRenderer::isCyclesAvailable() {
-#if SEP_HAS_CYCLES
+#ifdef SEP_HAS_CYCLES
     return SEPResult::SUCCESS;
 #else
     return SEPResult::FEATURE_UNAVAILABLE;
@@ -49,7 +49,7 @@ SEPResult CyclesRenderer::initialize() {
         return SEPResult::FEATURE_UNAVAILABLE;
     }
     try {
-#if SEP_HAS_CYCLES
+#ifdef SEP_HAS_CYCLES
         ::ccl::DeviceInfo device_info;
         cycles_device_ = ::ccl::Device::create(device_info,
                                                cycles_stats_,
@@ -76,7 +76,7 @@ SEPResult CyclesRenderer::createSceneFromPatterns(const std::vector<pattern::Pat
         return SEPResult::INVALID_ARGUMENT;
     }
     try {
-#if SEP_HAS_CYCLES
+#ifdef SEP_HAS_CYCLES
         patterns_ = patterns;
         
         // Create scene if not already created
@@ -114,7 +114,7 @@ SEPResult CyclesRenderer::renderScene(const RenderParams& params) {
         return SEPResult::INVALID_ARGUMENT;
     }
     try {
-#if SEP_HAS_CYCLES
+#ifdef SEP_HAS_CYCLES
         width_ = params.width;
         height_ = params.height;
         if (!cycles_scene_) {
@@ -198,7 +198,7 @@ bool CyclesRenderer::render(const std::string& filepath) {
         return false;
     }
 
-#if SEP_HAS_CYCLES
+#ifdef SEP_HAS_CYCLES
     // Initialize session
     ::ccl::SessionParams session_params;
     session_params.background = true;
@@ -224,7 +224,7 @@ bool CyclesRenderer::render(const std::string& filepath) {
 #endif
 }
 
-#if SEP_HAS_CYCLES
+#ifdef SEP_HAS_CYCLES
 void CyclesRenderer::createGeometryFromPattern(const pattern::PatternData& pattern) {
     // Create mesh
     ::ccl::Mesh *mesh = new ::ccl::Mesh();

--- a/src/core/engine.cpp
+++ b/src/core/engine.cpp
@@ -16,7 +16,7 @@
 #include "compat/cuda_api.hpp"
 #include "core/logging.h"  // This is actually the logging manager
 #include "memory/memory_tier_manager.hpp"
-#if SEP_HAS_BLENDER
+#ifdef SEP_HAS_BLENDER
 #include "blender/pattern_bridge.h"
 #include "blender/types.h" // For SEPBlenderBridge definition
 #endif
@@ -89,7 +89,7 @@ bool Engine::init(const sep::config::APIConfig& config) {
          fflush(stdout);
     }
 
-#if SEP_HAS_BLENDER
+#ifdef SEP_HAS_BLENDER
     printf("DEBUG: Engine::init - Initializing Blender bridge\n");
      fflush(stdout);
 

--- a/src/memory/quantum_coherence_manager.cpp
+++ b/src/memory/quantum_coherence_manager.cpp
@@ -12,7 +12,7 @@
 
 #include "memory/memory_tier_manager.hpp"
 #include "memory/types.h"
-#if SEP_HAS_BLENDER
+#ifdef SEP_HAS_BLENDER
 #include "blender/bridge.h"
 #endif
 


### PR DESCRIPTION
## Summary
- define fallback for `SEP_HAS_CYCLES`
- update Cycles/Blender guards to use `#ifdef`

## Testing
- `npm run build` *(fails: Cannot find module '@modelcontextprotocol/sdk/server')*

------
https://chatgpt.com/codex/tasks/task_e_6864e802f84c832aaea152ac3664784d