### PR TITLE
Integrate spdlog-based crow logging

### DIFF
--- a/include/crow/logging.h
+++ b/include/crow/logging.h
@@ -1,11 +1,17 @@
 #pragma once
 
-// This is a minimal version of the logging.h file from the Crow framework
-// It provides stub implementations for logging functionality
+// Minimal logging wrapper used by the Crow compatibility layer.
+// The original Crow project relies on its own logger but for SEP we
+// forward everything to spdlog so log output is consistent with the rest
+// of the engine.  When spdlog is not available (e.g. CUDA compilation)
+// the isolation headers provide light‑weight stubs.
 
 // Use relative path from project root
 #include "compat/shim.h"
+#include "memory/spdlog_isolation.h"
 #include <sstream>
+#include <memory>
+#include <spdlog/sinks/stdout_color_sinks.h>
 
 namespace crow {
     enum class LogLevel {
@@ -18,38 +24,73 @@ namespace crow {
 
     class LogHandler {
     public:
-        void operator()(const sep::shim::string& message) {
-            // In a real implementation, this would log to stderr
-            // For now, we'll just provide a stub
-        }
+        LogHandler();
+        void operator()(LogLevel level, const sep::shim::string& message);
+
+    private:
+        std::shared_ptr<::spdlog::logger> logger_;
     };
 
     class Logger {
     public:
-        Logger(LogLevel level) : level_(level) {}
+        explicit Logger(LogLevel level);
 
         template <typename T>
         Logger& operator<<(T const& value) {
-            // In a real implementation, this would append to a message
-            // For now, we'll just provide a stub
+            stream_ << value;
             return *this;
         }
 
         ~Logger() {
-            // In a real implementation, this would flush the log message
-            // For now, we'll just provide a stub
+            if (!stream_.str().empty())
+            {
+                handler_(level_, stream_.str().c_str());
+            }
         }
 
     private:
         LogLevel level_;
-        // Using a simple string instead of stringstream to avoid template issues
-        sep::shim::string message_;
+        std::ostringstream stream_;
         LogHandler handler_;
     };
+
+    // Implementation
+    inline LogHandler::LogHandler()
+        : logger_(::spdlog::get("crow"))
+    {
+        if (!logger_)
+        {
+            logger_ = ::spdlog::stderr_color_mt("crow");
+            logger_->set_level(::spdlog::level::trace);
+        }
+    }
+
+    inline void LogHandler::operator()(LogLevel lvl, const sep::shim::string& message)
+    {
+        if (logger_)
+        {
+            ::spdlog::level::level_enum slvl;
+            switch (lvl)
+            {
+            case LogLevel::Debug:    slvl = ::spdlog::level::debug; break;
+            case LogLevel::Info:     slvl = ::spdlog::level::info; break;
+            case LogLevel::Warning:  slvl = ::spdlog::level::warn; break;
+            case LogLevel::Error:    slvl = ::spdlog::level::err; break;
+            case LogLevel::Critical: slvl = ::spdlog::level::critical; break;
+            default:                 slvl = ::spdlog::level::info; break;
+            }
+            logger_->log(slvl, "{}", message.c_str());
+        }
+    }
+
+    inline Logger::Logger(LogLevel level)
+        : level_(level)
+    {}
+
 }
 
 // Define logging macros - use non-template version to avoid template argument issues
-#define CROW_LOG_ERROR crow::Logger(crow::LogLevel::Error)
-#define CROW_LOG_WARNING crow::Logger(crow::LogLevel::Warning)
-#define CROW_LOG_INFO crow::Logger(crow::LogLevel::Info)
-#define CROW_LOG_DEBUG crow::Logger(crow::LogLevel::Debug)
+#define CROW_LOG_ERROR ::crow::Logger(::crow::LogLevel::Error)
+#define CROW_LOG_WARNING ::crow::Logger(::crow::LogLevel::Warning)
+#define CROW_LOG_INFO ::crow::Logger(::crow::LogLevel::Info)
+#define CROW_LOG_DEBUG ::crow::Logger(::crow::LogLevel::Debug)

--- a/include/memory/spdlog_isolation.h
+++ b/include/memory/spdlog_isolation.h
@@ -41,8 +41,8 @@ public:
 // It provides stub implementations for spdlog functionality that can be
 // safely included in CUDA files without causing template instantiation errors
 
-// Check for CUDA compilation - either via __CUDACC__ or our custom SEP_CUDA_COMPILATION flag
-#if defined(__CUDACC__) || defined(SEP_CUDA_COMPILATION)
+// Check for CUDA compilation or missing spdlog installation.
+#if defined(__CUDACC__) || defined(SEP_CUDA_COMPILATION) || !__has_include(<spdlog/spdlog.h>)
 // When compiling with CUDA, provide stub implementations
 
 // Include our isolation headers


### PR DESCRIPTION
## Summary
- hook Crow logging classes to `spdlog`
- fallback to stubs if `spdlog` is unavailable

## Testing
- `cmake -DBUILD_TESTING=ON ..` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6864ff1548f0832ab1b02d985602c561