### PR TITLE
Fix missing endif in compat memory

### DIFF
--- a/include/compat/memory.h
+++ b/include/compat/memory.h
@@ -140,5 +140,7 @@ bool memsetDevice(T* ptr, int value, size_t count) {
 #endif
 }
 
+#endif  // !SEP_CUDA_AVAILABLE
+
 }  // namespace cuda
 }  // namespace sep


### PR DESCRIPTION
## Summary
- close conditional in `memory.h`

## Testing
- `bash -x build.sh 2>&1 | tee build.log` *(fails: intern/atomic_ops_utils.h not found)*

------
https://chatgpt.com/codex/tasks/task_e_68650a6707fc832a8ec5e87ae69caa50