### PR TITLE
Fix CUDA dependency check

### DIFF
--- a/src/core/engine.cpp
+++ b/src/core/engine.cpp
@@ -1,7 +1,7 @@
-#ifndef SEP_USE_CUDA
-#define SEP_USE_CUDA 1
-#endif
+#include "compat/macros.h"
+#if SEP_CUDA_AVAILABLE
 #include <cuda_runtime.h>  // for sep::cuda::cudaMemcpyAsync
+#endif
 #include "api/types.h"
 #include "core/common.h"  // defines sep::SEPResult
 #include "core/engine.h"
@@ -10,8 +10,7 @@
 #include "compat/core.h"
 #include "compat/shim.h"
 #include <vector>
-#include "compat/cuda_common.h" 
-#include "compat/macros.h"
+#include "compat/cuda_common.h"
 #include "compat/memory.h"
 #include "compat/stream.h"
 #include <vector>


### PR DESCRIPTION
## Summary
- gate CUDA runtime includes on `SEP_CUDA_AVAILABLE` so CPU-only builds don't require nvcc

## Testing
- `cmake -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Debug -DCUDAToolkit_ROOT=/usr ..` *(fails: Could not find nvcc executable)*

------
https://chatgpt.com/codex/tasks/task_e_6865bf8cf818832a91ebb2ed18a224a8