### PR TITLE
Improve PipeWire capture handling and tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,9 +8,6 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(SEPConfig)
 configure_sep()
 
-# Build stub implementation of the OpenPGL API to satisfy linking against
-# precompiled Cycles libraries when the real OpenPGL dependency is missing.
-add_subdirectory(extern/openpgl_stub)
 
 # Ensure our custom Crow wrappers take precedence over the third-party headers
 include_directories(BEFORE
@@ -78,8 +75,5 @@ target_link_libraries(sep_engine
         glog
         gflags
         embree4
-        openpgl_stub
         ${HTTP_PARSER_LIBRARY}
-        cuew_stub
-        openpgl_stub
 )

--- a/src/audio/pipewire_capture.cpp
+++ b/src/audio/pipewire_capture.cpp
@@ -13,6 +13,7 @@
 #include <cmath>
 #include <spdlog/spdlog.h>
 #include <glm/gtc/constants.hpp>
+#include <spa/utils/result.h>
 
 
 // Initialize PipeWire before namespace declarations
@@ -104,8 +105,14 @@ AudioError PipeWireCapture::init(const AudioConfig& config)
     }
 
     // Start the loop before creating context
-    if (pw_thread_loop_start(loop_) < 0) {
-        spdlog::error("Failed to start PipeWire thread loop");
+    int start_err = pw_thread_loop_start(loop_);
+    if (start_err < 0)
+    {
+        spdlog::error("Failed to start PipeWire thread loop: {}", spa_strerror(start_err));
+        if (start_err == -EEXIST)
+        {
+            spdlog::error("Thread loop already running");
+        }
         cleanup();
         return AudioError::INIT_FAILED;
     }
@@ -242,7 +249,8 @@ AudioError PipeWireCapture::setupStream()
     int err = pw_stream_connect(stream_,
                                 PW_DIRECTION_INPUT,
                                 PW_ID_ANY,
-                                static_cast<pw_stream_flags>(PW_STREAM_FLAG_AUTOCONNECT | PW_STREAM_FLAG_RT_PROCESS),
+                                static_cast<pw_stream_flags>(PW_STREAM_FLAG_AUTOCONNECT |
+                                                             PW_STREAM_FLAG_RT_PROCESS),
                                 params,
                                 1);
 
@@ -250,10 +258,12 @@ AudioError PipeWireCapture::setupStream()
 
     if (err < 0)
     {
-        spdlog::error("Failed to connect stream: {}", strerror(-err));
-        spdlog::error("Stream flags: autoconnect={}, rt_process={}",
-                      (err & PW_STREAM_FLAG_AUTOCONNECT),
-                      (err & PW_STREAM_FLAG_RT_PROCESS));
+        spdlog::error("Failed to connect stream: {}", spa_strerror(err));
+        spdlog::error("Source: {} rate: {}", config_.source, config_.rate);
+        if (err == -ENOENT)
+        {
+            spdlog::error("Requested capture device not found");
+        }
         result = AudioError::STREAM_FAILED;
     }
 
@@ -272,7 +282,15 @@ AudioError PipeWireCapture::start()
     int err = pw_thread_loop_start(loop_);
     if (err < 0)
     {
-        spdlog::error("Failed to start PipeWire thread loop: {}", strerror(-err));
+        spdlog::error("Failed to start PipeWire thread loop: {}", spa_strerror(err));
+        if (err == -EEXIST)
+        {
+            spdlog::warn("Thread loop was already running");
+        }
+        else if (err == -EACCES || err == -EPERM)
+        {
+            spdlog::error("Insufficient permissions to start real-time thread");
+        }
         return AudioError::STREAM_FAILED;
     }
 

--- a/src/blender/CMakeLists.txt
+++ b/src/blender/CMakeLists.txt
@@ -36,7 +36,6 @@ target_link_libraries(sep_blender
         ${GLOG_LIBRARIES}
         ${ZSTD_LIBRARIES}
         ${EMBREE_LIBRARIES}
-        openpgl_stub
     PRIVATE
         sep_compat
         ${CMAKE_SOURCE_DIR}/libsep_compat.a
@@ -112,12 +111,9 @@ if(SEP_HAS_CYCLES)
       CUDA::cudart  # For CUDA runtime
       CUDA::cuda_driver
       CUDA::nvrtc
-      cuew_stub
-      openpgl_stub
       glog
       gflags
       embree4
-      openpgl_stub
   )
 endif()
 

--- a/tests/audio/CMakeLists.txt
+++ b/tests/audio/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(audio_tests
     pipeline_test.cpp
     fft_accuracy_test.cpp
     pipewire_lifecycle_test.cpp
+    pipewire_capture_metrics_test.cpp
 )
 
 target_include_directories(audio_tests PRIVATE

--- a/tests/audio/pipewire_capture_metrics_test.cpp
+++ b/tests/audio/pipewire_capture_metrics_test.cpp
@@ -1,0 +1,20 @@
+#include <gtest/gtest.h>
+#include "audio/pipewire_capture.h"
+#include <chrono>
+#include <thread>
+
+using namespace sep::audio;
+
+TEST(PipeWireCaptureMetrics, StartStopUpdatesMetrics) {
+    PipeWireCapture cap;
+    AudioConfig cfg{};
+    auto initErr = cap.init(cfg);
+    if (initErr != AudioError::NONE) {
+        GTEST_SKIP() << "PipeWire unavailable";
+    }
+
+    ASSERT_EQ(cap.start(), AudioError::NONE);
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    EXPECT_GT(cap.getMetrics().total_samples, 0u);
+    EXPECT_EQ(cap.stop(), AudioError::NONE);
+}


### PR DESCRIPTION
## Summary
- enhance PipeWire thread loop error logging
- give more context on stream connection failures
- drop stub libraries from build configuration
- add unit test for PipeWire metric updates

## Testing
- `cmake -S . -B build` *(fails: CUDA toolkit not found)*

------
https://chatgpt.com/codex/tasks/task_e_686538abcef0832ab74f82a5903a5e42