### PR TITLE
Integrate spdlog-backed Crow logging

### DIFF
--- a/include/crow/logging.h
+++ b/include/crow/logging.h
@@ -5,6 +5,7 @@
 
 // Use relative path from project root
 #include "compat/shim.h"
+#include "memory/spdlog_isolation.h"
 #include <sstream>
 
 namespace crow {
@@ -18,33 +19,66 @@ namespace crow {
 
     class LogHandler {
     public:
+        explicit LogHandler(spdlog::level::level_enum level,
+                            std::shared_ptr<spdlog::logger> logger =
+                                spdlog::default_logger())
+            : level_(level), logger_(std::move(logger)) {}
+
         void operator()(const sep::shim::string& message) {
-            // In a real implementation, this would log to stderr
-            // For now, we'll just provide a stub
+            if (logger_) {
+                logger_->log(level_, message.c_str());
+            } else {
+                spdlog::log(level_, message.c_str());
+            }
         }
+
+    private:
+        spdlog::level::level_enum           level_;
+        std::shared_ptr<spdlog::logger> logger_;
     };
 
     class Logger {
     public:
-        Logger(LogLevel level) : level_(level) {}
+        explicit Logger(LogLevel level,
+                        std::shared_ptr<spdlog::logger> logger =
+                            spdlog::default_logger())
+            : level_(level), logger_(std::move(logger)) {}
 
         template <typename T>
         Logger& operator<<(T const& value) {
-            // In a real implementation, this would append to a message
-            // For now, we'll just provide a stub
+            message_ << value;
             return *this;
         }
 
         ~Logger() {
-            // In a real implementation, this would flush the log message
-            // For now, we'll just provide a stub
+            if (logger_) {
+                logger_->log(toSpd(level_), message_.str());
+            } else {
+                spdlog::log(toSpd(level_), message_.str());
+            }
         }
 
     private:
-        LogLevel level_;
-        // Using a simple string instead of stringstream to avoid template issues
-        sep::shim::string message_;
-        LogHandler handler_;
+        static spdlog::level::level_enum toSpd(LogLevel level) {
+            switch (level) {
+            case LogLevel::Debug:
+                return spdlog::level::debug;
+            case LogLevel::Info:
+                return spdlog::level::info;
+            case LogLevel::Warning:
+                return spdlog::level::warn;
+            case LogLevel::Error:
+                return spdlog::level::err;
+            case LogLevel::Critical:
+                return spdlog::level::critical;
+            default:
+                return spdlog::level::info;
+            }
+        }
+
+        LogLevel                                level_;
+        std::shared_ptr<spdlog::logger>         logger_;
+        std::ostringstream                      message_;
     };
 }
 

--- a/include/memory/spdlog_isolation.h
+++ b/include/memory/spdlog_isolation.h
@@ -5,6 +5,16 @@
 #include <sstream>
 #include <string>
 
+#if defined(__CUDACC__) || defined(SEP_CUDA_COMPILATION)
+#  define SEP_SPDLOG_FALLBACK 1
+#elif defined(__has_include)
+#  if __has_include(<spdlog/spdlog.h>)
+#    define SEP_SPDLOG_AVAILABLE 1
+#  else
+#    define SEP_SPDLOG_FALLBACK 1
+#  endif
+#endif
+
 namespace sep {
 namespace spdlog {
 
@@ -41,8 +51,8 @@ public:
 // It provides stub implementations for spdlog functionality that can be
 // safely included in CUDA files without causing template instantiation errors
 
-// Check for CUDA compilation - either via __CUDACC__ or our custom SEP_CUDA_COMPILATION flag
-#if defined(__CUDACC__) || defined(SEP_CUDA_COMPILATION)
+// Fallback implementation when CUDA is used or spdlog headers are unavailable
+#if defined(SEP_SPDLOG_FALLBACK)
 // When compiling with CUDA, provide stub implementations
 
 // Include our isolation headers
@@ -293,7 +303,7 @@ public:
 } // namespace details
 } // namespace spdlog
 
-#else
+#elif defined(SEP_SPDLOG_AVAILABLE)
 #    include <spdlog/spdlog.h>
 #    include <spdlog/details/registry.h>
 #    include <chrono>
@@ -367,4 +377,4 @@ public:
 } // namespace details
 } // namespace spdlog
 } // namespace sep
-#endif // defined(__CUDACC__) || defined(SEP_CUDA_COMPILATION)
+#endif // SEP_SPDLOG_FALLBACK


### PR DESCRIPTION
## Summary
- wrap Crow LogHandler and Logger around spdlog::logger
- allow spdlog_isolation to forward to real spdlog when available

## Testing
- `cmake -S . -B _sep/testbed/build -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Debug -DCUDAToolkit_ROOT=/usr > _sep/testbed/cmake.log && tail -n 20 _sep/testbed/cmake.log`
- `ctest --output-on-failure -j4 > ../test.log && tail -n 20 ../test.log`


------
https://chatgpt.com/codex/tasks/task_e_6864ff1548f0832ab1b02d985602c561