### PR TITLE
Use official http_parser library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,17 @@ find_package(Threads REQUIRED)
 find_package(CURL REQUIRED)
 find_package(fmt REQUIRED)
 find_package(spdlog REQUIRED)
+find_path(HTTP_PARSER_INCLUDE_DIR http_parser.h)
+find_library(HTTP_PARSER_LIBRARY http_parser)
+if(HTTP_PARSER_INCLUDE_DIR AND HTTP_PARSER_LIBRARY)
+    add_library(http_parser::http_parser INTERFACE IMPORTED)
+    set_target_properties(http_parser::http_parser PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES ${HTTP_PARSER_INCLUDE_DIR}
+        INTERFACE_LINK_LIBRARIES ${HTTP_PARSER_LIBRARY}
+    )
+else()
+    message(FATAL_ERROR "http_parser library not found")
+endif()
 
 # Add subdirectories
 add_subdirectory(src/core)
@@ -45,6 +56,7 @@ target_link_libraries(sep_engine
         ${OIIO_LIBRARIES}
         ${ZSTD_LIBRARIES}
         ${CURL_LIBRARIES}
+        http_parser::http_parser
         fmt::fmt
         spdlog::spdlog
         glog

--- a/include/crow/crow_isolation.h
+++ b/include/crow/crow_isolation.h
@@ -207,47 +207,13 @@ namespace crow {
     #define CROW_CATCHALL_ROUTE(app) app.catchall_route()
     #define CROW_BP_CATCHALL_ROUTE(bp) bp.catchall_rule()
 
-    // HTTP parser stubs
+    // Use the official http-parser types inside a dedicated namespace to keep
+    // compatibility with code that expects crow::http_parser_stub symbols.
     namespace http_parser_stub {
-        enum class http_errno {
-            HPE_OK,
-            HPE_UNKNOWN
-        };
-
-        enum class http_parser_type {
-            HTTP_REQUEST,
-            HTTP_RESPONSE,
-            HTTP_BOTH
-        };
-
-        struct http_parser {
-            unsigned int   type : 2;
-            unsigned int   flags : 8;
-            unsigned int   state : 8;
-            unsigned int   header_state : 8;
-            unsigned int   index : 8;
-            uint32_t  nread;
-            uint64_t  content_length;
-            unsigned short http_major;
-            unsigned short http_minor;
-            unsigned int   status_code : 16;
-            unsigned int   method : 8;
-            unsigned int   http_errno : 7;
-            unsigned int   upgrade : 1;
-            void*          data;
-        };
-
-        struct http_parser_settings {
-            void* on_message_begin;
-            void* on_url;
-            void* on_status;
-            void* on_header_field;
-            void* on_header_value;
-            void* on_headers_complete;
-            void* on_body;
-            void* on_message_complete;
-            void* on_chunk_header;
-            void* on_chunk_complete;
-        };
+        using http_errno = ::http_errno;
+        using http_parser_type = ::http_parser_type;
+        using http_parser = ::http_parser;
+        using http_parser_settings = ::http_parser_settings;
+        using http_parser_url = ::http_parser_url;
     }  // namespace http_parser_stub
 }  // namespace crow

--- a/include/crow/http_parser_fixed.h
+++ b/include/crow/http_parser_fixed.h
@@ -3,7 +3,8 @@
 // This is a fixed version of the http_parser_fixed.h file from the Crow framework
 // It provides stub implementations for HTTP parser functionality
 
-// Include our own headers
+// Include the official http-parser header and our compatibility helpers
+#include <http_parser.h>
 #include "compat/shim.h"
 #include "common.h"
 #include "crow_isolation.h"
@@ -14,75 +15,46 @@
 
 namespace crow {
     namespace http_parser_stub {
-        // These are already defined in crow_isolation.h, so we don't need to redefine them
-        // enum class http_errno {...};
-        // enum class http_parser_type {...};
-        // struct http_parser {...};
-        // struct http_parser_settings {...};
+        // Alias the official http-parser types inside the stub namespace for
+        // compatibility with existing code.
+        using http_errno = ::http_errno;
+        using http_parser_type = ::http_parser_type;
+        using http_parser = ::http_parser;
+        using http_parser_settings = ::http_parser_settings;
+        using http_parser_url = ::http_parser_url;
 
-        // Add any additional HTTP parser functionality needed here
-        
-        // Stub implementation for http_parser_init
+        // Thin wrappers around the real http-parser functions
         inline void http_parser_init(http_parser* parser, http_parser_type type) {
-            parser->type = static_cast<unsigned int>(type);
-            parser->flags = 0;
-            parser->state = 0;
-            parser->header_state = 0;
-            parser->index = 0;
-            parser->nread = 0;
-            parser->content_length = 0;
-            parser->http_major = 0;
-            parser->http_minor = 0;
-            parser->status_code = 0;
-            parser->method = 0;
-            parser->http_errno = 0;
-            parser->upgrade = 0;
-            parser->data = nullptr;
+            ::http_parser_init(parser, type);
         }
 
-        // Stub implementation for http_parser_execute
-        inline size_t http_parser_execute(http_parser* parser, 
-                                         const http_parser_settings* settings,
-                                         const char* data,
-                                         size_t len) {
-            return len;
+        inline size_t http_parser_execute(http_parser* parser,
+                                          const http_parser_settings* settings,
+                                          const char* data,
+                                          size_t len) {
+            return ::http_parser_execute(parser, settings, data, len);
         }
-
-        // Stub implementation for http_parser_url_init
-        struct http_parser_url {
-            unsigned short field_set;
-            unsigned short port;
-            unsigned short field_data[16];
-        };
 
         inline void http_parser_url_init(http_parser_url* u) {
-            u->field_set = 0;
-            u->port = 0;
-            for (int i = 0; i < 16; i++) {
-                u->field_data[i] = 0;
-            }
+            ::http_parser_url_init(u);
         }
 
-        // Stub implementation for http_parser_parse_url
         inline int http_parser_parse_url(const char* buf, size_t buflen,
-                                        int is_connect,
-                                        http_parser_url* u) {
-            return 0;
+                                         int is_connect,
+                                         http_parser_url* u) {
+            return ::http_parser_parse_url(buf, buflen, is_connect, u);
         }
 
-        // Stub implementation for http_errno_name
         inline const char* http_errno_name(http_errno err) {
-            return "OK";
+            return ::http_errno_name(err);
         }
 
-        // Stub implementation for http_errno_description
         inline const char* http_errno_description(http_errno err) {
-            return "Success";
+            return ::http_errno_description(err);
         }
 
-        // Stub implementation for http_method_str
         inline const char* http_method_str(unsigned int method) {
-            return "GET";
+            return ::http_method_str(static_cast<http_method>(method));
         }
     }  // namespace http_parser_stub
 }  // namespace crow

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -24,6 +24,7 @@ target_link_libraries(sep_api
         sep_compat
         sep_blender
         sep_audio
+        http_parser::http_parser
 )
 
 target_include_directories(sep_api


### PR DESCRIPTION
## Summary
- link with the real http_parser library and expose it via imported target
- delegate Crow http parser wrappers to the real implementation
- remove manual parser structs and alias official types
- link `sep_api` and `sep_engine` against http_parser

## Testing
- `ctest tests/api` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_6864ff10b1d4832ab2eac25ea1812d8e