### PR TITLE
Remove CUDA conditionals

### DIFF
--- a/include/compat/cuda.h
+++ b/include/compat/cuda.h
@@ -3,15 +3,9 @@
 // Forward declarations and includes
 #include "macros.h"
 
-#if SEP_CUDA_AVAILABLE
-// Use angle brackets to specifically target system CUDA headers
-#include <cuda_runtime.h>
-#else
-// Include the compatibility header that defines stub types
-
 #include "types.h"
 #include <cstddef>
 #include <memory>
 #include <string>
 #include <vector>
-#endif  // SEP_CUDA_AVAILABLE
+#include "compat/cuda_runtime.h"

--- a/include/compat/cuda_common.h
+++ b/include/compat/cuda_common.h
@@ -2,11 +2,7 @@
 #define CUDA_COMMON_H
 
 // Include CUDA runtime or provide shims first
-#if SEP_CUDA_AVAILABLE
-#include <cuda_runtime.h>
-#else
-#include "compat/cuda_runtime.h"  // Contains shim definitions
-#endif
+#include "compat/cuda_runtime.h"  // Always rely on the shim header
 
 // GLM configuration after CUDA runtime
 #ifndef GLM_FORCE_CUDA

--- a/include/compat/cuda_defs.h
+++ b/include/compat/cuda_defs.h
@@ -11,19 +11,14 @@
 #define SEP_HD
 #endif
 
-// Include CUDA runtime first if available
-#if SEP_CUDA_AVAILABLE
-#include <cuda_runtime.h>
-#endif
+// Always include the compatibility runtime header
+#include "compat/cuda_runtime.h"
 
 #include <cstddef>
 #include <string>
 #include "core/common.h"
 #include "compat/macros.h"
 
