### PR TITLE
Fix build issues in PipeWire and CUDA stubs

### DIFF
--- a/include/compat/cuda_runtime.h
+++ b/include/compat/cuda_runtime.h
@@ -78,6 +78,12 @@ constexpr unsigned int cudaStreamNonBlocking = 0x01;
 namespace sep {
 namespace cuda {
 
+using ::cudaError_t;
+using ::cudaStream_t;
+using ::cudaEvent_t;
+using ::cudaMemcpyKind;
+
+
 // Function declarations
 cudaError_t cudaSetDevice(int device);
 cudaError_t cudaGetDeviceCount(int* count);

--- a/src/audio/pipewire_capture.cpp
+++ b/src/audio/pipewire_capture.cpp
@@ -21,15 +21,8 @@ static struct PWInit {
     bool ok{false};
     PWInit()
     {
-        int err = pw_init(nullptr, nullptr);
-        if (err >= 0)
-        {
-            ok = true;
-        }
-        else
-        {
-            spdlog::error("PipeWire initialization failed: {}", spa_strerror(err));
-        }
+        pw_init(nullptr, nullptr);
+        ok = true;
     }
     ~PWInit()
     {


### PR DESCRIPTION
## Summary
- alias CUDA stub types inside the `sep::cuda` namespace to avoid build errors
- initialize PipeWire without reading a return value

## Testing
- `cmake -DBUILD_TESTING=ON ..` *(fails: core/error_handler.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686587306408832abaa35368198abe85