### PR TITLE
Fix missing cufft build failure

### DIFF
--- a/include/compat/cufft.h
+++ b/include/compat/cufft.h
@@ -9,11 +9,21 @@
 #define SEP_CUDA_AVAILABLE 0
 #endif
 
-#if SEP_CUDA_AVAILABLE
-// When CUDA is available, include the real CUDA FFT headers
+#if SEP_CUDA_AVAILABLE && defined(__has_include)
+#if __has_include(<cufft.h>)
 #include <cufft.h>
+#define SEP_HAS_CUFFT 1
 #else
-// When CUDA is not available, define stub types and functions
+#define SEP_HAS_CUFFT 0
+#endif
+#else
+#define SEP_HAS_CUFFT 0
+#endif
+
+#if SEP_HAS_CUFFT
+// When CUDA and cuFFT are available, the real header has been included
+#else
+// Otherwise, define stub types and functions
 
 #ifdef __cplusplus
 namespace sep {

--- a/src/audio/pipeline.cpp
+++ b/src/audio/pipeline.cpp
@@ -5,9 +5,7 @@
 #include <memory>
 #include <glm/glm.hpp>
 #include <glm/gtc/constants.hpp>
-#if SEP_CUDA_AVAILABLE
-#    include "compat/cufft.h"
-#endif
+#include "compat/cufft.h"
 #ifdef SEP_USE_FFTW
 #    include <fftw3.h>
 #endif
@@ -98,7 +96,7 @@ SpectralData AudioPipeline::performFFT(const std::vector<float>& samples) {
     SpectralData spectral;
     const size_t N = samples.size();
 
-#if SEP_CUDA_AVAILABLE
+#if SEP_CUDA_AVAILABLE && SEP_HAS_CUFFT
     cufftHandle plan;
     cufftPlan1d(&plan, static_cast<int>(N), CUFFT_R2C, 1);
     std::vector<cufftReal> input(samples.begin(), samples.end());


### PR DESCRIPTION
## Summary
- make cufft header optional with SEP_HAS_CUFFT
- only use cuFFT when the header is present

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865bc3f887c832aab2819cec63f141b