### PR TITLE
Improve build setup docs and CUDA detection

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -22,3 +22,15 @@ git submodule update --init extern/cycles
 ```
 
 This ensures the build scripts can locate the Cycles sources.
+
+## Required System Packages
+
+The build relies on the system `http_parser` library and the CUDA toolkit.
+On Ubuntu-based distributions install them with:
+
+```bash
+sudo apt-get install libhttp-parser-dev nvidia-cuda-toolkit
+```
+
+If the CUDA toolkit is installed in a non-standard location set `CUDAToolkit_ROOT`
+so CMake can locate `nvcc`.

--- a/src/compat/CMakeLists.txt
+++ b/src/compat/CMakeLists.txt
@@ -24,7 +24,10 @@ if(WITH_OPENSUBDIV)
 endif()
 
 # Find CUDA toolkit to provide imported targets and variables
-find_package(CUDAToolkit REQUIRED)
+find_package(CUDAToolkit QUIET)
+if(NOT CUDAToolkit_FOUND OR NOT CUDAToolkit_NVCC_EXECUTABLE)
+    message(FATAL_ERROR "CUDA toolkit not found. Install 'nvidia-cuda-toolkit' or set CUDAToolkit_ROOT")
+endif()
 
 add_library(sep_compat STATIC
     cuda_api.cu


### PR DESCRIPTION
## Summary
- document system packages required to configure SEP
- fail early if CUDA toolkit can't be located

## Testing
- `./build.sh` *(fails: required package OpenImageIO not found)*

------
https://chatgpt.com/codex/tasks/task_e_68650a6707fc832a8ec5e87ae69caa50