### PR TITLE
Fix CMake library names and dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ find_package(OpenColorIO REQUIRED)
 find_package(Imath REQUIRED)
 find_package(TBB REQUIRED)
 find_package(OpenImageIO REQUIRED)
+find_package(OpenSubdiv REQUIRED)
 find_package(embree REQUIRED)
 find_package(OSL REQUIRED)
 find_package(Alembic REQUIRED)
@@ -91,19 +92,19 @@ target_link_libraries(sep_engine
 
         # 2. Cycles and its dependencies (order is important here too)
         # Link the main Cycles libs first
-        libcycles_session
-        libcycles_scene
-        libcycles_device
-        libcycles_kernel_osl # The one with the real symbols
-        libcycles_subd
+        cycles_session
+        cycles_scene
+        cycles_device
+        cycles_kernel_osl # The one with the real symbols
+        cycles_subd
         cycles_util
         extern_cuew
         extern_hipew
 
         # Now link the external dependencies that Cycles needs
-        OpenImageIO
-        OpenVDB
-        OpenSubdiv
+        ${OPENIMAGEIO_LIBRARIES}
+        ${OPENVDB_LIBRARIES}
+        ${OPENSUBDIV_LIBRARIES}
         ${OSL_LIBRARIES} # Link the real OSL libs, not the stub
         ${TBB_LIBRARIES}
 


### PR DESCRIPTION
## Summary
- add missing `find_package(OpenSubdiv)` call
- link against cycles libraries using correct logical names
- use variables exported by `find_package` for OpenImageIO, OpenVDB and OpenSubdiv

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865d9158edc832a9442c7cd754063b9