### PR TITLE
Implement simple embedding model

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ add_subdirectory(src/core)
 add_subdirectory(src/compat)
 add_subdirectory(src/memory)
 add_subdirectory(src/quantum)
+add_subdirectory(src/embeddings)
 add_subdirectory(src/api)
 add_subdirectory(src/audio)
 if(SEP_HAS_BLENDER)
@@ -81,6 +82,7 @@ target_link_libraries(sep_engine
         sep_compat
         sep_memory
         sep_quantum
+        sep_embeddings
         sep_audio
         sep_blender
         ${EMBREE_LIBRARIES}

--- a/_sep/testbed/CMakeLists.txt
+++ b/_sep/testbed/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library(testbed_tests STATIC
     audio_pipeline_test.cpp
     api_makejsonresponse_test.cpp
 )
+add_subdirectory(embeddings)
 
 target_include_directories(testbed_tests PRIVATE
     ${CMAKE_SOURCE_DIR}/include

--- a/_sep/testbed/embeddings/CMakeLists.txt
+++ b/_sep/testbed/embeddings/CMakeLists.txt
@@ -1,0 +1,23 @@
+if(NOT BUILD_TESTING)
+    return()
+endif()
+
+find_package(GTest REQUIRED)
+
+add_executable(testbed_embedding_tests
+    simple_embedding_model_test.cpp
+)
+
+target_include_directories(testbed_embedding_tests PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/src
+)
+
+target_link_libraries(testbed_embedding_tests PRIVATE
+    sep_embeddings
+    GTest::GTest
+    GTest::Main
+)
+
+add_test(NAME testbed_embedding_tests COMMAND testbed_embedding_tests)
+

--- a/_sep/testbed/embeddings/simple_embedding_model_test.cpp
+++ b/_sep/testbed/embeddings/simple_embedding_model_test.cpp
@@ -1,0 +1,10 @@
+#include "embeddings/simple_embedding_model.h"
+#include <gtest/gtest.h>
+
+TEST(SimpleEmbeddingModelTestbed, Deterministic) {
+    sep::embeddings::SimpleEmbeddingModel model;
+    auto e1 = model.compute("abc");
+    auto e2 = model.compute("abc");
+    EXPECT_EQ(e1, e2);
+}
+

--- a/_sep/testbed/embeddings/simple_embedding_test.hpp
+++ b/_sep/testbed/embeddings/simple_embedding_test.hpp
@@ -1,0 +1,12 @@
+#pragma once
+#include "embeddings/simple_embedding_model.h"
+#include <string>
+#include <vector>
+
+namespace sep::testbed::embeddings {
+inline std::vector<double> compute_test_embedding(const std::string& text) {
+    static sep::embeddings::SimpleEmbeddingModel model;
+    return model.compute(text);
+}
+} // namespace sep::testbed::embeddings
+

--- a/include/embeddings/simple_embedding_model.h
+++ b/include/embeddings/simple_embedding_model.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <array>
+#include <string>
+#include <vector>
+
+namespace sep::embeddings {
+
+class SimpleEmbeddingModel {
+public:
+    static constexpr std::size_t kDim = 5;
+
+    SimpleEmbeddingModel();
+
+    std::vector<double> compute(const std::string& text) const;
+
+private:
+    std::array<double, kDim> weights_;
+};
+
+} // namespace sep::embeddings
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,6 +18,7 @@ add_subdirectory(compat)
 add_subdirectory(core)
 add_subdirectory(memory)
 add_subdirectory(quantum)
+add_subdirectory(embeddings)
 
 # Link dependencies
 target_link_libraries(sep_main PRIVATE

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -23,6 +23,7 @@ target_link_libraries(sep_api
     PRIVATE
         ${CURL_LIBRARIES}
         sep_compat
+        sep_embeddings
         sep_blender
         sep_audio
         http_parser::http_parser

--- a/src/api/sep_engine.cpp
+++ b/src/api/sep_engine.cpp
@@ -23,9 +23,10 @@
 #include "memory/memory_tier_manager.hpp"
 
 #include "core/logging.h" // Include logging header first
-#include "quantum/types.h" // For quantum::Pattern::generation 
+#include "quantum/types.h" // For quantum::Pattern::generation
 #include "compat/math_common.h" // Include math common for sqrt_safe
 #include "../../_sep/testbed/context_algorithms.hpp"
+#include "embeddings/simple_embedding_model.h"
 
 using json = nlohmann::json;
 
@@ -337,30 +338,26 @@ nlohmann::json SepEngine::extractEmbeddings(const nlohmann::json& request_data)
 {
     if (!impl_->initialized) {
         json result;
-        result["success"] = false; 
+        result["success"] = false;
         result["error"]   = "Engine not initialized";
         return result;
     }
     impl_->health_metrics.totalRequests++;
 
-        std::vector<double> embeddings;
+    if (!request_data.contains("text") || !request_data["text"].is_string()) {
+        return makeErrorResponse(api::ErrorCode::InvalidArgument,
+                                 "Missing text field");
+    }
 
-        // Embedding generation was previously delegated to a Node.js IPC
-        // service from the old testbed. That script has been removed, so we
-        // now use the deterministic fallback vector directly.
+    static sep::embeddings::SimpleEmbeddingModel model;
+    std::vector<double> embeddings = model.compute(request_data["text"].get<std::string>());
 
-        if (embeddings.empty())
-        {
-            // Fallback deterministic vector
-            embeddings = {0.1, 0.2, 0.3, 0.4, 0.5};
-        }
+    impl_->health_metrics.successfulRequests++;
 
-        impl_->health_metrics.successfulRequests++;
-
-        json result;
-        result["success"]    = true; 
-        result["embeddings"] = embeddings;
-        return result;
+    json result;
+    result["success"]    = true;
+    result["embeddings"] = embeddings;
+    return result;
 }
 
 nlohmann::json SepEngine::calculateSimilarity(const nlohmann::json& request_data)

--- a/src/embeddings/CMakeLists.txt
+++ b/src/embeddings/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_library(sep_embeddings STATIC
+    simple_embedding_model.cpp
+)
+
+target_include_directories(sep_embeddings PUBLIC
+    ${CMAKE_SOURCE_DIR}/include
+)
+

--- a/src/embeddings/simple_embedding_model.cpp
+++ b/src/embeddings/simple_embedding_model.cpp
@@ -1,0 +1,27 @@
+#include "embeddings/simple_embedding_model.h"
+#include <cmath>
+
+namespace sep::embeddings {
+
+SimpleEmbeddingModel::SimpleEmbeddingModel() {
+    weights_ = {0.01, 0.02, 0.03, 0.04, 0.05};
+}
+
+std::vector<double> SimpleEmbeddingModel::compute(const std::string& text) const {
+    std::vector<double> out(kDim, 0.0);
+    for (unsigned char c : text) {
+        for (std::size_t i = 0; i < kDim; ++i) {
+            out[i] += static_cast<double>(c) * weights_[i];
+        }
+    }
+    double norm = 0.0;
+    for (double v : out) norm += v * v;
+    norm = std::sqrt(norm);
+    if (norm > 0.0) {
+        for (double& v : out) v /= norm;
+    }
+    return out;
+}
+
+} // namespace sep::embeddings
+

--- a/tests/api/CMakeLists.txt
+++ b/tests/api/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(api_tests
     long_double_math_test.cpp
     context_api_test.cpp
     context_ops_test.cpp
+    embedding_model_test.cpp
 )
 
 target_include_directories(api_tests PRIVATE

--- a/tests/api/embedding_model_test.cpp
+++ b/tests/api/embedding_model_test.cpp
@@ -1,0 +1,17 @@
+#include <gtest/gtest.h>
+#include "api/sep_engine.h"
+
+using namespace sep::api;
+
+TEST(SepEngineEmbeddings, DeterministicOutput) {
+    auto &engine = SepEngine::getInstance();
+    ASSERT_TRUE(engine.initialize({}));
+
+    nlohmann::json req = {{"text", "hello"}};
+
+    auto r1 = engine.extractEmbeddings(req);
+    auto r2 = engine.extractEmbeddings(req);
+
+    EXPECT_EQ(r1, r2);
+}
+


### PR DESCRIPTION
## Summary
- add simple embedding model
- expose embeddings through SepEngine
- compile embeddings module and integrate in build
- provide testbed harness for embeddings
- add determinism test for embeddings

## Testing
- `cmake -S . -B build` *(fails: fftw3f not found until packages installed)*
- `cmake --build build -j 4` *(fails: event.cu link error)*

------
https://chatgpt.com/codex/tasks/task_e_68658188f1dc832a8eb2aa6839d9f071