### PR TITLE
Implement CUDA memory allocation helpers

### DIFF
--- a/docs/diagrams/include-memory.md
+++ b/docs/diagrams/include-memory.md
@@ -34,7 +34,7 @@ graph TD
 
 ### unified_memory.h
 - **`UnifiedMemory<T>`** – RAII wrapper for CUDA unified memory.
-- **CUDA helpers** `allocateDeviceMemory()`, `freeDeviceMemory()`, `allocateUnifiedMemory()`, `freeUnifiedMemory()` route calls through `MemoryTierManager` so allocations go to the correct tier.
+- **CUDA helpers** `allocateDeviceMemory()`, `freeDeviceMemory()`, `allocateUnifiedMemory()`, `freeUnifiedMemory()` use the CUDA runtime when available and fall back to standard allocations on the host when CUDA is disabled.
 
 ### logger.hpp
 - Minimal logger interface used by the memory subsystem for diagnostics.

--- a/include/compat/memory.h
+++ b/include/compat/memory.h
@@ -78,24 +78,22 @@ private:
 bool checkMemory(size_t required_size);
 
 #if !SEP_CUDA_AVAILABLE
-// Stub implementations when CUDA is not available
+// Host-only implementations when CUDA is not available
 inline void* allocateDeviceMemory(size_t size) {
-    return std::malloc(size);
+    return ::operator new(size, std::nothrow);
 }
 
 inline void freeDeviceMemory(void* ptr) {
-    if (ptr)
-        std::free(ptr);
+    ::operator delete(ptr);
 }
 
 inline void* allocateUnifiedMemory(size_t size, cudaStream_t stream = nullptr) {
     (void)stream;
-    return std::malloc(size);
+    return ::operator new(size, std::nothrow);
 }
 
 inline void freeUnifiedMemory(void* ptr) {
-    if (ptr)
-        std::free(ptr);
+    ::operator delete(ptr);
 }
 #else
 // Declarations for actual CUDA implementations

--- a/include/memory/unified_memory.h
+++ b/include/memory/unified_memory.h
@@ -2,9 +2,8 @@
 
 #include "compat/raii.h"
 #include "compat/cuda_common.h"
-#include "memory/memory_tier_manager.hpp"
+#include "compat/memory.h"
 #include "memory/types.h"
-#include "memory/memory_tier.hpp"
 #include <cstddef>
 
 namespace sep {
@@ -80,39 +79,10 @@ private:
 };
 
 namespace cuda {
-
-// Implementation of CUDA memory functions
-inline void* allocateDeviceMemory(std::size_t size) {
-  auto* block = memory::MemoryTierManager::getInstance().allocate(size, ::sep::memory::TierType::UNIFIED);
-  return block ? block->ptr : nullptr;
-}
-
-inline void freeDeviceMemory(void* ptr) {
-  auto& mgr = memory::MemoryTierManager::getInstance();
-  memory::MemoryBlock* block = mgr.findBlockByPtr(ptr);
-  if (block) {
-    mgr.deallocate(block);
-  } else {
-    auto logger = sep::logging::Manager::getInstance().getLogger("memory");
-    if (logger) {
-      logger->error("Attempted to free unknown pointer {}", ptr);
-    }
-  }
-}
-
-inline void* allocateUnifiedMemory(std::size_t size, cudaStream_t stream) {
-  auto* blk = memory::MemoryTierManager::getInstance().allocate(
-      size, ::sep::memory::TierType::UNIFIED);
-  if (blk && stream)
-    cudaStreamAttachMemAsync(stream, blk->ptr);
-  return blk ? blk->ptr : nullptr;
-}
-
-inline void freeUnifiedMemory(void* ptr) {
-  auto& mgr = memory::MemoryTierManager::getInstance();
-  if (auto* blk = mgr.findBlockByPtr(ptr))
-    mgr.deallocate(blk);
-}
-
+// Functions implemented in compat/raii.cpp
+void* allocateDeviceMemory(std::size_t size);
+void  freeDeviceMemory(void* ptr);
+void* allocateUnifiedMemory(std::size_t size, cudaStream_t stream = nullptr);
+void  freeUnifiedMemory(void* ptr);
 } // namespace cuda
 }  // namespace sep

--- a/src/compat/raii.cpp
+++ b/src/compat/raii.cpp
@@ -224,34 +224,57 @@ template class DeviceBufferRAII<double>;
 
 // Implementation of memory management functions
 void* allocateDeviceMemory(std::size_t size) {
-    auto* block = sep::memory::MemoryTierManager::getInstance().allocate(size, sep::memory::TierType::UNIFIED);
-    return block ? block->ptr : nullptr;
+#if SEP_CUDA_AVAILABLE
+    void* ptr = nullptr;
+    cudaError_t err = cudaMalloc(&ptr, size);
+    if (err != cudaSuccess) {
+        logCudaError("cudaMalloc", err);
+        return nullptr;
+    }
+    return ptr;
+#else
+    return ::operator new(size, std::nothrow);
+#endif
 }
 
 void freeDeviceMemory(void* ptr) {
-    if (!ptr)
-        return;
-    auto& mgr = memory::MemoryTierManager::getInstance();
-    auto* blk = mgr.findBlockByPtr(ptr);
-    if (blk)
-        mgr.deallocate(blk);
+#if SEP_CUDA_AVAILABLE
+    if (ptr) {
+        cudaError_t err = cudaFree(ptr);
+        if (err != cudaSuccess)
+            logCudaError("cudaFree", err);
+    }
+#else
+    ::operator delete(ptr);
+#endif
 }
 
 void* allocateUnifiedMemory(std::size_t size, cudaStream_t stream) {
-    auto* blk = memory::MemoryTierManager::getInstance().allocate(size, sep::memory::TierType::UNIFIED);
-    if (blk && stream) {
-        cudaError_t err = cudaStreamAttachMemAsync(stream, blk->ptr, 0, 0);
-        if (err != cudaSuccess) {
-            if (debugAllocEnabled()) {
-                (void)fprintf(stderr, "Failed to attach memory to CUDA stream: %s\n", cudaGetErrorString(err));
-            }
-        }
+#if SEP_CUDA_AVAILABLE
+    void* ptr = nullptr;
+    cudaError_t err = cudaMallocManaged(&ptr, size);
+    if (err != cudaSuccess) {
+        logCudaError("cudaMallocManaged", err);
+        return nullptr;
     }
-    return blk ? blk->ptr : nullptr;
+    if (ptr && stream) {
+        err = cudaStreamAttachMemAsync(stream, ptr, 0, 0);
+        if (err != cudaSuccess)
+            logCudaError("cudaStreamAttachMemAsync", err);
+    }
+    return ptr;
+#else
+    (void)stream;
+    return ::operator new(size, std::nothrow);
+#endif
 }
 
 void freeUnifiedMemory(void* ptr) {
+#if SEP_CUDA_AVAILABLE
     freeDeviceMemory(ptr);
+#else
+    ::operator delete(ptr);
+#endif
 }
 
 }  // namespace sep::cuda


### PR DESCRIPTION
## Summary
- implement real CUDA-based device and unified memory helpers
- use standard new/delete when CUDA isn't available
- remove stale MemoryTierManager logic from unified memory header
- document the runtime-based helpers in docs

## Testing
- `cmake -S . -B build -DSEP_BUILD_TESTS=ON -DSEP_USE_CUDA=OFF` *(fails: could not find nvcc)*
- `ctest --test-dir build --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6864ff19c174832a99d12f05b7dd92d9