### PR TITLE
Fix CUDA stub includes

### DIFF
--- a/include/compat/cuda_defs.h
+++ b/include/compat/cuda_defs.h
@@ -4,7 +4,11 @@
 #include <string>
 #include "core/common.h"
 #include "compat/macros.h"
+#if SEP_CUDA_AVAILABLE
 #include <cuda_runtime.h>
+#else
+#include "compat/cuda_runtime.h"
+#endif
 
 namespace sep {
 namespace cuda {
@@ -33,6 +37,3 @@ using SepCudaStatus = Status;
 }  // namespace cuda
 }  // namespace sep
 
-#if SEP_CUDA_AVAILABLE
-#include <cuda_runtime.h>
-#endif

--- a/include/compat/cuda_runtime.h
+++ b/include/compat/cuda_runtime.h
@@ -99,6 +99,11 @@ cudaError_t cudaMemGetInfo(size_t* free, size_t* total);
 }  // namespace cuda
 }  // namespace sep
 
+#if defined(__cplusplus)
+// Expose stub functions in the global namespace for drop-in compatibility
+using namespace sep::cuda;
+#endif
+
 #endif // __cplusplus
 #endif // !SEP_CUDA_AVAILABLE
 


### PR DESCRIPTION
## Summary
- fix CUDA stub include guard in `cuda_defs.h`
- expose CUDA stub functions globally for easier use

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686587306408832abaa35368198abe85