### PR TITLE
Fix build error due to malformed preprocessor branch

### DIFF
--- a/include/crow/common.h
+++ b/include/crow/common.h
@@ -22,7 +22,8 @@
 #endif
 #endif
 
-namespace crow {
+namespace crow
+ {
     const char cr = '\r';
     const char lf = '\n';
     const sep::shim::string crlf("\r\n");
@@ -144,4 +145,5 @@ namespace crow {
         routing_handle_result() {}
     };
 
-} // namespace crow\n#endif
+} // namespace crow
+#endif


### PR DESCRIPTION
## Summary
- correct the end of `crow/common.h` so the `#endif` is on a new line

## Testing
- `./build.sh` *(fails: CUDA toolkit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68650d3cad08832aad0c3e97fdb8eb4f