### PR TITLE
Fix Cycles renderer compile errors

### DIFF
--- a/include/blender/cycles_renderer.h
+++ b/include/blender/cycles_renderer.h
@@ -39,6 +39,7 @@ private:
     bool initialized_{false};
     int width_{0};
     int height_{0};
+    RenderParams last_params_{};
     std::vector<pattern::PatternData> patterns_;
     ScenePtr cycles_scene_{nullptr};
     ::ccl::Stats cycles_stats_;

--- a/src/blender/cycles_renderer.cpp
+++ b/src/blender/cycles_renderer.cpp
@@ -128,11 +128,13 @@ SEPResult CyclesRenderer::renderScene(const RenderParams& params) {
             cam->set_blades(0);
             cam->set_bladesrotation(0.0f);
             cam->set_focaldistance(10.0f);
-            cam->compute_viewplane();
+            /* API update: compute_viewplane() was replaced with
+             * compute_auto_viewplane() in newer Cycles versions. */
+            cam->compute_auto_viewplane();
         }
 
         // Configure render settings
-        cycles_scene_->params.samples = params.samples;
+        last_params_ = params;
         cycles_scene_->integrator->set_aa_samples(static_cast<int>(params.samples));
         cycles_scene_->integrator->set_use_denoise(params.use_denoising);
         cycles_scene_->params.background = true;
@@ -168,7 +170,7 @@ bool CyclesRenderer::render(const std::string& filepath) {
     ::ccl::SessionParams session_params;
     session_params.background = true;
     session_params.threads = 0; // Auto-detect thread count
-    session_params.samples = static_cast<int>(params.samples);
+    session_params.samples = static_cast<int>(last_params_.samples);
     
     ::ccl::Session *session = new ::ccl::Session(session_params, cycles_scene_->params);
     session->scene = std::move(cycles_scene_);


### PR DESCRIPTION
## Summary
- update Cycles renderer to use `compute_auto_viewplane`
- store last render parameters for later use
- remove invalid access to `SceneParams::samples`

## Testing
- `bash build.sh` *(fails: include could not find requested file `SEPConfig`)*
- `cmake -S . -B build` *(fails: Unknown CMake command `configure_sep`)*
- `npm run lint` *(fails: Missing script `lint`)*

------
https://chatgpt.com/codex/tasks/task_e_6864f7c319dc832a9c8e7c10de1fc311