### PR TITLE
Implement CUDA memory APIs

### DIFF
--- a/include/memory/unified_memory.h
+++ b/include/memory/unified_memory.h
@@ -2,9 +2,7 @@
 
 #include "compat/raii.h"
 #include "compat/cuda_common.h"
-#include "memory/memory_tier_manager.hpp"
 #include "memory/types.h"
-#include "memory/memory_tier.hpp"
 #include <cstddef>
 
 namespace sep {
@@ -80,39 +78,10 @@ private:
 };
 
 namespace cuda {
-
-// Implementation of CUDA memory functions
-inline void* allocateDeviceMemory(std::size_t size) {
-  auto* block = memory::MemoryTierManager::getInstance().allocate(size, ::sep::memory::TierType::UNIFIED);
-  return block ? block->ptr : nullptr;
-}
-
-inline void freeDeviceMemory(void* ptr) {
-  auto& mgr = memory::MemoryTierManager::getInstance();
-  memory::MemoryBlock* block = mgr.findBlockByPtr(ptr);
-  if (block) {
-    mgr.deallocate(block);
-  } else {
-    auto logger = sep::logging::Manager::getInstance().getLogger("memory");
-    if (logger) {
-      logger->error("Attempted to free unknown pointer {}", ptr);
-    }
-  }
-}
-
-inline void* allocateUnifiedMemory(std::size_t size, cudaStream_t stream) {
-  auto* blk = memory::MemoryTierManager::getInstance().allocate(
-      size, ::sep::memory::TierType::UNIFIED);
-  if (blk && stream)
-    cudaStreamAttachMemAsync(stream, blk->ptr);
-  return blk ? blk->ptr : nullptr;
-}
-
-inline void freeUnifiedMemory(void* ptr) {
-  auto& mgr = memory::MemoryTierManager::getInstance();
-  if (auto* blk = mgr.findBlockByPtr(ptr))
-    mgr.deallocate(blk);
-}
-
+// Memory helpers are implemented in the CUDA RAII module.
+void* allocateDeviceMemory(std::size_t size);
+void  freeDeviceMemory(void* ptr);
+void* allocateUnifiedMemory(std::size_t size, cudaStream_t stream = nullptr);
+void  freeUnifiedMemory(void* ptr);
 } // namespace cuda
 }  // namespace sep

--- a/src/compat/raii.cpp
+++ b/src/compat/raii.cpp
@@ -7,13 +7,15 @@
 // Include standard headers first
 #include <cstdint>
 #include <cstdio>
-#include <cstdlib>  // for std::malloc and std::free
+#include <cstdlib>  // for memory allocation
+#if defined(_MSC_VER)
+#include <malloc.h>
+#endif
 #include <iostream>
 #include <utility>
 
 // Include CUDA headers in the correct order
 #include "compat/raii.h"
-#include "memory/memory_tier_manager.hpp" // Include header for interface
 #include "compat/cuda_helpers.h"         // For CUDA_CHECK macro
 #include "compat/cuda_common.h"
 #if SEP_CUDA_AVAILABLE
@@ -224,30 +226,58 @@ template class DeviceBufferRAII<double>;
 
 // Implementation of memory management functions
 void* allocateDeviceMemory(std::size_t size) {
-    auto* block = sep::memory::MemoryTierManager::getInstance().allocate(size, sep::memory::TierType::UNIFIED);
-    return block ? block->ptr : nullptr;
+#if SEP_CUDA_AVAILABLE
+    void* ptr = nullptr;
+    cudaError_t err = cudaMalloc(&ptr, size);
+    if (err != cudaSuccess) {
+        if (debugAllocEnabled())
+            (void)fprintf(stderr, "cudaMalloc failed: %s\n", cudaGetErrorString(err));
+        return nullptr;
+    }
+    return ptr;
+#else
+#if defined(_MSC_VER)
+    return _aligned_malloc(size, 64);
+#else
+    return std::aligned_alloc(64, ((size + 63) / 64) * 64);
+#endif
+#endif
 }
 
 void freeDeviceMemory(void* ptr) {
     if (!ptr)
         return;
-    auto& mgr = memory::MemoryTierManager::getInstance();
-    auto* blk = mgr.findBlockByPtr(ptr);
-    if (blk)
-        mgr.deallocate(blk);
+#if SEP_CUDA_AVAILABLE
+    CUDA_CHECK(cudaFree(ptr));
+#else
+#ifdef _MSC_VER
+    _aligned_free(ptr);
+#else
+    std::free(ptr);
+#endif
+#endif
 }
 
 void* allocateUnifiedMemory(std::size_t size, cudaStream_t stream) {
-    auto* blk = memory::MemoryTierManager::getInstance().allocate(size, sep::memory::TierType::UNIFIED);
-    if (blk && stream) {
-        cudaError_t err = cudaStreamAttachMemAsync(stream, blk->ptr, 0, 0);
-        if (err != cudaSuccess) {
-            if (debugAllocEnabled()) {
-                (void)fprintf(stderr, "Failed to attach memory to CUDA stream: %s\n", cudaGetErrorString(err));
-            }
-        }
+#if SEP_CUDA_AVAILABLE
+    void* ptr = nullptr;
+    cudaError_t err = cudaMallocManaged(&ptr, size);
+    if (err != cudaSuccess) {
+        if (debugAllocEnabled())
+            (void)fprintf(stderr, "cudaMallocManaged failed: %s\n", cudaGetErrorString(err));
+        return nullptr;
     }
-    return blk ? blk->ptr : nullptr;
+    if (stream)
+        cudaStreamAttachMemAsync(stream, ptr);
+    return ptr;
+#else
+    (void)stream;
+#if defined(_MSC_VER)
+    return _aligned_malloc(size, 64);
+#else
+    return std::aligned_alloc(64, ((size + 63) / 64) * 64);
+#endif
+#endif
 }
 
 void freeUnifiedMemory(void* ptr) {


### PR DESCRIPTION
## Summary
- implement `allocateDeviceMemory`/`allocateUnifiedMemory` with CUDA runtime APIs
- fallback to aligned host memory when CUDA is unavailable
- expose memory helpers in `unified_memory.h`

## Testing
- `g++ -std=c++17 -I../include -I../src ../src/compat/raii.cpp ../src/compat/utils.cu ../src/compat/cuda_api_stub.cpp ../tests/cuda/compat_test.cpp -o cuda_test_example -lpthread -lgtest` *(fails: `nlohmann/json.hpp` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864ff19c174832a99d12f05b7dd92d9