### PR TITLE
Add PipeWire lifecycle tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,4 +96,22 @@ The future development of the SEP Engine is focused on enhancing its capabilitie
 
 ---
 
+## PipeWire Runtime Dependencies
+
+The audio module uses PipeWire for capturing realtime audio. Make sure the
+`libpipewire-0.3` libraries and the PipeWire daemon are available on your
+system. On Debian-based distributions install them with:
+
+```bash
+sudo apt-get install pipewire pipewire-audio-client-libraries
+```
+
+After installation, confirm the daemon is running:
+
+```bash
+systemctl --user status pipewire
+```
+
+Audio initialization will fail if PipeWire is not active.
+
 This project represents an attempt to construct a first-principles, computationally-grounded theory of everything. It is a work in progress, but it offers a robust and testable foundation for exploring the deepest questions about our reality.

--- a/tests/audio/CMakeLists.txt
+++ b/tests/audio/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(audio_tests
     pipeline_features_test.cpp
     pipeline_test.cpp
     fft_accuracy_test.cpp
+    pipewire_lifecycle_test.cpp
 )
 
 target_include_directories(audio_tests PRIVATE

--- a/tests/audio/pipewire_lifecycle_test.cpp
+++ b/tests/audio/pipewire_lifecycle_test.cpp
@@ -1,0 +1,25 @@
+#include <gtest/gtest.h>
+#include "audio/pipewire_capture.h"
+
+using namespace sep::audio;
+
+TEST(PipeWireCaptureLifecycle, StartBeforeInitFails) {
+    PipeWireCapture cap;
+    EXPECT_EQ(cap.start(), AudioError::INIT_FAILED);
+}
+
+TEST(PipeWireCaptureLifecycle, InitAndStop) {
+    PipeWireCapture cap;
+    AudioConfig cfg;
+    auto result = cap.init(cfg);
+    EXPECT_NE(result, AudioError::INTERNAL_ERROR);
+    EXPECT_EQ(cap.stop(), AudioError::NONE);
+}
+
+TEST(PipeWireCaptureLifecycle, CallbackSettable) {
+    PipeWireCapture cap;
+    bool called = false;
+    cap.setCallback([&called](const float*, size_t){ called = true; });
+    EXPECT_FALSE(called);
+    EXPECT_EQ(cap.getMetrics().total_samples, 0u);
+}


### PR DESCRIPTION
## Summary
- add integration tests for PipeWire capture lifecycle
- document PipeWire runtime dependencies

## Testing
- `pkg-config --libs libpipewire-0.3 | head`

------
https://chatgpt.com/codex/tasks/task_e_6865321414b0832a8235cdc255a65586