### PR TITLE
Improve CUDA long double math support

### DIFF
--- a/extern/cycles/include/cuda_unified_fix.h
+++ b/extern/cycles/include/cuda_unified_fix.h
@@ -177,21 +177,29 @@ constexpr int FP_CLASS_NAN = 4;        // NaN values
 extern "C" {
 
 // Define stubs for long double math functions that GCC-14 expects but are missing in CUDA
-inline long double acosl(long double x) {
+SEP_HD inline long double acosl(long double x) {
     if (x < -1.0L || x > 1.0L) {
         errno = EDOM;
         return NAN;
     }
     return static_cast<long double>(acos(static_cast<double>(x)));
 }
-inline long double asinl(long double x) {
-    return asin((double)x);
+SEP_HD inline long double asinl(long double x) {
+    if (x < -1.0L || x > 1.0L) {
+        errno = EDOM;
+        return NAN;
+    }
+    return static_cast<long double>(asin(static_cast<double>(x)));
 }
-inline long double atanl(long double x) {
-    return atan((double)x);
+SEP_HD inline long double atanl(long double x) {
+    return static_cast<long double>(atan(static_cast<double>(x)));
 }
-inline long double atan2l(long double y, long double x) {
-    return atan2((double)y, (double)x);
+SEP_HD inline long double atan2l(long double y, long double x) {
+    if (x == 0.0L && y == 0.0L) {
+        errno = EDOM;
+        return NAN;
+    }
+    return static_cast<long double>(atan2((double)y, (double)x));
 }
 inline long double ceill(long double x) {
     return ceil((double)x);
@@ -220,7 +228,7 @@ inline long double frexpl(long double x, int* exp) {
 inline long double ldexpl(long double x, int exp) {
     return ldexp((double)x, exp);
 }
-inline long double logl(long double x) {
+SEP_HD inline long double logl(long double x) {
     if (x <= 0.0L) {
         errno = EDOM;
         return NAN;

--- a/include/compat/cuda_unified_fix.h
+++ b/include/compat/cuda_unified_fix.h
@@ -189,21 +189,29 @@ constexpr int FP_CLASS_NAN = 4;        // NaN values
 extern "C" {
 
 // Define stubs for long double math functions that GCC-14 expects but are missing in CUDA
-inline long double acosl(long double x) {
+SEP_HD inline long double acosl(long double x) {
     if (x < -1.0L || x > 1.0L) {
         errno = EDOM;
         return NAN;
     }
     return static_cast<long double>(acos(static_cast<double>(x)));
 }
-inline long double asinl(long double x) {
-    return asin((double)x);
+SEP_HD inline long double asinl(long double x) {
+    if (x < -1.0L || x > 1.0L) {
+        errno = EDOM;
+        return NAN;
+    }
+    return static_cast<long double>(asin(static_cast<double>(x)));
 }
-inline long double atanl(long double x) {
-    return atan((double)x);
+SEP_HD inline long double atanl(long double x) {
+    return static_cast<long double>(atan(static_cast<double>(x)));
 }
-inline long double atan2l(long double y, long double x) {
-    return atan2((double)y, (double)x);
+SEP_HD inline long double atan2l(long double y, long double x) {
+    if (x == 0.0L && y == 0.0L) {
+        errno = EDOM;
+        return NAN;
+    }
+    return static_cast<long double>(atan2((double)y, (double)x));
 }
 inline long double ceill(long double x) {
     return ceil((double)x);
@@ -232,7 +240,7 @@ inline long double frexpl(long double x, int* exp) {
 inline long double ldexpl(long double x, int exp) {
     return ldexp((double)x, exp);
 }
-inline long double logl(long double x) {
+SEP_HD inline long double logl(long double x) {
     if (x <= 0.0L) {
         errno = EDOM;
         return NAN;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ add_subdirectory(quantum)
 add_subdirectory(memory)
 add_subdirectory(audio)
 add_subdirectory(api)
+add_subdirectory(cuda)
 
 # Configure test discovery
 include(CTest)

--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -1,0 +1,20 @@
+if(NOT BUILD_TESTING)
+    return()
+endif()
+
+find_package(GTest REQUIRED)
+
+add_executable(long_double_math_tests
+    long_double_math_test.cpp
+)
+
+target_include_directories(long_double_math_tests PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+
+target_link_libraries(long_double_math_tests PRIVATE
+    GTest::GTest
+    GTest::Main
+)
+
+add_test(NAME long_double_math_tests COMMAND long_double_math_tests)

--- a/tests/cuda/long_double_math_test.cpp
+++ b/tests/cuda/long_double_math_test.cpp
@@ -1,0 +1,31 @@
+#include "compat/cuda_unified_fix.h"
+#include <gtest/gtest.h>
+#include <cmath>
+#include <cerrno>
+
+TEST(LongDoubleMath, AcoslMatchesStd) {
+    long double v = 0.5L;
+    long double expected = ::acosl(v);
+    long double result = acosl(v);
+    EXPECT_NEAR(static_cast<double>(result), static_cast<double>(expected), 1e-12);
+}
+
+TEST(LongDoubleMath, Atan2lMatchesStd) {
+    long double y = 0.7L;
+    long double x = -0.4L;
+    long double expected = ::atan2l(y, x);
+    long double result = atan2l(y, x);
+    EXPECT_NEAR(static_cast<double>(result), static_cast<double>(expected), 1e-12);
+}
+
+TEST(LongDoubleMath, AcoslDomainError) {
+    errno = 0;
+    long double r = acosl(1.5L);
+    EXPECT_EQ(errno, EDOM);
+    EXPECT_TRUE(std::isnan(static_cast<double>(r)));
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary
- provide device/host-compatible implementations of long double math stubs
- add new CUDA test directory and verify acosl/atan2l correctness

## Testing
- `g++ -std=c++17 -Iinclude tests/cuda/long_double_math_test.cpp /usr/lib/x86_64-linux-gnu/libgtest.a /usr/lib/x86_64-linux-gnu/libgtest_main.a -lpthread -o long_double_math_tests && ./long_double_math_tests`

------
https://chatgpt.com/codex/tasks/task_e_6864ff2cdd4c832ab22921114d352050