### PR TITLE
Fix missing OpenVDB link

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,7 @@ target_link_libraries(sep_engine
         # Now link the external dependencies that Cycles needs
         OpenImageIO
         bf_intern_openvdb
+        OpenVDB::openvdb
         bf_intern_opensubdiv
         ${OSL_LIBRARIES} # Link the real OSL libs, not the stub
         ${TBB_LIBRARIES}

--- a/src/blender/CMakeLists.txt
+++ b/src/blender/CMakeLists.txt
@@ -126,6 +126,7 @@ if(TARGET cycles_scene)
       extern_hipew
       ${OSL_LIBRARIES}
       bf_intern_openvdb
+      OpenVDB::openvdb
       bf_intern_opensubdiv
 )
 else()
@@ -152,6 +153,7 @@ else()
       extern_hipew
       ${OSL_LIBRARIES}
       bf_intern_openvdb
+      OpenVDB::openvdb
       bf_intern_opensubdiv
   )
 endif()


### PR DESCRIPTION
## Summary
- link against `OpenVDB::openvdb` in the main build
- ensure the blender target also links to `OpenVDB::openvdb`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865db55b1f0832ab89cf1f4b4cf66ae