### PR TITLE
Fix linking errors by adding stub libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,11 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(SEPConfig)
 configure_sep()
 
+# Build lightweight stubs for optional GPU and path guiding libraries
+add_subdirectory(extern/cuew_stub)
+add_subdirectory(extern/openpgl_stub)
+add_subdirectory(extern/cycles/third_party/hipew)
+
 # Ensure our custom Crow wrappers take precedence over the third-party headers
 include_directories(BEFORE
     ${CMAKE_SOURCE_DIR}/include
@@ -74,4 +79,7 @@ target_link_libraries(sep_engine
         gflags
         embree4
         ${HTTP_PARSER_LIBRARY}
+        cuew_stub
+        openpgl_stub
+        extern_hipew
 )

--- a/src/blender/CMakeLists.txt
+++ b/src/blender/CMakeLists.txt
@@ -111,6 +111,9 @@ if(SEP_HAS_CYCLES)
       CUDA::cudart  # For CUDA runtime
       CUDA::cuda_driver
       CUDA::nvrtc
+      cuew_stub
+      openpgl_stub
+      extern_hipew
       glog
       gflags
       embree4


### PR DESCRIPTION
## Summary
- build cuew, OpenPGL and hipew stubs
- link stub libraries to Blender and engine targets

## Testing
- `cmake -S . -B _sep/testbed/build` *(fails: CUDA toolkit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68651b529e70832ab623306f1f97524f