### PR TITLE
Implement context ops in SepEngine

### DIFF
--- a/_sep/testbed/context_algorithms.hpp
+++ b/_sep/testbed/context_algorithms.hpp
@@ -1,0 +1,100 @@
+#ifndef SEP_TESTBED_CONTEXT_ALGORITHMS_HPP
+#define SEP_TESTBED_CONTEXT_ALGORITHMS_HPP
+
+#include <nlohmann/json.hpp>
+#include <vector>
+#include <string>
+#include <cmath>
+
+namespace sep {
+namespace testbed {
+
+struct ValidationReport {
+    bool overall_valid{true};
+    std::vector<size_t> invalid_indices;
+};
+
+inline ValidationReport validate_contexts(const nlohmann::json& contexts) {
+    ValidationReport report{};
+    if (!contexts.is_array()) {
+        report.overall_valid = false;
+        return report;
+    }
+    size_t index = 0;
+    for (const auto& ctx : contexts) {
+        bool ok = ctx.is_object() && ctx.contains("type") && ctx["type"].is_string() &&
+                  ctx.contains("metadata") && ctx["metadata"].is_object() &&
+                  ctx["metadata"].contains("timestamp");
+        if (!ok) {
+            report.overall_valid = false;
+            report.invalid_indices.push_back(index);
+        }
+        ++index;
+    }
+    return report;
+}
+
+struct BlendReport {
+    bool success{false};
+    std::vector<double> blended;
+    double coherence{0.0};
+    std::string error;
+};
+
+inline BlendReport blend_embeddings(const std::vector<std::vector<double>>& embeddings,
+                                   const std::vector<double>& weights) {
+    BlendReport report{};
+    if (embeddings.empty()) {
+        report.error = "No contexts provided";
+        return report;
+    }
+    size_t dim = embeddings[0].size();
+    for (const auto& e : embeddings) {
+        if (e.size() != dim) {
+            report.error = "Inconsistent embedding dimensions";
+            return report;
+        }
+    }
+    if (!weights.empty() && weights.size() != embeddings.size()) {
+        report.error = "Weights size mismatch";
+        return report;
+    }
+    std::vector<double> w = weights;
+    if (w.empty()) {
+        w.assign(embeddings.size(), 1.0 / static_cast<double>(embeddings.size()));
+    }
+    double sum_w = 0.0;
+    for (double v : w) sum_w += v;
+    if (sum_w == 0.0) {
+        report.error = "Weights sum to zero";
+        return report;
+    }
+    for (double& v : w) v /= sum_w;
+    std::vector<double> mean(dim, 0.0);
+    for (size_t i = 0; i < embeddings.size(); ++i) {
+        for (size_t j = 0; j < dim; ++j) {
+            mean[j] += embeddings[i][j] * w[i];
+        }
+    }
+    double avg_distance = 0.0;
+    for (size_t i = 0; i < embeddings.size(); ++i) {
+        double dist = 0.0;
+        for (size_t j = 0; j < dim; ++j) {
+            double diff = embeddings[i][j] - mean[j];
+            dist += diff * diff;
+        }
+        avg_distance += std::sqrt(dist);
+    }
+    avg_distance /= static_cast<double>(embeddings.size());
+    double coherence = 1.0 / (1.0 + avg_distance);
+
+    report.success = true;
+    report.blended = std::move(mean);
+    report.coherence = coherence;
+    return report;
+}
+
+} // namespace testbed
+} // namespace sep
+
+#endif // SEP_TESTBED_CONTEXT_ALGORITHMS_HPP

--- a/src/api/sep_engine.cpp
+++ b/src/api/sep_engine.cpp
@@ -25,6 +25,7 @@
 #include "core/logging.h" // Include logging header first
 #include "quantum/types.h" // For quantum::Pattern::generation 
 #include "compat/math_common.h" // Include math common for sqrt_safe
