### PR TITLE
Link http-parser library and wrap parser API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,10 @@ configure_sep()
 # Find required packages
 find_package(Threads REQUIRED)
 find_package(CURL REQUIRED)
+find_library(HTTP_PARSER_LIBRARY http_parser)
+if(NOT HTTP_PARSER_LIBRARY)
+    message(FATAL_ERROR "http_parser library not found")
+endif()
 find_package(fmt REQUIRED)
 find_package(spdlog REQUIRED)
 
@@ -50,4 +54,5 @@ target_link_libraries(sep_engine
         glog
         gflags
         embree4
+        ${HTTP_PARSER_LIBRARY}
 )

--- a/include/crow/crow_isolation.h
+++ b/include/crow/crow_isolation.h
@@ -206,48 +206,4 @@ namespace crow {
     #define CROW_MIDDLEWARES(app, ...) .middlewares(__VA_ARGS__)
     #define CROW_CATCHALL_ROUTE(app) app.catchall_route()
     #define CROW_BP_CATCHALL_ROUTE(bp) bp.catchall_rule()
-
-    // HTTP parser stubs
-    namespace http_parser_stub {
-        enum class http_errno {
-            HPE_OK,
-            HPE_UNKNOWN
-        };
-
-        enum class http_parser_type {
-            HTTP_REQUEST,
-            HTTP_RESPONSE,
-            HTTP_BOTH
-        };
-
-        struct http_parser {
-            unsigned int   type : 2;
-            unsigned int   flags : 8;
-            unsigned int   state : 8;
-            unsigned int   header_state : 8;
-            unsigned int   index : 8;
-            uint32_t  nread;
-            uint64_t  content_length;
-            unsigned short http_major;
-            unsigned short http_minor;
-            unsigned int   status_code : 16;
-            unsigned int   method : 8;
-            unsigned int   http_errno : 7;
-            unsigned int   upgrade : 1;
-            void*          data;
-        };
-
-        struct http_parser_settings {
-            void* on_message_begin;
-            void* on_url;
-            void* on_status;
-            void* on_header_field;
-            void* on_header_value;
-            void* on_headers_complete;
-            void* on_body;
-            void* on_message_complete;
-            void* on_chunk_header;
-            void* on_chunk_complete;
-        };
-    }  // namespace http_parser_stub
 }  // namespace crow

--- a/include/crow/http_parser_fixed.h
+++ b/include/crow/http_parser_fixed.h
@@ -4,13 +4,9 @@
 // It provides stub implementations for HTTP parser functionality
 
 // Include our own headers
+#include <http_parser.h>
 #include "compat/shim.h"
 #include "common.h"
-#include "crow_isolation.h"
-
-// Define HTTP parser constants
-#define HTTP_PARSER_VERSION_MAJOR 2
-#define HTTP_PARSER_VERSION_MINOR 9
 
 namespace crow {
     namespace http_parser_stub {
@@ -20,69 +16,41 @@ namespace crow {
         // struct http_parser {...};
         // struct http_parser_settings {...};
 
-        // Add any additional HTTP parser functionality needed here
-        
-        // Stub implementation for http_parser_init
+        // Delegate http_parser_* functions to the system http-parser library
+
         inline void http_parser_init(http_parser* parser, http_parser_type type) {
-            parser->type = static_cast<unsigned int>(type);
-            parser->flags = 0;
-            parser->state = 0;
-            parser->header_state = 0;
-            parser->index = 0;
-            parser->nread = 0;
-            parser->content_length = 0;
-            parser->http_major = 0;
-            parser->http_minor = 0;
-            parser->status_code = 0;
-            parser->method = 0;
-            parser->http_errno = 0;
-            parser->upgrade = 0;
-            parser->data = nullptr;
+            ::http_parser_init(parser, type);
         }
 
-        // Stub implementation for http_parser_execute
-        inline size_t http_parser_execute(http_parser* parser, 
+        inline size_t http_parser_execute(http_parser* parser,
                                          const http_parser_settings* settings,
                                          const char* data,
                                          size_t len) {
-            return len;
+            return ::http_parser_execute(parser, settings, data, len);
         }
 
-        // Stub implementation for http_parser_url_init
-        struct http_parser_url {
-            unsigned short field_set;
-            unsigned short port;
-            unsigned short field_data[16];
-        };
+        using ::http_parser_url;
 
         inline void http_parser_url_init(http_parser_url* u) {
-            u->field_set = 0;
-            u->port = 0;
-            for (int i = 0; i < 16; i++) {
-                u->field_data[i] = 0;
-            }
+            ::http_parser_url_init(u);
         }
 
-        // Stub implementation for http_parser_parse_url
         inline int http_parser_parse_url(const char* buf, size_t buflen,
                                         int is_connect,
                                         http_parser_url* u) {
-            return 0;
+            return ::http_parser_parse_url(buf, buflen, is_connect, u);
         }
 
-        // Stub implementation for http_errno_name
         inline const char* http_errno_name(http_errno err) {
-            return "OK";
+            return ::http_errno_name(err);
         }
 
-        // Stub implementation for http_errno_description
         inline const char* http_errno_description(http_errno err) {
-            return "Success";
+            return ::http_errno_description(err);
         }
 
-        // Stub implementation for http_method_str
         inline const char* http_method_str(unsigned int method) {
-            return "GET";
+            return ::http_method_str(static_cast<http_method>(method));
         }
     }  // namespace http_parser_stub
 }  // namespace crow

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -21,6 +21,7 @@ target_link_libraries(sep_api
         sep_core
     PRIVATE
         ${CURL_LIBRARIES}
+        ${HTTP_PARSER_LIBRARY}
         sep_compat
         sep_blender
         sep_audio

--- a/tests/api/CMakeLists.txt
+++ b/tests/api/CMakeLists.txt
@@ -16,6 +16,7 @@ target_include_directories(api_tests PRIVATE
 
 target_link_libraries(api_tests PRIVATE
     sep_api
+    ${HTTP_PARSER_LIBRARY}
     GTest::GTest
     GTest::Main
 )


### PR DESCRIPTION
## Summary
- integrate official http-parser library
- expose http-parser functions via crow wrapper
- drop obsolete http parser stubs
- link http-parser in main, API and tests CMake files

## Testing
- `cmake ..` *(fails: Could not find nvcc)*
- `ctest tests/api` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_6864ff10b1d4832ab2eac25ea1812d8e