### PR TITLE
Fix closing brace for PipeWireCapture

### DIFF
--- a/include/audio/pipewire_capture.h
+++ b/include/audio/pipewire_capture.h
@@ -73,6 +73,7 @@ class PipeWireCapture : public AudioCapture {
     // Internal methods
     void cleanup();
     AudioError setupStream();
+};
 #else
 
 class PipeWireCapture : public AudioCapture {


### PR DESCRIPTION
## Summary
- close the `PipeWireCapture` class before the fallback implementation

## Testing
- `cmake -S . -B _testbuild` *(fails: required packages fftw3f missing)*

------
https://chatgpt.com/codex/tasks/task_e_68658541dae4832a8ce62f2fc12d5570