### PR TITLE
Fix compile issues in quantum optimizer and CUDA launcher

### DIFF
--- a/include/quantum/quantum_manifold_optimizer.h
+++ b/include/quantum/quantum_manifold_optimizer.h
@@ -60,12 +60,11 @@ using ::sep::quantum::QuantumProcessorQFH;
 class QuantumManifoldOptimizer {
 public:
     struct Config {
-        using namespace sep::config;
         MemoryTierEnum tier{MemoryTierEnum::STM};
-        CudaConfig cuda;
-        APIConfig api;
-        LogConfig log;
-        AnalyticsConfig analytics;
+        ::sep::config::CudaConfig cuda;
+        ::sep::config::APIConfig api;
+        ::sep::config::LogConfig log;
+        ::sep::config::AnalyticsConfig analytics;
         float base_resonance_frequency{0.42f};
         float convergence_threshold{0.001f};
         float step_size{0.05f};

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -238,7 +238,7 @@ sep::SEPResult MemoryTierManager::launch_pattern_processing(sep::pattern::Patter
                                                             void* stream) {
 #ifdef SEP_USE_CUDA
     cudaStream_t cuda_stream = reinterpret_cast<cudaStream_t>(stream);
-    cudaError_t err = sep::cuda::launch_pattern_processing(
+    cudaError_t err = sep::pattern::cuda::launch_pattern_processing(
         patterns, results, config, pattern_count, previous_patterns, cuda_stream);
     if (err != cudaSuccess) {
         return sep::SEPResult::CUDA_ERROR;

--- a/src/quantum/manifold_config.cpp
+++ b/src/quantum/manifold_config.cpp
@@ -19,7 +19,7 @@ QuantumConfig quantum{
 };
 
 // CUDA acceleration parameters
-CudaConfig cuda{
+::sep::config::CudaConfig cuda{
   .warp_tile_size = 16,
   .coherence_block_size = 256,
   .similarity_grid_dim = 32,
@@ -27,7 +27,7 @@ CudaConfig cuda{
 };
 
 // API coherence modulation
-APIConfig api{
+::sep::config::APIConfig api{
   .base_coherence = 0.5f,
   .context_weight = 0.3f,
   .state_weight = 0.7f,


### PR DESCRIPTION
## Summary
- correct CUDA launch namespace for pattern processing
- use fully-qualified config types in `QuantumManifoldOptimizer` definitions
- adjust manifold configuration defaults to use fully-qualified types

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865a63b8330832a986ed3b0a7144281