### PR TITLE
Implement CUDA kernels

### DIFF
--- a/src/compat/quantum_kernels.cu
+++ b/src/compat/quantum_kernels.cu
@@ -185,15 +185,16 @@ SEP_GLOBAL void blend_kernel(float* d_output, const float* d_embeddings, const f
 
 // Kernel launch implementations
 cudaError_t launchQBSAKernel(const std::uint32_t* d_probe_indices, const std::uint32_t* d_expectations,
-                              std::uint32_t num_probes, std::uint32_t* d_bitfield, std::uint32_t* d_corrections,
-                              std::uint32_t* d_correction_count, cudaStream_t stream) {
+                             std::uint32_t num_probes, std::uint32_t* d_bitfield, std::uint32_t* d_corrections,
+                             std::uint32_t* d_correction_count, cudaStream_t stream) {
     sep::cuda::KernelTrace trace{"qbsa_kernel", reinterpret_cast<void*>(stream)};
     const uint32_t block_size = sep::cuda::constants::get_default_block_size();
     const uint32_t grid_size = (num_probes + block_size - 1) / block_size;
 
-    return sep::cuda::launchKernel("qbsa_kernel", dim3(grid_size), dim3(block_size), stream, detail::qbsa_kernel,
-                                   d_probe_indices, d_expectations, num_probes, d_bitfield, d_corrections,
-                                   d_correction_count);
+    detail::qbsa_kernel<<<grid_size, block_size, 0, stream>>>(d_probe_indices, d_expectations, num_probes,
+                                                              d_bitfield, d_corrections, d_correction_count);
+
+    return cudaGetLastError();
 }
 
 cudaError_t launchQSHKernel(const std::uint64_t* d_chunks, std::uint32_t num_chunks, std::uint32_t* d_collapse_indices,
@@ -202,8 +203,10 @@ cudaError_t launchQSHKernel(const std::uint64_t* d_chunks, std::uint32_t num_chu
     const uint32_t block_size = sep::cuda::constants::get_default_block_size();
     const uint32_t grid_size = (num_chunks + block_size - 1) / block_size;
 
-    return sep::cuda::launchKernel("qsh_kernel", dim3(grid_size), dim3(block_size), stream, detail::qsh_kernel,
-                                   d_chunks, num_chunks, d_collapse_indices, d_collapse_counts);
+    detail::qsh_kernel<<<grid_size, block_size, 0, stream>>>(d_chunks, num_chunks, d_collapse_indices,
+                                                             d_collapse_counts);
+
+    return cudaGetLastError();
 }
 
 cudaError_t launchSimilarityKernel(float* d_similarity, const float* d_emb_a, const float* d_emb_b,


### PR DESCRIPTION
## Summary
- implement direct kernel launches for QBSA and QSH
- return `cudaGetLastError()` from launchers

## Testing
- `cmake .. -DBUILD_TESTING=ON -DSEP_USE_CUDA=ON` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6864ff20a1bc832a85fd8d68527aa20f