### PR TITLE
Fix cufft stub definitions

### DIFF
--- a/include/compat/cufft.h
+++ b/include/compat/cufft.h
@@ -23,6 +23,10 @@ namespace cuda {
 typedef int cufftResult;
 typedef int cufftHandle;
 typedef int cufftType;
+typedef float cufftReal;
+typedef double cufftDoubleReal;
+struct cufftComplex { float x, y; };
+struct cufftDoubleComplex { double x, y; };
 
 // CUFFT Transform types
 #define CUFFT_R2C 0x2a
@@ -57,6 +61,10 @@ cufftResult cufftExecC2R(cufftHandle plan, void* idata, void* odata);
 using sep::cuda::cufftResult;
 using sep::cuda::cufftHandle;
 using sep::cuda::cufftType;
+using sep::cuda::cufftReal;
+using sep::cuda::cufftDoubleReal;
+using sep::cuda::cufftComplex;
+using sep::cuda::cufftDoubleComplex;
 
 // Define the function prototypes in global namespace
 inline cufftResult cufftPlan1d(cufftHandle* plan, int nx, int type, int batch) {


### PR DESCRIPTION
## Summary
- add cufftReal and cufftComplex definitions when CUDA is unavailable
- export the new cufft types in the global namespace

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865bc3f887c832aab2819cec63f141b