### PR TITLE
Fix header preprocessor closing

### DIFF
--- a/include/crow/common.h
+++ b/include/crow/common.h
@@ -144,4 +144,5 @@ namespace crow {
         routing_handle_result() {}
     };
 
-} // namespace crow\n#endif
+} // namespace crow
+#endif


### PR DESCRIPTION
## Summary
- fix incorrect `#endif` usage in `include/crow/common.h`

## Testing
- `./build.sh` *(fails: CUDA toolkit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68650d3cad08832aad0c3e97fdb8eb4f