### PR TITLE
Enhance CUDA long double math support

### DIFF
--- a/extern/cycles/include/cuda_unified_fix.h
+++ b/extern/cycles/include/cuda_unified_fix.h
@@ -177,21 +177,56 @@ constexpr int FP_CLASS_NAN = 4;        // NaN values
 extern "C" {
 
 // Define stubs for long double math functions that GCC-14 expects but are missing in CUDA
+#if defined(__CUDACC_VER_MAJOR__) && (__CUDACC_VER_MAJOR__ >= 12)
+#  define SEP_HAS_CUDA_LDOUBLE_FUNCS 1
+#else
+#  define SEP_HAS_CUDA_LDOUBLE_FUNCS 0
+#endif
+
 inline long double acosl(long double x) {
     if (x < -1.0L || x > 1.0L) {
         errno = EDOM;
         return NAN;
     }
-    return static_cast<long double>(acos(static_cast<double>(x)));
+#if defined(__CUDACC__) && SEP_HAS_CUDA_LDOUBLE_FUNCS
+    return ::acosl(x);
+#else
+    long double r = static_cast<long double>(acos(static_cast<double>(x)));
+    long double delta = (cos(r) - x) / sin(r);
+    r += delta;
+    return r;
+#endif
 }
 inline long double asinl(long double x) {
-    return asin((double)x);
+    if (x < -1.0L || x > 1.0L) {
+        errno = EDOM;
+        return NAN;
+    }
+#if defined(__CUDACC__) && SEP_HAS_CUDA_LDOUBLE_FUNCS
+    return ::asinl(x);
+#else
+    long double r = static_cast<long double>(asin(static_cast<double>(x)));
+    long double delta = (x - sin(r)) / cos(r);
+    r += delta;
+    return r;
+#endif
 }
 inline long double atanl(long double x) {
-    return atan((double)x);
+#if defined(__CUDACC__) && SEP_HAS_CUDA_LDOUBLE_FUNCS
+    return ::atanl(x);
+#else
+    long double r = static_cast<long double>(atan(static_cast<double>(x)));
+    long double t = tan(r);
+    r -= (t - x) * (1.0L / (1.0L + t * t));
+    return r;
+#endif
 }
 inline long double atan2l(long double y, long double x) {
-    return atan2((double)y, (double)x);
+#if defined(__CUDACC__) && SEP_HAS_CUDA_LDOUBLE_FUNCS
+    return ::atan2l(y, x);
+#else
+    return static_cast<long double>(atan2(static_cast<double>(y), static_cast<double>(x)));
+#endif
 }
 inline long double ceill(long double x) {
     return ceil((double)x);
@@ -225,7 +260,14 @@ inline long double logl(long double x) {
         errno = EDOM;
         return NAN;
     }
-    return log((double)x);
+#if defined(__CUDACC__) && SEP_HAS_CUDA_LDOUBLE_FUNCS
+    return ::logl(x);
+#else
+    long double r = static_cast<long double>(log(static_cast<double>(x)));
+    long double exp_r = exp(r);
+    r += (x - exp_r) / exp_r;
+    return r;
+#endif
 }
 inline long double log10l(long double x) {
     return log10((double)x);
@@ -246,7 +288,19 @@ inline long double sinhl(long double x) {
     return sinh((double)x);
 }
 inline long double sqrtl(long double x) {
-    return sqrt((double)x);
+#if defined(__CUDACC__) && SEP_HAS_CUDA_LDOUBLE_FUNCS
+    return ::sqrtl(x);
+#else
+    if (x < 0.0L) {
+        errno = EDOM;
+        return NAN;
+    }
+    long double r = static_cast<long double>(sqrt(static_cast<double>(x)));
+    if (x != 0.0L) {
+        r = 0.5L * (r + x / r);
+    }
+    return r;
+#endif
 }
 inline long double tanl(long double x) {
     return tan((double)x);

--- a/include/compat/cuda_unified_fix.h
+++ b/include/compat/cuda_unified_fix.h
@@ -189,21 +189,62 @@ constexpr int FP_CLASS_NAN = 4;        // NaN values
 extern "C" {
 
 // Define stubs for long double math functions that GCC-14 expects but are missing in CUDA
+// When CUDA provides native long double support we call the device version
+// otherwise we fall back to a high precision refinement of the double variant.
+
+#if defined(__CUDACC_VER_MAJOR__) && (__CUDACC_VER_MAJOR__ >= 12)
+#  define SEP_HAS_CUDA_LDOUBLE_FUNCS 1
+#else
+#  define SEP_HAS_CUDA_LDOUBLE_FUNCS 0
+#endif
+
 inline long double acosl(long double x) {
     if (x < -1.0L || x > 1.0L) {
         errno = EDOM;
         return NAN;
     }
-    return static_cast<long double>(acos(static_cast<double>(x)));
+#if defined(__CUDACC__) && SEP_HAS_CUDA_LDOUBLE_FUNCS
+    return ::acosl(x);
+#else
+    long double r = static_cast<long double>(acos(static_cast<double>(x)));
+    long double delta = (cos(r) - x) / sin(r);
+    r += delta;
+    return r;
+#endif
 }
+
 inline long double asinl(long double x) {
-    return asin((double)x);
+    if (x < -1.0L || x > 1.0L) {
+        errno = EDOM;
+        return NAN;
+    }
+#if defined(__CUDACC__) && SEP_HAS_CUDA_LDOUBLE_FUNCS
+    return ::asinl(x);
+#else
+    long double r = static_cast<long double>(asin(static_cast<double>(x)));
+    long double delta = (x - sin(r)) / cos(r);
+    r += delta;
+    return r;
+#endif
 }
+
 inline long double atanl(long double x) {
-    return atan((double)x);
+#if defined(__CUDACC__) && SEP_HAS_CUDA_LDOUBLE_FUNCS
+    return ::atanl(x);
+#else
+    long double r = static_cast<long double>(atan(static_cast<double>(x)));
+    long double t = tan(r);
+    r -= (t - x) * (1.0L / (1.0L + t * t));
+    return r;
+#endif
 }
+
 inline long double atan2l(long double y, long double x) {
-    return atan2((double)y, (double)x);
+#if defined(__CUDACC__) && SEP_HAS_CUDA_LDOUBLE_FUNCS
+    return ::atan2l(y, x);
+#else
+    return static_cast<long double>(atan2(static_cast<double>(y), static_cast<double>(x)));
+#endif
 }
 inline long double ceill(long double x) {
     return ceil((double)x);
@@ -237,7 +278,14 @@ inline long double logl(long double x) {
         errno = EDOM;
         return NAN;
     }
-    return log((double)x);
+#if defined(__CUDACC__) && SEP_HAS_CUDA_LDOUBLE_FUNCS
+    return ::logl(x);
+#else
+    long double r = static_cast<long double>(log(static_cast<double>(x)));
+    long double exp_r = exp(r);
+    r += (x - exp_r) / exp_r;
+    return r;
+#endif
 }
 inline long double log10l(long double x) {
     return log10((double)x);
@@ -258,7 +306,19 @@ inline long double sinhl(long double x) {
     return sinh((double)x);
 }
 inline long double sqrtl(long double x) {
-    return sqrt((double)x);
+#if defined(__CUDACC__) && SEP_HAS_CUDA_LDOUBLE_FUNCS
+    return ::sqrtl(x);
+#else
+    if (x < 0.0L) {
+        errno = EDOM;
+        return NAN;
+    }
+    long double r = static_cast<long double>(sqrt(static_cast<double>(x)));
+    if (x != 0.0L) {
+        r = 0.5L * (r + x / r);
+    }
+    return r;
+#endif
 }
 inline long double tanl(long double x) {
     return tan((double)x);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ add_subdirectory(quantum)
 add_subdirectory(memory)
 add_subdirectory(audio)
 add_subdirectory(api)
+add_subdirectory(cuda)
 
 # Configure test discovery
 include(CTest)

--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -1,0 +1,25 @@
+if(NOT BUILD_TESTING)
+    return()
+endif()
+
+find_package(GTest REQUIRED)
+
+add_executable(long_double_math_test
+    long_double_math_test.cpp
+)
+
+target_include_directories(long_double_math_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/src
+)
+
+target_link_libraries(long_double_math_test PRIVATE
+    sep_compat
+    sep_core
+    GTest::GTest
+    GTest::Main
+    CUDA::cudart
+    CUDA::cuda_driver
+)
+
+add_test(NAME long_double_math_test COMMAND long_double_math_test)

--- a/tests/cuda/long_double_math_test.cpp
+++ b/tests/cuda/long_double_math_test.cpp
@@ -1,0 +1,52 @@
+#include <gtest/gtest.h>
+#include <cmath>
+#include "compat/cuda_unified_fix.h"
+
+__global__ void device_acosl(long double* out, long double x) {
+    out[0] = acosl(x);
+}
+
+__global__ void device_atan2l(long double* out, long double y, long double x) {
+    out[0] = atan2l(y, x);
+}
+
+TEST(LongDoubleMathHost, AcoslAccuracy) {
+    long double v = 0.5L;
+    long double expected = std::acosl(v);
+    EXPECT_NEAR(static_cast<double>(acosl(v)), static_cast<double>(expected), 1e-9);
+}
+
+TEST(LongDoubleMathHost, Atan2lAccuracy) {
+    long double y = 0.5L, x = -0.3L;
+    long double expected = std::atan2l(y, x);
+    EXPECT_NEAR(static_cast<double>(atan2l(y, x)), static_cast<double>(expected), 1e-9);
+}
+
+TEST(LongDoubleMathDevice, AcoslAccuracy) {
+    long double* d_out;
+    ASSERT_EQ(cudaMalloc(&d_out, sizeof(long double)), cudaSuccess);
+    device_acosl<<<1,1>>>(d_out, 0.5L);
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+    long double h_val;
+    ASSERT_EQ(cudaMemcpy(&h_val, d_out, sizeof(long double), cudaMemcpyDeviceToHost), cudaSuccess);
+    cudaFree(d_out);
+    long double expected = std::acosl(0.5L);
+    EXPECT_NEAR(static_cast<double>(h_val), static_cast<double>(expected), 1e-9);
+}
+
+TEST(LongDoubleMathDevice, Atan2lAccuracy) {
+    long double* d_out;
+    ASSERT_EQ(cudaMalloc(&d_out, sizeof(long double)), cudaSuccess);
+    device_atan2l<<<1,1>>>(d_out, 0.5L, -0.3L);
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+    long double h_val;
+    ASSERT_EQ(cudaMemcpy(&h_val, d_out, sizeof(long double), cudaMemcpyDeviceToHost), cudaSuccess);
+    cudaFree(d_out);
+    long double expected = std::atan2l(0.5L, -0.3L);
+    EXPECT_NEAR(static_cast<double>(h_val), static_cast<double>(expected), 1e-9);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary
- refine CUDA compatibility wrappers for high precision long double math
- add new CUDA tests for `acosl` and `atan2l`
- include new test directory in build

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6864ff2cdd4c832ab22921114d352050