### PR TITLE
Implement CUDA memory allocation

### DIFF
--- a/include/compat/memory.h
+++ b/include/compat/memory.h
@@ -78,24 +78,24 @@ private:
 bool checkMemory(size_t required_size);
 
 #if !SEP_CUDA_AVAILABLE
-// Stub implementations when CUDA is not available
+// Host-only implementations when CUDA is not available
 inline void* allocateDeviceMemory(size_t size) {
-    return std::malloc(size);
+    if (size == 0)
+        return nullptr;
+    return new (std::nothrow) std::uint8_t[size];
 }
 
 inline void freeDeviceMemory(void* ptr) {
-    if (ptr)
-        std::free(ptr);
+    delete[] static_cast<std::uint8_t*>(ptr);
 }
 
 inline void* allocateUnifiedMemory(size_t size, cudaStream_t stream = nullptr) {
     (void)stream;
-    return std::malloc(size);
+    return allocateDeviceMemory(size);
 }
 
 inline void freeUnifiedMemory(void* ptr) {
-    if (ptr)
-        std::free(ptr);
+    freeDeviceMemory(ptr);
 }
 #else
 // Declarations for actual CUDA implementations

--- a/include/memory/unified_memory.h
+++ b/include/memory/unified_memory.h
@@ -2,9 +2,7 @@
 
 #include "compat/raii.h"
 #include "compat/cuda_common.h"
-#include "memory/memory_tier_manager.hpp"
 #include "memory/types.h"
-#include "memory/memory_tier.hpp"
 #include <cstddef>
 
 namespace sep {
@@ -80,39 +78,10 @@ private:
 };
 
 namespace cuda {
-
-// Implementation of CUDA memory functions
-inline void* allocateDeviceMemory(std::size_t size) {
-  auto* block = memory::MemoryTierManager::getInstance().allocate(size, ::sep::memory::TierType::UNIFIED);
-  return block ? block->ptr : nullptr;
-}
-
-inline void freeDeviceMemory(void* ptr) {
-  auto& mgr = memory::MemoryTierManager::getInstance();
-  memory::MemoryBlock* block = mgr.findBlockByPtr(ptr);
-  if (block) {
-    mgr.deallocate(block);
-  } else {
-    auto logger = sep::logging::Manager::getInstance().getLogger("memory");
-    if (logger) {
-      logger->error("Attempted to free unknown pointer {}", ptr);
-    }
-  }
-}
-
-inline void* allocateUnifiedMemory(std::size_t size, cudaStream_t stream) {
-  auto* blk = memory::MemoryTierManager::getInstance().allocate(
-      size, ::sep::memory::TierType::UNIFIED);
-  if (blk && stream)
-    cudaStreamAttachMemAsync(stream, blk->ptr);
-  return blk ? blk->ptr : nullptr;
-}
-
-inline void freeUnifiedMemory(void* ptr) {
-  auto& mgr = memory::MemoryTierManager::getInstance();
-  if (auto* blk = mgr.findBlockByPtr(ptr))
-    mgr.deallocate(blk);
-}
-
+// Use implementations provided by compat/raii
+using ::sep::cuda::allocateDeviceMemory;
+using ::sep::cuda::freeDeviceMemory;
+using ::sep::cuda::allocateUnifiedMemory;
+using ::sep::cuda::freeUnifiedMemory;
 } // namespace cuda
 }  // namespace sep

--- a/src/compat/raii.cpp
+++ b/src/compat/raii.cpp
@@ -13,7 +13,6 @@
 
 // Include CUDA headers in the correct order
 #include "compat/raii.h"
-#include "memory/memory_tier_manager.hpp" // Include header for interface
 #include "compat/cuda_helpers.h"         // For CUDA_CHECK macro
 #include "compat/cuda_common.h"
 #if SEP_CUDA_AVAILABLE
