### PR TITLE
Improve CUDA long double math handling

### DIFF
--- a/extern/cycles/include/cuda_unified_fix.h
+++ b/extern/cycles/include/cuda_unified_fix.h
@@ -75,6 +75,14 @@ CUDA_UNIFIED_FIX_BEGIN_SCOPE()
 #include <cmath>
 #pragma GCC diagnostic pop
 #endif
+
+// Map standard long double functions to SEP implementations
+#define acosl sep_acosl
+#define asinl sep_asinl
+#define atanl sep_atanl
+#define atan2l sep_atan2l
+#define sqrtl sep_sqrtl
+#define logl sep_logl
 CUDA_UNIFIED_FIX_END_SCOPE()
 
 // Indicate whether CUDA support is available for this compilation unit.
@@ -177,21 +185,57 @@ constexpr int FP_CLASS_NAN = 4;        // NaN values
 extern "C" {
 
 // Define stubs for long double math functions that GCC-14 expects but are missing in CUDA
-inline long double acosl(long double x) {
+SEP_HOST SEP_DEVICE inline long double sep_acosl(long double x) {
+#if defined(__CUDA_ARCH__)
     if (x < -1.0L || x > 1.0L) {
         errno = EDOM;
         return NAN;
     }
-    return static_cast<long double>(acos(static_cast<double>(x)));
+#if defined(__CUDA_LONG_DOUBLE_MATH_FUNCTIONS__)
+    return ::acosl(x);
+#else
+    return static_cast<long double>(::acos(static_cast<double>(x)));
+#endif
+#else
+    return __builtin_acosl(x);
+#endif
 }
-inline long double asinl(long double x) {
-    return asin((double)x);
+SEP_HOST SEP_DEVICE inline long double sep_asinl(long double x) {
+#if defined(__CUDA_ARCH__)
+    if (x < -1.0L || x > 1.0L) {
+        errno = EDOM;
+        return NAN;
+    }
+#if defined(__CUDA_LONG_DOUBLE_MATH_FUNCTIONS__)
+    return ::asinl(x);
+#else
+    return static_cast<long double>(::asin(static_cast<double>(x)));
+#endif
+#else
+    return __builtin_asinl(x);
+#endif
 }
-inline long double atanl(long double x) {
-    return atan((double)x);
+SEP_HOST SEP_DEVICE inline long double sep_atanl(long double x) {
+#if defined(__CUDA_ARCH__)
+#if defined(__CUDA_LONG_DOUBLE_MATH_FUNCTIONS__)
+    return ::atanl(x);
+#else
+    return static_cast<long double>(::atan(static_cast<double>(x)));
+#endif
+#else
+    return __builtin_atanl(x);
+#endif
 }
-inline long double atan2l(long double y, long double x) {
-    return atan2((double)y, (double)x);
+SEP_HOST SEP_DEVICE inline long double sep_atan2l(long double y, long double x) {
+#if defined(__CUDA_ARCH__)
+#if defined(__CUDA_LONG_DOUBLE_MATH_FUNCTIONS__)
+    return ::atan2l(y, x);
+#else
+    return static_cast<long double>(::atan2(static_cast<double>(y), static_cast<double>(x)));
+#endif
+#else
+    return __builtin_atan2l(y, x);
+#endif
 }
 inline long double ceill(long double x) {
     return ceil((double)x);
@@ -220,12 +264,20 @@ inline long double frexpl(long double x, int* exp) {
 inline long double ldexpl(long double x, int exp) {
     return ldexp((double)x, exp);
 }
-inline long double logl(long double x) {
+SEP_HOST SEP_DEVICE inline long double sep_logl(long double x) {
+#if defined(__CUDA_ARCH__)
     if (x <= 0.0L) {
         errno = EDOM;
         return NAN;
     }
-    return log((double)x);
+#if defined(__CUDA_LONG_DOUBLE_MATH_FUNCTIONS__)
+    return ::logl(x);
+#else
+    return static_cast<long double>(::log(static_cast<double>(x)));
+#endif
+#else
+    return __builtin_logl(x);
+#endif
 }
 inline long double log10l(long double x) {
     return log10((double)x);
@@ -245,8 +297,20 @@ inline long double sinl(long double x) {
 inline long double sinhl(long double x) {
     return sinh((double)x);
 }
-inline long double sqrtl(long double x) {
-    return sqrt((double)x);
+SEP_HOST SEP_DEVICE inline long double sep_sqrtl(long double x) {
+#if defined(__CUDA_ARCH__)
+    if (x < 0.0L) {
+        errno = EDOM;
+        return NAN;
+    }
+#if defined(__CUDA_LONG_DOUBLE_MATH_FUNCTIONS__)
+    return ::sqrtl(x);
+#else
+    return static_cast<long double>(::sqrt(static_cast<double>(x)));
+#endif
+#else
+    return __builtin_sqrtl(x);
+#endif
 }
 inline long double tanl(long double x) {
     return tan((double)x);

--- a/include/compat/cuda_unified_fix.h
+++ b/include/compat/cuda_unified_fix.h
@@ -75,6 +75,14 @@ CUDA_UNIFIED_FIX_BEGIN_SCOPE()
 #include <cmath>
 #pragma GCC diagnostic pop
 #endif
+
+// Map standard long double functions to SEP implementations
+#define acosl sep_acosl
+#define asinl sep_asinl
+#define atanl sep_atanl
+#define atan2l sep_atan2l
+#define sqrtl sep_sqrtl
+#define logl sep_logl
 CUDA_UNIFIED_FIX_END_SCOPE()
 
 // Indicate whether CUDA support is available for this compilation unit.
@@ -189,21 +197,60 @@ constexpr int FP_CLASS_NAN = 4;        // NaN values
 extern "C" {
 
 // Define stubs for long double math functions that GCC-14 expects but are missing in CUDA
-inline long double acosl(long double x) {
+SEP_HOST SEP_DEVICE inline long double sep_acosl(long double x) {
+#if defined(__CUDA_ARCH__)
     if (x < -1.0L || x > 1.0L) {
         errno = EDOM;
         return NAN;
     }
-    return static_cast<long double>(acos(static_cast<double>(x)));
+#if defined(__CUDA_LONG_DOUBLE_MATH_FUNCTIONS__)
+    return ::acosl(x);
+#else
+    return static_cast<long double>(::acos(static_cast<double>(x)));
+#endif
+#else
+    return __builtin_acosl(x);
+#endif
 }
-inline long double asinl(long double x) {
-    return asin((double)x);
+
+SEP_HOST SEP_DEVICE inline long double sep_asinl(long double x) {
+#if defined(__CUDA_ARCH__)
+    if (x < -1.0L || x > 1.0L) {
+        errno = EDOM;
+        return NAN;
+    }
+#if defined(__CUDA_LONG_DOUBLE_MATH_FUNCTIONS__)
+    return ::asinl(x);
+#else
+    return static_cast<long double>(::asin(static_cast<double>(x)));
+#endif
+#else
+    return __builtin_asinl(x);
+#endif
 }
-inline long double atanl(long double x) {
-    return atan((double)x);
+
+SEP_HOST SEP_DEVICE inline long double sep_atanl(long double x) {
+#if defined(__CUDA_ARCH__)
+#if defined(__CUDA_LONG_DOUBLE_MATH_FUNCTIONS__)
+    return ::atanl(x);
+#else
+    return static_cast<long double>(::atan(static_cast<double>(x)));
+#endif
+#else
+    return __builtin_atanl(x);
+#endif
 }
-inline long double atan2l(long double y, long double x) {
-    return atan2((double)y, (double)x);
+
+SEP_HOST SEP_DEVICE inline long double sep_atan2l(long double y, long double x) {
+#if defined(__CUDA_ARCH__)
+#if defined(__CUDA_LONG_DOUBLE_MATH_FUNCTIONS__)
+    return ::atan2l(y, x);
+#else
+    return static_cast<long double>(::atan2(static_cast<double>(y), static_cast<double>(x)));
+#endif
+#else
+    return __builtin_atan2l(y, x);
+#endif
 }
 inline long double ceill(long double x) {
     return ceil((double)x);
@@ -232,12 +279,20 @@ inline long double frexpl(long double x, int* exp) {
 inline long double ldexpl(long double x, int exp) {
     return ldexp((double)x, exp);
 }
-inline long double logl(long double x) {
+SEP_HOST SEP_DEVICE inline long double sep_logl(long double x) {
+#if defined(__CUDA_ARCH__)
     if (x <= 0.0L) {
         errno = EDOM;
         return NAN;
     }
-    return log((double)x);
+#if defined(__CUDA_LONG_DOUBLE_MATH_FUNCTIONS__)
+    return ::logl(x);
+#else
+    return static_cast<long double>(::log(static_cast<double>(x)));
+#endif
+#else
+    return __builtin_logl(x);
+#endif
 }
 inline long double log10l(long double x) {
     return log10((double)x);
@@ -257,8 +312,20 @@ inline long double sinl(long double x) {
 inline long double sinhl(long double x) {
     return sinh((double)x);
 }
-inline long double sqrtl(long double x) {
-    return sqrt((double)x);
+SEP_HOST SEP_DEVICE inline long double sep_sqrtl(long double x) {
+#if defined(__CUDA_ARCH__)
+    if (x < 0.0L) {
+        errno = EDOM;
+        return NAN;
+    }
+#if defined(__CUDA_LONG_DOUBLE_MATH_FUNCTIONS__)
+    return ::sqrtl(x);
+#else
+    return static_cast<long double>(::sqrt(static_cast<double>(x)));
+#endif
+#else
+    return __builtin_sqrtl(x);
+#endif
 }
 inline long double tanl(long double x) {
     return tan((double)x);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ add_subdirectory(quantum)
 add_subdirectory(memory)
 add_subdirectory(audio)
 add_subdirectory(api)
+add_subdirectory(compat)
 
 # Configure test discovery
 include(CTest)

--- a/tests/compat/CMakeLists.txt
+++ b/tests/compat/CMakeLists.txt
@@ -1,0 +1,20 @@
+if(NOT BUILD_TESTING)
+    return()
+endif()
+
+find_package(GTest REQUIRED)
+
+add_executable(long_double_math_host_tests long_double_math_test.cpp)
+target_include_directories(long_double_math_host_tests PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+target_link_libraries(long_double_math_host_tests PRIVATE GTest::GTest GTest::Main)
+add_test(NAME long_double_math_host_tests COMMAND long_double_math_host_tests)
+
+add_executable(long_double_math_device_tests long_double_math_test.cpp)
+target_compile_definitions(long_double_math_device_tests PRIVATE __CUDACC__)
+target_include_directories(long_double_math_device_tests PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)
+target_link_libraries(long_double_math_device_tests PRIVATE GTest::GTest GTest::Main)
+add_test(NAME long_double_math_device_tests COMMAND long_double_math_device_tests)

--- a/tests/compat/long_double_math_test.cpp
+++ b/tests/compat/long_double_math_test.cpp
@@ -1,0 +1,28 @@
+#include <gtest/gtest.h>
+#include <cerrno>
+#include <cmath>
+#include "compat/cuda_unified_fix.h"
+
+TEST(LongDoubleMath, AcoslAccuracy) {
+    long double values[] = {-1.0L, -0.5L, 0.0L, 0.5L, 1.0L};
+    for (long double v : values) {
+        errno = 0;
+        long double res = acosl(v);
+        long double ref = ::acosl(v);
+        EXPECT_NEAR(static_cast<double>(res), static_cast<double>(ref), 1e-9);
+        EXPECT_EQ(errno, 0);
+    }
+}
+
+TEST(LongDoubleMath, AcoslDomain) {
+    errno = 0;
+    long double res = acosl(1.5L);
+    EXPECT_TRUE(std::isnan(res));
+    EXPECT_EQ(errno, EDOM);
+}
+
+TEST(LongDoubleMath, Atan2lAccuracy) {
+    long double res = atan2l(0.75L, -0.25L);
+    long double ref = ::atan2l(0.75L, -0.25L);
+    EXPECT_NEAR(static_cast<double>(res), static_cast<double>(ref), 1e-9);
+}


### PR DESCRIPTION
## Summary
- add higher precision long double wrappers
- expose wrapper macros after system headers
- add regression tests for `acosl` and `atan2l`

## Testing
- `./ldmath_host`


------
https://chatgpt.com/codex/tasks/task_e_6864ff2cdd4c832ab22921114d352050