### PR TITLE
Fix unterminated preprocessor branch in stub Crow header

### DIFF
--- a/include/crow/common.h
+++ b/include/crow/common.h
@@ -144,4 +144,5 @@ namespace crow {
         routing_handle_result() {}
     };
 
-} // namespace crow\n#endif
+} // namespace crow
+#endif


### PR DESCRIPTION
## Summary
- fix closing `#endif` in `include/crow/common.h`

## Testing
- `g++ -std=c++17 -I./include -D__CUDACC__ -c -include include/crow/common.h -x c++ - <<'EOF'
int main() {return 0;}
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68650d3cad08832aad0c3e97fdb8eb4f