### PR TITLE
Integrate spdlog with Crow stub logging

### DIFF
--- a/include/crow/logging.h
+++ b/include/crow/logging.h
@@ -1,11 +1,14 @@
 #pragma once
 
-// This is a minimal version of the logging.h file from the Crow framework
-// It provides stub implementations for logging functionality
+// Minimal logging helpers used by tests and small utilities.
+// These wrappers route Crow style log calls through spdlog so that
+// log output behaves consistently with the rest of the project.
 
-// Use relative path from project root
 #include "compat/shim.h"
+#include "memory/spdlog_isolation.h"
 #include <sstream>
+#include <spdlog/sinks/stdout_color_sinks.h>
+#include <memory>
 
 namespace crow {
     enum class LogLevel {
@@ -18,33 +21,57 @@ namespace crow {
 
     class LogHandler {
     public:
-        void operator()(const sep::shim::string& message) {
-            // In a real implementation, this would log to stderr
-            // For now, we'll just provide a stub
+        explicit LogHandler(std::shared_ptr<sep::spdlog::logger> logger = sep::spdlog::details::registry::instance().get("crow"))
+            : logger_(std::move(logger))
+        {
+            if (!logger_)
+            {
+                logger_ = ::spdlog::stderr_color_mt("crow");
+            }
         }
+
+        void operator()(LogLevel level, const sep::shim::string& message) const
+        {
+            logger_->log(toSpdLevel(level), message.c_str());
+        }
+
+    private:
+        static sep::spdlog::level toSpdLevel(LogLevel level)
+        {
+            switch (level)
+            {
+                case LogLevel::Debug:    return sep::spdlog::level::debug;
+                case LogLevel::Info:     return sep::spdlog::level::info;
+                case LogLevel::Warning:  return sep::spdlog::level::warn;
+                case LogLevel::Error:    return sep::spdlog::level::err;
+                case LogLevel::Critical: return sep::spdlog::level::critical;
+            }
+            return sep::spdlog::level::info;
+        }
+
+        std::shared_ptr<sep::spdlog::logger> logger_;
     };
 
     class Logger {
     public:
-        Logger(LogLevel level) : level_(level) {}
+        explicit Logger(LogLevel level) : level_(level) {}
 
         template <typename T>
-        Logger& operator<<(T const& value) {
-            // In a real implementation, this would append to a message
-            // For now, we'll just provide a stub
+        Logger& operator<<(const T& value)
+        {
+            ss_ << value;
             return *this;
         }
 
-        ~Logger() {
-            // In a real implementation, this would flush the log message
-            // For now, we'll just provide a stub
+        ~Logger()
+        {
+            handler_(level_, ss_.str().c_str());
         }
 
     private:
         LogLevel level_;
-        // Using a simple string instead of stringstream to avoid template issues
-        sep::shim::string message_;
-        LogHandler handler_;
+        std::ostringstream ss_;
+        LogHandler        handler_;
     };
 }
 

--- a/include/memory/spdlog_isolation.h
+++ b/include/memory/spdlog_isolation.h
@@ -41,8 +41,9 @@ public:
 // It provides stub implementations for spdlog functionality that can be
 // safely included in CUDA files without causing template instantiation errors
 
-// Check for CUDA compilation - either via __CUDACC__ or our custom SEP_CUDA_COMPILATION flag
-#if defined(__CUDACC__) || defined(SEP_CUDA_COMPILATION)
+// When spdlog is unavailable or when building for CUDA we provide lightweight
+// fallback types. Otherwise the real spdlog headers are used.
+#if (defined(__CUDACC__) || defined(SEP_CUDA_COMPILATION)) || !__has_include(<spdlog/spdlog.h>)
 // When compiling with CUDA, provide stub implementations
 
 // Include our isolation headers
@@ -367,4 +368,4 @@ public:
 } // namespace details
 } // namespace spdlog
 } // namespace sep
-#endif // defined(__CUDACC__) || defined(SEP_CUDA_COMPILATION)
+#endif // fallback implementation


### PR DESCRIPTION
## Summary
- hook Crow logging helpers up to spdlog so they emit real messages
- allow `spdlog_isolation.h` to use the real headers when present

## Testing
- `g++ -std=c++17 /tmp/test_logging.cpp -Iinclude -pthread -lspdlog -lfmt $(pkg-config --cflags --libs gtest) -o /tmp/test_logging`
- `/tmp/test_logging`

------
https://chatgpt.com/codex/tasks/task_e_6864ff1548f0832ab1b02d985602c561