### PR TITLE
Add GPU context shader loading and buffer APIs

### DIFF
--- a/_sep/testbed/shader_reload_integration.cpp
+++ b/_sep/testbed/shader_reload_integration.cpp
@@ -1,6 +1,8 @@
 #include <gtest/gtest.h>
 #include "blender/gpu_context.h"
 #include "compat/shim.h"
+#include <fstream>
+#include <cstdio>
 
 using namespace sep;
 
@@ -16,6 +18,14 @@ TEST(GPUContextIntegration, ShaderReload) {
     EXPECT_EQ(ctx.reloadComputeShaderIfNeeded(), SEPResult::SUCCESS);
     EXPECT_EQ(ctx.getShaderRevision(), rev1);
 
-    ASSERT_EQ(ctx.loadComputeShader("updated.spv"), SEPResult::SUCCESS);
+    // Simulate an updated shader by copying to a new temporary file
+    sep::shim::string updated = "dummy_updated.spv";
+    {
+        std::ifstream in(shader.c_str(), std::ios::binary);
+        std::ofstream out(updated.c_str(), std::ios::binary);
+        out << in.rdbuf();
+    }
+    ASSERT_EQ(ctx.loadComputeShader(updated), SEPResult::SUCCESS);
     EXPECT_GT(ctx.getShaderRevision(), rev1);
+    std::remove(updated.c_str());
 }

--- a/include/blender/gpu_context.h
+++ b/include/blender/gpu_context.h
@@ -13,6 +13,8 @@ struct GPUBuffer {
     bool mapped{false};
 };
 
+struct GpuBufferPtr;
+
 // Minimal implementation of GPU context for pattern_processor.cpp
 class GPUContext {
 public:
@@ -30,21 +32,17 @@ public:
     // Error state helpers
     bool hasError() const { return has_error_; }
     const ::sep::shim::string& getLastError() const { return last_error_; }
-    void clearError() { has_error_ = false; last_error_.clear(); }
+    void clearError() { has_error_ = false; last_error_ = {}; }
 
     // Buffer helpers
-    virtual GPUBuffer createBuffer(size_t size, const void* data = nullptr);
+    virtual GpuBufferPtr createBuffer(size_t size, const void* data = nullptr);
     virtual void deleteBuffer(GPUBuffer* buffer);
     virtual void* mapBuffer(GPUBuffer* buffer);
     virtual void unmapBuffer(GPUBuffer* buffer);
 
     // Simplified shader handling for tests
-    SEPResult loadComputeShader(const ::sep::shim::string& path) {
-        ++shader_revision_;
-        return SEPResult::SUCCESS;
-    }
-
-    SEPResult reloadComputeShaderIfNeeded() { return SEPResult::SUCCESS; }
+    SEPResult loadComputeShader(const ::sep::shim::string& path);
+    SEPResult reloadComputeShaderIfNeeded();
     uint32_t getShaderRevision() const { return shader_revision_; }
 
 private:
@@ -53,6 +51,8 @@ private:
     bool has_error_{false};
     ::sep::shim::string last_error_{};
     uint32_t shader_revision_{0};
+    ::sep::shim::string shader_path_{};
+    long long shader_timestamp_{0};
 };
 
 // RAII wrapper for GPUBuffer that works with the simplified context

--- a/src/blender/gpu_context.cpp
+++ b/src/blender/gpu_context.cpp
@@ -1,9 +1,8 @@
 #include "blender/gpu_context.h"
 #include <cstdlib>
 #include <cstring>
-
-#include <cstring>
 #include <new>
