### PR TITLE
Fix CUDA dependency assumptions

### DIFF
--- a/src/core/engine.cpp
+++ b/src/core/engine.cpp
@@ -219,7 +219,7 @@ void Engine::process_batch(const std::vector<::sep::PinState>& inputs, std::uint
         std::vector<std::uint32_t> expectations;
         generate_probes(inputs, probe_indices, expectations, tick);
 
-#ifdef SEP_USE_CUDA
+#if defined(SEP_USE_CUDA) && defined(__CUDACC__)
         // Process QBSA using CUDA
         auto qbsa_status = sep_cuda_process_batch(
             probe_indices.data(),
@@ -256,7 +256,7 @@ void Engine::process_batch(const std::vector<::sep::PinState>& inputs, std::uint
 #endif
 
         // Update results from device buffers
-#ifdef SEP_USE_CUDA
+#if defined(SEP_USE_CUDA) && defined(__CUDACC__)
         qbsa_result.corrections.assign(
             impl_->d_corrections_.begin(),
             impl_->d_corrections_.end());
@@ -267,7 +267,7 @@ void Engine::process_batch(const std::vector<::sep::PinState>& inputs, std::uint
 #endif
 
         // Reconstruct nested collapse indices using counts
-#ifdef SEP_USE_CUDA
+#if defined(SEP_USE_CUDA) && defined(__CUDACC__)
         qsh_result.collapse_indices.clear();
         qsh_result.collapse_indices.resize(inputs.size());
         for (std::size_t i = 0; i < inputs.size(); ++i) {

--- a/src/memory/memory_tier.cpp
+++ b/src/memory/memory_tier.cpp
@@ -38,6 +38,7 @@ MemoryTier::MemoryTier(const Config& config) : config_(config), memory_pool_(nul
     if (config.type == TierType::HOST) {
         memory_pool_ = std::malloc(config.size);
     } else {
+#if defined(SEP_USE_CUDA) && defined(__CUDACC__)
         memory_pool_ = nullptr;
         cudaError_t err = sep_cuda_allocate_managed(&memory_pool_, config.size);
         if (err != cudaSuccess) {
@@ -46,6 +47,10 @@ MemoryTier::MemoryTier(const Config& config) : config_(config), memory_pool_(nul
                 logger->error("Failed to allocate managed memory: {}", err);
             }
         }
+#else
+        // Fallback to host memory when CUDA runtime is unavailable
+        memory_pool_ = std::malloc(config.size);
+#endif
     }
     if (!memory_pool_) {
 #if SEP_HAS_EXCEPTIONS
@@ -80,7 +85,11 @@ MemoryTier::~MemoryTier() {
         if (config_.type == TierType::HOST) {
             std::free(memory_pool_);
         } else {
+#if defined(SEP_USE_CUDA) && defined(__CUDACC__)
             sep_cuda_deallocate(memory_pool_);
+#else
+            std::free(memory_pool_);
+#endif
         }
         memory_pool_ = nullptr;
     }
@@ -156,6 +165,7 @@ sep::SEPResult MemoryTier::defragment() {
             if (block.offset != current_offset) {
                 // Move memory to new position
                 void* new_location = static_cast<char*>(memory_pool_) + current_offset;
+#if defined(SEP_USE_CUDA) && defined(__CUDACC__)
                 cudaError_t err = sep_cuda_memcpy_async(new_location, block.ptr, block.size, cudaMemcpyDefault, nullptr);
                 if (err != cudaSuccess) {
                     if (logger) {
@@ -170,6 +180,9 @@ sep::SEPResult MemoryTier::defragment() {
                     }
                     return sep::SEPResult::CUDA_ERROR;
                 }
+#else
+                std::memmove(new_location, block.ptr, block.size);
+#endif
 
                 block.ptr = new_location;
                 block.offset = current_offset;
@@ -267,6 +280,7 @@ bool MemoryTier::moveData(MemoryBlock* dst, const MemoryBlock* src) {
     if (config_.type == TierType::HOST) {
         std::memcpy(dst->ptr, src->ptr, size);
     } else {
+#if defined(SEP_USE_CUDA) && defined(__CUDACC__)
         cudaError_t err = sep_cuda_memcpy_async(dst->ptr, src->ptr, size, cudaMemcpyDefault, nullptr);
         if (err != cudaSuccess) {
             if (logger) {
@@ -281,6 +295,9 @@ bool MemoryTier::moveData(MemoryBlock* dst, const MemoryBlock* src) {
             }
             return false;
         }
+#else
+        std::memcpy(dst->ptr, src->ptr, size);
+#endif
     }
     return true;
 }
@@ -341,6 +358,7 @@ bool MemoryTier::resize(std::size_t new_size) {
     if (config_.type == TierType::HOST) {
         new_pool = std::malloc(new_size);
     } else {
+#if defined(SEP_USE_CUDA) && defined(__CUDACC__)
         cudaError_t err = sep_cuda_allocate_managed(&new_pool, new_size);
         if (err != cudaSuccess) {
             if (logger) {
@@ -349,6 +367,9 @@ bool MemoryTier::resize(std::size_t new_size) {
             sep::metrics::allocationFailures().value++;
             return false;
         }
+#else
+        new_pool = std::malloc(new_size);
+#endif
     }
     if (!new_pool) {
         if (logger) {
@@ -364,11 +385,15 @@ bool MemoryTier::resize(std::size_t new_size) {
         if (!block.allocated)
             continue;
         if (offset + block.size > new_size) {
-            if (config_.type == TierType::HOST)
-                std::free(new_pool);
-            else {
-                sep_cuda_deallocate(new_pool);
-            }
+        if (config_.type == TierType::HOST)
+            std::free(new_pool);
+        else {
+#if defined(SEP_USE_CUDA) && defined(__CUDACC__)
+            sep_cuda_deallocate(new_pool);
+#else
+            std::free(new_pool);
+#endif
+        }
             sep::metrics::allocationFailures().value++;
             return false;
         }
@@ -398,7 +423,11 @@ bool MemoryTier::resize(std::size_t new_size) {
         if (config_.type == TierType::HOST)
             std::free(memory_pool_);
         else {
+#if defined(SEP_USE_CUDA) && defined(__CUDACC__)
             sep_cuda_deallocate(memory_pool_);
+#else
+            std::free(memory_pool_);
+#endif
         }
     }
     memory_pool_ = new_pool;

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -237,7 +237,7 @@ sep::SEPResult MemoryTierManager::launch_pattern_processing(sep::pattern::Patter
                                                             size_t pattern_count,
                                                             const sep::pattern::PatternData* previous_patterns,
                                                             void* stream) {
-#ifdef SEP_USE_CUDA
+#if defined(SEP_USE_CUDA) && defined(__CUDACC__)
     cudaStream_t cuda_stream = reinterpret_cast<cudaStream_t>(stream);
     cudaError_t err = sep::cuda::launch_pattern_processing(
         patterns, results, config, pattern_count, previous_patterns, cuda_stream);


### PR DESCRIPTION
## Summary
- add CPU fallbacks when CUDA build tools are missing
- guard CUDA calls in Engine and MemoryTier classes

## Testing
- `cmake -B build -S .` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6866acc78420832aa0dbf9ba00a9b438