### PR TITLE
Fix crow isolation macros and build includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,12 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(SEPConfig)
 configure_sep()
 
-# Make the real Crow headers available to all targets
-include_directories(BEFORE ${CMAKE_SOURCE_DIR}/extern/crow/include)
+# Ensure our custom Crow wrappers take precedence over the third-party headers
+include_directories(BEFORE
+    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/extern/crow/include
+)
+add_compile_definitions(CROW_USE_BOOST)
 
 # Find required packages
 find_package(Threads REQUIRED)

--- a/include/crow/asio_isolation.h
+++ b/include/crow/asio_isolation.h
@@ -5,16 +5,17 @@
 // required classes directly to Boost.ASIO so networking code uses the real
 // library.
 
-#include <boost/asio.hpp>
-#include <boost/asio/ssl.hpp>
+#include <asio.hpp>
+#include <asio/ssl.hpp>
+#include <system_error>
 
 // Alias the Boost.ASIO namespace so existing code using `asio_stub` or `asio`
 // continues to compile.
-namespace crow_asio_stub = boost::asio;
-namespace asio = boost::asio;
+namespace crow_asio_stub = ::asio;
+namespace asio = ::asio;
 
 namespace crow {
 // Alias the stub namespace inside crow as before
 namespace asio_stub = ::crow_asio_stub;
-using error_code = boost::system::error_code;
+using error_code = std::error_code;
 } // namespace crow

--- a/include/crow/crow_isolation.h
+++ b/include/crow/crow_isolation.h
@@ -198,5 +198,6 @@ namespace crow {
 
     }  // namespace http_parser_stub
 
-#endif  // CROW_ISOLATION_H
 }  // namespace crow
+
+#endif  // __CUDACC__


### PR DESCRIPTION
## Summary
- ensure custom crow headers are prioritized in CMake
- close namespace correctly in `crow_isolation.h`
- align `asio_isolation.h` with standalone ASIO

## Testing
- `cmake -S . -B build` *(fails: CUDA toolkit not found)*

------
https://chatgpt.com/codex/tasks/task_e_686511de8320832aaab2f3b2b848ed68