### PR TITLE
Fix CUDA API prototypes

### DIFF
--- a/include/compat/cuda_api.hpp
+++ b/include/compat/cuda_api.hpp
@@ -81,7 +81,7 @@ cudaError_t launch_pattern_processing(pattern::PatternData* patterns,
                                     const pattern::PatternConfig& config,
                                     size_t pattern_count,
                                     const pattern::PatternData* previous_patterns,
-                                    void* stream);
+                                    cudaStream_t stream);
 
 } // namespace sep::cuda
 #endif // __cplusplus

--- a/src/compat/cuda_api.cu
+++ b/src/compat/cuda_api.cu
@@ -68,7 +68,7 @@ cudaError_t launch_pattern_processing(pattern::PatternData* patterns,
                                     const pattern::PatternConfig& config,
                                     size_t pattern_count,
                                     const pattern::PatternData* previous_patterns,
-                                    void* stream) {
+                                    cudaStream_t stream) {
     if (!patterns || !results) {
         return cudaErrorInvalidValue;
     }
@@ -77,8 +77,7 @@ cudaError_t launch_pattern_processing(pattern::PatternData* patterns,
         const uint32_t block_size = constants::get_default_block_size();
         const uint32_t grid_size = (pattern_count + block_size - 1) / block_size;
 
-        detail::pattern_processing_kernel<<<grid_size, block_size, 0,
-            reinterpret_cast<cudaStream_t>(stream)>>>(
+        detail::pattern_processing_kernel<<<grid_size, block_size, 0, stream>>>(
             patterns, results, config, pattern_count, previous_patterns);
 
         return cudaGetLastError();
@@ -310,7 +309,7 @@ cudaError_t sep_cuda_allocate_managed(void** ptr, size_t size) {
     return sep::cuda::allocateManaged(ptr, size);
 }
 
-cudaError_t sep::cuda::deallocate(void* ptr) {
+cudaError_t sep_cuda_deallocate(void* ptr) {
     return sep::cuda::deallocate(ptr);
 }
 


### PR DESCRIPTION
## Summary
- fix parameter type for `launch_pattern_processing` to use `cudaStream_t`
- implement missing `sep_cuda_deallocate` wrapper

## Testing
- `cmake -S _sep/testbed -B _build_testbed`
- `make -C _build_testbed`


------
https://chatgpt.com/codex/tasks/task_e_6866a9a939b8832aa4d9d7d68ad875d8