### PR TITLE
Fix missing kernel launch and configuration refs

### DIFF
--- a/include/quantum/quantum_manifold_optimizer.h
+++ b/include/quantum/quantum_manifold_optimizer.h
@@ -60,12 +60,11 @@ using ::sep::quantum::QuantumProcessorQFH;
 class QuantumManifoldOptimizer {
 public:
     struct Config {
-        using namespace sep::config;
         MemoryTierEnum tier{MemoryTierEnum::STM};
-        CudaConfig cuda;
-        APIConfig api;
-        LogConfig log;
-        AnalyticsConfig analytics;
+        sep::config::CudaConfig cuda;
+        sep::config::APIConfig api;
+        sep::config::LogConfig log;
+        sep::config::AnalyticsConfig analytics;
         float base_resonance_frequency{0.42f};
         float convergence_threshold{0.001f};
         float step_size{0.05f};

--- a/src/compat/pattern_kernels.cu
+++ b/src/compat/pattern_kernels.cu
@@ -133,10 +133,25 @@ __global__ void processPatternKernel(PatternData* patterns, PatternData* results
 extern "C" cudaError_t launchProcessPatternKernel(PatternData* patterns, PatternData* results, PatternConfig config,
                                                    size_t patternCount, const PatternData* previousPatterns,
                                                    cudaStream_t stream) {
-    dim3 blockSize(constants::get_default_block_size());
+    dim3 blockSize(sep::cuda::constants::get_default_block_size());
     dim3 gridSize((patternCount + BLOCK_SIZE - 1) / BLOCK_SIZE);
 
     processPatternKernel<<<gridSize, blockSize, 0, stream>>>(patterns, results, config, patternCount, previousPatterns);
+
+    return cudaGetLastError();
+}
+
+cudaError_t ::sep::cuda::launch_pattern_processing(pattern::PatternData* patterns,
+                                                 pattern::PatternData* results,
+                                                 const pattern::PatternConfig& config,
+                                                 size_t pattern_count,
+                                                 const pattern::PatternData* previous_patterns,
+                                                 cudaStream_t stream) {
+    dim3 block_size(sep::cuda::constants::get_default_block_size());
+    dim3 grid_size((pattern_count + block_size.x - 1) / block_size.x);
+
+    processPatternKernel<<<grid_size, block_size, 0, stream>>>(
+        patterns, results, config, pattern_count, previous_patterns);
 
     return cudaGetLastError();
 }

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -12,6 +12,7 @@
 #include <cuda_runtime.h>
 
 #include "compat/cuda_helpers.h"
+#include "compat/kernels.cuh"
 #include "memory/logger.hpp"
 #include "quantum/pattern_evolution_bridge.h" 
 #include "core/manager.h"


### PR DESCRIPTION
## Summary
- fix `using namespace` inside `QuantumManifoldOptimizer::Config`
- include kernel header in `MemoryTierManager`
- implement missing `launch_pattern_processing` wrapper in CUDA pattern kernels

## Testing
- `g++ -std=c++17 -Iinclude -c src/memory/memory_tier_manager.cpp -o /tmp/test.o` *(fails: nlohmann/json.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6865a63b8330832a986ed3b0a7144281