+#include <sys/stat.h>
 
 namespace sep {
 
@@ -12,6 +11,16 @@ GPUContext::GPUContext() = default;
 GPUContext::~GPUContext() = default;
 
 SEPResult GPUContext::init(int device_index) {
+    int count = 0;
+    SEP_RETURN_IF_ERROR(getDeviceCount(count));
+    if (device_index == -1) {
+        device_index = 0;
+    }
+    if (device_index < 0 || device_index >= count) {
+        has_error_ = true;
+        last_error_ = "Invalid device index";
+        return SEPResult::INVALID_DEVICE;
+    }
     device_index_ = device_index;
     initialized_ = true;
     clearError();
@@ -32,6 +41,37 @@ SEPResult GPUContext::selectDevice(int device_index) {
         return SEPResult::INVALID_DEVICE;
     }
     device_index_ = device_index;
+    return SEPResult::SUCCESS;
+}
+
+SEPResult GPUContext::loadComputeShader(const ::sep::shim::string& path) {
+    struct stat st;
+    if (stat(path.c_str(), &st) != 0) {
+        has_error_ = true;
+        last_error_ = "shader not found";
+        return SEPResult::FILE_NOT_FOUND;
+    }
+    shader_path_ = path;
+    shader_timestamp_ = static_cast<long long>(st.st_mtime);
+    ++shader_revision_;
+    return SEPResult::SUCCESS;
+}
+
+SEPResult GPUContext::reloadComputeShaderIfNeeded() {
+    if (shader_path_.empty()) {
+        return SEPResult::SUCCESS;
+    }
+    struct stat st;
+    if (stat(shader_path_.c_str(), &st) != 0) {
+        has_error_ = true;
+        last_error_ = "shader not found";
+        return SEPResult::FILE_NOT_FOUND;
+    }
+    long long mtime = static_cast<long long>(st.st_mtime);
+    if (mtime != shader_timestamp_) {
+        shader_timestamp_ = mtime;
+        ++shader_revision_;
+    }
     return SEPResult::SUCCESS;
 }
 
@@ -71,7 +111,7 @@ void GPUContext::deleteBuffer(GPUBuffer* buffer) {
 }
 
 void* GPUContext::mapBuffer(GPUBuffer* buffer) {
-    if (!buffer || buffer->mapped) {
+    if (!initialized_ || !buffer || buffer->mapped) {
         has_error_ = true;
         last_error_ = "invalid map";
         return nullptr;

--- a/tests/blender/CMakeLists.txt
+++ b/tests/blender/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(blender_tests STATIC
     buffer_map_integration.cpp
     shader_reload_integration.cpp
     gpu_context_integration_test.cpp
+    gpu_context_regression.cpp
 )
 
 target_include_directories(blender_tests PRIVATE

--- a/tests/blender/gpu_context_regression.cpp
+++ b/tests/blender/gpu_context_regression.cpp
@@ -1,30 +1,34 @@
 #include <gtest/gtest.h>
 #include "blender/gpu_context.h"
-#include "compat/shim.h"
 #include <fstream>
 #include <cstdio>
 
 using namespace sep;
 
-TEST(GPUContextIntegration, ShaderReload) {
+TEST(GPUContextRegression, Initialization) {
+    GPUContext ctx;
+    EXPECT_EQ(ctx.init(), SEPResult::SUCCESS);
+    EXPECT_FALSE(ctx.hasError());
+}
+
+TEST(GPUContextRegression, ShaderReload) {
     GPUContext ctx;
     ASSERT_EQ(ctx.init(), SEPResult::SUCCESS);
 
     sep::shim::string shader = "_sep/testbed/dummy.spv";
     ASSERT_EQ(ctx.loadComputeShader(shader), SEPResult::SUCCESS);
-    uint32_t rev1 = ctx.getShaderRevision();
-    EXPECT_GT(rev1, 0u);
+    uint32_t rev = ctx.getShaderRevision();
 
     EXPECT_EQ(ctx.reloadComputeShaderIfNeeded(), SEPResult::SUCCESS);
-    EXPECT_EQ(ctx.getShaderRevision(), rev1);
+    EXPECT_EQ(ctx.getShaderRevision(), rev);
 
-    sep::shim::string temp = "_sep/testbed/dummy_copy.spv";
+    sep::shim::string temp = "_sep/testbed/dummy_temp.spv";
     {
         std::ifstream in(shader.c_str(), std::ios::binary);
         std::ofstream out(temp.c_str(), std::ios::binary);
         out << in.rdbuf();
     }
     ASSERT_EQ(ctx.loadComputeShader(temp), SEPResult::SUCCESS);
-    EXPECT_GT(ctx.getShaderRevision(), rev1);
+    EXPECT_GT(ctx.getShaderRevision(), rev);
     std::remove(temp.c_str());
 }


### PR DESCRIPTION
## Summary
- implement GPU device init, shader loading and buffer mapping
- expose buffer helper return type and shader reload logic
- update shader reload tests to use real files
- add regression tests for GPUContext initialization and shader reloads

## Testing
- `bash tests/blender/run_tests.sh` *(fails: CUDA toolkit not found)*

------
https://chatgpt.com/codex/tasks/task_e_686538ad23c8832a909d09cae7a812c7