### PR TITLE
Fix missing CUDA wrappers and add CPU fallback

### DIFF
--- a/src/compat/cuda_api.cu
+++ b/src/compat/cuda_api.cu
@@ -310,7 +310,7 @@ cudaError_t sep_cuda_allocate_managed(void** ptr, size_t size) {
     return sep::cuda::allocateManaged(ptr, size);
 }
 
-cudaError_t sep::cuda::deallocate(void* ptr) {
+cudaError_t sep_cuda_deallocate(void* ptr) {
     return sep::cuda::deallocate(ptr);
 }
 

--- a/src/core/engine.cpp
+++ b/src/core/engine.cpp
@@ -17,6 +17,7 @@
 #include "compat/cuda_api.hpp"
 #include "core/logging.h"  // This is actually the logging manager
 #include "memory/memory_tier_manager.hpp"
+#include "quantum/qbsa.h"
 #ifdef SEP_HAS_BLENDER
 #include "blender/pattern_bridge.h"
 #include "blender/types.h" // For SEPBlenderBridge definition
@@ -26,7 +27,8 @@
 
 #include <cstdint> 
 #include <cstdio> 
-#include <exception> 
+#include <exception>
+#include <numeric>
 
 // Define namespace alias for clarity
 namespace logging = sep::logging; 
@@ -217,6 +219,7 @@ void Engine::process_batch(const std::vector<::sep::PinState>& inputs, std::uint
         std::vector<std::uint32_t> expectations;
         generate_probes(inputs, probe_indices, expectations, tick);
 
+#ifdef SEP_USE_CUDA
         // Process QBSA using CUDA
         auto qbsa_status = sep_cuda_process_batch(
             probe_indices.data(),
@@ -244,8 +247,16 @@ void Engine::process_batch(const std::vector<::sep::PinState>& inputs, std::uint
             ::sep::core::ErrorHandler::instance().reportError({qsh_status, "QSH processing failed", "Engine::process_batch"});
             return;
         }
+#else
+        // CPU fallback when CUDA is unavailable
+        sep::quantum::QBSAProcessor cpu_proc;
+        qbsa_result = cpu_proc.analyze(probe_indices, expectations);
+        qbsa_result.collapse_detected =
+            cpu_proc.detectCollapse(qbsa_result, inputs.size());
+#endif
 
         // Update results from device buffers
+#ifdef SEP_USE_CUDA
         qbsa_result.corrections.assign(
             impl_->d_corrections_.begin(),
             impl_->d_corrections_.end());
@@ -253,8 +264,10 @@ void Engine::process_batch(const std::vector<::sep::PinState>& inputs, std::uint
             static_cast<float>(impl_->d_correction_count_[0]) /
             inputs.size();
         qbsa_result.collapse_detected = impl_->d_correction_count_[0] > 0;
+#endif
 
         // Reconstruct nested collapse indices using counts
+#ifdef SEP_USE_CUDA
         qsh_result.collapse_indices.clear();
         qsh_result.collapse_indices.resize(inputs.size());
         for (std::size_t i = 0; i < inputs.size(); ++i) {
@@ -271,6 +284,7 @@ void Engine::process_batch(const std::vector<::sep::PinState>& inputs, std::uint
             qsh_result.collapse_counts.begin(),
             qsh_result.collapse_counts.end(),
             0u);
+#endif
 
         // Update state history
         StateNode node;

--- a/src/memory/memory_tier.cpp
+++ b/src/memory/memory_tier.cpp
@@ -341,7 +341,7 @@ bool MemoryTier::resize(std::size_t new_size) {
     if (config_.type == TierType::HOST) {
         new_pool = std::malloc(new_size);
     } else {
-        cudaError_t err = sep::cuda::allocateManaged(&new_pool, new_size);
+        cudaError_t err = sep_cuda_allocate_managed(&new_pool, new_size);
         if (err != cudaSuccess) {
             if (logger) {
                 LOG_ERROR(logger, "Failed to allocate managed memory: {}", err);
@@ -367,7 +367,7 @@ bool MemoryTier::resize(std::size_t new_size) {
             if (config_.type == TierType::HOST)
                 std::free(new_pool);
             else {
-                sep::cuda::deallocate(new_pool);
+                sep_cuda_deallocate(new_pool);
             }
             sep::metrics::allocationFailures().value++;
             return false;
@@ -398,7 +398,7 @@ bool MemoryTier::resize(std::size_t new_size) {
         if (config_.type == TierType::HOST)
             std::free(memory_pool_);
         else {
-            sep::cuda::deallocate(memory_pool_);
+            sep_cuda_deallocate(memory_pool_);
         }
     }
     memory_pool_ = new_pool;


### PR DESCRIPTION
## Summary
- add missing `sep_cuda_deallocate` wrapper
- use wrapper functions in `MemoryTier` to avoid undefined symbols
- conditionally invoke CUDA processing in `Engine::process_batch` with a CPU fallback using `QBSAProcessor`

## Testing
- `ctest --output-on-failure` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_6866a9a939b8832aa4d9d7d68ad875d8