### PR TITLE
Fix linking errors by adding stub libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,8 @@ add_subdirectory(src/quantum)
 add_subdirectory(src/api)
 add_subdirectory(src/audio)
 add_subdirectory(src/blender)
+add_subdirectory(extern/cuew_stub)
+add_subdirectory(extern/openpgl_stub)
 
 # Main executable
 add_executable(sep_engine src/main.cpp)

--- a/src/blender/CMakeLists.txt
+++ b/src/blender/CMakeLists.txt
@@ -36,6 +36,8 @@ target_link_libraries(sep_blender
         ${GLOG_LIBRARIES}
         ${ZSTD_LIBRARIES}
         ${EMBREE_LIBRARIES}
+        cuew_stub
+        openpgl_stub
     PRIVATE
         sep_compat
         ${CMAKE_SOURCE_DIR}/libsep_compat.a


### PR DESCRIPTION
## Summary
- include stub libraries for cuew and openpgl
- link cuew_stub and openpgl_stub in Blender target

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68651b529e70832ab623306f1f97524f