### PR TITLE
Implement GPU dispatch and experimental kernel

### DIFF
--- a/_sep/testbed/CMakeLists.txt
+++ b/_sep/testbed/CMakeLists.txt
@@ -24,3 +24,5 @@ target_link_libraries(testbed_tests PRIVATE
 )
 
 add_test(NAME testbed_tests COMMAND testbed_tests)
+
+add_subdirectory(cuda)

--- a/_sep/testbed/cuda/CMakeLists.txt
+++ b/_sep/testbed/cuda/CMakeLists.txt
@@ -1,0 +1,4 @@
+if(SEP_HAS_CUDA)
+  add_library(testbed_cuda_kernels STATIC increment_kernel.cu)
+  set_property(TARGET testbed_cuda_kernels PROPERTY CUDA_STANDARD 17)
+endif()

--- a/_sep/testbed/cuda/increment_kernel.cu
+++ b/_sep/testbed/cuda/increment_kernel.cu
@@ -1,0 +1,15 @@
+#include <cuda_runtime.h>
+extern "C" __global__ void increment_kernel(int* data, unsigned int n) {
+    unsigned int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < n) {
+        data[idx] += 1;
+    }
+}
+
+extern "C" cudaError_t launch_increment_kernel(int* d_data, unsigned int n, cudaStream_t stream) {
+    if (!d_data) return cudaErrorInvalidValue;
+    const unsigned int block = 64;
+    const unsigned int grid = (n + block - 1) / block;
+    increment_kernel<<<grid, block, 0, stream>>>(d_data, n);
+    return cudaGetLastError();
+}

--- a/_sep/testbed/cuda/increment_kernel.hpp
+++ b/_sep/testbed/cuda/increment_kernel.hpp
@@ -1,0 +1,3 @@
+#pragma once
+#include <cuda_runtime.h>
+extern "C" cudaError_t launch_increment_kernel(int* d_data, unsigned int n, cudaStream_t stream);

--- a/src/compat/cuda_api_stub.cpp
+++ b/src/compat/cuda_api_stub.cpp
@@ -1,15 +1,23 @@
-#ifndef SEP_USE_CUDA
 #include "compat/cuda_api.hpp"
 #include "core/common.h"
 #include "compat/constants.h"
