### PR TITLE
Resolve Cycles linkage failures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ find_package(http_parser REQUIRED)
 find_package(spdlog REQUIRED)
 
 # Add subdirectories
+add_subdirectory(extern/openpgl_stub)
 add_subdirectory(src/core)
 add_subdirectory(src/compat)
 add_subdirectory(src/memory)

--- a/src/blender/CMakeLists.txt
+++ b/src/blender/CMakeLists.txt
@@ -108,6 +108,13 @@ target_link_libraries(sep_blender PRIVATE
     glog
     gflags
     embree4
+    cycles_scene
+    cycles_graph
+    cycles_kernel_osl
+    extern_cuew
+    extern_hipew
+    openpgl_stub
+    ${OSL_LIBRARIES}
 )
 
 


### PR DESCRIPTION
## Summary
- include openpgl stub in the build
- link Blender integration against missing Cycles libs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865ae404c20832aa648eee995a8e3af