### PR TITLE
Link stub libs for missing dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ tests/io_curve_svg/
 sep_engine
 extern/*
 !extern/cycles/
+!extern/openpgl_stub/
+!extern/cuew_stub/
 build/
 _build/
 changes.diff

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,8 @@ add_subdirectory(src/quantum)
 add_subdirectory(src/api)
 add_subdirectory(src/audio)
 add_subdirectory(src/blender)
+add_subdirectory(extern/cuew_stub)
+add_subdirectory(extern/openpgl_stub)
 
 # Main executable
 add_executable(sep_engine src/main.cpp)
@@ -40,4 +42,9 @@ target_link_libraries(sep_engine
         ${CURL_LIBRARIES}
         fmt::fmt
         spdlog::spdlog
+        glog
+        gflags
+        embree4
+        cuew_stub
+        openpgl_stub
 )

--- a/extern/cuew_stub/CMakeLists.txt
+++ b/extern/cuew_stub/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_library(cuew_stub STATIC cuew_stub.c)

--- a/extern/cuew_stub/cuew_stub.c
+++ b/extern/cuew_stub/cuew_stub.c
@@ -1,0 +1,11 @@
+#include <stdarg.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+const char* cuewErrorString(int) { return "cuew_stub"; }
+const char* cuewCompilerPath() { return ""; }
+int cuewCompilerVersion() { return 0; }
+int cuewInit(int) { return 0; }
+#ifdef __cplusplus
+}
+#endif

--- a/extern/openpgl_stub/CMakeLists.txt
+++ b/extern/openpgl_stub/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_library(openpgl_stub STATIC openpgl_stub.cpp)

--- a/extern/openpgl_stub/openpgl_stub.cpp
+++ b/extern/openpgl_stub/openpgl_stub.cpp
@@ -1,0 +1,24 @@
+#ifdef __cplusplus
+extern "C" {
+#endif
+void* pglNewDevice() { return nullptr; }
+void pglReleaseDevice(void*) {}
+void* pglNewPathSegmentStorage() { return nullptr; }
+void pglReleasePathSegmentStorage(void*) {}
+void pglPathSegmentStorageAddSegment(void*, void*) {}
+void pglPathSegmentStorageNextSegment(void*) {}
+void* pglNewSurfaceSamplingDistribution() { return nullptr; }
+void pglReleaseSurfaceSamplingDistribution(void*) {}
+void* pglNewVolumeSamplingDistribution() { return nullptr; }
+void pglReleaseVolumeSamplingDistribution(void*) {}
+void pglFieldInitSurfaceSamplingDistribution(void*) {}
+void pglFieldInitVolumeSamplingDistribution(void*) {}
+void pglSurfaceSamplingDistributionApplyCosineProduct(void*) {}
+double pglSurfaceSamplingDistributionPDF(void*) { return 0.0; }
+double pglSurfaceSamplingDistributionSamplePDF(void*) { return 0.0; }
+void pglVolumeSamplingDistributionApplySingleLobeHenyeyGreensteinProduct(void*) {}
+double pglVolumeSamplingDistributionPDF(void*) { return 0.0; }
+double pglVolumeSamplingDistributionSamplePDF(void*) { return 0.0; }
+#ifdef __cplusplus
+}
+#endif

--- a/src/blender/CMakeLists.txt
+++ b/src/blender/CMakeLists.txt
@@ -93,6 +93,11 @@ if(SEP_HAS_CYCLES)
       CUDA::cudart  # For CUDA runtime
       CUDA::cuda_driver
       CUDA::nvrtc
+      glog
+      gflags
+      embree4
+      cuew_stub
+      openpgl_stub
   )
 endif()
 


### PR DESCRIPTION
## Summary
- allow stub dependencies to be tracked under extern
- build simple cuew and openpgl stubs
- link glog, gflags, embree, cuew_stub and openpgl_stub

## Testing
- `cmake -S . -B _sep/testbed` *(fails: include could not find requested file: SEPConfig)*

------
https://chatgpt.com/codex/tasks/task_e_6864f95e46a0832aab7086bf4fc1e6d5