### PR TITLE
Fix link issues by providing custom output driver and disabling HIP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ add_subdirectory(extern/cycles/third_party/hipew)
 # Build Cycles from source when precompiled libraries are not available
 if(NOT EXISTS "${CMAKE_SOURCE_DIR}/lib/libcycles_device.a")
   message(STATUS "Prebuilt Cycles libraries not found; building from source")
+  set(WITH_CYCLES_DEVICE_HIP OFF CACHE BOOL "Disable HIP device" FORCE)
   add_subdirectory(extern/cycles)
 endif()
 
@@ -98,6 +99,7 @@ target_link_libraries(sep_engine
         cycles_kernel_osl # The one with the real symbols
         cycles_subd
         cycles_util
+        extern_sky
         extern_cuew
         extern_hipew
 

--- a/include/blender/oiio_output_driver.h
+++ b/include/blender/oiio_output_driver.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <functional>
+#include "session/output_driver.h"
+#include "util/string.h"
+
+CCL_NAMESPACE_BEGIN
+
+class OIIOOutputDriver : public OutputDriver {
+ public:
+  using LogFunction = std::function<void(const string &)>;
+
+  OIIOOutputDriver(const string_view filepath, const string_view pass, LogFunction log);
+  ~OIIOOutputDriver() override;
+
+  void write_render_tile(const Tile &tile) override;
+
+ protected:
+  string filepath_;
+  string pass_;
+  LogFunction log_;
+};
+
+CCL_NAMESPACE_END

--- a/src/blender/CMakeLists.txt
+++ b/src/blender/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(sep_blender STATIC
     blender_integration.cpp
     mesh_handler.cpp
     factory.cpp
+    oiio_output_driver.cpp
 )
 
 # Define required features
@@ -49,6 +50,7 @@ target_link_libraries(sep_blender PRIVATE CUDA::cudart)
 
 target_sources(sep_blender PRIVATE
     cycles_renderer.cpp
+    oiio_output_driver.cpp
 )
 
 set_source_files_properties(cycles_renderer.cpp

--- a/src/blender/cycles_renderer.cpp
+++ b/src/blender/cycles_renderer.cpp
@@ -19,7 +19,7 @@
 #include "session/session.h"
 
 // Cycles utility includes
-#include "app/oiio_output_driver.h"
+#include "blender/oiio_output_driver.h"
 #include "util/array.h"
 #include "util/math_base.h"
 #include "util/param.h"

--- a/src/blender/oiio_output_driver.cpp
+++ b/src/blender/oiio_output_driver.cpp
@@ -1,0 +1,71 @@
+#include "blender/oiio_output_driver.h"
+
+#include "scene/colorspace.h"
+#include "util/image.h"
+#include "util/unique_ptr.h"
+
+#include <OpenImageIO/imagebuf.h>
+#include <OpenImageIO/imagebufalgo.h>
+
+CCL_NAMESPACE_BEGIN
+
+OIIOOutputDriver::OIIOOutputDriver(const string_view filepath,
+                                   const string_view pass,
+                                   LogFunction log)
+    : filepath_(filepath), pass_(pass), log_(log) {}
+
+OIIOOutputDriver::~OIIOOutputDriver() = default;
+
+void OIIOOutputDriver::write_render_tile(const Tile &tile)
+{
+  /* Only write the full buffer, no intermediate tiles. */
+  if (!(tile.size == tile.full_size)) {
+    return;
+  }
+
+  log_(string_printf("Writing image %s", filepath_.c_str()));
+
+  unique_ptr<ImageOutput> image_output(ImageOutput::create(filepath_));
+  if (image_output == nullptr) {
+    log_("Failed to create image file");
+    return;
+  }
+
+  const int width = tile.size.x;
+  const int height = tile.size.y;
+
+  const ImageSpec spec(width, height, 4, TypeDesc::FLOAT);
+  if (!image_output->open(filepath_, spec)) {
+    log_("Failed to create image file");
+    return;
+  }
+
+  vector<float> pixels(width * height * 4);
+  if (!tile.get_pass_pixels(pass_, 4, pixels.data())) {
+    log_("Failed to read render pass pixels");
+    return;
+  }
+
+  /* Manipulate offset and stride to convert from bottom-up to top-down convention. */
+  OIIO::ImageBuf image_buffer(spec,
+                              pixels.data() + (height - 1) * width * 4,
+                              AutoStride,
+                              -width * 4 * sizeof(float),
+                              AutoStride);
+
+  /* Apply gamma correction for (some) non-linear file formats.
+   * TODO: use OpenColorIO view transform if available. */
+  if (ColorSpaceManager::detect_known_colorspace(
+          u_colorspace_auto, "", image_output->format_name(), true) == u_colorspace_srgb)
+  {
+    const float g = 1.0f / 2.2f;
+    OIIO::ImageBufAlgo::pow(image_buffer, image_buffer, {g, g, g, 1.0f});
+  }
+
+  /* Write to disk and close */
+  image_buffer.set_write_format(TypeDesc::FLOAT);
+  image_buffer.write(image_output.get());
+  image_output->close();
+}
+
+CCL_NAMESPACE_END


### PR DESCRIPTION
## Summary
- implement local `OIIOOutputDriver` and use it in the renderer
- build the driver in `sep_blender`
- disable HIP device when building Cycles from source
- link against the sky library from Cycles

## Testing
- No tests run due to build restrictions

------
https://chatgpt.com/codex/tasks/task_e_6865de029544832abd8a06b1174e3f8a