### PR TITLE
Fix memory allocation fallback

### DIFF
--- a/src/core/engine.cpp
+++ b/src/core/engine.cpp
@@ -1,6 +1,15 @@
 #include "compat/macros.h"
 #if defined(__CUDACC__)
-#include <cuda_runtime.h> // real CUDA header when available
+#  include <cuda_runtime.h> // real CUDA header when available
+#endif
+
+// Determine if real CUDA support is present at compile time. This mirrors the
+// logic used in other components so the engine can compile cleanly even when
+// CUDA sources are not built with NVCC.
+#if defined(__CUDACC__)
+#  define SEP_ENGINE_HAS_CUDA 1
+#else
+#  define SEP_ENGINE_HAS_CUDA 0
 #endif
 #include "api/types.h"
 #include "compat/core.h"
@@ -34,7 +43,7 @@ namespace logging = sep::logging;
 
 namespace sep {
 namespace core {
-#if defined(__CUDACC__)
+#if SEP_ENGINE_HAS_CUDA
 using namespace ::sep::cuda;
 #endif
 

--- a/src/memory/memory_tier.cpp
+++ b/src/memory/memory_tier.cpp
@@ -390,6 +390,7 @@ bool MemoryTier::resize(std::size_t new_size) {
   if (config_.type == TierType::HOST) {
     new_pool = std::malloc(new_size);
   } else {
+#if SEP_MEMORY_HAS_CUDA
     cudaError_t err = sep::cuda::allocateManaged(&new_pool, new_size);
     if (err != cudaSuccess) {
       if (logger) {
@@ -398,6 +399,17 @@ bool MemoryTier::resize(std::size_t new_size) {
       sep::metrics::allocationFailures().value++;
       return false;
     }
+#else
+    new_pool = std::malloc(new_size);
+    cudaError_t err = new_pool ? cudaSuccess : cudaErrorMemoryAllocation;
+    if (err != cudaSuccess) {
+      if (logger) {
+        LOG_ERROR(logger, "Failed to allocate host memory: {}", err);
+      }
+      sep::metrics::allocationFailures().value++;
+      return false;
+    }
+#endif
   }
   if (!new_pool) {
     if (logger) {


### PR DESCRIPTION
## Summary
- guard `sep::cuda::allocateManaged` usage in `MemoryTier::resize`
- add `SEP_ENGINE_HAS_CUDA` macro and guard `using namespace ::sep::cuda` in engine

## Testing
- `ctest --output-on-failure -j4` *(no tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_6866b4a4d360832aaa28760ce2899203