### PR TITLE
Improve long double math support

### DIFF
--- a/extern/cycles/include/cuda_unified_fix.h
+++ b/extern/cycles/include/cuda_unified_fix.h
@@ -182,16 +182,38 @@ inline long double acosl(long double x) {
         errno = EDOM;
         return NAN;
     }
-    return static_cast<long double>(acos(static_cast<double>(x)));
+#if defined(__CUDA_ARCH__)
+    long double r = sqrtl(1.0L - x * x);
+    return atan2l(r, x);
+#else
+    return std::acosl(x);
+#endif
 }
 inline long double asinl(long double x) {
-    return asin((double)x);
+    if (x < -1.0L || x > 1.0L) {
+        errno = EDOM;
+        return NAN;
+    }
+#if defined(__CUDA_ARCH__)
+    long double r = sqrtl(1.0L - x * x);
+    return atan2l(x, r);
+#else
+    return std::asinl(x);
+#endif
 }
 inline long double atanl(long double x) {
+#if defined(__CUDA_ARCH__)
     return atan((double)x);
+#else
+    return std::atanl(x);
+#endif
 }
 inline long double atan2l(long double y, long double x) {
+#if defined(__CUDA_ARCH__)
     return atan2((double)y, (double)x);
+#else
+    return std::atan2l(y, x);
+#endif
 }
 inline long double ceill(long double x) {
     return ceil((double)x);

--- a/include/compat/cuda_unified_fix.h
+++ b/include/compat/cuda_unified_fix.h
@@ -194,16 +194,39 @@ inline long double acosl(long double x) {
         errno = EDOM;
         return NAN;
     }
-    return static_cast<long double>(acos(static_cast<double>(x)));
+#if defined(__CUDA_ARCH__)
+    // Fallback for device builds lacking acosl
+    long double r = sqrtl(1.0L - x * x);
+    return atan2l(r, x);
+#else
+    return std::acosl(x);
+#endif
 }
 inline long double asinl(long double x) {
-    return asin((double)x);
+    if (x < -1.0L || x > 1.0L) {
+        errno = EDOM;
+        return NAN;
+    }
+#if defined(__CUDA_ARCH__)
+    long double r = sqrtl(1.0L - x * x);
+    return atan2l(x, r);
+#else
+    return std::asinl(x);
+#endif
 }
 inline long double atanl(long double x) {
+#if defined(__CUDA_ARCH__)
     return atan((double)x);
+#else
+    return std::atanl(x);
+#endif
 }
 inline long double atan2l(long double y, long double x) {
+#if defined(__CUDA_ARCH__)
     return atan2((double)y, (double)x);
+#else
+    return std::atan2l(y, x);
+#endif
 }
 inline long double ceill(long double x) {
     return ceil((double)x);

--- a/tests/api/CMakeLists.txt
+++ b/tests/api/CMakeLists.txt
@@ -7,6 +7,7 @@ find_package(GTest REQUIRED)
 add_executable(api_tests
     server_test.cpp
     health_endpoint_test.cpp
+    long_double_math_test.cpp
 )
 
 target_include_directories(api_tests PRIVATE

--- a/tests/api/long_double_math_test.cpp
+++ b/tests/api/long_double_math_test.cpp
@@ -1,0 +1,30 @@
+#include "compat/cuda_unified_fix.h"
+#include <gtest/gtest.h>
+#include <cmath>
+#include <cerrno>
+
+TEST(LongDoubleMath, AcoslAccuracy) {
+    long double values[] = {-1.0L, -0.5L, 0.0L, 0.5L, 1.0L};
+    for (long double v : values) {
+        errno = 0;
+        long double expected = std::acosl(v);
+        long double result = acosl(v);
+        if (v < -1.0L || v > 1.0L) {
+            EXPECT_TRUE(std::isnan(result));
+            EXPECT_EQ(errno, EDOM);
+        } else {
+            EXPECT_NEAR(static_cast<double>(result), static_cast<double>(expected), 1e-12);
+        }
+    }
+}
+
+TEST(LongDoubleMath, Atan2lAccuracy) {
+    long double vals[] = {-1.0L, -0.5L, 0.0L, 0.5L, 1.0L};
+    for (long double y : vals) {
+        for (long double x : vals) {
+            long double expected = std::atan2l(y, x);
+            long double result = atan2l(y, x);
+            EXPECT_NEAR(static_cast<double>(result), static_cast<double>(expected), 1e-12);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement domain-aware `acosl`, `asinl`, `atanl`, and `atan2l` wrappers
- use high precision fallback when CUDA long double support is absent
- add `long_double_math_test` verifying accuracy of wrappers

## Testing
- `cmake -DBUILD_TESTING=ON ..` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6864ff2cdd4c832ab22921114d352050