### PR TITLE
Fix missing cufft type definitions

### DIFF
--- a/include/compat/cufft.h
+++ b/include/compat/cufft.h
@@ -23,6 +23,11 @@ namespace cuda {
 typedef int cufftResult;
 typedef int cufftHandle;
 typedef int cufftType;
+typedef float cufftReal;
+struct cufftComplex {
+    float x;
+    float y;
+};
 
 // CUFFT Transform types
 #define CUFFT_R2C 0x2a
@@ -57,6 +62,8 @@ cufftResult cufftExecC2R(cufftHandle plan, void* idata, void* odata);
 using sep::cuda::cufftResult;
 using sep::cuda::cufftHandle;
 using sep::cuda::cufftType;
+using sep::cuda::cufftReal;
+using sep::cuda::cufftComplex;
 
 // Define the function prototypes in global namespace
 inline cufftResult cufftPlan1d(cufftHandle* plan, int nx, int type, int batch) {


### PR DESCRIPTION
## Summary
- extend CUDA compatibility shims with `cufftReal` and `cufftComplex`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865bc3f887c832aab2819cec63f141b