### PR TITLE
Fix CUDA config and stub headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,19 +12,15 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(SEPConfig)
 configure_sep()
 
-# Detect CUDA toolkit and expose SEP_HAS_CUDA for conditional builds
-find_package(CUDAToolkit QUIET)
-if(CUDAToolkit_FOUND AND CUDAToolkit_NVCC_EXECUTABLE)
-    set(SEP_HAS_CUDA 1)
-else()
-    set(SEP_HAS_CUDA 0)
-endif()
-message(STATUS "CUDA support: ${SEP_HAS_CUDA}")
+# Detect CUDA toolkit (required)
+find_package(CUDAToolkit REQUIRED)
+set(SEP_HAS_CUDA 1)
+message(STATUS "CUDA support enabled")
 
-add_compile_definitions(SEP_HAS_CUDA=${SEP_HAS_CUDA})
+add_compile_definitions(SEP_HAS_CUDA=1 SEP_USE_CUDA=1)
 
-# Disable Blender integration by default to reduce dependencies
-option(SEP_HAS_BLENDER "Build Blender integration" OFF)
+# Blender integration is required
+option(SEP_HAS_BLENDER "Build Blender integration" ON)
 
 # Ensure our custom Crow wrappers take precedence over the third-party headers
 include_directories(BEFORE

--- a/include/compat/cuda_runtime.h
+++ b/include/compat/cuda_runtime.h
@@ -86,17 +86,23 @@ cudaError_t cudaGetDeviceCount(int* count);
 cudaError_t cudaGetDeviceProperties(cudaDeviceProp* prop, int device);
 cudaError_t cudaGetLastError(void);
 const char* cudaGetErrorString(cudaError_t error);
-cudaError_t cudaStreamCreate(cudaStream_t* stream);
-cudaError_t cudaStreamCreateWithFlags(cudaStream_t* stream, unsigned int flags);
-cudaError_t cudaStreamDestroy(cudaStream_t stream);
-cudaError_t cudaStreamSynchronize(cudaStream_t stream);
-cudaError_t cudaMalloc(void** ptr, size_t size);
-cudaError_t cudaFree(void* ptr);
-cudaError_t cudaMallocHost(void** ptr, size_t size);
-cudaError_t cudaMallocManaged(void** ptr, size_t size);
-cudaError_t cudaMemcpy(void* dst, const void* src, size_t size, int kind);
-cudaError_t cudaMemcpyAsync(void* dst, const void* src, size_t size, int kind, cudaStream_t stream);
-cudaError_t cudaMemGetInfo(size_t* free, size_t* total);
+  cudaError_t cudaStreamCreate(cudaStream_t* stream);
+  cudaError_t cudaStreamCreateWithFlags(cudaStream_t* stream, unsigned int flags);
+  cudaError_t cudaStreamDestroy(cudaStream_t stream);
+  cudaError_t cudaStreamSynchronize(cudaStream_t stream);
+  cudaError_t cudaStreamWaitEvent(cudaStream_t stream, cudaEvent_t event, unsigned int flags);
+  cudaError_t cudaEventRecord(cudaEvent_t event, cudaStream_t stream);
+  cudaError_t cudaEventCreate(void** event);
+  cudaError_t cudaEventDestroy(cudaEvent_t event);
+  cudaError_t cudaEventSynchronize(cudaEvent_t event);
+  cudaError_t cudaEventElapsedTime(float* ms, cudaEvent_t start, cudaEvent_t end);
+  cudaError_t cudaMalloc(void** ptr, size_t size);
+  cudaError_t cudaFree(void* ptr);
+  cudaError_t cudaMallocHost(void** ptr, size_t size);
+  cudaError_t cudaMallocManaged(void** ptr, size_t size);
+  cudaError_t cudaMemcpy(void* dst, const void* src, size_t size, int kind);
+  cudaError_t cudaMemcpyAsync(void* dst, const void* src, size_t size, int kind, cudaStream_t stream);
+  cudaError_t cudaMemGetInfo(size_t* free, size_t* total);
 
 }  // namespace cuda
 }  // namespace sep

