### PR TITLE
Implement context validation and blending algorithms

### DIFF
--- a/_sep/testbed/context_algorithms.hpp
+++ b/_sep/testbed/context_algorithms.hpp
@@ -28,9 +28,12 @@ inline std::pair<bool,int> validate_contexts_impl(const nlohmann::json& contexts
             return {false, static_cast<int>(i)};
         }
         if (ctx.contains("metadata") && ctx["metadata"].is_object()) {
-            if (!ctx["metadata"].contains("timestamp")) {
+            if (!ctx["metadata"].contains("timestamp") ||
+                !ctx["metadata"]["timestamp"].is_number()) {
                 return {false, static_cast<int>(i)};
             }
+        } else {
+            return {false, static_cast<int>(i)};
         }
     }
     return {true, -1};
@@ -104,7 +107,8 @@ inline ValidationReport validate_contexts(const nlohmann::json& contexts) {
     for (const auto& ctx : contexts) {
         bool ok = ctx.is_object() && ctx.contains("type") && ctx["type"].is_string() &&
                   ctx.contains("metadata") && ctx["metadata"].is_object() &&
-                  ctx["metadata"].contains("timestamp");
+                  ctx["metadata"].contains("timestamp") &&
+                  ctx["metadata"]["timestamp"].is_number();
         if (!ok) {
             report.overall_valid = false;
             report.invalid_indices.push_back(index);

--- a/include/api/sep_engine.h
+++ b/include/api/sep_engine.h
@@ -83,6 +83,11 @@ public:
     /**
      * @brief Validate context data
      *
+     * Expects a JSON object containing a "contexts" array where each element
+     * has a string "type", arbitrary "content" and a metadata object with a
+     * numeric "timestamp" field. The response includes a boolean "valid" flag
+     * and the indices of any invalid contexts.
+     *
      * @param request_data JSON request data containing context information
      * @return JSON response with validation results
      */
@@ -111,6 +116,11 @@ public:
 
     /**
      * @brief Blend contexts together
+     *
+     * Combines the numeric embeddings from each context using optional
+     * weights and returns a new context with the averaged embedding,
+     * aggregated timestamp and a coherence score measuring similarity of the
+     * inputs.
      *
      * @param request_data JSON request data containing contexts to blend
      * @return JSON response with blending results

--- a/src/api/sep_engine.cpp
+++ b/src/api/sep_engine.cpp
@@ -266,26 +266,6 @@ nlohmann::json SepEngine::validateContexts(const nlohmann::json& request_data)
 
     if (!request_data.contains("contexts") || !request_data["contexts"].is_array())
     {
-        json result;
-        result["success"] = false;
-        result["error"]   = "contexts must be an array";
-        return result;
-    }
-
-    auto [valid, invalid_index] =
-        sep::testbed::validate_contexts_impl(request_data["contexts"]);
-
-    impl_->health_metrics.successfulRequests++;
-
-    json result;
-    result["success"]       = valid;
-    result["context_count"] = request_data["contexts"].size();
-    if (!valid)
-    {
-        result["error"] = std::string("invalid context at index ") +
-                          std::to_string(invalid_index);
-    }
-    if (!request_data.contains("contexts") || !request_data["contexts"].is_array()) {
         return makeErrorResponse(api::ErrorCode::InvalidArgument, "Missing contexts array");
     }
 
@@ -294,9 +274,9 @@ nlohmann::json SepEngine::validateContexts(const nlohmann::json& request_data)
     impl_->health_metrics.successfulRequests++;
 
     json result;
-    result["success"]       = true;
-    result["valid"]         = report.overall_valid;
-    result["context_count"] = request_data["contexts"].size();
+    result["success"]         = true;
+    result["valid"]           = report.overall_valid;
+    result["context_count"]   = request_data["contexts"].size();
     result["invalid_indices"] = report.invalid_indices;
     return result;
 }
@@ -432,13 +412,17 @@ nlohmann::json SepEngine::blendContexts(const nlohmann::json& request_data)
     }
 
     std::vector<std::vector<double>> embeddings;
-    for (const auto& ctx : request_data["contexts"])
+    std::vector<double>           timestamps;
+    for (size_t idx = 0; idx < request_data["contexts"].size(); ++idx)
     {
-        if (!ctx.contains("content") || !ctx["content"].is_array())
+        const auto& ctx = request_data["contexts"][idx];
+        if (!ctx.contains("content") || !ctx["content"].is_array() ||
+            !ctx.contains("metadata") || !ctx["metadata"].is_object() ||
+            !ctx["metadata"].contains("timestamp"))
         {
             json result;
             result["success"] = false;
-            result["error"]   = "context missing content";
+            result["error"]   = std::string("invalid context at index ") + std::to_string(idx);
             return result;
         }
         std::vector<double> emb;
@@ -446,6 +430,7 @@ nlohmann::json SepEngine::blendContexts(const nlohmann::json& request_data)
         for (const auto& v : ctx["content"])
             emb.push_back(v.get<double>());
         embeddings.push_back(std::move(emb));
+        timestamps.push_back(ctx["metadata"]["timestamp"].get<double>());
     }
 
     size_t dim = embeddings[0].size();
@@ -460,7 +445,7 @@ nlohmann::json SepEngine::blendContexts(const nlohmann::json& request_data)
         }
     }
 
-    std::vector<float> weights;
+    std::vector<double> weights;
     if (request_data.contains("weights"))
     {
         if (!request_data["weights"].is_array() ||
@@ -472,10 +457,42 @@ nlohmann::json SepEngine::blendContexts(const nlohmann::json& request_data)
             return result;
         }
         for (const auto& w : request_data["weights"])
-            weights.push_back(w.get<float>());
+            weights.push_back(w.get<double>());
     }
 
-    auto blend = sep::testbed::blend_contexts_impl(embeddings, weights);
+    // Normalize weights and compute timestamp blend
+    if (weights.empty())
+        weights.assign(embeddings.size(), 1.0 / static_cast<double>(embeddings.size()));
+
+    double sum_w = 0.0;
+    for (double v : weights) sum_w += v;
+    if (sum_w == 0.0)
+    {
+        json result;
+        result["success"] = false;
+        result["error"]   = "weights sum to zero";
+        return result;
+    }
+    for (double& v : weights) v /= sum_w;
+
+    auto blend_report = sep::testbed::blend_embeddings(embeddings, weights);
+    if (!blend_report.success)
+    {
+        json result;
+        result["success"] = false;
+        result["error"]   = blend_report.error;
+        return result;
+    }
+
+    double ts = 0.0;
+    for (size_t i = 0; i < timestamps.size(); ++i)
+        ts += timestamps[i] * weights[i];
+
+    json blend;
+    blend["embedding"] = blend_report.blended;
+    blend["coherence"] = blend_report.coherence;
+    blend["metadata"]  = { {"timestamp", ts} };
+    blend["type"]       = "blended";
     blend["blended_context_id"] = generateId("blend");
 
     json result;

--- a/tests/api/context_api_test.cpp
+++ b/tests/api/context_api_test.cpp
@@ -30,7 +30,27 @@ TEST(SepEngineContextValidation, InvalidContextMissingType) {
         }}}
     };
     auto res = engine.validateContexts(req);
-    EXPECT_FALSE(res["success"].get<bool>());
+    EXPECT_TRUE(res["success"].get<bool>());
+    EXPECT_FALSE(res["valid"].get<bool>());
+    ASSERT_EQ(res["invalid_indices"].size(), 1u);
+    EXPECT_EQ(res["invalid_indices"][0].get<size_t>(), 0u);
+}
+
+TEST(SepEngineContextValidation, InvalidContextBadTimestamp) {
+    auto &engine = SepEngine::getInstance();
+    ASSERT_TRUE(engine.initialize({}));
+    nlohmann::json req = {
+        {"contexts", {{
+            {"type", "message"},
+            {"content", {1,2,3}},
+            {"metadata", {{"timestamp", "bad"}}}
+        }}}
+    };
+    auto res = engine.validateContexts(req);
+    EXPECT_TRUE(res["success"].get<bool>());
+    EXPECT_FALSE(res["valid"].get<bool>());
+    ASSERT_EQ(res["invalid_indices"].size(), 1u);
+    EXPECT_EQ(res["invalid_indices"][0].get<size_t>(), 0u);
 }
 
 TEST(SepEngineBlendContexts, BasicBlend) {
@@ -38,15 +58,19 @@ TEST(SepEngineBlendContexts, BasicBlend) {
     ASSERT_TRUE(engine.initialize({}));
     nlohmann::json req = {
         {"contexts", {
-            {{"content", {0.0, 1.0}}},
-            {{"content", {1.0, 0.0}}}
+            {{"content", {0.0, 1.0}}, {"metadata", {{"timestamp", 1}}}},
+            {{"content", {1.0, 0.0}}, {"metadata", {{"timestamp", 3}}}}
         }},
-        {"weights", {0.5, 0.5}}
+        {"weights", {0.25, 0.75}}
     };
     auto res = engine.blendContexts(req);
     EXPECT_TRUE(res["success"].get<bool>());
-    auto coherence = res["result"]["coherence"].get<double>();
-    EXPECT_GT(coherence, 0.0);
+    auto result = res["result"];
+    auto emb    = result["embedding"].get<std::vector<double>>();
+    ASSERT_EQ(emb.size(), 2u);
+    EXPECT_NEAR(emb[0], 1.5, 1e-6);
+    EXPECT_NEAR(emb[1], 0.25, 1e-6);
+    EXPECT_NEAR(result["metadata"]["timestamp"].get<double>(), 2.5, 1e-6);
 }
 
 TEST(SepEngineBlendContexts, DimensionMismatch) {
@@ -54,8 +78,8 @@ TEST(SepEngineBlendContexts, DimensionMismatch) {
     ASSERT_TRUE(engine.initialize({}));
     nlohmann::json req = {
         {"contexts", {
-            {{"content", {0.0, 1.0}}},
-            {{"content", {1.0}}}
+            {{"content", {0.0, 1.0}}, {"metadata", {{"timestamp", 1}}}},
+            {{"content", {1.0}}, {"metadata", {{"timestamp", 2}}}}
         }}
     };
     auto res = engine.blendContexts(req);


### PR DESCRIPTION
## Summary
- add strict timestamp checks in testbed validation logic
- implement new validation workflow in `SepEngine::validateContexts`
- implement weighted blending with timestamp aggregation
- document behavior of the context APIs
- expand unit tests for valid/invalid contexts and blending

## Testing
- `cmake .. -DHIREDIS_LIB=/lib/x86_64-linux-gnu/libhiredis.so.1.1.0 -DHIREDIS_INCLUDE_DIR=/usr/include/hiredis -DSEP_HAS_CUDA=0` *(fails: `ar: ... event.cu.o: No such file or directory`)*


------
https://chatgpt.com/codex/tasks/task_e_68658188ace4832a88fe6a1bb55d2f52