### PR TITLE
Fix unresolved references in build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ add_subdirectory(src/audio)
 add_subdirectory(src/blender)
 add_subdirectory(extern/cycles/third_party/cuew)
 add_subdirectory(extern/cycles/third_party/hipew)
+add_subdirectory(extern/cycles/third_party/sky)
 
 # Build Cycles from source when precompiled libraries are not available
 if(NOT EXISTS "${CMAKE_SOURCE_DIR}/lib/libcycles_device.a")
@@ -100,6 +101,7 @@ target_link_libraries(sep_engine
         cycles_util
         extern_cuew
         extern_hipew
+        extern_sky
 
         # Now link the external dependencies that Cycles needs
         OpenImageIO

--- a/src/blender/CMakeLists.txt
+++ b/src/blender/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(sep_blender STATIC
     blender_integration.cpp
     mesh_handler.cpp
     factory.cpp
+    ${CMAKE_SOURCE_DIR}/extern/cycles/src/app/oiio_output_driver.cpp
 )
 
 # Define required features

--- a/src/compat/CMakeLists.txt
+++ b/src/compat/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(sep_compat STATIC
     event.cu
     stream.cpp
     raii.cpp
+    hip_compat.cpp
 )
 
 set_source_files_properties(

--- a/src/compat/hip_compat.cpp
+++ b/src/compat/hip_compat.cpp
@@ -1,0 +1,9 @@
+extern "C" {
+struct hipDeviceProp_t;
+typedef int hipError_t;
+hipError_t hipGetDeviceProperties(hipDeviceProp_t* prop, int device);
+hipError_t hipGetDevicePropertiesR0600(hipDeviceProp_t* prop, int device)
+{
+    return hipGetDeviceProperties(prop, device);
+}
+}


### PR DESCRIPTION
## Summary
- compile Cycles OIIO output driver by including its source file
- build sky model library and link it into the engine
- add HIP compatibility wrapper and link to sep_compat

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865de029544832abd8a06b1174e3f8a