-#if !SEP_CUDA_AVAILABLE
-#include "compat/cuda_runtime.h"
-#endif
 
 namespace sep {
 namespace cuda {

--- a/include/compat/cuda_helpers.h
+++ b/include/compat/cuda_helpers.h
@@ -2,9 +2,7 @@
 
 #include <cstdio>
 
-#if SEP_CUDA_AVAILABLE
-#include <cuda_runtime.h>
-#endif
+#include "compat/cuda_runtime.h"
 
 #include "compat/cuda_defs.h"
 

--- a/include/compat/cuda_runtime.h
+++ b/include/compat/cuda_runtime.h
@@ -1,13 +1,9 @@
 #ifndef SEP_COMPAT_CUDA_RUNTIME_H
 #define SEP_COMPAT_CUDA_RUNTIME_H
 
-#if SEP_CUDA_AVAILABLE
-#include <cuda_runtime.h>
-#else
-
-// Include standard headers needed for types
-#include <stddef.h>  // For size_t
-#include <string.h> // For memcpy
+// Always use the lightweight runtime shim
+#include <stddef.h>
+#include <string.h>
 
 // Forward declare CUDA types in global scope
 typedef int cudaError_t;
@@ -62,13 +58,6 @@ struct cudaDeviceProp {
 // Stream flags in global scope
 constexpr unsigned int cudaStreamDefault = 0x00;
 constexpr unsigned int cudaStreamNonBlocking = 0x01;
-#endif
-
-#if SEP_CUDA_AVAILABLE
-// When CUDA is available, include the real CUDA runtime
-#include <cuda_runtime.h>
-#else
-// When CUDA is not available, define stub types and functions
 
 #ifdef __cplusplus
 namespace sep {
@@ -78,7 +67,6 @@ using ::cudaError_t;
 using ::cudaStream_t;
 using ::cudaEvent_t;
 using ::cudaMemcpyKind;
-
 
 // Function declarations
 cudaError_t cudaSetDevice(int device);
@@ -90,6 +78,11 @@ cudaError_t cudaStreamCreate(cudaStream_t* stream);
 cudaError_t cudaStreamCreateWithFlags(cudaStream_t* stream, unsigned int flags);
 cudaError_t cudaStreamDestroy(cudaStream_t stream);
 cudaError_t cudaStreamSynchronize(cudaStream_t stream);
+cudaError_t cudaStreamWaitEvent(cudaStream_t stream, cudaEvent_t event, unsigned int flags);
+cudaError_t cudaEventRecord(cudaEvent_t event, cudaStream_t stream);
+cudaError_t cudaEventCreate(cudaEvent_t* event);
+cudaError_t cudaEventDestroy(cudaEvent_t event);
+cudaError_t cudaEventSynchronize(cudaEvent_t event);
 cudaError_t cudaMalloc(void** ptr, size_t size);
 cudaError_t cudaFree(void* ptr);
 cudaError_t cudaMallocHost(void** ptr, size_t size);
@@ -102,11 +95,9 @@ cudaError_t cudaMemGetInfo(size_t* free, size_t* total);
 }  // namespace sep
 
 #if defined(__cplusplus)
-// Expose stub functions in the global namespace for drop-in compatibility
-using namespace sep::cuda;
+using namespace sep::cuda; // Provide global aliases
 #endif
 
 #endif // __cplusplus
-#endif // !SEP_CUDA_AVAILABLE
 
 #endif // SEP_COMPAT_CUDA_RUNTIME_H

--- a/include/compat/raii.h
+++ b/include/compat/raii.h
@@ -8,10 +8,6 @@
 #include "compat/math_common.h"
 #include "compat/cuda_runtime.h"
 #include "compat/cuda_common.h"
-#if SEP_CUDA_AVAILABLE
-#include <cuda_runtime.h>
-#else
-#endif
 #include "core/types.h"
 
 namespace sep {

--- a/include/compat/stream.h
+++ b/include/compat/stream.h
@@ -5,11 +5,7 @@
 #include "compat/macros.h"
 
 // Then include CUDA runtime compatibility header for GCC 14 fixes
-#if SEP_CUDA_AVAILABLE
-#include <cuda_runtime.h>
-#else
 #include "compat/cuda_runtime.h"
-#endif
 
 // Standard includes
 #include <memory>

--- a/src/compat/raii.cpp
+++ b/src/compat/raii.cpp
@@ -56,6 +56,14 @@ cudaError_t cudaStreamSynchronize(cudaStream_t /*stream*/) {
     return cudaSuccess;
 }
 
+cudaError_t cudaStreamWaitEvent(cudaStream_t /*stream*/, cudaEvent_t /*event*/, unsigned int /*flags*/) {
+    return cudaSuccess;
+}
+
+cudaError_t cudaEventRecord(cudaEvent_t /*event*/, cudaStream_t /*stream*/) {
+    return cudaSuccess;
+}
+
 cudaError_t cudaEventCreate(void** event) {
     if (event) {
         *event = nullptr;

--- a/src/compat/stream.cpp
+++ b/src/compat/stream.cpp
@@ -1,15 +1,10 @@
 #include <memory>
 
 #include "compat/cuda_common.h"
-#if !SEP_CUDA_AVAILABLE
-#include "compat/cuda_runtime.h"
-#endif
 
 #include "compat/stream.h"
 #include "compat/cuda_helpers.h" // for logCudaError
-#if !SEP_CUDA_AVAILABLE
 #include "compat/cuda_impl.h"
-#endif
 
 namespace sep::cuda {
 
@@ -19,29 +14,15 @@ struct Stream::Impl {
 
   void setHandle(cudaStream_t handle) { stream_handle_ = handle; }
   void synchronize() {
-#if SEP_CUDA_AVAILABLE
     if (stream_handle_) cudaStreamSynchronize(stream_handle_);
-#else
-    (void)stream_handle_;
-#endif
   }
   void wait(void* event) {
-#if SEP_CUDA_AVAILABLE
     if (stream_handle_ && event)
       cudaStreamWaitEvent(stream_handle_, static_cast<cudaEvent_t>(event), 0);
-#else
-    (void)stream_handle_;
-    (void)event;
-#endif
   }
   void record(void* event) {
-#if SEP_CUDA_AVAILABLE
     if (stream_handle_ && event)
       cudaEventRecord(static_cast<cudaEvent_t>(event), stream_handle_);
-#else
-    (void)stream_handle_;
-    (void)event;
-#endif
   }
   void* handle() const { return stream_handle_; }
   bool isValid() const { return stream_handle_ != nullptr; }


### PR DESCRIPTION
## Summary
- drop SEP_CUDA_AVAILABLE guards
- always include CUDA stub headers
- add missing CUDA stub functions

## Testing
- `npm run build` *(fails: Cannot find module '@modelcontextprotocol/sdk/server')*

------
https://chatgpt.com/codex/tasks/task_e_68659da710b4832a98b1b2a6529d298d