### PR TITLE
Add testbed suite and all-tests target

### DIFF
--- a/_sep/testbed/CMakeLists.txt
+++ b/_sep/testbed/CMakeLists.txt
@@ -1,0 +1,26 @@
+if(NOT BUILD_TESTING)
+    return()
+endif()
+
+find_package(GTest REQUIRED)
+
+add_library(testbed_tests STATIC
+    core_error_handler_test.cpp
+    audio_pipeline_test.cpp
+    api_makejsonresponse_test.cpp
+)
+
+target_include_directories(testbed_tests PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/src
+)
+
+target_link_libraries(testbed_tests PRIVATE
+    sep_core
+    sep_audio
+    sep_api
+    GTest::GTest
+    GTest::Main
+)
+
+add_test(NAME testbed_tests COMMAND testbed_tests)

--- a/_sep/testbed/api_makejsonresponse_test.cpp
+++ b/_sep/testbed/api_makejsonresponse_test.cpp
@@ -1,0 +1,14 @@
+#include "api/server.h"
+#include "config/api_config.h"
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+
+TEST(APIServerTest, MakeJsonResponseSuccess) {
+    sep::config::APIConfig cfg{};
+    sep::api::SEPApiServer server(cfg);
+    auto resp = server.makeJsonResponse(200, "ok");
+    EXPECT_EQ(resp->getCode(), 200);
+    auto body = nlohmann::json::parse(resp->getBody());
+    EXPECT_EQ(body["status"], "success");
+    EXPECT_EQ(body["message"], "ok");
+}

--- a/_sep/testbed/audio_pipeline_test.cpp
+++ b/_sep/testbed/audio_pipeline_test.cpp
@@ -1,0 +1,9 @@
+#include "audio/pipeline.h"
+#include <gtest/gtest.h>
+
+TEST(AudioPipelineTest, ApplyHannWindowPreservesSize) {
+    sep::audio::AudioPipeline pipeline(48000, 2);
+    std::vector<float> samples(8, 1.0f);
+    pipeline.applyHannWindow(samples);
+    ASSERT_EQ(samples.size(), 8u);
+}

--- a/_sep/testbed/core_error_handler_test.cpp
+++ b/_sep/testbed/core_error_handler_test.cpp
@@ -1,0 +1,23 @@
+#include "core/error_handler.h"
+#include <gtest/gtest.h>
+
+TEST(ErrorHandlerTest, ReportAndRetrieveError) {
+    auto &handler = sep::core::ErrorHandler::instance();
+    handler.clearErrors();
+    sep::Error err(sep::SEPResult::INVALID_ARGUMENT, "invalid arg");
+    handler.reportError(err);
+    auto errors = handler.getErrors();
+    ASSERT_EQ(errors.size(), 1u);
+    EXPECT_EQ(errors[0].code, sep::SEPResult::INVALID_ARGUMENT);
+    EXPECT_STREQ(errors[0].message.c_str(), "invalid arg");
+}
+
+TEST(ErrorHandlerTest, HasErrorsFlag) {
+    auto &handler = sep::core::ErrorHandler::instance();
+    handler.clearErrors();
+    EXPECT_FALSE(handler.hasErrors());
+    handler.reportError(sep::Error(sep::SEPResult::UNKNOWN_ERROR, "oops"));
+    EXPECT_TRUE(handler.hasErrors());
+    handler.clearErrors();
+    EXPECT_FALSE(handler.hasErrors());
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,7 +30,19 @@ add_subdirectory(memory)
 add_subdirectory(audio)
 add_subdirectory(api)
 add_subdirectory(cuda)
+add_subdirectory(${CMAKE_SOURCE_DIR}/_sep/testbed)
 
 # Configure test discovery
 include(CTest)
 enable_testing()
+
+add_custom_target(run_all_tests
+    COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure
+    DEPENDS
+        blender_tests
+        quantum_optimizer_tests
+        memory_manager_tests
+        audio_tests
+        api_tests
+        long_double_math_test
+        testbed_tests)


### PR DESCRIPTION
## Summary
- add `_sep/testbed` with new gtest cases for API, audio, and core modules
- hook testbed into `tests/CMakeLists.txt`
- create `run_all_tests` target to invoke every test suite

## Testing
- `cmake .. -DBUILD_TESTING=ON` *(fails: CUDA toolkit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68653235aaa0832aa6811d329cd068ac