### PR TITLE
Fix Asio alias in Crow headers

### DIFF
--- a/extern/crow/include/crow/app.h
+++ b/extern/crow/include/crow/app.h
@@ -38,6 +38,7 @@
 
 namespace crow
 {
+    namespace asio = boost::asio;
 #ifdef CROW_ENABLE_SSL
     using ssl_context_t = asio::ssl::context;
 #endif

--- a/extern/crow/include/crow/http_connection.h
+++ b/extern/crow/include/crow/http_connection.h
@@ -21,6 +21,7 @@
 
 namespace crow
 {
+    namespace asio = boost::asio;
     using tcp = asio::ip::tcp;
 
 

--- a/extern/crow/include/crow/http_request.h
+++ b/extern/crow/include/crow/http_request.h
@@ -8,6 +8,7 @@
 
 namespace crow
 {
+    namespace asio = boost::asio;
     /// Find and return the value associated with the key. (returns an empty string if nothing is found)
     template<typename T>
     inline const std::string& get_header_value(const T& headers, const std::string& key)

--- a/extern/crow/include/crow/http_server.h
+++ b/extern/crow/include/crow/http_server.h
@@ -18,6 +18,7 @@
 
 namespace crow
 {
+    namespace asio = boost::asio;
     using tcp = asio::ip::tcp;
 
     template<typename Handler, typename Adaptor = SocketAdaptor, typename... Middlewares>

--- a/extern/crow/include/crow/task_timer.h
+++ b/extern/crow/include/crow/task_timer.h
@@ -12,6 +12,7 @@
 
 namespace crow
 {
+    namespace asio = boost::asio;
     namespace detail
     {
 

--- a/extern/crow/include/crow/websocket.h
+++ b/extern/crow/include/crow/websocket.h
@@ -8,6 +8,7 @@
 
 namespace crow
 {
+    namespace asio = boost::asio;
     namespace websocket
     {
         enum class WebSocketReadState


### PR DESCRIPTION
## Summary
- fix missing `crow::asio` alias across Crow headers to resolve pointer errors in `build.log`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865152f1a34832abb902fe624c38e00