### PR TITLE
Fix crow isolation and unify ASIO

### DIFF
--- a/extern/crow/task_timer.h
+++ b/extern/crow/task_timer.h
@@ -22,7 +22,7 @@ namespace crow {
 namespace asio = boost::asio;
 using error_code = boost::system::error_code;
 #else
-using error_code = std::error_code;
+using error_code = asio::error_code;
 #endif
 namespace detail {
 

--- a/include/crow/asio_isolation.h
+++ b/include/crow/asio_isolation.h
@@ -1,20 +1,19 @@
 #pragma once
 
-// Provide Boost.ASIO types without pulling in heavy headers when not needed.
-// This header previously defined stub implementations. It now aliases the
-// required classes directly to Boost.ASIO so networking code uses the real
-// library.
+// Provide ASIO types without pulling in heavy headers when not needed. This
+// project relies on the standalone version of ASIO so we include the standard
+// headers and alias the namespace used throughout the code base.
 
-#include <boost/asio.hpp>
-#include <boost/asio/ssl.hpp>
+#include <asio.hpp>
+#include <asio/ssl.hpp>
 
-// Alias the Boost.ASIO namespace so existing code using `asio_stub` or `asio`
-// continues to compile.
-namespace crow_asio_stub = boost::asio;
-namespace asio = boost::asio;
+// Alias the ASIO namespace so existing code using `asio_stub` or `asio`
+// continues to compile regardless of whether Boost or standalone ASIO is used.
+namespace crow_asio_stub = ::asio;
+namespace asio = ::asio;
 
 namespace crow {
 // Alias the stub namespace inside crow as before
 namespace asio_stub = ::crow_asio_stub;
-using error_code = boost::system::error_code;
+using error_code = ::asio::error_code;
 } // namespace crow

--- a/include/crow/crow_isolation.h
+++ b/include/crow/crow_isolation.h
@@ -199,4 +199,6 @@ namespace crow {
     }  // namespace http_parser_stub
 
 #endif  // CROW_ISOLATION_H
+#ifdef __CUDACC__
 }  // namespace crow
+#endif

--- a/include/crow/socket_adaptors.h
+++ b/include/crow/socket_adaptors.h
@@ -105,7 +105,7 @@ namespace crow {
         error_code close() {
             error_code ec;
             if (!is_open()) {
-                ec = boost::asio::error::not_connected;
+                ec = asio::error::not_connected;
             } else {
                 raw_socket().close(ec);
             }


### PR DESCRIPTION
## Summary
- guard crow namespace closing to prevent CPU build errors
- unify ASIO usage to standalone version and update aliases
- fix error handling constant for new ASIO
- update task_timer error_code alias

## Testing
- `npm run build` *(fails: Cannot find module '@modelcontextprotocol/sdk/server')*

------
https://chatgpt.com/codex/tasks/task_e_686511de8320832aaab2f3b2b848ed68