### PR TITLE
Fix Crow include path and isolation header

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,11 @@ include(SEPConfig)
 configure_sep()
 
 # Make the real Crow headers available to all targets
-include_directories(BEFORE ${CMAKE_SOURCE_DIR}/extern/Crow/include)
+# Use the bundled Crow headers rather than any system installed copy.
+# The original path used an incorrect case which caused the build to
+# pick up system headers from /usr/local/include leading to missing
+# macro definitions at compile time.
+include_directories(BEFORE ${CMAKE_SOURCE_DIR}/extern/crow/include)
 
 # Find required packages
 find_package(Threads REQUIRED)

--- a/include/crow/crow_isolation.h
+++ b/include/crow/crow_isolation.h
@@ -8,7 +8,7 @@
 
 #ifndef __CUDACC__
 
-#include <crow.h>
+#include "crow.h"  // Use bundled Crow to ensure consistent macro definitions
 
 #else
 


### PR DESCRIPTION
## Summary
- fix incorrect case in Crow include path in root CMakeLists
- ensure crow_isolation.h uses bundled Crow header

## Testing
- `cmake -S . -B build_test` *(fails: CUDA toolkit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68650f7a52f0832aa6d6353f0efa40a1