### PR TITLE
Fix build issues in SEP

### DIFF
--- a/_sep/testbed/context_algorithms.hpp
+++ b/_sep/testbed/context_algorithms.hpp
@@ -92,6 +92,8 @@ inline nlohmann::json blend_contexts_impl(
     result["embedding"] = blend;
     result["coherence"] = coherence;
     return result;
+}
+
 struct ValidationReport {
     bool overall_valid{true};
     std::vector<size_t> invalid_indices;

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -239,7 +239,7 @@ sep::SEPResult MemoryTierManager::launch_pattern_processing(sep::pattern::Patter
                                                             void* stream) {
 #ifdef SEP_USE_CUDA
     cudaStream_t cuda_stream = reinterpret_cast<cudaStream_t>(stream);
-    cudaError_t err = sep::pattern::cuda::launch_pattern_processing(
+    cudaError_t err = sep::cuda::launch_pattern_processing(
         patterns, results, config, pattern_count, previous_patterns, cuda_stream);
     if (err != cudaSuccess) {
         return sep::SEPResult::CUDA_ERROR;

--- a/tests/blender/mock_process.cpp
+++ b/tests/blender/mock_process.cpp
@@ -11,7 +11,6 @@
 // Define the actual implementation of the function that will be used
 // This completely replaces the implementation in src/pattern/process.cpp
 namespace sep {
-namespace pattern {
 namespace cuda {
 
 // Host-side implementations
@@ -34,13 +33,12 @@ cudaError_t launch_pattern_processing(PatternData* patterns,
 }
 
 }  // namespace cuda
-}  // namespace pattern
 }  // namespace sep
 
 // Also provide the mangled name version for extra safety
 extern "C" {
     // This is the mangled name for the launch_pattern_processing function
-    cudaError_t _ZN3sep7pattern4cuda23launch_pattern_processingEPNS0_11PatternDataEPS2_RKNS0_13PatternConfigEmPKS2_P11CUstream_st(
+    cudaError_t _ZN3sep4cuda25launch_pattern_processingEPNS_7pattern11PatternDataES3_RKNS1_13PatternConfigEmPKS2_P11CUstream_st(
         sep::pattern::PatternData* patterns,
         sep::pattern::PatternData* results,
         const sep::pattern::PatternConfig& config,
@@ -51,7 +49,7 @@ extern "C" {
         std::cout << "Mock launch_pattern_processing called via mangled name" << std::endl;
 
         // Just call our implementation above
-        return sep::pattern::cuda::launch_pattern_processing(
+        return sep::cuda::launch_pattern_processing(
             patterns, results, config, pattern_count, previous_patterns, stream);
     }
 }


### PR DESCRIPTION
## Summary
- correct CUDA namespace usage in memory manager
- fix namespaced mock function for Blender tests
- close function scope in testbed utilities

## Testing
- `npm run build` *(fails: Cannot find module '@modelcontextprotocol/sdk/server')*

------
https://chatgpt.com/codex/tasks/task_e_6865a96dc470832aa04e1428d8731260