### PR TITLE
Fix ASIO aliasing in Crow headers

### DIFF
--- a/extern/crow/include/crow/http_request.h
+++ b/extern/crow/include/crow/http_request.h
@@ -8,6 +8,7 @@
 
 namespace crow
 {
+    namespace asio = boost::asio;
     /// Find and return the value associated with the key. (returns an empty string if nothing is found)
     template<typename T>
     inline const std::string& get_header_value(const T& headers, const std::string& key)

--- a/extern/crow/include/crow/socket_adaptors.h
+++ b/extern/crow/include/crow/socket_adaptors.h
@@ -52,32 +52,32 @@ namespace crow
 
         void close()
         {
-            asio::error_code ec;
+            boost::system::error_code ec;
             socket_.close(ec);
         }
 
         void shutdown_readwrite()
         {
-            asio::error_code ec;
+            boost::system::error_code ec;
             socket_.shutdown(asio::socket_base::shutdown_type::shutdown_both, ec);
         }
 
         void shutdown_write()
         {
-            asio::error_code ec;
+            boost::system::error_code ec;
             socket_.shutdown(asio::socket_base::shutdown_type::shutdown_send, ec);
         }
 
         void shutdown_read()
         {
-            asio::error_code ec;
+            boost::system::error_code ec;
             socket_.shutdown(asio::socket_base::shutdown_type::shutdown_receive, ec);
         }
 
         template<typename F>
         void start(F f)
         {
-            f(asio::error_code());
+            f(boost::system::error_code());
         }
 
         tcp::socket socket_;
@@ -117,7 +117,7 @@ namespace crow
         {
             if (is_open())
             {
-                asio::error_code ec;
+                boost::system::error_code ec;
                 raw_socket().close(ec);
             }
         }
@@ -126,7 +126,7 @@ namespace crow
         {
             if (is_open())
             {
-                asio::error_code ec;
+                boost::system::error_code ec;
                 raw_socket().shutdown(asio::socket_base::shutdown_type::shutdown_both, ec);
             }
         }
@@ -135,7 +135,7 @@ namespace crow
         {
             if (is_open())
             {
-                asio::error_code ec;
+                boost::system::error_code ec;
                 raw_socket().shutdown(asio::socket_base::shutdown_type::shutdown_send, ec);
             }
         }
@@ -144,7 +144,7 @@ namespace crow
         {
             if (is_open())
             {
-                asio::error_code ec;
+                boost::system::error_code ec;
                 raw_socket().shutdown(asio::socket_base::shutdown_type::shutdown_receive, ec);
             }
         }
@@ -158,9 +158,9 @@ namespace crow
         void start(F f)
         {
             ssl_socket_->async_handshake(asio::ssl::stream_base::server,
-                                         [f](const asio::error_code& ec) {
-                                             f(ec);
-                                         });
+                                         [f](const boost::system::error_code& ec) {
+                                            f(ec);
+                                        });
         }
 
         std::unique_ptr<asio::ssl::stream<tcp::socket>> ssl_socket_;


### PR DESCRIPTION
## Summary
- alias boost::asio namespace in Crow http_request.h
- use boost::system::error_code in socket adaptor implementations

## Testing
- `cmake -S . -B build` *(fails: CUDA toolkit not found)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6865152f1a34832abb902fe624c38e00