### PR TITLE
Fix CUDA symbol links for memory tier

### DIFF
--- a/src/memory/CMakeLists.txt
+++ b/src/memory/CMakeLists.txt
@@ -14,14 +14,14 @@ find_path(HIREDIS_INCLUDE_DIR NAMES hiredis.h PATHS /usr/include/hiredis REQUIRE
 target_link_libraries(sep_memory
     PUBLIC
         sep_core
-    PRIVATE
-        sep_compat # Link compat once, it handles CUDA internally
+        sep_compat # CUDA utilities required by memory tier
         ${HIREDIS_LIB}
 )
 
 # CUDA and Redis are always required
 target_compile_definitions(sep_memory PRIVATE
     SEP_HAS_CUDA=1
+    SEP_USE_CUDA=1
     SEP_HAS_REDIS=1
 )
 


### PR DESCRIPTION
## Summary
- expose sep_compat as a public dependency of `sep_memory`
- compile `sep_memory` with `SEP_USE_CUDA=1` to ensure CUDA paths are enabled

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686661309410832abc61e3d91445a2a7