### PR TITLE
Add CUDA fallback and tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,20 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(SEPConfig)
 configure_sep()
 
+# Detect CUDA toolkit and expose SEP_HAS_CUDA for conditional builds
+find_package(CUDAToolkit QUIET)
+if(CUDAToolkit_FOUND AND CUDAToolkit_NVCC_EXECUTABLE)
+    set(SEP_HAS_CUDA 1)
+else()
+    set(SEP_HAS_CUDA 0)
+endif()
+message(STATUS "CUDA support: ${SEP_HAS_CUDA}")
+
+add_compile_definitions(SEP_HAS_CUDA=${SEP_HAS_CUDA})
+
+# Disable Blender integration by default to reduce dependencies
+option(SEP_HAS_BLENDER "Build Blender integration" OFF)
+
 # Build stub implementation of the OpenPGL API to satisfy linking against
 # precompiled Cycles libraries when the real OpenPGL dependency is missing.
 add_subdirectory(extern/openpgl_stub)
@@ -48,7 +62,9 @@ add_subdirectory(src/memory)
 add_subdirectory(src/quantum)
 add_subdirectory(src/api)
 add_subdirectory(src/audio)
-add_subdirectory(src/blender)
+if(SEP_HAS_BLENDER)
+    add_subdirectory(src/blender)
+endif()
 
 # Main executable
 add_executable(sep_engine src/main.cpp)

--- a/src/blender/CMakeLists.txt
+++ b/src/blender/CMakeLists.txt
@@ -1,4 +1,6 @@
-find_package(CUDAToolkit REQUIRED)
+if(SEP_HAS_CUDA)
+    find_package(CUDAToolkit REQUIRED)
+endif()
 find_package(TBB REQUIRED)
 find_package(PkgConfig REQUIRED)
 
@@ -25,7 +27,7 @@ target_compile_definitions(sep_blender
     PUBLIC
         SEP_HAS_BLENDER=1
     PRIVATE
-        SEP_HAS_CUDA=1
+        SEP_HAS_CUDA=${SEP_HAS_CUDA}
 )
 
 # Link dependencies

--- a/src/compat/CMakeLists.txt
+++ b/src/compat/CMakeLists.txt
@@ -23,43 +23,54 @@ if(WITH_OPENSUBDIV)
     set(WITH_CYCLES_OPENSUBDIV ${WITH_OPENSUBDIV})
 endif()
 
-# Find CUDA toolkit to provide imported targets and variables
-find_package(CUDAToolkit QUIET)
-if(NOT CUDAToolkit_FOUND OR NOT CUDAToolkit_NVCC_EXECUTABLE)
-    message(FATAL_ERROR "CUDA toolkit not found. Install 'nvidia-cuda-toolkit' or set CUDAToolkit_ROOT")
+if(SEP_HAS_CUDA)
+    # Build full CUDA implementation when the toolkit is available
+    find_package(CUDAToolkit REQUIRED)
+
+    add_library(sep_compat STATIC
+        cuda_api.cu
+        core.cu
+        pattern_kernels.cu
+        kernels.cu
+        quantum_kernels.cu
+        utils.cu
+        event.cu
+        stream.cpp
+        raii.cpp
+    )
+
+    set_source_files_properties(
+        cuda_api.cu core.cu pattern_kernels.cu kernels.cu quantum_kernels.cu utils.cu event.cu
+        PROPERTIES
+        COMPILE_FLAGS "${CUDA_NVCC_FLAGS}"
+    )
+
+    set_target_properties(sep_compat PROPERTIES
+        CUDA_SEPARABLE_COMPILATION ON
+        CUDA_RESOLVE_DEVICE_SYMBOLS ON
+        POSITION_INDEPENDENT_CODE ON
+        CUDA_ARCHITECTURES native
+    )
+
+    set_property(TARGET sep_compat PROPERTY CUDA_STANDARD 17)
+
+    target_compile_definitions(sep_compat PUBLIC SEP_USE_CUDA=1)
+else()
+    # CPU fallback when CUDA is not available
+    add_library(sep_compat STATIC
+        cuda_api_stub.cpp
+        stream.cpp
+        raii.cpp
+        event.cu
+    )
+
+    # Compile .cu sources with the host compiler
+    set_source_files_properties(event.cu PROPERTIES LANGUAGE CXX)
+
+    set_target_properties(sep_compat PROPERTIES
+        POSITION_INDEPENDENT_CODE ON
+    )
 endif()
