### PR TITLE
Implement PipeWire capture and tests

### DIFF
--- a/include/audio/pipewire_capture.h
+++ b/include/audio/pipewire_capture.h
@@ -11,11 +11,18 @@
 #include <mutex>
 
 #include "audio/pipewire_includes.h"
-#include <pipewire/stream.h> // ensure pw_stream_state is defined
 #include "audio/capture.h"
 
-#if __has_include(<pipewire/stream.h>)
-#include <pipewire/stream.h>
+#ifndef SEP_HAS_PIPEWIRE
+#  if __has_include(<pipewire/pipewire.h>)
+#    define SEP_HAS_PIPEWIRE 1
+#  else
+#    define SEP_HAS_PIPEWIRE 0
+#  endif
+#endif
+
+#if SEP_HAS_PIPEWIRE
+#  include <pipewire/stream.h>
 #endif
 
 // Forward declarations to avoid exposing PipeWire types in header
@@ -27,7 +34,8 @@ struct spa_hook;
 
 namespace sep {
 namespace audio {
-  
+
+#if SEP_HAS_PIPEWIRE
 
 class PipeWireCapture : public AudioCapture {
   public:
@@ -65,7 +73,18 @@ class PipeWireCapture : public AudioCapture {
     // Internal methods
     void cleanup();
     AudioError setupStream();
+#else
+
+class PipeWireCapture : public AudioCapture {
+  public:
+    AudioError init(const AudioConfig&) override { return AudioError::INIT_FAILED; }
+    AudioError start() override { return AudioError::INIT_FAILED; }
+    AudioError stop() override { return AudioError::NONE; }
+    void setCallback(AudioCallback) override {}
+    AudioMetrics getMetrics() const override { return {}; }
 };
+
+#endif
 
 } // namespace audio
 } // namespace sep

--- a/src/audio/pipewire_capture.cpp
+++ b/src/audio/pipewire_capture.cpp
@@ -18,8 +18,26 @@
 
 // Initialize PipeWire before namespace declarations
 static struct PWInit {
-    PWInit() { pw_init(nullptr, nullptr); }
-    ~PWInit() { pw_deinit(); }
+    bool ok{false};
+    PWInit()
+    {
+        int err = pw_init(nullptr, nullptr);
+        if (err >= 0)
+        {
+            ok = true;
+        }
+        else
+        {
+            spdlog::error("PipeWire initialization failed: {}", spa_strerror(err));
+        }
+    }
+    ~PWInit()
+    {
+        if (ok)
+        {
+            pw_deinit();
+        }
+    }
 } pw_init_once;
 
 namespace sep {
@@ -78,6 +96,12 @@ AudioError PipeWireCapture::init(const AudioConfig& config)
     std::lock_guard<std::mutex> lock(mutex_);
     config_ = config;
 
+    if (!pw_init_once.ok)
+    {
+        spdlog::error("PipeWire library failed to initialize");
+        return AudioError::INIT_FAILED;
+    }
+
     // Check for runtime directory first
     const char* runtime_dir = getenv("XDG_RUNTIME_DIR");
     if (!runtime_dir) {
@@ -101,6 +125,7 @@ AudioError PipeWireCapture::init(const AudioConfig& config)
     if (!loop_)
     {
         spdlog::error("Failed to create PipeWire thread loop: {}", strerror(errno));
+        spdlog::error("Ensure libpipewire is installed and accessible");
         return AudioError::INIT_FAILED;
     }
 
@@ -186,7 +211,7 @@ AudioError PipeWireCapture::setupStream()
 {
     static const struct pw_stream_events events = createStreamEvents();
 
-    // Create stream with test sink target
+    // Create stream for capturing audio
     stream_ = pw_stream_new(core_,
                             config_.description.c_str(),
                             pw_properties_new(PW_KEY_MEDIA_TYPE,
@@ -218,7 +243,6 @@ AudioError PipeWireCapture::setupStream()
     if (!stream_)
     {
         spdlog::error("Failed to create PipeWire stream");
-        spdlog::error("Target sink: sep_test_sink");
         return AudioError::STREAM_FAILED;
     }
 

--- a/src/compat/CMakeLists.txt
+++ b/src/compat/CMakeLists.txt
@@ -61,11 +61,9 @@ else()
         cuda_api_stub.cpp
         stream.cpp
         raii.cpp
-        event.cu
     )
 
-    # Compile .cu sources with the host compiler
-    set_source_files_properties(event.cu PROPERTIES LANGUAGE CXX)
+    # event.cu depends on CUDA headers; skip when CUDA is unavailable
 
     set_target_properties(sep_compat PROPERTIES
         POSITION_INDEPENDENT_CODE ON

--- a/tests/audio/CMakeLists.txt
+++ b/tests/audio/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(audio_tests
     fft_accuracy_test.cpp
     pipewire_lifecycle_test.cpp
     pipewire_capture_metrics_test.cpp
+    pipewire_capture_integration_test.cpp
 )
 
 target_include_directories(audio_tests PRIVATE

--- a/tests/audio/pipewire_capture_integration_test.cpp
+++ b/tests/audio/pipewire_capture_integration_test.cpp
@@ -1,0 +1,23 @@
+#include <gtest/gtest.h>
+#include "audio/pipewire_capture.h"
+#include <chrono>
+#include <thread>
+
+using namespace sep::audio;
+
+TEST(PipeWireCaptureIntegration, MetricsIncrease)
+{
+    PipeWireCapture cap;
+    AudioConfig cfg{};
+    auto initErr = cap.init(cfg);
+    if (initErr != AudioError::NONE) {
+        GTEST_SKIP() << "PipeWire unavailable";
+    }
+    ASSERT_EQ(cap.start(), AudioError::NONE);
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    auto metrics = cap.getMetrics();
+    EXPECT_GT(metrics.total_samples, 0u);
+    EXPECT_GT(metrics.peak_level, 0.0f);
+    EXPECT_GT(metrics.rms_level, 0.0f);
+    EXPECT_EQ(cap.stop(), AudioError::NONE);
+}


### PR DESCRIPTION
## Summary
- add compile-time check for PipeWire availability
- enhance PipeWire initialization with error checks
- improve error output when thread loop creation fails
- skip CUDA event source when CUDA is unavailable
- add integration test verifying capture metrics

## Testing
- `cmake -DBUILD_TESTING=ON ..` *(fails: Could not build due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68658184ec18832aa1811a9fb1b79698