@@ -224,34 +223,65 @@ template class DeviceBufferRAII<double>;
 
 // Implementation of memory management functions
 void* allocateDeviceMemory(std::size_t size) {
-    auto* block = sep::memory::MemoryTierManager::getInstance().allocate(size, sep::memory::TierType::UNIFIED);
-    return block ? block->ptr : nullptr;
+#if SEP_CUDA_AVAILABLE
+    void* ptr = nullptr;
+    cudaError_t err = cudaMalloc(&ptr, size);
+    if (err != cudaSuccess) {
+        if (debugAllocEnabled()) {
+            (void)fprintf(stderr, "cudaMalloc failed: %s\n", cudaGetErrorString(err));
+        }
+        return nullptr;
+    }
+    return ptr;
+#else
+    if (size == 0)
+        return nullptr;
+    return new (std::nothrow) std::uint8_t[size];
+#endif
 }
 
 void freeDeviceMemory(void* ptr) {
     if (!ptr)
         return;
-    auto& mgr = memory::MemoryTierManager::getInstance();
-    auto* blk = mgr.findBlockByPtr(ptr);
-    if (blk)
-        mgr.deallocate(blk);
+#if SEP_CUDA_AVAILABLE
+    cudaError_t err = cudaFree(ptr);
+    if (err != cudaSuccess && debugAllocEnabled()) {
+        (void)fprintf(stderr, "cudaFree failed: %s\n", cudaGetErrorString(err));
+    }
+#else
+    delete[] static_cast<std::uint8_t*>(ptr);
+#endif
 }
 
 void* allocateUnifiedMemory(std::size_t size, cudaStream_t stream) {
-    auto* blk = memory::MemoryTierManager::getInstance().allocate(size, sep::memory::TierType::UNIFIED);
-    if (blk && stream) {
-        cudaError_t err = cudaStreamAttachMemAsync(stream, blk->ptr, 0, 0);
-        if (err != cudaSuccess) {
-            if (debugAllocEnabled()) {
-                (void)fprintf(stderr, "Failed to attach memory to CUDA stream: %s\n", cudaGetErrorString(err));
-            }
+#if SEP_CUDA_AVAILABLE
+    void* ptr = nullptr;
+    cudaError_t err = cudaMallocManaged(&ptr, size);
+    if (err != cudaSuccess) {
+        if (debugAllocEnabled()) {
+            (void)fprintf(stderr, "cudaMallocManaged failed: %s\n", cudaGetErrorString(err));
+        }
+        return nullptr;
+    }
+    if (stream) {
+        err = cudaStreamAttachMemAsync(stream, ptr, 0, 0);
+        if (err != cudaSuccess && debugAllocEnabled()) {
+            (void)fprintf(stderr, "cudaStreamAttachMemAsync failed: %s\n", cudaGetErrorString(err));
         }
     }
-    return blk ? blk->ptr : nullptr;
+    return ptr;
+#else
+    (void)stream;
+    return allocateDeviceMemory(size);
+#endif
 }
 
 void freeUnifiedMemory(void* ptr) {
+#if SEP_CUDA_AVAILABLE
     freeDeviceMemory(ptr);
+#else
+    freeDeviceMemory(ptr);
+#endif
 }
 
 }  // namespace sep::cuda


### PR DESCRIPTION
## Summary
- add host-path allocation alternatives and CUDA runtime implementations
- link UnifiedMemory helpers directly to CUDA versions
- drop memory tier manager dependency from RAII memory functions

## Testing
- `g++ -std=c++17 -Iinclude -c src/compat/raii.cpp -o /tmp/raii.o`
- `g++ -std=c++17 -Iinclude -Itests -Isrc -pthread tests/cuda/*.cpp src/compat/raii.cpp src/compat/cuda_api.cu src/compat/utils.cu src/compat/event.cu src/compat/stream.cpp src/compat/core.cu src/compat/pattern_kernels.cu src/compat/quantum_kernels.cu -lgtest -lgtest_main -o /tmp/cuda_tests` *(failed: missing headers and macros)*
- `apt-get install -y nlohmann-json3-dev`

------
https://chatgpt.com/codex/tasks/task_e_6864ff19c174832a99d12f05b7dd92d9