### PR TITLE
Fix memory tier resize without CUDA

### DIFF
--- a/src/core/engine.cpp
+++ b/src/core/engine.cpp
@@ -25,6 +25,7 @@
 #include "audio/factory.h"
 
 #include <cstdint>
+#include <algorithm>
 #include <cstdio>
 #include <exception>
 #include <numeric>

--- a/src/memory/memory_tier.cpp
+++ b/src/memory/memory_tier.cpp
@@ -390,6 +390,7 @@ bool MemoryTier::resize(std::size_t new_size) {
   if (config_.type == TierType::HOST) {
     new_pool = std::malloc(new_size);
   } else {
+#if SEP_MEMORY_HAS_CUDA
     cudaError_t err = sep::cuda::allocateManaged(&new_pool, new_size);
     if (err != cudaSuccess) {
       if (logger) {
@@ -398,6 +399,17 @@ bool MemoryTier::resize(std::size_t new_size) {
       sep::metrics::allocationFailures().value++;
       return false;
     }
+#else
+    new_pool = std::malloc(new_size);
+    cudaError_t err = new_pool ? cudaSuccess : cudaErrorMemoryAllocation;
+    if (err != cudaSuccess) {
+      if (logger) {
+        LOG_ERROR(logger, "Failed to allocate host memory: {}", err);
+      }
+      sep::metrics::allocationFailures().value++;
+      return false;
+    }
+#endif
   }
   if (!new_pool) {
     if (logger) {


### PR DESCRIPTION
## Summary
- handle memory resize when CUDA isn't enabled
- include `<algorithm>` for std::fill usage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6866b4a4d360832aaa28760ce2899203