### PR TITLE
Fix CUDA deallocate wrapper

### DIFF
--- a/src/compat/cuda_api.cu
+++ b/src/compat/cuda_api.cu
@@ -310,7 +310,7 @@ cudaError_t sep_cuda_allocate_managed(void** ptr, size_t size) {
     return sep::cuda::allocateManaged(ptr, size);
 }
 
-cudaError_t sep::cuda::deallocate(void* ptr) {
+cudaError_t sep_cuda_deallocate(void* ptr) {
     return sep::cuda::deallocate(ptr);
 }
 


### PR DESCRIPTION
## Summary
- fix missing `sep_cuda_deallocate` wrapper definition

## Testing
- `scripts/code_analysis_suite.sh analyze` *(fails: compile_commands.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6866a9a939b8832aa4d9d7d68ad875d8