### PR TITLE
Integrate spdlog logging wrappers

### DIFF
--- a/include/compat/macros.h
+++ b/include/compat/macros.h
@@ -24,6 +24,17 @@
 #define SEP_HAS_CYCLES 0
 #endif
 
+// -----------------------------------------------------------------------------
+// spdlog availability
+// -----------------------------------------------------------------------------
+#ifndef SEP_HAS_SPDLOG
+#if __has_include(<spdlog/spdlog.h>)
+#define SEP_HAS_SPDLOG 1
+#else
+#define SEP_HAS_SPDLOG 0
+#endif
+#endif
+
 // Backwards compatibility for legacy macros used across the code base.
 #ifndef SEP_HAS_CUDA_RUNTIME
 #define SEP_HAS_CUDA_RUNTIME SEP_CUDA_AVAILABLE

--- a/include/crow/logging.h
+++ b/include/crow/logging.h
@@ -1,55 +1,80 @@
 #pragma once
 
-// This is a minimal version of the logging.h file from the Crow framework
-// It provides stub implementations for logging functionality
-
-// Use relative path from project root
 #include "compat/shim.h"
+#include "memory/spdlog_isolation.h"
+#include <memory>
 #include <sstream>
+#if SEP_HAS_SPDLOG
+#include <spdlog/sinks/stdout_sinks.h>
+#include <spdlog/sinks/stdout_color_sinks.h>
+#endif
 
 namespace crow {
-    enum class LogLevel {
-        Debug = 0,
-        Info,
-        Warning,
-        Error,
-        Critical
-    };
 
-    class LogHandler {
-    public:
-        void operator()(const sep::shim::string& message) {
-            // In a real implementation, this would log to stderr
-            // For now, we'll just provide a stub
-        }
-    };
+enum class LogLevel { Debug = 0, Info, Warning, Error, Critical };
 
-    class Logger {
-    public:
-        Logger(LogLevel level) : level_(level) {}
-
-        template <typename T>
-        Logger& operator<<(T const& value) {
-            // In a real implementation, this would append to a message
-            // For now, we'll just provide a stub
-            return *this;
-        }
-
-        ~Logger() {
-            // In a real implementation, this would flush the log message
-            // For now, we'll just provide a stub
-        }
-
-    private:
-        LogLevel level_;
-        // Using a simple string instead of stringstream to avoid template issues
-        sep::shim::string message_;
-        LogHandler handler_;
-    };
+namespace detail {
+inline sep::spdlog::level to_spd_level(LogLevel lvl) {
+    using SepLevel = sep::spdlog::level;
+    switch (lvl) {
+        case LogLevel::Debug: return SepLevel::debug;
+        case LogLevel::Info: return SepLevel::info;
+        case LogLevel::Warning: return SepLevel::warn;
+        case LogLevel::Error: return SepLevel::err;
+        case LogLevel::Critical: return SepLevel::critical;
+    }
+    return SepLevel::info;
 }
 
-// Define logging macros - use non-template version to avoid template argument issues
-#define CROW_LOG_ERROR crow::Logger(crow::LogLevel::Error)
+inline std::shared_ptr<sep::spdlog::logger> get_logger() {
+    auto logger = sep::spdlog::details::registry::instance().get("crow");
+#if SEP_HAS_SPDLOG
+    if (!logger) {
+        logger = std::make_shared<sep::spdlog::logger>("crow", std::make_shared<::spdlog::sinks::stderr_sink_mt>());
+        sep::spdlog::details::registry::instance().register_logger(logger);
+    }
+#endif
+    return logger;
+}
+} // namespace detail
+
+class LogHandler {
+public:
+    LogHandler() : logger_(detail::get_logger()) {}
+    void operator()(const std::string& message, LogLevel level) {
+#if SEP_HAS_SPDLOG
+        logger_->log(detail::to_spd_level(level), message);
+#else
+        (void)message;
+        (void)level;
+#endif
+    }
+private:
+    std::shared_ptr<sep::spdlog::logger> logger_;
+};
+
+class Logger {
+public:
+    explicit Logger(LogLevel level) : level_(level) {}
+
+    template <typename T>
+    Logger& operator<<(const T& value) {
+        stream_ << value;
+        return *this;
+    }
+
+    ~Logger() { handler_(stream_.str(), level_); }
+
+private:
+    LogLevel   level_;
+    std::ostringstream stream_;
+    LogHandler handler_;
+};
+
+} // namespace crow
+
+#define CROW_LOG_ERROR   crow::Logger(crow::LogLevel::Error)
 #define CROW_LOG_WARNING crow::Logger(crow::LogLevel::Warning)
-#define CROW_LOG_INFO crow::Logger(crow::LogLevel::Info)
-#define CROW_LOG_DEBUG crow::Logger(crow::LogLevel::Debug)
+#define CROW_LOG_INFO    crow::Logger(crow::LogLevel::Info)
+#define CROW_LOG_DEBUG   crow::Logger(crow::LogLevel::Debug)
+

--- a/include/memory/spdlog_isolation.h
+++ b/include/memory/spdlog_isolation.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "compat/cuda_common.h"
+#include "compat/macros.h"
 
 #include <sstream>
 #include <string>
@@ -41,8 +42,8 @@ public:
 // It provides stub implementations for spdlog functionality that can be
 // safely included in CUDA files without causing template instantiation errors
 
-// Check for CUDA compilation - either via __CUDACC__ or our custom SEP_CUDA_COMPILATION flag
-#if defined(__CUDACC__) || defined(SEP_CUDA_COMPILATION)
+// Check for CUDA compilation or missing spdlog headers
+#if defined(__CUDACC__) || defined(SEP_CUDA_COMPILATION) || !SEP_HAS_SPDLOG
 // When compiling with CUDA, provide stub implementations
 
 // Include our isolation headers
@@ -367,4 +368,4 @@ public:
 } // namespace details
 } // namespace spdlog
 } // namespace sep
-#endif // defined(__CUDACC__) || defined(SEP_CUDA_COMPILATION)
+#endif // defined(__CUDACC__) || defined(SEP_CUDA_COMPILATION) || !SEP_HAS_SPDLOG


### PR DESCRIPTION
## Summary
- add `SEP_HAS_SPDLOG` feature macro
- update `spdlog_isolation.h` to check for real spdlog headers
- rework Crow `Logger` to wrap `spdlog::logger`

## Testing
- `g++ -std=c++17 /tmp/test.cpp -Iinclude -lpthread -lspdlog -lfmt -o /tmp/test_app && /tmp/test_app`

------
https://chatgpt.com/codex/tasks/task_e_6864ff1548f0832ab1b02d985602c561