### PR TITLE
Fix pointer initialization and apply RAII

### DIFF
--- a/include/memory/memory_tier_manager.hpp
+++ b/include/memory/memory_tier_manager.hpp
@@ -119,8 +119,8 @@ public:
     void calculateRelationshipCoherence();
     void loadLTMFromPersistence();
     void storeLTMToPersistence(const ::sep::quantum::Pattern& pattern, const persistence::PersistentPatternData& data);
-    ::sep::quantum::Pattern* findPattern(std::size_t id);
-    const ::sep::quantum::Pattern* findPattern(std::size_t id) const;
+    std::unique_ptr<::sep::quantum::Pattern> findPattern(std::size_t id);
+    std::unique_ptr<::sep::quantum::Pattern> findPattern(std::size_t id) const;
     void registerPattern(std::size_t id, const ::sep::pattern::PatternData& pattern);
     const ::sep::pattern::PatternData* getPatternData(std::size_t id) const;
     void cleanupExpiredPatterns();

--- a/src/blender/api.cpp
+++ b/src/blender/api.cpp
@@ -62,6 +62,8 @@ extern "C" sep::SEPResult sep_blender_init(sep::GPUContext* gpu_ctx, const SEPCo
         // bridge_ptr goes out of scope and cleans up
         return static_cast<sep::SEPResult>(static_cast<int32_t>(result));
     }
+
+    *bridge_out = bridge_ptr.release();
     return sep::SEPResult::SUCCESS;
 }
 

--- a/src/blender/cycles_renderer.cpp
+++ b/src/blender/cycles_renderer.cpp
@@ -173,7 +173,7 @@ bool CyclesRenderer::render(const std::string& filepath) {
     session_params.threads = 0; // Auto-detect thread count
     session_params.samples = static_cast<int>(last_params_.samples);
     
-    ::ccl::Session *session = new ::ccl::Session(session_params, cycles_scene_->params);
+    auto session = std::make_unique<::ccl::Session>(session_params, cycles_scene_->params);
     session->scene = std::move(cycles_scene_);
 
     session->set_output_driver(::ccl::make_unique<::ccl::OIIOOutputDriver>(
@@ -185,13 +185,13 @@ bool CyclesRenderer::render(const std::string& filepath) {
     session->start();
     session->wait();
 
-    delete session;
+    session.reset();
     return true;
 }
 
 void CyclesRenderer::createGeometryFromPattern(const pattern::PatternData& pattern) {
     // Create mesh
-    ::ccl::Mesh *mesh = new ::ccl::Mesh();
+    auto mesh = std::make_unique<::ccl::Mesh>();
     
     // Convert pattern data to vertices and faces
     std::vector<::ccl::float3> verts;
@@ -218,7 +218,7 @@ void CyclesRenderer::createGeometryFromPattern(const pattern::PatternData& patte
     mesh->attributes.add(::ccl::ATTR_STD_UV, ::ccl::ustring("uvmap"));
     
     // Add mesh to scene
-    cycles_scene_->geometry.push_back(std::unique_ptr<::ccl::Geometry>(mesh));
+    cycles_scene_->geometry.push_back(std::move(mesh));
 }
 
 void CyclesRenderer::convertPatternToMesh(const pattern::PatternData& pattern,

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -373,13 +373,13 @@ void MemoryTierManager::storeLTMToPersistence(const ::sep::quantum::Pattern& pat
     redis_manager_->storePattern(id, data, "ltm");
 }
 
-::sep::quantum::Pattern* MemoryTierManager::findPattern(std::size_t id) {
+std::unique_ptr<::sep::quantum::Pattern> MemoryTierManager::findPattern(std::size_t id) {
     auto it = pattern_registry_.find(id);
     if (it == pattern_registry_.end()) { 
         return nullptr;
     }
     const sep::pattern::PatternData* data = it->second.get();
-    sep::quantum::Pattern* pattern = new sep::quantum::Pattern();
+    auto pattern = std::make_unique<sep::quantum::Pattern>();
     pattern->id = data->id;
     const float values[] = {data->attributes.x, data->attributes.y, data->attributes.z, data->attributes.w};
     pattern->data.assign(values, values + 4);
@@ -390,13 +390,13 @@ void MemoryTierManager::storeLTMToPersistence(const ::sep::quantum::Pattern& pat
     return pattern;
 }
 
-const ::sep::quantum::Pattern* MemoryTierManager::findPattern(std::size_t id) const {
+std::unique_ptr<::sep::quantum::Pattern> MemoryTierManager::findPattern(std::size_t id) const {
     auto it = pattern_registry_.find(id);
     if (it == pattern_registry_.end()) {
         return nullptr;
     }
     const sep::pattern::PatternData* data = it->second.get();
-    sep::quantum::Pattern* pattern = new sep::quantum::Pattern();
+    auto pattern = std::make_unique<sep::quantum::Pattern>();
     pattern->id = data->id;
     const float values[] = {data->attributes.x, data->attributes.y, data->attributes.z, data->attributes.w};
     pattern->data.assign(values, values + 4);


### PR DESCRIPTION
## Summary
- fix SEP bridge initialization
- use RAII for Cycles session and mesh objects
- return unique_ptr from MemoryTierManager find functions

## Testing
- `cmake .. && make -j$(nproc) tests` *(fails: could not find requested file SEPConfig)*
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_6864f95e46a0832aab7086bf4fc1e6d5