### PR TITLE
Fix Cycles linking when prebuilt libs missing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,12 @@ add_subdirectory(src/blender)
 add_subdirectory(extern/cycles/third_party/cuew)
 add_subdirectory(extern/cycles/third_party/hipew)
 
+# Build Cycles from source when precompiled libraries are not available
+if(NOT EXISTS "${CMAKE_SOURCE_DIR}/lib/libcycles_device.a")
+  message(STATUS "Prebuilt Cycles libraries not found; building from source")
+  add_subdirectory(extern/cycles)
+endif()
+
 # Main executable
 add_executable(sep_engine src/main.cpp)
 

--- a/src/blender/CMakeLists.txt
+++ b/src/blender/CMakeLists.txt
@@ -95,26 +95,51 @@ target_include_directories(sep_blender PRIVATE
 )
 
 # Link against Cycles libraries and required dependencies
-target_link_libraries(sep_blender PRIVATE
-    ${CMAKE_SOURCE_DIR}/lib/libcycles_device.a
-    ${CMAKE_SOURCE_DIR}/lib/libcycles_kernel.a
-    ${CMAKE_SOURCE_DIR}/lib/libcycles_util.a
-    ${CMAKE_SOURCE_DIR}/lib/libcycles_subd.a
-    ${CMAKE_SOURCE_DIR}/lib/libbf_intern_guardedalloc.a # For MEM_* functions
-    TBB::tbb  # For parallel execution
-    CUDA::cudart  # For CUDA runtime
-    CUDA::cuda_driver
-    CUDA::nvrtc
-    glog
-    gflags
-    embree4
-    extern_cuew
-    extern_hipew
-    cycles_scene
-    cycles_graph
-    cycles_kernel_osl
-    ${OSL_LIBRARIES}
-)
+if(TARGET cycles_scene)
+  # Linking against Cycles built from source
+  target_link_libraries(sep_blender PRIVATE
+      cycles_device
+      cycles_kernel
+      cycles_util
+      cycles_subd
+      bf_intern_guardedalloc
+      TBB::tbb
+      CUDA::cudart
+      CUDA::cuda_driver
+      CUDA::nvrtc
+      glog
+      gflags
+      embree4
+      extern_cuew
+      extern_hipew
+      cycles_scene
+      cycles_graph
+      cycles_kernel_osl
+      ${OSL_LIBRARIES}
+  )
+else()
+  # Fallback to precompiled static libraries
+  target_link_libraries(sep_blender PRIVATE
+      ${CMAKE_SOURCE_DIR}/lib/libcycles_device.a
+      ${CMAKE_SOURCE_DIR}/lib/libcycles_kernel.a
+      ${CMAKE_SOURCE_DIR}/lib/libcycles_util.a
+      ${CMAKE_SOURCE_DIR}/lib/libcycles_subd.a
+      ${CMAKE_SOURCE_DIR}/lib/libbf_intern_guardedalloc.a
+      TBB::tbb
+      CUDA::cudart
+      CUDA::cuda_driver
+      CUDA::nvrtc
+      glog
+      gflags
+      embree4
+      extern_cuew
+      extern_hipew
+      cycles_scene
+      cycles_graph
+      cycles_kernel_osl
+      ${OSL_LIBRARIES}
+  )
+endif()
 
 
 # Add Blender's include directories for memory allocation functions


### PR DESCRIPTION
## Summary
- build Cycles from source if libcycles_device.a isn't present
- link `sep_blender` against built Cycles targets when available

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865b809338c832a953c22f61f3b8f57