+#ifdef SEP_USE_CUDA
+#include "compat/kernels.h"
+#include "compat/raii.h"
+#include "compat/cuda_helpers.h"
+#endif
 
 extern "C" {
 
-// CPU implementations used when CUDA is unavailable. Separating the logic
-// allows the public API wrappers below to remain small and to potentially
-// dispatch to real GPU kernels in the future.
+// When CUDA is unavailable we fall back to CPU implementations. When
+// SEP_USE_CUDA is defined we dispatch to the actual GPU kernels in
+// kernels.cu via the launch helpers.
 namespace {
 bool g_initialized = false;
+#ifdef SEP_USE_CUDA
+using StreamPtr = std::unique_ptr<sep::cuda::StreamRAII>;
+static StreamPtr g_stream;
+#endif
 
 static inline std::uint64_t bit_reverse64(std::uint64_t v) {
     std::uint64_t r = 0;
@@ -19,6 +27,7 @@ static inline std::uint64_t bit_reverse64(std::uint64_t v) {
     return r;
 }
 
+#ifndef SEP_USE_CUDA
 sep::SEPResult cpu_process_batch(const std::uint32_t* probe_indices,
                                  const std::uint32_t* expectations,
                                  std::uint32_t num_probes,
@@ -72,14 +81,28 @@ sep::SEPResult cpu_process_symmetry(const std::uint64_t* chunks,
 
     return sep::SEPResult::SUCCESS;
 }
+#endif // SEP_USE_CUDA
 }  // namespace
 
-sep::SEPResult sep_cuda_init(int /*device_id*/) {
+sep::SEPResult sep_cuda_init(int device_id) {
+#ifdef SEP_USE_CUDA
+    if (device_id >= 0) {
+        sep::cuda::CudaWrapper::getInstance().setDevice(device_id);
+    }
+    g_stream = std::make_unique<sep::cuda::StreamRAII>();
+    if (!g_stream || !g_stream->valid()) {
+        g_stream.reset();
+        return sep::SEPResult::UNKNOWN_ERROR;
+    }
+#endif
     g_initialized = true;
     return sep::SEPResult::SUCCESS;
 }
 
 sep::SEPResult sep_cuda_cleanup(void) {
+#ifdef SEP_USE_CUDA
+    g_stream.reset();
+#endif
     g_initialized = false;
     return sep::SEPResult::SUCCESS;
 }
@@ -95,8 +118,66 @@ sep::SEPResult sep_cuda_process_batch(const std::uint32_t* probe_indices,
         return sep::SEPResult::INVALID_ARGUMENT;
     }
 
+#ifdef SEP_USE_CUDA
+    const uint32_t bitfield_words = sep::cuda::constants::get_bitfield_words();
+    const uint32_t max_block_size = sep::cuda::constants::get_max_block_size();
+
+    const size_t probe_size = num_probes * sizeof(std::uint32_t);
+    const size_t bitfield_size = bitfield_words * sizeof(std::uint32_t);
+    const size_t corrections_size = max_block_size * sizeof(std::uint32_t);
+    const size_t count_size = sizeof(std::uint32_t);
+
+    sep::cuda::DeviceBufferRAII<std::uint32_t> d_probe_indices(num_probes);
+    sep::cuda::DeviceBufferRAII<std::uint32_t> d_expectations(num_probes);
+    sep::cuda::DeviceBufferRAII<std::uint32_t> d_bitfield(bitfield_words);
+    sep::cuda::DeviceBufferRAII<std::uint32_t> d_corrections(max_block_size);
+    sep::cuda::DeviceBufferRAII<std::uint32_t> d_correction_count(1);
+
+    if (!d_probe_indices.valid() || !d_expectations.valid() ||
+        !d_bitfield.valid() || !d_corrections.valid() ||
+        !d_correction_count.valid()) {
+        return sep::SEPResult::UNKNOWN_ERROR;
+    }
+
+    try {
+        CUDA_CHECK(cudaStreamSynchronize(g_stream->get()));
+        CUDA_CHECK(sep::cuda::cudaMemcpyAsync(d_probe_indices.get(), probe_indices,
+                                              probe_size, cudaMemcpyHostToDevice,
+                                              g_stream->get()));
+        CUDA_CHECK(sep::cuda::cudaMemcpyAsync(d_expectations.get(), expectations,
+                                              probe_size, cudaMemcpyHostToDevice,
+                                              g_stream->get()));
+        CUDA_CHECK(cudaMemsetAsync(d_correction_count.get(), 0, count_size,
+                                   g_stream->get()));
+        CUDA_CHECK(sep::cuda::launchQBSAKernel(d_probe_indices.get(),
+                                               d_expectations.get(), num_probes,
+                                               d_bitfield.get(),
+                                               d_corrections.get(),
+                                               d_correction_count.get(),
+                                               g_stream->get()));
+        CUDA_CHECK(sep::cuda::cudaMemcpyAsync(bitfield, d_bitfield.get(),
+                                              bitfield_size,
+                                              cudaMemcpyDeviceToHost,
+                                              g_stream->get()));
+        CUDA_CHECK(sep::cuda::cudaMemcpyAsync(correction_indices,
+                                              d_corrections.get(),
+                                              corrections_size,
+                                              cudaMemcpyDeviceToHost,
+                                              g_stream->get()));
+        CUDA_CHECK(sep::cuda::cudaMemcpyAsync(correction_count,
+                                              d_correction_count.get(), count_size,
+                                              cudaMemcpyDeviceToHost,
+                                              g_stream->get()));
+        CUDA_CHECK(cudaStreamSynchronize(g_stream->get()));
+    } catch (...) {
+        return sep::SEPResult::UNKNOWN_ERROR;
+    }
+
+    return sep::SEPResult::SUCCESS;
+#else
     return cpu_process_batch(probe_indices, expectations, num_probes, bitfield,
                               correction_indices, correction_count);
+#endif
 }
 
 sep::SEPResult sep_cuda_process_symmetry(const std::uint64_t* chunks,
@@ -107,9 +188,48 @@ sep::SEPResult sep_cuda_process_symmetry(const std::uint64_t* chunks,
         return sep::SEPResult::INVALID_ARGUMENT;
     }
 
+#ifdef SEP_USE_CUDA
+    const uint32_t pairs = sep::cuda::constants::get_symmetry_pairs();
+
+    const size_t chunks_size = num_chunks * sizeof(std::uint64_t);
+    const size_t indices_size = num_chunks * pairs * sizeof(std::uint32_t);
+    const size_t counts_size = num_chunks * sizeof(std::uint32_t);
+
+    sep::cuda::DeviceBufferRAII<std::uint64_t> d_chunks(num_chunks);
+    sep::cuda::DeviceBufferRAII<std::uint32_t> d_collapse_indices(num_chunks * pairs);
+    sep::cuda::DeviceBufferRAII<std::uint32_t> d_collapse_counts(num_chunks);
+
+    if (!d_chunks.valid() || !d_collapse_indices.valid() || !d_collapse_counts.valid()) {
+        return sep::SEPResult::UNKNOWN_ERROR;
+    }
+
+    try {
+        CUDA_CHECK(cudaStreamSynchronize(g_stream->get()));
+        CUDA_CHECK(sep::cuda::cudaMemcpyAsync(d_chunks.get(), chunks, chunks_size,
+                                              cudaMemcpyHostToDevice,
+                                              g_stream->get()));
+        CUDA_CHECK(sep::cuda::launchQSHKernel(d_chunks.get(), num_chunks,
+                                              d_collapse_indices.get(),
+                                              d_collapse_counts.get(),
+                                              g_stream->get()));
+        CUDA_CHECK(sep::cuda::cudaMemcpyAsync(collapse_indices,
+                                              d_collapse_indices.get(), indices_size,
+                                              cudaMemcpyDeviceToHost,
+                                              g_stream->get()));
+        CUDA_CHECK(sep::cuda::cudaMemcpyAsync(collapse_counts,
+                                              d_collapse_counts.get(), counts_size,
+                                              cudaMemcpyDeviceToHost,
+                                              g_stream->get()));
+        CUDA_CHECK(cudaStreamSynchronize(g_stream->get()));
+    } catch (...) {
+        return sep::SEPResult::UNKNOWN_ERROR;
+    }
+
+    return sep::SEPResult::SUCCESS;
+#else
     return cpu_process_symmetry(chunks, num_chunks, collapse_indices,
                                 collapse_counts);
+#endif
 }
 
 }  // extern "C"
-#endif  // SEP_USE_CUDA

--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -12,12 +12,21 @@ add_executable(cuda_api_tests
     processing_api_test.cpp
 )
 
+add_executable(increment_kernel_test
+    increment_kernel_test.cpp
+)
+
 target_include_directories(long_double_math_test PRIVATE
     ${CMAKE_SOURCE_DIR}/include
     ${CMAKE_SOURCE_DIR}/src
 )
 
 target_include_directories(cuda_api_tests PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/src
+)
+
+target_include_directories(increment_kernel_test PRIVATE
     ${CMAKE_SOURCE_DIR}/include
     ${CMAKE_SOURCE_DIR}/src
 )
@@ -40,5 +49,16 @@ target_link_libraries(cuda_api_tests PRIVATE
     $<IF:$<BOOL:${SEP_HAS_CUDA}>,CUDA::cuda_driver,>
 )
 
+target_link_libraries(increment_kernel_test PRIVATE
+    testbed_cuda_kernels
+    sep_compat
+    sep_core
+    GTest::GTest
+    GTest::Main
+    $<IF:$<BOOL:${SEP_HAS_CUDA}>,CUDA::cudart,>
+    $<IF:$<BOOL:${SEP_HAS_CUDA}>,CUDA::cuda_driver,>
+)
+
 add_test(NAME long_double_math_test COMMAND long_double_math_test)
 add_test(NAME cuda_api_tests COMMAND cuda_api_tests)
+add_test(NAME increment_kernel_test COMMAND increment_kernel_test)

--- a/tests/cuda/increment_kernel_test.cpp
+++ b/tests/cuda/increment_kernel_test.cpp
@@ -1,0 +1,22 @@
+#include <gtest/gtest.h>
+#include "compat/raii.h"
+#include "_sep/testbed/cuda/increment_kernel.hpp"
+
+TEST(TestbedCudaKernel, IncrementKernel) {
+    const unsigned int n = 32;
+    sep::cuda::DeviceBufferRAII<int> d_data(n);
+    ASSERT_TRUE(d_data.valid());
+
+    std::vector<int> host(n, 1);
+    EXPECT_EQ(cudaMemcpy(d_data.get(), host.data(), n * sizeof(int), cudaMemcpyHostToDevice), cudaSuccess);
+
+    EXPECT_EQ(launch_increment_kernel(d_data.get(), n, 0), cudaSuccess);
+    EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+    host.assign(n, 0);
+    EXPECT_EQ(cudaMemcpy(host.data(), d_data.get(), n * sizeof(int), cudaMemcpyDeviceToHost), cudaSuccess);
+
+    for (int v : host) {
+        EXPECT_EQ(v, 2); // original 1 + 1
+    }
+}


### PR DESCRIPTION
## Summary
- extend `cuda_api_stub.cpp` to dispatch to CUDA kernels when enabled
- add experimental increment kernel in `_sep/testbed/cuda`
- hook testbed CUDA directory into build
- create unit test for the experimental kernel

## Testing
- `cmake .. -DBUILD_TESTING=ON` *(fails: Could not find HIREDIS_LIB)*
- `ctest --output-on-failure` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_686581847eb0832abc233afb12234482