### PR TITLE
Fix ASIO headers to resolve pointer build errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,9 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(SEPConfig)
 configure_sep()
 
-# Make the real Crow headers available to all targets
-include_directories(BEFORE ${CMAKE_SOURCE_DIR}/extern/crow/include)
+# Make the real Crow headers available, but allow local wrappers to override
+include_directories(${CMAKE_SOURCE_DIR}/extern/crow/include)
+add_definitions(-DCROW_USE_BOOST)
 
 # Find required packages
 find_package(Threads REQUIRED)

--- a/extern/crow/asio_isolation.h
+++ b/extern/crow/asio_isolation.h
@@ -633,13 +633,8 @@ public:
 #    define SEP_ASIO_INCLUDED
 
 // Choose between Boost ASIO and standalone ASIO
-#    ifdef CROW_USE_BOOST
 #        include <boost/asio.hpp>
 namespace asio = boost::asio;
-#    else
-#        include <asio.hpp>
-#        define ASIO_STANDALONE
-#    endif
 
 #    endif // SEP_ASIO_INCLUDED
 #endif

--- a/extern/crow/crow_isolation.h
+++ b/extern/crow/crow_isolation.h
@@ -47,7 +47,7 @@ extern const char* last_error;
 // Check for CUDA compilation or absence of the full Crow headers
 // We also fall back to the stubs when RTTI is disabled or <crow/app.h> cannot be found
 #if defined(__CUDACC__) || defined(SEP_CUDA_COMPILATION) || defined(CROW_DISABLE_RTTI) \
-    || !(__has_include(<crow/app.h>) && __has_include(<asio.hpp>))
+    || !(__has_include(<crow/app.h>) && __has_include(<boost/asio.hpp>))
 // When compiling with CUDA or Crow is unavailable, provide stub implementations
 #    ifndef SEP_FULL_CROW_AVAILABLE
 #        define SEP_FULL_CROW_AVAILABLE 0

--- a/extern/crow/http_connection.h
+++ b/extern/crow/http_connection.h
@@ -1,12 +1,6 @@
 #pragma once
 
-#ifdef CROW_USE_BOOST
 #include <boost/asio.hpp>
-#else
-#ifndef ASIO_STANDALONE
-#define ASIO_STANDALONE
-#endif
-#include <asio.hpp>
 #include "crow/asio_isolation.h"
 #endif
 

--- a/extern/crow/include/crow/http_connection.h
+++ b/extern/crow/include/crow/http_connection.h
@@ -1,8 +1,5 @@
 #pragma once
-#ifndef ASIO_STANDALONE
-#define ASIO_STANDALONE
-#endif
-#include <asio.hpp>
+#include <boost/asio.hpp>
 #include <algorithm>
 #include <atomic>
 #include <chrono>

--- a/extern/crow/include/crow/http_request.h
+++ b/extern/crow/include/crow/http_request.h
@@ -1,9 +1,6 @@
 #pragma once
 
-#ifndef ASIO_STANDALONE
-#define ASIO_STANDALONE
-#endif
-#include <asio.hpp>
+#include <boost/asio.hpp>
 
 #include "crow/common.h"
 #include "crow/ci_map.h"

--- a/extern/crow/include/crow/http_server.h
+++ b/extern/crow/include/crow/http_server.h
@@ -1,12 +1,9 @@
 #pragma once
 
 #include <chrono>
-#ifndef ASIO_STANDALONE
-#define ASIO_STANDALONE
-#endif
-#include <asio.hpp>
+#include <boost/asio.hpp>
 #ifdef CROW_ENABLE_SSL
-#include <asio/ssl.hpp>
+#include <boost/asio/ssl.hpp>
 #endif
 #include <cstdint>
 #include <atomic>

--- a/extern/crow/include/crow/socket_adaptors.h
+++ b/extern/crow/include/crow/socket_adaptors.h
@@ -1,20 +1,18 @@
 #pragma once
-#ifndef ASIO_STANDALONE
-#define ASIO_STANDALONE
-#endif
-#include <asio.hpp>
+#include <boost/asio.hpp>
 #ifdef CROW_ENABLE_SSL
-#include <asio/ssl.hpp>
+#include <boost/asio/ssl.hpp>
 #endif
 #include "crow/settings.h"
