### PR TITLE
Switch isolation headers to real Crow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,9 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(SEPConfig)
 configure_sep()
 
+# Make the real Crow headers available to all targets
+include_directories(BEFORE ${CMAKE_SOURCE_DIR}/extern/Crow/include)
+
 # Find required packages
 find_package(Threads REQUIRED)
 find_package(CURL REQUIRED)

--- a/include/crow/app.h
+++ b/include/crow/app.h
@@ -1,47 +1,34 @@
 #pragma once
 
-// This is a fixed version of the app.h file from the Crow framework
-// It provides stub implementations for the Crow application class
+// Lightweight wrapper utilities for Crow applications.  When building without
+// CUDA the real Crow headers are included by crow_isolation.h.
 
-// Include our own headers
-#include "compat/shim.h"
-#include "common.h"
 #include "crow_isolation.h"
 
 namespace crow {
-    // The Crow class is already defined in crow_isolation.h as a template
-    // This file just ensures that it's properly included and instantiated
-    
-    // Create a factory function to create a Crow app
-    template <typename... Middlewares>
-    inline crow<Middlewares...>* make_app() {
-        return new crow<Middlewares...>();
-    }
-    
-    // Add any additional Crow app functionality needed here
-    
-    // Helper function to set up routes
-    template <typename... Middlewares>
-    inline DummyRoute route(crow<Middlewares...>* app, const sep::shim::string& url) {
-        if (app) {
-            return app->route(url);
-        }
-        return {};
-    }
-    
-    // Helper function to run the app
-    template <typename... Middlewares>
-    inline void run(crow<Middlewares...>* app) {
-        if (app) {
-            app->run();
-        }
-    }
-    
-    // Helper function to stop the app
-    template <typename... Middlewares>
-    inline void stop(crow<Middlewares...>* app) {
-        if (app) {
-            app->stop();
-        }
-    }
+
+// Factory helper to create a Crow application.
+template <typename... Middlewares>
+inline Crow<Middlewares...>* make_app() {
+    return new Crow<Middlewares...>();
 }
+
+// Convenience wrapper around Crow::route_dynamic.
+template <typename... Middlewares>
+inline auto route(Crow<Middlewares...>* app, const std::string& url) {
+    return app->route_dynamic(url);
+}
+
+template <typename... Middlewares>
+inline void run(Crow<Middlewares...>* app) {
+    if (app)
+        app->run();
+}
+
+template <typename... Middlewares>
+inline void stop(Crow<Middlewares...>* app) {
+    if (app)
+        app->stop();
+}
+
+} // namespace crow

--- a/include/crow/common.h
+++ b/include/crow/common.h
@@ -1,7 +1,12 @@
 #pragma once
 
+// When not compiling with NVCC, include the real Crow common header directly.
+#ifndef __CUDACC__
+#include <crow/common.h>
+#else
+
 // This is a minimal version of the common.h file from the Crow framework
-// It provides stub implementations for common functionality
+// used during CUDA compilation to avoid heavy template instantiation.
 
 // Include our own headers
 #include "compat/shim.h"
@@ -139,4 +144,4 @@ namespace crow {
         routing_handle_result() {}
     };
 
-} // namespace crow
+} // namespace crow\n#endif

--- a/include/crow/crow_isolation.h
+++ b/include/crow/crow_isolation.h
@@ -1,12 +1,19 @@
+
 #pragma once
 
 #define SEP_CROW_ISOLATION_INCLUDED
 
-// This header file is used to isolate Crow-related code from CUDA compilation
-// It provides stub implementations for Crow functionality that can be
-// safely included in CUDA files without causing template instantiation errors
+// This header isolates Crow-related code from CUDA compilation.  When not
+// compiling with NVCC we simply include the real Crow headers.  Otherwise we
+// provide lightweight stub definitions that avoid heavy template instantiation.
 
-// Include our own headers
+#ifndef __CUDACC__
+
+#include <crow.h>
+
+#else
+
+// Include our own headers when building with CUDA
 #include "compat/shim.h"
 #include "common.h"
 
@@ -104,25 +111,6 @@ namespace crow {
         response res;
     };
 
-    // Minimal stub representing a route rule returned by CROW_ROUTE and friends
-    class DummyRoute {
-    public:
-        template<typename... Args>
-        DummyRoute& methods(Args&&...) {
-            return *this;
-        }
-
-        template<typename F>
-        DummyRoute& operator()(F&& f) {
-            return *this;
-        }
-
-        template<typename... Args>
-        DummyRoute& websocket(Args&&...) {
-            return *this;
-        }
-    };
-
     // Non-templated base class for Crow app to avoid template issues
     class CrowBase {
     public:
@@ -134,17 +122,9 @@ namespace crow {
         void run() {}
         void stop() {}
 
-        DummyRoute route(const sep::shim::string&) {
-            return {};
-        }
-
-        DummyRoute route_dynamic(const sep::shim::string&) {
-            return {};
-        }
-
-        DummyRoute catchall_route() {
-            return {};
-        }
+        void route(const sep::shim::string&) {}
+        void route_dynamic(const sep::shim::string&) {}
+        void catchall_route() {}
     };
 
     // Forward declaration of the templated Crow class
@@ -250,4 +230,4 @@ namespace crow {
             void* on_chunk_complete;
         };
     }  // namespace http_parser_stub
-}  // namespace crow
+}  // namespace crow\n#endif

--- a/include/crow/http_request.h
+++ b/include/crow/http_request.h
@@ -3,9 +3,7 @@
 // This is a fixed version of the http_request.h file from the Crow framework
 // It provides stub implementations for HTTP request functionality
 
-// Include our own headers
-#include "compat/shim.h"
-#include "common.h"
+// Include the isolation header which pulls in the real Crow request
 #include "crow_isolation.h"
 
 namespace crow {


### PR DESCRIPTION
## Summary
- pull in real Crow headers via new extern/Crow path
- rework crow_isolation.h to include real Crow when not using CUDA
- update Crow wrappers in app.h and http_request.h
- ensure common.h forwards to the real Crow headers
- adjust include paths in CMakeLists.txt

## Testing
- `cmake --build build` *(fails: Could not find nvcc)*
- `ctest --test-dir build` *(no tests discovered)*

------
https://chatgpt.com/codex/tasks/task_e_6864ff047834832a9a22eddb6ae9aade