### PR TITLE
Fix crow error_code types

### DIFF
--- a/extern/crow/include/crow/http_connection.h
+++ b/extern/crow/include/crow/http_connection.h
@@ -79,7 +79,7 @@ namespace crow
         void start()
         {
             auto self = this->shared_from_this();
-            adaptor_.start([self](const asio::error_code& ec) {
+            adaptor_.start([self](const boost::system::error_code& ec) {
                 if (!ec)
                 {
                     self->start_deadline();
@@ -466,7 +466,7 @@ namespace crow
             auto self = this->shared_from_this();
             adaptor_.socket().async_read_some(
               asio::buffer(buffer_),
-              [self](const asio::error_code& ec, std::size_t bytes_transferred) {
+              [self](const boost::system::error_code& ec, std::size_t bytes_transferred) {
                   bool error_while_reading = true;
                   if (!ec)
                   {
@@ -509,7 +509,7 @@ namespace crow
             auto self = this->shared_from_this();
             asio::async_write(
               adaptor_.socket(), buffers_,
-              [self](const asio::error_code& ec, std::size_t /*bytes_transferred*/) {
+              [self](const boost::system::error_code& ec, std::size_t /*bytes_transferred*/) {
                   self->res.clear();
                   self->res_body_copy_.clear();                  
                   if (!self->continue_requested)
@@ -540,7 +540,7 @@ namespace crow
         inline void do_write_sync(std::vector<asio::const_buffer>& buffers)
         {
 
-            asio::write(adaptor_.socket(), buffers, [&](asio::error_code ec, std::size_t) {
+            asio::write(adaptor_.socket(), buffers, [&](boost::system::error_code ec, std::size_t) {
                 if (!ec)
                 {
                     return false;

--- a/extern/crow/include/crow/http_server.h
+++ b/extern/crow/include/crow/http_server.h
@@ -50,7 +50,7 @@ namespace crow
         {
             tick_function_();
             tick_timer_.expires_after(std::chrono::milliseconds(tick_interval_.count()));
-            tick_timer_.async_wait([this](const asio::error_code& ec) {
+            tick_timer_.async_wait([this](const boost::system::error_code& ec) {
                 if (ec)
                     return;
                 on_tick();
@@ -126,7 +126,7 @@ namespace crow
             {
                 tick_timer_.expires_after(std::chrono::milliseconds(tick_interval_.count()));
                 tick_timer_.async_wait(
-                  [this](const asio::error_code& ec) {
+                  [this](const boost::system::error_code& ec) {
                       if (ec)
                           return;
                       on_tick();
@@ -141,7 +141,7 @@ namespace crow
             CROW_LOG_INFO << "Call `app.loglevel(crow::LogLevel::Warning)` to hide Info level logs.";
 
             signals_.async_wait(
-              [&](const asio::error_code& /*error*/, int /*signal_number*/) {
+              [&](const boost::system::error_code& /*error*/, int /*signal_number*/) {
                   stop();
               });
 
@@ -225,7 +225,7 @@ namespace crow
 
                 acceptor_.async_accept(
                   p->socket(),
-                  [this, p, &is, service_idx](asio::error_code ec) {
+                  [this, p, &is, service_idx](boost::system::error_code ec) {
                       if (!ec)
                       {
                           is.post(

--- a/extern/crow/include/crow/task_timer.h
+++ b/extern/crow/include/crow/task_timer.h
@@ -34,8 +34,7 @@ namespace crow
               io_service_(io_service), timer_(io_service_)
             {
                 timer_.expires_after(std::chrono::seconds(1));
-                timer_.async_wait(
-                  std::bind(&task_timer::tick_handler, this, std::placeholders::_1));
+                timer_.async_wait([this](const error_code& e) { tick_handler(e); });
             }
 
             ~task_timer() { timer_.cancel(); }
@@ -112,15 +111,14 @@ namespace crow
                 if (tasks_.empty()) highest_id_ = 0;
             }
 
-            void tick_handler(const asio::error_code& ec)
+            void tick_handler(const error_code& ec)
             {
                 if (ec) return;
 
                 process_tasks();
 
                 timer_.expires_after(std::chrono::seconds(1));
-                timer_.async_wait(
-                  std::bind(&task_timer::tick_handler, this, std::placeholders::_1));
+                timer_.async_wait([this](const error_code& e) { tick_handler(e); });
             }
 
         private:

--- a/extern/crow/include/crow/websocket.h
+++ b/extern/crow/include/crow/websocket.h
@@ -300,7 +300,7 @@ namespace crow
                         //asio::async_read(adaptor_.socket(), asio::buffer(&mini_header_, 1),
                         adaptor_.socket().async_read_some(
                           asio::buffer(&mini_header_, 2),
-                          [this](const asio::error_code& ec, std::size_t
+                          [this](const boost::system::error_code& ec, std::size_t
 #ifdef CROW_ENABLE_DEBUG
                                                                bytes_transferred
 #endif
@@ -368,7 +368,7 @@ namespace crow
                         remaining_length16_ = 0;
                         asio::async_read(
                           adaptor_.socket(), asio::buffer(&remaining_length16_, 2),
-                          [this](const asio::error_code& ec, std::size_t
+                          [this](const boost::system::error_code& ec, std::size_t
 #ifdef CROW_ENABLE_DEBUG
                                                                bytes_transferred
 #endif
@@ -404,7 +404,7 @@ namespace crow
                     {
                         asio::async_read(
                           adaptor_.socket(), asio::buffer(&remaining_length_, 8),
-                          [this](const asio::error_code& ec, std::size_t
+                          [this](const boost::system::error_code& ec, std::size_t
 #ifdef CROW_ENABLE_DEBUG
                                                                bytes_transferred
 #endif
@@ -448,7 +448,7 @@ namespace crow
                         {
                             asio::async_read(
                               adaptor_.socket(), asio::buffer((char*)&mask_, 4),
-                              [this](const asio::error_code& ec, std::size_t
+                              [this](const boost::system::error_code& ec, std::size_t
 #ifdef CROW_ENABLE_DEBUG
                                                                    bytes_transferred
 #endif
@@ -490,7 +490,7 @@ namespace crow
                             to_read = remaining_length_;
                         adaptor_.socket().async_read_some(
                           asio::buffer(buffer_, static_cast<std::size_t>(to_read)),
-                          [this](const asio::error_code& ec, std::size_t bytes_transferred) {
+                          [this](const boost::system::error_code& ec, std::size_t bytes_transferred) {
                               is_reading = false;
 
                               if (!ec)
@@ -642,7 +642,7 @@ namespace crow
                     auto watch = std::weak_ptr<void>{anchor_};
                     asio::async_write(
                       adaptor_.socket(), buffers,
-                      [&, watch](const asio::error_code& ec, std::size_t /*bytes_transferred*/) {
+                      [&, watch](const boost::system::error_code& ec, std::size_t /*bytes_transferred*/) {
                           if (!ec && !close_connection_)
                           {
                               sending_buffers_.clear();


### PR DESCRIPTION
## Summary
- update Crow HTTP server, connection, websocket, and task timer to use `boost::system::error_code`
- use lambdas for async wait callbacks in `task_timer`

## Testing
- `g++ -std=c++17 /tmp/test.cpp -I. -Iextern/crow/include -Iextern/crow/include/crow -Iinclude -c`
- `g++ -std=c++17 /tmp/test_ws.cpp -I. -Iextern/crow/include -Iinclude -c`
- `g++ -std=c++17 /tmp/test_server.cpp -I. -Iextern/crow/include -Iinclude -c`
- `npm run build` *(fails: Cannot find module '@modelcontextprotocol/sdk/server')*

------
https://chatgpt.com/codex/tasks/task_e_6865181a68b0832ab01baf071ff7c1ba