### PR TITLE
Fix missing asio alias in crow headers

### DIFF
--- a/extern/crow/include/crow/http_request.h
+++ b/extern/crow/include/crow/http_request.h
@@ -8,6 +8,12 @@
 
 namespace crow
 {
+    // The original Crow headers rely on a short alias for boost::asio
+    // but this file was missing the declaration which caused build
+    // failures when referring to `asio::io_service` and related types.
+    // Match the upstream headers and provide the alias here.
+    namespace asio = boost::asio;
+    using error_code = boost::system::error_code;
     /// Find and return the value associated with the key. (returns an empty string if nothing is found)
     template<typename T>
     inline const std::string& get_header_value(const T& headers, const std::string& key)

--- a/extern/crow/include/crow/task_timer.h
+++ b/extern/crow/include/crow/task_timer.h
@@ -12,6 +12,9 @@
 
 namespace crow
 {
+    // Provide the boost::asio alias used throughout the Crow headers.
+    namespace asio = boost::asio;
+    using error_code = boost::system::error_code;
     namespace detail
     {
 


### PR DESCRIPTION
## Summary
- update `http_request.h` to declare boost::asio alias
- update `task_timer.h` with matching alias

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865152f1a34832abb902fe624c38e00