### PR TITLE
Fix link order to resolve CUDA references

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,8 +89,9 @@ target_link_libraries(sep_engine
         sep_embeddings
         sep_quantum
         sep_memory
-        sep_compat # GPU abstraction, depends on core
-        sep_core   # Foundational library, linked last among SEP libs
+        # Link core before compat so the provider comes last
+        sep_core   # Foundational library consumed by other libs
+        sep_compat # GPU abstraction, depends on core and others
 
         # 2. Cycles and its dependencies (order is important here too)
         # Link the main Cycles libs first


### PR DESCRIPTION
## Summary
- link `sep_core` before `sep_compat` so CUDA symbols resolve when linking `sep_engine`

## Testing
- `N/A`

------
https://chatgpt.com/codex/tasks/task_e_6865e46e1bd0832a9f4f6d64e88cf873