### PR TITLE
Fix ASIO alias for crow headers

### DIFF
--- a/include/crow/asio_isolation.h
+++ b/include/crow/asio_isolation.h
@@ -15,5 +15,9 @@ namespace asio = ::asio;
 namespace crow {
 // Alias the stub namespace inside crow as before
 namespace asio_stub = ::crow_asio_stub;
+// Provide a direct alias matching the upstream library expectations
+// so headers can refer to `crow::asio::...` types without pulling in
+// Boost. This maps directly to the standalone Asio namespace.
+using namespace ::asio;
 using error_code = ::asio::error_code;
 } // namespace crow


### PR DESCRIPTION
## Summary
- map `crow::asio` to the standalone Asio namespace
- keep `crow::asio_stub` alias in place

## Testing
- `g++ -std=c++17 /tmp/test.cpp -I./ -Iextern/crow/include -Iinclude -c`

------
https://chatgpt.com/codex/tasks/task_e_6865152f1a34832abb902fe624c38e00