### PR TITLE
Implement CUDA memory allocation helpers

### DIFF
--- a/include/compat/memory.h
+++ b/include/compat/memory.h
@@ -78,32 +78,12 @@ private:
 bool checkMemory(size_t required_size);
 
 #if !SEP_CUDA_AVAILABLE
-// Stub implementations when CUDA is not available
-inline void* allocateDeviceMemory(size_t size) {
-    return std::malloc(size);
-}
-
-inline void freeDeviceMemory(void* ptr) {
-    if (ptr)
-        std::free(ptr);
-}
-
-inline void* allocateUnifiedMemory(size_t size, cudaStream_t stream = nullptr) {
-    (void)stream;
-    return std::malloc(size);
-}
-
-inline void freeUnifiedMemory(void* ptr) {
-    if (ptr)
-        std::free(ptr);
-}
-#else
-// Declarations for actual CUDA implementations
+// Declarations for host-only implementations provided in raii.cpp
+#endif
 void* allocateDeviceMemory(size_t size);
 void freeDeviceMemory(void* ptr);
 void* allocateUnifiedMemory(size_t size, cudaStream_t stream = nullptr);
 void freeUnifiedMemory(void* ptr);
-#endif
 
 // Memory copy utilities
 template <typename T>

--- a/include/memory/unified_memory.h
+++ b/include/memory/unified_memory.h
@@ -80,39 +80,10 @@ private:
 };
 
 namespace cuda {
-
-// Implementation of CUDA memory functions
-inline void* allocateDeviceMemory(std::size_t size) {
-  auto* block = memory::MemoryTierManager::getInstance().allocate(size, ::sep::memory::TierType::UNIFIED);
-  return block ? block->ptr : nullptr;
-}
-
-inline void freeDeviceMemory(void* ptr) {
-  auto& mgr = memory::MemoryTierManager::getInstance();
-  memory::MemoryBlock* block = mgr.findBlockByPtr(ptr);
-  if (block) {
-    mgr.deallocate(block);
-  } else {
-    auto logger = sep::logging::Manager::getInstance().getLogger("memory");
-    if (logger) {
-      logger->error("Attempted to free unknown pointer {}", ptr);
-    }
-  }
-}
-
-inline void* allocateUnifiedMemory(std::size_t size, cudaStream_t stream) {
-  auto* blk = memory::MemoryTierManager::getInstance().allocate(
-      size, ::sep::memory::TierType::UNIFIED);
-  if (blk && stream)
-    cudaStreamAttachMemAsync(stream, blk->ptr);
-  return blk ? blk->ptr : nullptr;
-}
-
-inline void freeUnifiedMemory(void* ptr) {
-  auto& mgr = memory::MemoryTierManager::getInstance();
-  if (auto* blk = mgr.findBlockByPtr(ptr))
-    mgr.deallocate(blk);
-}
-
+// Memory helpers implemented in src/compat/raii.cpp
+void* allocateDeviceMemory(std::size_t size);
+void freeDeviceMemory(void* ptr);
+void* allocateUnifiedMemory(std::size_t size, cudaStream_t stream = nullptr);
+void freeUnifiedMemory(void* ptr);
 } // namespace cuda
 }  // namespace sep

--- a/src/compat/raii.cpp
+++ b/src/compat/raii.cpp
@@ -224,34 +224,59 @@ template class DeviceBufferRAII<double>;
 
 // Implementation of memory management functions
 void* allocateDeviceMemory(std::size_t size) {
-    auto* block = sep::memory::MemoryTierManager::getInstance().allocate(size, sep::memory::TierType::UNIFIED);
-    return block ? block->ptr : nullptr;
+#if SEP_CUDA_AVAILABLE
+    void* ptr = nullptr;
+    cudaError_t err = cudaMalloc(&ptr, size);
+    if (err != cudaSuccess) {
+        if (debugAllocEnabled()) {
+            (void)fprintf(stderr, "cudaMalloc failed: %s\n", cudaGetErrorString(err));
+        }
+        return nullptr;
+    }
+    return ptr;
+#else
+    return std::malloc(size);
+#endif
 }
 
 void freeDeviceMemory(void* ptr) {
     if (!ptr)
         return;
-    auto& mgr = memory::MemoryTierManager::getInstance();
-    auto* blk = mgr.findBlockByPtr(ptr);
-    if (blk)
-        mgr.deallocate(blk);
+#if SEP_CUDA_AVAILABLE
+    cudaFree(ptr);
+#else
+    std::free(ptr);
+#endif
 }
 
 void* allocateUnifiedMemory(std::size_t size, cudaStream_t stream) {
-    auto* blk = memory::MemoryTierManager::getInstance().allocate(size, sep::memory::TierType::UNIFIED);
-    if (blk && stream) {
-        cudaError_t err = cudaStreamAttachMemAsync(stream, blk->ptr, 0, 0);
-        if (err != cudaSuccess) {
-            if (debugAllocEnabled()) {
-                (void)fprintf(stderr, "Failed to attach memory to CUDA stream: %s\n", cudaGetErrorString(err));
-            }
+#if SEP_CUDA_AVAILABLE
+    void* ptr = nullptr;
+    cudaError_t err = cudaMallocManaged(&ptr, size);
+    if (err != cudaSuccess) {
+        if (debugAllocEnabled()) {
+            (void)fprintf(stderr, "cudaMallocManaged failed: %s\n", cudaGetErrorString(err));
         }
+        return nullptr;
     }
-    return blk ? blk->ptr : nullptr;
+    if (stream) {
+        cudaStreamAttachMemAsync(stream, ptr, 0, 0);
+    }
+    return ptr;
+#else
+    (void)stream;
+    return std::malloc(size);
+#endif
 }
 
 void freeUnifiedMemory(void* ptr) {
-    freeDeviceMemory(ptr);
+    if (!ptr)
+        return;
+#if SEP_CUDA_AVAILABLE
+    cudaFree(ptr);
+#else
+    std::free(ptr);
+#endif
 }
 
 }  // namespace sep::cuda


### PR DESCRIPTION
## Summary
- implement CUDA-based allocateDeviceMemory/freeDeviceMemory
- add allocateUnifiedMemory/freeUnifiedMemory with cudaMallocManaged
- remove inline memory helper definitions from `unified_memory.h`
- expose memory helper declarations in `compat/memory.h`

## Testing
- `cmake .. -DBUILD_TESTING=ON` *(fails: Could not find nvcc)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6864ff19c174832a99d12f05b7dd92d9