### PR TITLE
Fix build linking missing stub libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,15 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(SEPConfig)
 configure_sep()
 
+# Build minimal stub libraries and third-party helpers needed for
+# the precompiled Cycles integration. These provide implementations
+# for CUDA and path guiding entry points when the real SDKs are
+# not available during compilation.
+add_subdirectory(extern/openpgl_stub)
+add_subdirectory(extern/cuew_stub)
+add_subdirectory(extern/cycles/third_party/cuew)
+add_subdirectory(extern/cycles/third_party/hipew)
+
 # Ensure our custom Crow wrappers take precedence over the third-party headers
 include_directories(BEFORE
     ${CMAKE_SOURCE_DIR}/include

--- a/src/blender/CMakeLists.txt
+++ b/src/blender/CMakeLists.txt
@@ -40,6 +40,10 @@ target_link_libraries(sep_blender
         sep_compat
         ${CMAKE_SOURCE_DIR}/libsep_compat.a
         TBB::tbb
+        extern_cuew
+        extern_hipew
+        cuew_stub
+        openpgl_stub
 )
 
 # Enable CUDA support


### PR DESCRIPTION
## Summary
- link stub libraries and helper libs required by prebuilt Cycles
- link new libs in Blender integration target

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68651b529e70832ab623306f1f97524f