--- a/include/compat/macros.h
+++ b/include/compat/macros.h
@@ -8,7 +8,7 @@
 // inconsistent checks.
 
 #ifndef SEP_CUDA_AVAILABLE
-#if defined(__CUDACC__) || defined(SEP_USE_CUDA)
+#if defined(__CUDACC__) || defined(SEP_USE_CUDA) || (defined(SEP_HAS_CUDA) && SEP_HAS_CUDA)
 #define SEP_CUDA_AVAILABLE 1
 #else
 #define SEP_CUDA_AVAILABLE 0

--- a/src/compat/CMakeLists.txt
+++ b/src/compat/CMakeLists.txt
@@ -23,51 +23,37 @@ if(WITH_OPENSUBDIV)
     set(WITH_CYCLES_OPENSUBDIV ${WITH_OPENSUBDIV})
 endif()
 
-if(SEP_HAS_CUDA)
-    # Build full CUDA implementation when the toolkit is available
-    find_package(CUDAToolkit REQUIRED)
+# Build full CUDA implementation - CUDA is required
+find_package(CUDAToolkit REQUIRED)
 
-    add_library(sep_compat STATIC
-        cuda_api.cu
-        core.cu
-        pattern_kernels.cu
-        kernels.cu
-        quantum_kernels.cu
-        utils.cu
-        event.cu
-        stream.cpp
-        raii.cpp
-    )
+add_library(sep_compat STATIC
+    cuda_api.cu
+    core.cu
+    pattern_kernels.cu
+    kernels.cu
+    quantum_kernels.cu
+    utils.cu
+    event.cu
+    stream.cpp
+    raii.cpp
+)
 
-    set_source_files_properties(
-        cuda_api.cu core.cu pattern_kernels.cu kernels.cu quantum_kernels.cu utils.cu event.cu
-        PROPERTIES
-        COMPILE_FLAGS "${CUDA_NVCC_FLAGS}"
-    )
+set_source_files_properties(
+    cuda_api.cu core.cu pattern_kernels.cu kernels.cu quantum_kernels.cu utils.cu event.cu
+    PROPERTIES
+    COMPILE_FLAGS "${CUDA_NVCC_FLAGS}"
+)
 
-    set_target_properties(sep_compat PROPERTIES
-        CUDA_SEPARABLE_COMPILATION ON
-        CUDA_RESOLVE_DEVICE_SYMBOLS ON
-        POSITION_INDEPENDENT_CODE ON
-        CUDA_ARCHITECTURES native
-    )
+set_target_properties(sep_compat PROPERTIES
+    CUDA_SEPARABLE_COMPILATION ON
+    CUDA_RESOLVE_DEVICE_SYMBOLS ON
+    POSITION_INDEPENDENT_CODE ON
+    CUDA_ARCHITECTURES native
+)
 
-    set_property(TARGET sep_compat PROPERTY CUDA_STANDARD 17)
+set_property(TARGET sep_compat PROPERTY CUDA_STANDARD 17)
 
-    target_compile_definitions(sep_compat PUBLIC SEP_USE_CUDA=1)
-else()
-    # CPU fallback when CUDA is not available
-    add_library(sep_compat STATIC
-        stream.cpp
-        raii.cpp
-    )
-
-    # event.cu depends on CUDA headers; skip when CUDA is unavailable
-
-    set_target_properties(sep_compat PROPERTIES
-        POSITION_INDEPENDENT_CODE ON
-    )
-endif()
+target_compile_definitions(sep_compat PUBLIC SEP_USE_CUDA=1)
 
 # Include directories
 target_include_directories(sep_compat


### PR DESCRIPTION
## Summary
- require CUDA toolkit in core build files
- enable Blender integration by default
- update macros to respect `SEP_HAS_CUDA`
- build `sep_compat` with CUDA unconditionally
- expand CUDA runtime stubs with missing function declarations

## Testing
- `cmake -S . -B build-test` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_68659da710b4832a98b1b2a6529d298d