### PR TITLE
Document audio options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,7 @@ find_package(Alembic REQUIRED)
 
 # Audio support can be disabled
 option(SEP_ENABLE_AUDIO "Enable audio support" ON)
+# Invoke cmake with `-DSEP_ENABLE_AUDIO=OFF` to build without audio capture
 
 # Add subdirectories
 add_subdirectory(src/core)

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,14 @@ Execute the engine from the build directory (`cmake-make`):
 ./sep_engine
 ```
 
+Pass `--disable-audio` to skip initializing audio capture. This is useful on
+systems without working audio devices or when `SEP_ENABLE_AUDIO` was set to
+`OFF` during configuration:
+
+```bash
+./sep_engine --disable-audio
+```
+
 Configuration files are located in `config`. Command‑line flags and environment variables override these defaults.
 
 ### New Configuration Sections


### PR DESCRIPTION
## Summary
- mention `--disable-audio` runtime flag
- show how to disable audio capture via `SEP_ENABLE_AUDIO` in CMake

## Testing
- `apt-get install -y xxd`

------
https://chatgpt.com/codex/tasks/task_e_6866d02a4c6c832aa3df7bc695a19e0c