+#include "../../_sep/testbed/context_algorithms.hpp"
 
 using json = nlohmann::json;
 
@@ -262,16 +263,20 @@ nlohmann::json SepEngine::validateContexts(const nlohmann::json& request_data)
     }
     impl_->health_metrics.totalRequests++;
 
-        // Mock context validation
-        bool valid = request_data.contains("contexts") && request_data["contexts"].is_array();
+    if (!request_data.contains("contexts") || !request_data["contexts"].is_array()) {
+        return makeErrorResponse(api::ErrorCode::InvalidArgument, "Missing contexts array");
+    }
 
-        impl_->health_metrics.successfulRequests++;
+    auto report = sep::testbed::validate_contexts(request_data["contexts"]);
 
-        json result;
-        result["success"]       = true; 
-        result["valid"]         = valid;
-        result["context_count"] = valid ? request_data["contexts"].size() : 0;
-        return result;
+    impl_->health_metrics.successfulRequests++;
+
+    json result;
+    result["success"]       = true;
+    result["valid"]         = report.overall_valid;
+    result["context_count"] = request_data["contexts"].size();
+    result["invalid_indices"] = report.invalid_indices;
+    return result;
 }
 
 nlohmann::json SepEngine::getPatternHistory(const nlohmann::json& request_data)
