### PR TITLE
Add tests and PipeWire dependency docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,19 @@ The future development of the SEP Engine is focused on enhancing its capabilitie
 ├── THESIS.md # The full theoretical thesis behind the framework
 └── README.md # This document
 
+### Runtime Dependencies
+
+The audio module uses PipeWire for real-time capture and analysis. A running
+PipeWire daemon and the `libpipewire-0.3` package are required at runtime. On
+Debian-based systems install it via:
+
+```bash
+sudo apt install libpipewire-0.3-dev libfftw3-dev
+```
+
+Make sure the service is active (`systemctl --user status pipewire`) before
+executing `sep_engine` or the audio tests.
+
 ---
 
 This project represents an attempt to construct a first-principles, computationally-grounded theory of everything. It is a work in progress, but it offers a robust and testable foundation for exploring the deepest questions about our reality.

--- a/tests/audio/capture_test.cpp
+++ b/tests/audio/capture_test.cpp
@@ -8,3 +8,24 @@ TEST(PipeWireCaptureTest, MetricsAccess) {
     AudioMetrics metrics = cap.getMetrics();
     EXPECT_EQ(metrics.total_samples, 0u);
 }
+TEST(PipeWireCaptureTest, StartWithoutInit) {
+    PipeWireCapture cap;
+    EXPECT_EQ(cap.start(), AudioError::INIT_FAILED);
+}
+
+TEST(PipeWireCaptureTest, StopWithoutInit) {
+    PipeWireCapture cap;
+    EXPECT_EQ(cap.stop(), AudioError::NONE);
+}
+
+TEST(PipeWireCaptureTest, InitStartStopSequence) {
+    PipeWireCapture cap;
+    AudioConfig cfg{};
+    AudioError err = cap.init(cfg);
+    if (err == AudioError::NONE) {
+        EXPECT_EQ(cap.start(), AudioError::NONE);
+        EXPECT_EQ(cap.stop(), AudioError::NONE);
+    } else {
+        EXPECT_EQ(err, AudioError::INIT_FAILED);
+    }
+}


### PR DESCRIPTION
## Summary
- add lifecycle unit tests for `PipeWireCapture`
- document runtime PipeWire requirements in README

## Testing
- `cmake .. -DBUILD_TESTING=ON` *(fails: CUDA toolkit not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865321414b0832a8235cdc255a65586