### PR TITLE
Fix missing CPU fallback in memory tier

### DIFF
--- a/src/core/engine.cpp
+++ b/src/core/engine.cpp
@@ -1,5 +1,5 @@
 #include "compat/macros.h"
-#if defined(__CUDACC__)
+#if SEP_HAS_CUDA
 #include <cuda_runtime.h> // real CUDA header when available
 #endif
 #include "api/types.h"
@@ -34,7 +34,7 @@ namespace logging = sep::logging;
 
 namespace sep {
 namespace core {
-#if defined(__CUDACC__)
+#if SEP_HAS_CUDA
 using namespace ::sep::cuda;
 #endif
 

--- a/src/memory/memory_tier.cpp
+++ b/src/memory/memory_tier.cpp
@@ -390,7 +390,8 @@ bool MemoryTier::resize(std::size_t new_size) {
   if (config_.type == TierType::HOST) {
     new_pool = std::malloc(new_size);
   } else {
-    cudaError_t err = sep::cuda::allocateManaged(&new_pool, new_size);
+#if SEP_MEMORY_HAS_CUDA
+    cudaError_t err = cudaMallocManaged(&new_pool, new_size);
     if (err != cudaSuccess) {
       if (logger) {
         LOG_ERROR(logger, "Failed to allocate managed memory: {}", err);
@@ -398,6 +399,17 @@ bool MemoryTier::resize(std::size_t new_size) {
       sep::metrics::allocationFailures().value++;
       return false;
     }
+#else
+    new_pool = std::malloc(new_size);
+    cudaError_t err = new_pool ? cudaSuccess : cudaErrorMemoryAllocation;
+    if (err != cudaSuccess) {
+      if (logger) {
+        LOG_ERROR(logger, "Failed to allocate host memory: {}", err);
+      }
+      sep::metrics::allocationFailures().value++;
+      return false;
+    }
+#endif
   }
   if (!new_pool) {
     if (logger) {


### PR DESCRIPTION
## Summary
- avoid linking against CUDA-only symbols when CUDA isn't used
- guard CUDA includes in the engine by SEP_HAS_CUDA

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6866b4a4d360832aaa28760ce2899203