@@ -389,22 +394,58 @@ nlohmann::json SepEngine::calculateSimilarity(const nlohmann::json& request_data
 
 nlohmann::json SepEngine::blendContexts(const nlohmann::json& request_data)
 {
-    (void)request_data;  // Mark parameter as used
     if (!impl_->initialized) {
-        json result; 
-        result["success"] = false; 
+        json result;
+        result["success"] = false;
         result["error"]   = "Engine not initialized";
         return result;
     }
-        // Mock context blending
-        json blend_result;
-        blend_result["blended_context_id"] = generateId("blend");
-        blend_result["coherence"]          = 0.75;
+    if (!request_data.contains("contexts") || !request_data["contexts"].is_array()) {
+        return makeErrorResponse(api::ErrorCode::InvalidArgument, "Missing contexts array");
+    }
 
-        json result;
-        result["success"] = true; 
-        result["result"]  = blend_result;
-        return result;
+    std::vector<std::vector<double>> embeddings;
+    for (const auto& c : request_data["contexts"]) {
+        if (!c.is_array()) {
+            return makeErrorResponse(api::ErrorCode::InvalidArgument, "Context must be an array of numbers");
+        }
+        std::vector<double> vec;
+        for (const auto& v : c) {
+            if (!v.is_number()) {
+                return makeErrorResponse(api::ErrorCode::InvalidArgument, "Context contains non-numeric value");
+            }
+            vec.push_back(v.get<double>());
+        }
+        embeddings.push_back(std::move(vec));
+    }
+
+    std::vector<double> weights;
+    if (request_data.contains("weights")) {
+        if (!request_data["weights"].is_array()) {
+            return makeErrorResponse(api::ErrorCode::InvalidArgument, "Weights must be an array");
+        }
+        for (const auto& w : request_data["weights"]) {
+            if (!w.is_number()) {
+                return makeErrorResponse(api::ErrorCode::InvalidArgument, "Weights contain non-numeric value");
+            }
+            weights.push_back(w.get<double>());
+        }
+    }
+
+    auto blend = sep::testbed::blend_embeddings(embeddings, weights);
+    if (!blend.success) {
+        return makeErrorResponse(api::ErrorCode::InvalidArgument, blend.error);
+    }
+
+    json blend_result;
+    blend_result["blended_context_id"] = generateId("blend");
+    blend_result["coherence"]          = blend.coherence;
+    blend_result["embedding"]          = blend.blended;
+
+    json result;
+    result["success"] = true;
+    result["result"]  = blend_result;
+    return result;
 }
 
 nlohmann::json SepEngine::getHealthStatus()

--- a/tests/api/CMakeLists.txt
+++ b/tests/api/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(api_tests
     server_test.cpp
     health_endpoint_test.cpp
     long_double_math_test.cpp
+    context_ops_test.cpp
 )
 
 target_include_directories(api_tests PRIVATE

--- a/tests/api/context_ops_test.cpp
+++ b/tests/api/context_ops_test.cpp
@@ -1,0 +1,74 @@
+#include <gtest/gtest.h>
+#include "api/sep_engine.h"
+#include <nlohmann/json.hpp>
+
+using namespace sep::api;
+
+class SepEngineContextOpsTest : public ::testing::Test {
+protected:
+    void SetUp() override { engine.initialize({}); }
+    void TearDown() override { engine.shutdown(); }
+    SepEngine& engine = SepEngine::getInstance();
+};
+
+TEST_F(SepEngineContextOpsTest, ValidateContextsSuccess) {
+    nlohmann::json req = {
+        {"contexts", {
+            {{"type","message"}, {"content","hi"}, {"metadata",{{"timestamp","1"}}}},
+            {{"type","message"}, {"content","bye"}, {"metadata",{{"timestamp","2"}}}}
+        }}
+    };
+    auto res = engine.validateContexts(req);
+    EXPECT_TRUE(res["success"].get<bool>());
+    EXPECT_TRUE(res["valid"].get<bool>());
+    EXPECT_EQ(res["context_count"].get<size_t>(), 2u);
+    EXPECT_TRUE(res["invalid_indices"].empty());
+}
+
+TEST_F(SepEngineContextOpsTest, ValidateContextsError) {
+    nlohmann::json req = {
+        {"contexts", {
+            {{"type","message"}, {"content","hi"}, {"metadata",{{"timestamp","1"}}}},
+            {{"type","message"}, {"content","bye"}}
+        }}
+    };
+    auto res = engine.validateContexts(req);
+    EXPECT_TRUE(res["success"].get<bool>());
+    EXPECT_FALSE(res["valid"].get<bool>());
+    ASSERT_EQ(res["invalid_indices"].size(), 1u);
+    EXPECT_EQ(res["invalid_indices"][0].get<size_t>(), 1u);
+}
+
+TEST_F(SepEngineContextOpsTest, BlendContextsSuccess) {
+    nlohmann::json req = {
+        {"contexts", {
+            {0.0, 0.0, 0.0},
+            {1.0, 1.0, 1.0}
+        }},
+        {"weights", {0.5, 0.5}}
+    };
+    auto res = engine.blendContexts(req);
+    ASSERT_TRUE(res["success"].get<bool>());
+    auto result = res["result"];
+    auto embedding = result["embedding"].get<std::vector<double>>();
+    ASSERT_EQ(embedding.size(), 3u);
+    for (double v : embedding) {
+        EXPECT_NEAR(v, 0.5, 1e-6);
+    }
+    double coherence = result["coherence"].get<double>();
+    EXPECT_GT(coherence, 0.0);
+    EXPECT_LE(coherence, 1.0);
+}
+
+TEST_F(SepEngineContextOpsTest, BlendContextsDimensionMismatch) {
+    nlohmann::json req = {
+        {"contexts", {
+            {0.0, 0.0},
+            {1.0, 1.0, 1.0}
+        }},
+        {"weights", {0.5, 0.5}}
+    };
+    auto res = engine.blendContexts(req);
+    EXPECT_FALSE(res["success"].get<bool>());
+}
+


### PR DESCRIPTION
## Summary
- implement validation logic for `SepEngine::validateContexts`
- implement blending algorithm in `SepEngine::blendContexts`
- provide helper algorithms in `/_sep/testbed/context_algorithms.hpp`
- add API unit tests for context validation and blending

## Testing
- `cmake -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Debug ..` *(fails: CUDA toolkit not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865322666f8832a866df9a218fea1fb