### PR TITLE
Fix build linking for OpenVDB and OpenSubdiv

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,8 +103,8 @@ target_link_libraries(sep_engine
 
         # Now link the external dependencies that Cycles needs
         OpenImageIO
-        bf_intern_openvdb
-        bf_intern_opensubdiv
+        ${OPENVDB_LIBRARIES}
+        ${OPENSUBDIV_LIBRARIES}
         ${OSL_LIBRARIES} # Link the real OSL libs, not the stub
         ${TBB_LIBRARIES}
 

--- a/src/blender/CMakeLists.txt
+++ b/src/blender/CMakeLists.txt
@@ -125,8 +125,8 @@ if(TARGET cycles_scene)
       extern_cuew
       extern_hipew
       ${OSL_LIBRARIES}
-      bf_intern_openvdb
-      bf_intern_opensubdiv
+      ${OPENVDB_LIBRARIES}
+      ${OPENSUBDIV_LIBRARIES}
 )
 else()
   # Fallback to precompiled static libraries
@@ -151,8 +151,8 @@ else()
       extern_cuew
       extern_hipew
       ${OSL_LIBRARIES}
-      bf_intern_openvdb
-      bf_intern_opensubdiv
+      ${OPENVDB_LIBRARIES}
+      ${OPENSUBDIV_LIBRARIES}
   )
 endif()
 


### PR DESCRIPTION
## Summary
- link against OpenVDB and OpenSubdiv using variables from `find_package`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865db55b1f0832ab89cf1f4b4cf66ae