-
-add_library(sep_compat STATIC
-    cuda_api.cu
-    core.cu
-    pattern_kernels.cu
-    kernels.cu
-    quantum_kernels.cu
-    utils.cu
-    event.cu
-    stream.cpp
-    raii.cpp
-)
-
-# Set CUDA source file properties
-set_source_files_properties(
-    cuda_api.cu core.cu pattern_kernels.cu kernels.cu quantum_kernels.cu utils.cu event.cu
-    PROPERTIES
-    COMPILE_FLAGS "${CUDA_NVCC_FLAGS}"
-)
-
-# Configure CUDA target using custom pipeline
-
-# Configure CUDA properties
-set_target_properties(sep_compat PROPERTIES
-    CUDA_SEPARABLE_COMPILATION ON
-    CUDA_RESOLVE_DEVICE_SYMBOLS ON
-    POSITION_INDEPENDENT_CODE ON
-    CUDA_ARCHITECTURES native
-)
-
-# Set CUDA standard
-set_property(TARGET sep_compat PROPERTY CUDA_STANDARD 17)
 
 # Include directories
 target_include_directories(sep_compat
@@ -75,6 +86,6 @@ target_include_directories(sep_compat
 target_link_libraries(sep_compat
     PUBLIC
         sep_core
-        CUDA::cudart
-        CUDA::cuda_driver
+        $<IF:$<BOOL:${SEP_HAS_CUDA}>,CUDA::cudart,>
+        $<IF:$<BOOL:${SEP_HAS_CUDA}>,CUDA::cuda_driver,>
 )

--- a/src/compat/cuda_api_stub.cpp
+++ b/src/compat/cuda_api_stub.cpp
@@ -5,7 +5,9 @@
 
 extern "C" {
 
-// Simple CPU fallback implementations for environments without CUDA
+// CPU implementations used when CUDA is unavailable. Separating the logic
+// allows the public API wrappers below to remain small and to potentially
+// dispatch to real GPU kernels in the future.
 namespace {
 bool g_initialized = false;
 
@@ -15,6 +17,60 @@ static inline std::uint64_t bit_reverse64(std::uint64_t v) {
         r = (r << 1) | ((v >> i) & 1ULL);
     }
     return r;
+}
+
+sep::SEPResult cpu_process_batch(const std::uint32_t* probe_indices,
+                                 const std::uint32_t* expectations,
+                                 std::uint32_t num_probes,
+                                 std::uint32_t* bitfield,
+                                 std::uint32_t* correction_indices,
+                                 std::uint32_t* correction_count) {
+    std::uint32_t count = 0;
+    for (std::uint32_t i = 0; i < num_probes; ++i) {
+        std::uint32_t bit_index = probe_indices[i];
+        std::uint32_t expected  = expectations[i];
+
+        std::uint32_t word_idx = bit_index / 32u;
+        std::uint32_t bit_pos  = bit_index % 32u;
+        std::uint32_t mask     = 1u << bit_pos;
+        std::uint32_t current  = (bitfield[word_idx] >> bit_pos) & 1u;
+
+        if (current != expected) {
+            bitfield[word_idx] ^= mask;
+            correction_indices[count] = bit_index;
+            ++count;
+        }
+    }
+
+    *correction_count = count;
+    return sep::SEPResult::SUCCESS;
+}
+
+sep::SEPResult cpu_process_symmetry(const std::uint64_t* chunks,
+                                    std::uint32_t num_chunks,
+                                    std::uint32_t* collapse_indices,
+                                    std::uint32_t* collapse_counts) {
+    constexpr std::uint32_t pairs = sep::cuda::constants::SYMMETRY_PAIRS;
+
+    for (std::uint32_t c = 0; c < num_chunks; ++c) {
+        std::uint64_t chunk      = chunks[c];
+        std::uint64_t reversed   = bit_reverse64(chunk);
+        std::uint64_t diff       = chunk ^ reversed;
+        std::uint32_t match_mask = static_cast<std::uint32_t>(~diff) &
+                                   ((1u << pairs) - 1u);
+
+        std::uint32_t base  = c * pairs;
+        std::uint32_t count = 0;
+        while (match_mask && count < pairs) {
+            std::uint32_t i = __builtin_ctz(match_mask);
+            collapse_indices[base + count] = i;
+            ++count;
+            match_mask &= match_mask - 1u;
+        }
+        collapse_counts[c] = count;
+    }
+
+    return sep::SEPResult::SUCCESS;
 }
 }  // namespace
 
@@ -39,25 +95,8 @@ sep::SEPResult sep_cuda_process_batch(const std::uint32_t* probe_indices,
         return sep::SEPResult::INVALID_ARGUMENT;
     }
 
-    std::uint32_t count = 0;
-    for (std::uint32_t i = 0; i < num_probes; ++i) {
-        std::uint32_t bit_index = probe_indices[i];
-        std::uint32_t expected  = expectations[i];
-
-        std::uint32_t word_idx = bit_index / 32u;
-        std::uint32_t bit_pos  = bit_index % 32u;
-        std::uint32_t mask     = 1u << bit_pos;
-        std::uint32_t current  = (bitfield[word_idx] >> bit_pos) & 1u;
-
-        if (current != expected) {
-            bitfield[word_idx] ^= mask;
-            correction_indices[count] = bit_index;
-            ++count;
-        }
-    }
-
-    *correction_count = count;
-    return sep::SEPResult::SUCCESS;
+    return cpu_process_batch(probe_indices, expectations, num_probes, bitfield,
+                              correction_indices, correction_count);
 }
 
 sep::SEPResult sep_cuda_process_symmetry(const std::uint64_t* chunks,
@@ -68,27 +107,8 @@ sep::SEPResult sep_cuda_process_symmetry(const std::uint64_t* chunks,
         return sep::SEPResult::INVALID_ARGUMENT;
     }
 
-    constexpr std::uint32_t pairs = sep::cuda::constants::SYMMETRY_PAIRS;
-
-    for (std::uint32_t c = 0; c < num_chunks; ++c) {
-        std::uint64_t chunk      = chunks[c];
-        std::uint64_t reversed   = bit_reverse64(chunk);
-        std::uint64_t diff       = chunk ^ reversed;
-        std::uint32_t match_mask = static_cast<std::uint32_t>(~diff) &
-                                   ((1u << pairs) - 1u);
-
-        std::uint32_t base  = c * pairs;
-        std::uint32_t count = 0;
-        while (match_mask && count < pairs) {
-            std::uint32_t i = __builtin_ctz(match_mask);
-            collapse_indices[base + count] = i;
-            ++count;
-            match_mask &= match_mask - 1u;
-        }
-        collapse_counts[c] = count;
-    }
-
-    return sep::SEPResult::SUCCESS;
+    return cpu_process_symmetry(chunks, num_chunks, collapse_indices,
+                                collapse_counts);
 }
 
 }  // extern "C"

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -16,8 +16,8 @@ add_library(sep_core
 # Link dependencies
 target_link_libraries(sep_core)
 
-# CUDA is always required
-target_compile_definitions(sep_core PRIVATE SEP_HAS_CUDA=1)
+# Enable CUDA support when available
+target_compile_definitions(sep_core PRIVATE SEP_HAS_CUDA=${SEP_HAS_CUDA})
 
 # Set library properties
 set_target_properties(sep_core PROPERTIES

--- a/src/memory/CMakeLists.txt
+++ b/src/memory/CMakeLists.txt
@@ -21,7 +21,7 @@ target_link_libraries(sep_memory
 
 # CUDA and Redis are always required
 target_compile_definitions(sep_memory PRIVATE
-    SEP_HAS_CUDA=1
+    SEP_HAS_CUDA=${SEP_HAS_CUDA}
     SEP_HAS_REDIS=1
 )
 

--- a/src/quantum/CMakeLists.txt
+++ b/src/quantum/CMakeLists.txt
@@ -34,8 +34,8 @@ target_include_directories(sep_quantum PUBLIC
     $<INSTALL_INTERFACE:include>
 )
 
-# CUDA is required for quantum operations
-target_compile_definitions(sep_quantum PRIVATE SEP_HAS_CUDA=1)
+# Enable CUDA when available for quantum operations
+target_compile_definitions(sep_quantum PRIVATE SEP_HAS_CUDA=${SEP_HAS_CUDA})
 
 # Set library properties
 set_target_properties(sep_quantum PROPERTIES

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -1,6 +1,8 @@
 # Set C++ standard
 # Find required packages
-find_package(CUDAToolkit REQUIRED)
+if(SEP_HAS_CUDA)
+    find_package(CUDAToolkit REQUIRED)
+endif()
 find_package(fmt REQUIRED)
 
 # Add test sources
@@ -19,15 +21,15 @@ target_link_libraries(cycles_test PRIVATE
     fmt::fmt
     sep_core
     sep_compat
-    CUDA::cudart
-    CUDA::cuda_driver
+    $<IF:$<BOOL:${SEP_HAS_CUDA}>,CUDA::cudart,>
+    $<IF:$<BOOL:${SEP_HAS_CUDA}>,CUDA::cuda_driver,>
 )
 
 # Configure include directories
 target_include_directories(cycles_test PRIVATE
     ${CMAKE_SOURCE_DIR}/include
     ${CMAKE_SOURCE_DIR}/src
-    ${CUDAToolkit_INCLUDE_DIRS}
+    $<IF:$<BOOL:${SEP_HAS_CUDA}>,${CUDAToolkit_INCLUDE_DIRS},>
 )
 
 # Add test to CTest

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -45,4 +45,5 @@ add_custom_target(run_all_tests
         audio_tests
         api_tests
         long_double_math_test
+        cuda_api_tests
         testbed_tests)

--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -8,7 +8,16 @@ add_executable(long_double_math_test
     long_double_math_test.cpp
 )
 
+add_executable(cuda_api_tests
+    processing_api_test.cpp
+)
+
 target_include_directories(long_double_math_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/src
+)
+
+target_include_directories(cuda_api_tests PRIVATE
     ${CMAKE_SOURCE_DIR}/include
     ${CMAKE_SOURCE_DIR}/src
 )
@@ -18,8 +27,18 @@ target_link_libraries(long_double_math_test PRIVATE
     sep_core
     GTest::GTest
     GTest::Main
-    CUDA::cudart
-    CUDA::cuda_driver
+    $<IF:$<BOOL:${SEP_HAS_CUDA}>,CUDA::cudart,>
+    $<IF:$<BOOL:${SEP_HAS_CUDA}>,CUDA::cuda_driver,>
+)
+
+target_link_libraries(cuda_api_tests PRIVATE
+    sep_compat
+    sep_core
+    GTest::GTest
+    GTest::Main
+    $<IF:$<BOOL:${SEP_HAS_CUDA}>,CUDA::cudart,>
+    $<IF:$<BOOL:${SEP_HAS_CUDA}>,CUDA::cuda_driver,>
 )
 
 add_test(NAME long_double_math_test COMMAND long_double_math_test)
+add_test(NAME cuda_api_tests COMMAND cuda_api_tests)

--- a/tests/cuda/processing_api_test.cpp
+++ b/tests/cuda/processing_api_test.cpp
@@ -1,0 +1,57 @@
+#include <gtest/gtest.h>
+#include "compat/cuda_api.hpp"
+#include "compat/constants.h"
+
+using namespace sep;
+
+class CudaApiProcessingTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        int count = 0;
+        if (sep::cuda::cudaGetDeviceCount(&count) != cudaSuccess || count == 0) {
+            GTEST_SKIP() << "CUDA device not available";
+        }
+        EXPECT_EQ(sep_cuda_init(0), SEPResult::SUCCESS);
+    }
+
+    void TearDown() override { sep_cuda_cleanup(); }
+};
+
+TEST_F(CudaApiProcessingTest, ProcessBatchBasic) {
+    const uint32_t num_probes = 4;
+    uint32_t probe_indices[num_probes] = {0, 1, 32, 33};
+    uint32_t expectations[num_probes]  = {1, 0, 1, 0};
+
+    uint32_t bitfield[sep::cuda::constants::BITFIELD_WORDS] = {0};
+    uint32_t corrections[sep::cuda::constants::MAX_BLOCK_SIZE] = {0};
+    uint32_t correction_count = 0;
+
+    ASSERT_EQ(sep_cuda_process_batch(probe_indices, expectations, num_probes,
+                                     bitfield, corrections, &correction_count),
+              SEPResult::SUCCESS);
+    EXPECT_EQ(correction_count, 2u);
+    EXPECT_EQ(bitfield[0], 1u);
+    EXPECT_EQ(bitfield[1], 1u);
+    EXPECT_EQ(corrections[0], 0u);
+    EXPECT_EQ(corrections[1], 32u);
+}
+
+TEST_F(CudaApiProcessingTest, ProcessSymmetryBasic) {
+    const uint32_t num_chunks = 2;
+    uint64_t chunks[num_chunks] = {0ULL, 0xFFFFFFFFFFFFFFFFULL};
+
+    constexpr uint32_t pairs = sep::cuda::constants::SYMMETRY_PAIRS;
+    uint32_t indices[num_chunks * pairs] = {0};
+    uint32_t counts[num_chunks] = {0};
+
+    ASSERT_EQ(sep_cuda_process_symmetry(chunks, num_chunks, indices, counts),
+              SEPResult::SUCCESS);
+
+    for (uint32_t c = 0; c < num_chunks; ++c) {
+        EXPECT_EQ(counts[c], pairs);
+        for (uint32_t i = 0; i < pairs; ++i) {
+            EXPECT_EQ(indices[c * pairs + i], i);
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement CPU fallback helpers in `cuda_api_stub.cpp`
- configure CUDA detection and optional blender build in root CMake
- build CPU-only version of `sep_compat` when CUDA isn't found
- provide compile-time CUDA toggle for core/memory/quantum
- add `cuda_api_tests` verifying processing helpers

## Testing
- `cmake .. -DBUILD_TESTING=ON` *(fails: could not run tests because none were configured)*

------
https://chatgpt.com/codex/tasks/task_e_686538ab1150832a8358a6f00cc22f65