### PR TITLE
Fix quantum config types and missing kernel include

### DIFF
--- a/include/quantum/quantum_manifold_optimizer.h
+++ b/include/quantum/quantum_manifold_optimizer.h
@@ -60,12 +60,11 @@ using ::sep::quantum::QuantumProcessorQFH;
 class QuantumManifoldOptimizer {
 public:
     struct Config {
-        using namespace sep::config;
         MemoryTierEnum tier{MemoryTierEnum::STM};
-        CudaConfig cuda;
-        APIConfig api;
-        LogConfig log;
-        AnalyticsConfig analytics;
+        sep::config::CudaConfig cuda;
+        sep::config::APIConfig api;
+        sep::config::LogConfig log;
+        sep::config::AnalyticsConfig analytics;
         float base_resonance_frequency{0.42f};
         float convergence_threshold{0.001f};
         float step_size{0.05f};

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -12,6 +12,7 @@
 #include <cuda_runtime.h>
 
 #include "compat/cuda_helpers.h"
+#include "compat/kernels.cuh"
 #include "memory/logger.hpp"
 #include "quantum/pattern_evolution_bridge.h" 
 #include "core/manager.h"


### PR DESCRIPTION
## Summary
- fix config type declarations in `QuantumManifoldOptimizer` to use fully qualified `sep::config` names
- include `compat/kernels.cuh` in `memory_tier_manager.cpp` so CUDA kernel launcher is visible

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6865a63b8330832a986ed3b0a7144281