### PR TITLE
Make all build dependencies mandatory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,21 +31,13 @@ add_compile_definitions(CROW_USE_BOOST)
 # Find required packages
 find_package(Threads REQUIRED)
 find_package(CURL REQUIRED)
-find_library(HTTP_PARSER_LIBRARY http_parser)
-find_path(HTTP_PARSER_INCLUDE_DIR http_parser.h)
-if(HTTP_PARSER_INCLUDE_DIR AND HTTP_PARSER_LIBRARY)
-    add_library(http_parser::http_parser INTERFACE IMPORTED)
-    set_target_properties(http_parser::http_parser PROPERTIES
-        INTERFACE_INCLUDE_DIRECTORIES ${HTTP_PARSER_INCLUDE_DIR}
-        INTERFACE_LINK_LIBRARIES ${HTTP_PARSER_LIBRARY}
-    )
-else()
-    message(WARNING "http_parser library not found; using bundled header-only implementation")
-    add_library(http_parser INTERFACE)
-    add_library(http_parser::http_parser ALIAS http_parser)
-    target_include_directories(http_parser INTERFACE ${CMAKE_SOURCE_DIR}/extern/crow/include)
-    set(HTTP_PARSER_LIBRARY http_parser)
-endif()
+find_library(HTTP_PARSER_LIBRARY http_parser REQUIRED)
+find_path(HTTP_PARSER_INCLUDE_DIR http_parser.h REQUIRED)
+add_library(http_parser::http_parser INTERFACE IMPORTED)
+set_target_properties(http_parser::http_parser PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES ${HTTP_PARSER_INCLUDE_DIR}
+    INTERFACE_LINK_LIBRARIES ${HTTP_PARSER_LIBRARY}
+)
 find_package(fmt REQUIRED)
 find_package(spdlog REQUIRED)
 

--- a/include/audio/pipewire_capture.h
+++ b/include/audio/pipewire_capture.h
@@ -14,16 +14,10 @@
 #include "audio/capture.h"
 
 #ifndef SEP_HAS_PIPEWIRE
-#  if __has_include(<pipewire/pipewire.h>)
-#    define SEP_HAS_PIPEWIRE 1
-#  else
-#    define SEP_HAS_PIPEWIRE 0
-#  endif
+#define SEP_HAS_PIPEWIRE 1
 #endif
 
-#if SEP_HAS_PIPEWIRE
-#  include <pipewire/stream.h>
-#endif
+#include <pipewire/stream.h>
 
 // Forward declarations to avoid exposing PipeWire types in header
 struct pw_context;
@@ -35,7 +29,6 @@ struct spa_hook;
 namespace sep {
 namespace audio {
 
-#if SEP_HAS_PIPEWIRE
 
 class PipeWireCapture : public AudioCapture {
   public:
@@ -74,18 +67,7 @@ class PipeWireCapture : public AudioCapture {
     void cleanup();
     AudioError setupStream();
 };
-#else
 
-class PipeWireCapture : public AudioCapture {
-  public:
-    AudioError init(const AudioConfig&) override { return AudioError::INIT_FAILED; }
-    AudioError start() override { return AudioError::INIT_FAILED; }
-    AudioError stop() override { return AudioError::NONE; }
-    void setCallback(AudioCallback) override {}
-    AudioMetrics getMetrics() const override { return {}; }
-};
-
-#endif
 
 } // namespace audio
 } // namespace sep

--- a/include/compat/macros.h
+++ b/include/compat/macros.h
@@ -21,18 +21,14 @@
 // Default to disabled when not explicitly specified. This avoids undefined macro
 // errors when building without Cycles integration.
 #ifndef SEP_HAS_CYCLES
-#define SEP_HAS_CYCLES 0
+#define SEP_HAS_CYCLES 1
 #endif
 
 // -----------------------------------------------------------------------------
 // spdlog availability
 // -----------------------------------------------------------------------------
 #ifndef SEP_HAS_SPDLOG
-#if __has_include(<spdlog/spdlog.h>)
 #define SEP_HAS_SPDLOG 1
-#else
-#define SEP_HAS_SPDLOG 0
-#endif
 #endif
 
 // Backwards compatibility for legacy macros used across the code base.

--- a/include/memory/redis_manager.h
+++ b/include/memory/redis_manager.h
@@ -2,14 +2,8 @@
 
 #include "memory/types.h"
 
-#if __has_include(<hiredis/hiredis.h>)
-#    include <hiredis/hiredis.h>
-#    define SEP_HAS_HIREDIS 1
-#else
-#    define SEP_HAS_HIREDIS 0
-struct redisContext;
-struct redisReply;
-#endif
+#include <hiredis/hiredis.h>
+#define SEP_HAS_HIREDIS 1
 
 #include <memory>
 #include <optional>

--- a/include/memory/spdlog_isolation.h
+++ b/include/memory/spdlog_isolation.h
@@ -8,15 +8,7 @@
 #include <vector>
 #include <mutex>
 
-#if defined(__CUDACC__) || defined(SEP_CUDA_COMPILATION)
-#  define SEP_SPDLOG_FALLBACK 1
-#elif defined(__has_include)
-#  if __has_include(<spdlog/spdlog.h>)
-#    define SEP_SPDLOG_AVAILABLE 1
-#  else
-#    define SEP_SPDLOG_FALLBACK 1
-#  endif
-#endif
+#define SEP_SPDLOG_AVAILABLE 1
 
 namespace sep {
 namespace spdlog {

--- a/src/memory/redis_manager.cpp
+++ b/src/memory/redis_manager.cpp
@@ -6,26 +6,8 @@
 #include "compat/cuda_common.h"
 #include <cuda_runtime.h>
 #include <cstdint>
-#if __has_include(<hiredis/hiredis.h>)
-#    include <hiredis/hiredis.h>
-#    define SEP_HAS_HIREDIS 1
-#else
-#    define SEP_HAS_HIREDIS 0
-struct redisContext
-{};
-struct redisReply
-{};
-inline redisContext* redisConnect(const char*, int)
-{
-    return nullptr;
-}
-inline void  redisFree(redisContext*) {}
-inline void  freeReplyObject(void*) {}
-inline void* redisCommand(redisContext*, const char*, ...)
-{
-    return nullptr;
-}
-#endif
+#include <hiredis/hiredis.h>
+#define SEP_HAS_HIREDIS 1
 // Define namespace alias to clarify that Manager is in the logging namespace
 namespace logging = sep::logging; 
 #include "memory/memory_tier_manager.hpp"


### PR DESCRIPTION
## Summary
- simplify HTTP parser handling in root CMakeLists.txt
- require spdlog, cycles, pipewire and hiredis
- remove stub fallbacks for Redis, PipeWire and spdlog

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865a18b58f4832aba2f352606a752d4