### PR TITLE
Fix header include order in Crow

### DIFF
--- a/extern/crow/include/crow.h
+++ b/extern/crow/include/crow.h
@@ -1,5 +1,7 @@
 #pragma once
 #include "crow/query_string.h"
+#include "crow/utility.h"
+#include "crow/common.h"
 #include "crow/http_parser_merged.h"
 #include "crow/ci_map.h"
 #include "crow/TinySHA1.hpp"
@@ -9,8 +11,6 @@
 #include "crow/mustache.h"
 #include "crow/logging.h"
 #include "crow/task_timer.h"
-#include "crow/utility.h"
-#include "crow/common.h"
 #include "crow/http_request.h"
 #include "crow/websocket.h"
 #include "crow/parser.h"


### PR DESCRIPTION
## Summary
- fix pointer related build issues by including `common.h` and `utility.h` before `http_parser_merged.h`

## Testing
- `g++ -std=c++17 -I extern/crow/include _sep/testbed/test_crow.cpp -o _sep/testbed/test_crow`
- `./_sep/testbed/test_crow`

------
https://chatgpt.com/codex/tasks/task_e_68650f7a52f0832aa6d6353f0efa40a1