### PR TITLE
Fix cuFFT detection in audio pipeline

### DIFF
--- a/src/audio/pipeline.cpp
+++ b/src/audio/pipeline.cpp
@@ -96,7 +96,7 @@ SpectralData AudioPipeline::performFFT(const std::vector<float>& samples) {
     SpectralData spectral;
     const size_t N = samples.size();
 
-#if SEP_CUDA_AVAILABLE && SEP_HAS_CUFFT
+#if SEP_CUDA_AVAILABLE && SEP_HAS_CUFFT && defined(cufftReal) && defined(cufftComplex)
     cufftHandle plan;
     cufftPlan1d(&plan, static_cast<int>(N), CUFFT_R2C, 1);
     std::vector<cufftReal> input(samples.begin(), samples.end());


### PR DESCRIPTION
## Summary
- check for `cufftReal` and `cufftComplex` before using cuFFT code path

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865bf8cf818832a91ebb2ed18a224a8