-#include <asio/version.hpp>
-#if ASIO_VERSION >= 101300 // 1.13.0
-#define GET_IO_SERVICE(s) ((asio::io_context&)(s).get_executor().context())
+#include <boost/asio/version.hpp>
+#if BOOST_ASIO_VERSION >= 101300 // 1.13.0
+#define GET_IO_SERVICE(s) ((boost::asio::io_context&)(s).get_executor().context())
 #else
 #define GET_IO_SERVICE(s) ((s).get_io_service())
 #endif
 namespace crow
 {
+    namespace asio = boost::asio;
     using tcp = asio::ip::tcp;
 
     /// A wrapper for the asio::ip::tcp::socket and asio::ssl::stream

--- a/extern/crow/include/crow/task_timer.h
+++ b/extern/crow/include/crow/task_timer.h
@@ -1,10 +1,7 @@
 #pragma once
 
-#ifndef ASIO_STANDALONE
-#define ASIO_STANDALONE
-#endif
-#include <asio.hpp>
-#include <asio/basic_waitable_timer.hpp>
+#include <boost/asio.hpp>
+#include <boost/asio/basic_waitable_timer.hpp>
 
 #include <chrono>
 #include <functional>

--- a/extern/crow/socket_adaptors.h
+++ b/extern/crow/socket_adaptors.h
@@ -1,23 +1,13 @@
 #pragma once
 
-#ifdef CROW_USE_BOOST
 #include <boost/asio.hpp>
 #include <boost/asio/version.hpp>
 #ifdef CROW_ENABLE_SSL
 #include <boost/asio/ssl.hpp>
 #endif
-#else
-#ifndef ASIO_STANDALONE
-#define ASIO_STANDALONE
-#endif
-#include <asio.hpp>
-#include "asio/version.hpp"
-#ifdef CROW_ENABLE_SSL
 #include "settings.h"
 #include "asio_isolation.h"
-#endif
 #include <system_error>
-#endif
 #include "logging.h"
 
 // Fix for the conditional expression to avoid the operator '&&' error

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -30,6 +30,7 @@ target_link_libraries(sep_api
 
 target_include_directories(sep_api
     PUBLIC
+        BEFORE
         ${CMAKE_SOURCE_DIR}/include
 )
 

--- a/third_party/crow/include/crow/http_connection.h
+++ b/third_party/crow/include/crow/http_connection.h
@@ -1,13 +1,6 @@
 #pragma once
 
-#ifdef CROW_USE_BOOST
 #include <boost/asio.hpp>
-#else
-#ifndef ASIO_STANDALONE
-#define ASIO_STANDALONE
-#endif
-#include <asio.hpp>
-#endif
 
 #include <algorithm>
 #include <atomic>

--- a/third_party/crow/include/crow/http_request.h
+++ b/third_party/crow/include/crow/http_request.h
@@ -1,13 +1,6 @@
 #pragma once
 
-#ifdef CROW_USE_BOOST
 #include <boost/asio.hpp>
-#else
-#ifndef ASIO_STANDALONE
-#define ASIO_STANDALONE
-#endif
-#include <asio.hpp>
-#endif
 
 #include "crow/common.h"
 #include "crow/ci_map.h"

--- a/third_party/crow/include/crow/http_server.h
+++ b/third_party/crow/include/crow/http_server.h
@@ -1,18 +1,8 @@
 #pragma once
 
-#ifdef CROW_USE_BOOST
 #include <boost/asio.hpp>
 #ifdef CROW_ENABLE_SSL
 #include <boost/asio/ssl.hpp>
-#endif
-#else
-#ifndef ASIO_STANDALONE
-#define ASIO_STANDALONE
-#endif
-#include <asio.hpp>
-#ifdef CROW_ENABLE_SSL
-#include <asio/ssl.hpp>
-#endif
 #endif
 
 #include <atomic>

--- a/third_party/crow/include/crow/socket_acceptors.h
+++ b/third_party/crow/include/crow/socket_acceptors.h
@@ -1,17 +1,7 @@
 #pragma once
-#ifdef CROW_USE_BOOST
 #include <boost/asio.hpp>
 #ifdef CROW_ENABLE_SSL
 #include <boost/asio/ssl.hpp>
-#endif
-#else
-#ifndef ASIO_STANDALONE
-#define ASIO_STANDALONE
-#endif
-#include <asio.hpp>
-#ifdef CROW_ENABLE_SSL
-#include <asio/ssl.hpp>
-#endif
 #endif
 
 #include "crow/logging.h"

--- a/third_party/crow/include/crow/socket_adaptors.h
+++ b/third_party/crow/include/crow/socket_adaptors.h
@@ -1,20 +1,9 @@
 #pragma once
 
-#ifdef CROW_USE_BOOST
 #include <boost/asio.hpp>
 #include <boost/asio/version.hpp>
 #ifdef CROW_ENABLE_SSL
 #include <boost/asio/ssl.hpp>
-#endif
-#else
-#ifndef ASIO_STANDALONE
-#define ASIO_STANDALONE
-#endif
-#include <asio.hpp>
-#include <asio/version.hpp>
-#ifdef CROW_ENABLE_SSL
-#include <asio/ssl.hpp>
-#endif
 #endif
 #include "crow/settings.h"
 

--- a/third_party/crow/include/crow/task_timer.h
+++ b/third_party/crow/include/crow/task_timer.h
@@ -1,15 +1,7 @@
 #pragma once
 
-#ifdef CROW_USE_BOOST
 #include <boost/asio.hpp>
 #include <boost/asio/basic_waitable_timer.hpp>
-#else
-#ifndef ASIO_STANDALONE
-#define ASIO_STANDALONE
-#endif
-#include <asio.hpp>
-#include <asio/basic_waitable_timer.hpp>
-#endif
 
 #include <chrono>
 #include <functional>


### PR DESCRIPTION
## Summary
- switch all ASIO includes to Boost.Asio
- ensure Boost-based Crow headers come before vendor ones
- enable `CROW_USE_BOOST` in the build
- adjust include order for sep_api target

## Testing
- `npm run build` *(fails: Cannot find module '@modelcontextprotocol/sdk/server')*

------
https://chatgpt.com/codex/tasks/task_e_686511de8320832aaab2f3b2b848ed68