### PR TITLE
Fix build config requiring CUDA

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,19 +12,13 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(SEPConfig)
 configure_sep()
 
-# Detect CUDA toolkit and expose SEP_HAS_CUDA for conditional builds
-find_package(CUDAToolkit QUIET)
-if(CUDAToolkit_FOUND AND CUDAToolkit_NVCC_EXECUTABLE)
-    set(SEP_HAS_CUDA 1)
-else()
-    set(SEP_HAS_CUDA 0)
-endif()
-message(STATUS "CUDA support: ${SEP_HAS_CUDA}")
+# CUDA is a hard requirement for the project
+find_package(CUDAToolkit REQUIRED)
+set(SEP_HAS_CUDA 1)
+add_compile_definitions(SEP_HAS_CUDA=1)
 
-add_compile_definitions(SEP_HAS_CUDA=${SEP_HAS_CUDA})
-
-# Disable Blender integration by default to reduce dependencies
-option(SEP_HAS_BLENDER "Build Blender integration" OFF)
+# Blender integration is always built
+set(SEP_HAS_BLENDER 1)
 
 # Ensure our custom Crow wrappers take precedence over the third-party headers
 include_directories(BEFORE
@@ -63,9 +57,7 @@ add_subdirectory(src/quantum)
 add_subdirectory(src/embeddings)
 add_subdirectory(src/api)
 add_subdirectory(src/audio)
-if(SEP_HAS_BLENDER)
-    add_subdirectory(src/blender)
-endif()
+add_subdirectory(src/blender)
 
 # Main executable
 add_executable(sep_engine src/main.cpp)

--- a/_sep/testbed/cuda/CMakeLists.txt
+++ b/_sep/testbed/cuda/CMakeLists.txt
@@ -1,4 +1,2 @@
-if(SEP_HAS_CUDA)
-  add_library(testbed_cuda_kernels STATIC increment_kernel.cu)
-  set_property(TARGET testbed_cuda_kernels PROPERTY CUDA_STANDARD 17)
-endif()
+add_library(testbed_cuda_kernels STATIC increment_kernel.cu)
+set_property(TARGET testbed_cuda_kernels PROPERTY CUDA_STANDARD 17)

--- a/src/blender/CMakeLists.txt
+++ b/src/blender/CMakeLists.txt
@@ -1,6 +1,4 @@
-if(SEP_HAS_CUDA)
-    find_package(CUDAToolkit REQUIRED)
-endif()
+find_package(CUDAToolkit REQUIRED)
 find_package(TBB REQUIRED)
 find_package(PkgConfig REQUIRED)
 
@@ -27,7 +25,7 @@ target_compile_definitions(sep_blender
     PUBLIC
         SEP_HAS_BLENDER=1
     PRIVATE
-        SEP_HAS_CUDA=${SEP_HAS_CUDA}
+        SEP_HAS_CUDA=1
 )
 
 # Link dependencies
@@ -45,10 +43,8 @@ target_link_libraries(sep_blender
 )
 
 # Enable CUDA support
-if(SEP_HAS_CUDA)
-    target_compile_definitions(sep_blender PRIVATE SEP_HAS_CUDA=1)
-    target_link_libraries(sep_blender PRIVATE CUDA::cudart)
-endif()
+target_compile_definitions(sep_blender PRIVATE SEP_HAS_CUDA=1)
+target_link_libraries(sep_blender PRIVATE CUDA::cudart)
 
 target_sources(sep_blender PRIVATE
     cycles_renderer.cpp
@@ -88,7 +84,7 @@ target_compile_definitions(sep_blender
 
 target_compile_definitions(sep_blender
     PUBLIC
-        SEP_HAS_CYCLES=${SEP_HAS_CYCLES}
+        SEP_HAS_CYCLES=1
     PRIVATE
         WITH_CYCLES_DEVICE_CUDA
 )
@@ -100,22 +96,20 @@ target_include_directories(sep_blender PRIVATE
 )
 
 # Link against Cycles libraries and required dependencies
-if(SEP_HAS_CYCLES)
-  target_link_libraries(sep_blender PRIVATE
-      ${CMAKE_SOURCE_DIR}/lib/libcycles_device.a
-      ${CMAKE_SOURCE_DIR}/lib/libcycles_kernel.a
-      ${CMAKE_SOURCE_DIR}/lib/libcycles_util.a
-      ${CMAKE_SOURCE_DIR}/lib/libcycles_subd.a
-      ${CMAKE_SOURCE_DIR}/lib/libbf_intern_guardedalloc.a # For MEM_* functions
-      TBB::tbb  # For parallel execution
-      CUDA::cudart  # For CUDA runtime
-      CUDA::cuda_driver
-      CUDA::nvrtc
-      glog
-      gflags
-      embree4
-  )
-endif()
+target_link_libraries(sep_blender PRIVATE
+    ${CMAKE_SOURCE_DIR}/lib/libcycles_device.a
+    ${CMAKE_SOURCE_DIR}/lib/libcycles_kernel.a
+    ${CMAKE_SOURCE_DIR}/lib/libcycles_util.a
+    ${CMAKE_SOURCE_DIR}/lib/libcycles_subd.a
+    ${CMAKE_SOURCE_DIR}/lib/libbf_intern_guardedalloc.a # For MEM_* functions
+    TBB::tbb  # For parallel execution
+    CUDA::cudart  # For CUDA runtime
+    CUDA::cuda_driver
+    CUDA::nvrtc
+    glog
+    gflags
+    embree4
+)
 
 
 # Add Blender's include directories for memory allocation functions
@@ -141,11 +135,9 @@ target_include_directories(sep_blender
         ${CMAKE_SOURCE_DIR}/extern/glm
         ${CMAKE_SOURCE_DIR}/extern/eigen
 )
-if(SEP_HAS_CYCLES)
-  target_include_directories(sep_blender PUBLIC
-      ${CMAKE_SOURCE_DIR}/extern/cycles/src
-  )
-endif()
+target_include_directories(sep_blender PUBLIC
+    ${CMAKE_SOURCE_DIR}/extern/cycles/src
+)
 
 set(OIIO_LIBRARIES ${OIIO_LIBRARIES} PARENT_SCOPE)
 set(GLOG_LIBRARIES ${GLOG_LIBRARIES} PARENT_SCOPE)

--- a/src/compat/CMakeLists.txt
+++ b/src/compat/CMakeLists.txt
@@ -23,51 +23,37 @@ if(WITH_OPENSUBDIV)
     set(WITH_CYCLES_OPENSUBDIV ${WITH_OPENSUBDIV})
 endif()
 
-if(SEP_HAS_CUDA)
-    # Build full CUDA implementation when the toolkit is available
-    find_package(CUDAToolkit REQUIRED)
+# Build full CUDA implementation
+find_package(CUDAToolkit REQUIRED)
 
-    add_library(sep_compat STATIC
-        cuda_api.cu
-        core.cu
-        pattern_kernels.cu
-        kernels.cu
-        quantum_kernels.cu
-        utils.cu
-        event.cu
-        stream.cpp
-        raii.cpp
-    )
+add_library(sep_compat STATIC
+    cuda_api.cu
+    core.cu
+    pattern_kernels.cu
+    kernels.cu
+    quantum_kernels.cu
+    utils.cu
+    event.cu
+    stream.cpp
+    raii.cpp
+)
 
-    set_source_files_properties(
-        cuda_api.cu core.cu pattern_kernels.cu kernels.cu quantum_kernels.cu utils.cu event.cu
-        PROPERTIES
-        COMPILE_FLAGS "${CUDA_NVCC_FLAGS}"
-    )
+set_source_files_properties(
+    cuda_api.cu core.cu pattern_kernels.cu kernels.cu quantum_kernels.cu utils.cu event.cu
+    PROPERTIES
+    COMPILE_FLAGS "${CUDA_NVCC_FLAGS}"
+)
 
-    set_target_properties(sep_compat PROPERTIES
-        CUDA_SEPARABLE_COMPILATION ON
-        CUDA_RESOLVE_DEVICE_SYMBOLS ON
-        POSITION_INDEPENDENT_CODE ON
-        CUDA_ARCHITECTURES native
-    )
+set_target_properties(sep_compat PROPERTIES
+    CUDA_SEPARABLE_COMPILATION ON
+    CUDA_RESOLVE_DEVICE_SYMBOLS ON
+    POSITION_INDEPENDENT_CODE ON
+    CUDA_ARCHITECTURES native
+)
 
-    set_property(TARGET sep_compat PROPERTY CUDA_STANDARD 17)
+set_property(TARGET sep_compat PROPERTY CUDA_STANDARD 17)
 
-    target_compile_definitions(sep_compat PUBLIC SEP_USE_CUDA=1)
-else()
-    # CPU fallback when CUDA is not available
-    add_library(sep_compat STATIC
-        stream.cpp
-        raii.cpp
-    )
-
-    # event.cu depends on CUDA headers; skip when CUDA is unavailable
-
-    set_target_properties(sep_compat PROPERTIES
-        POSITION_INDEPENDENT_CODE ON
-    )
-endif()
+target_compile_definitions(sep_compat PUBLIC SEP_USE_CUDA=1)
 
 # Include directories
 target_include_directories(sep_compat
@@ -83,6 +69,6 @@ target_include_directories(sep_compat
 target_link_libraries(sep_compat
     PUBLIC
         sep_core
-        $<IF:$<BOOL:${SEP_HAS_CUDA}>,CUDA::cudart,>
-        $<IF:$<BOOL:${SEP_HAS_CUDA}>,CUDA::cuda_driver,>
+        CUDA::cudart
+        CUDA::cuda_driver
 )

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -17,7 +17,7 @@ add_library(sep_core
 target_link_libraries(sep_core)
 
 # Enable CUDA support when available
-target_compile_definitions(sep_core PRIVATE SEP_HAS_CUDA=${SEP_HAS_CUDA})
+target_compile_definitions(sep_core PRIVATE SEP_HAS_CUDA=1)
 
 # Set library properties
 set_target_properties(sep_core PROPERTIES

--- a/src/memory/CMakeLists.txt
+++ b/src/memory/CMakeLists.txt
@@ -21,7 +21,7 @@ target_link_libraries(sep_memory
 
 # CUDA and Redis are always required
 target_compile_definitions(sep_memory PRIVATE
-    SEP_HAS_CUDA=${SEP_HAS_CUDA}
+    SEP_HAS_CUDA=1
     SEP_HAS_REDIS=1
 )
 

--- a/src/quantum/CMakeLists.txt
+++ b/src/quantum/CMakeLists.txt
@@ -35,7 +35,7 @@ target_include_directories(sep_quantum PUBLIC
 )
 
 # Enable CUDA when available for quantum operations
-target_compile_definitions(sep_quantum PRIVATE SEP_HAS_CUDA=${SEP_HAS_CUDA})
+target_compile_definitions(sep_quantum PRIVATE SEP_HAS_CUDA=1)
 
 # Set library properties
 set_target_properties(sep_quantum PROPERTIES

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -1,8 +1,6 @@
 # Set C++ standard
 # Find required packages
-if(SEP_HAS_CUDA)
-    find_package(CUDAToolkit REQUIRED)
-endif()
+find_package(CUDAToolkit REQUIRED)
 find_package(fmt REQUIRED)
 
 # Add test sources
@@ -21,15 +19,15 @@ target_link_libraries(cycles_test PRIVATE
     fmt::fmt
     sep_core
     sep_compat
-    $<IF:$<BOOL:${SEP_HAS_CUDA}>,CUDA::cudart,>
-    $<IF:$<BOOL:${SEP_HAS_CUDA}>,CUDA::cuda_driver,>
+    CUDA::cudart
+    CUDA::cuda_driver
 )
 
 # Configure include directories
 target_include_directories(cycles_test PRIVATE
     ${CMAKE_SOURCE_DIR}/include
     ${CMAKE_SOURCE_DIR}/src
-    $<IF:$<BOOL:${SEP_HAS_CUDA}>,${CUDAToolkit_INCLUDE_DIRS},>
+    ${CUDAToolkit_INCLUDE_DIRS}
 )
 
 # Add test to CTest

--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -36,8 +36,8 @@ target_link_libraries(long_double_math_test PRIVATE
     sep_core
     GTest::GTest
     GTest::Main
-    $<IF:$<BOOL:${SEP_HAS_CUDA}>,CUDA::cudart,>
-    $<IF:$<BOOL:${SEP_HAS_CUDA}>,CUDA::cuda_driver,>
+    CUDA::cudart
+    CUDA::cuda_driver
 )
 
 target_link_libraries(cuda_api_tests PRIVATE
@@ -45,8 +45,8 @@ target_link_libraries(cuda_api_tests PRIVATE
     sep_core
     GTest::GTest
     GTest::Main
-    $<IF:$<BOOL:${SEP_HAS_CUDA}>,CUDA::cudart,>
-    $<IF:$<BOOL:${SEP_HAS_CUDA}>,CUDA::cuda_driver,>
+    CUDA::cudart
+    CUDA::cuda_driver
 )
 
 target_link_libraries(increment_kernel_test PRIVATE
@@ -55,8 +55,8 @@ target_link_libraries(increment_kernel_test PRIVATE
     sep_core
     GTest::GTest
     GTest::Main
-    $<IF:$<BOOL:${SEP_HAS_CUDA}>,CUDA::cudart,>
-    $<IF:$<BOOL:${SEP_HAS_CUDA}>,CUDA::cuda_driver,>
+    CUDA::cudart
+    CUDA::cuda_driver
 )
 
 add_test(NAME long_double_math_test COMMAND long_double_math_test)


### PR DESCRIPTION
## Summary
- require CUDA toolkit at configure time
- always build Blender integration
- remove optional CUDA logic from `sep_compat` and tests
- simplify compile definitions across subprojects

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68659da710b4832a98b1b2a6529d298d