### PR TITLE
Add diagram documentation worker

### DIFF
--- a/_sep/testbed/diagram_doc_worker.py
+++ b/_sep/testbed/diagram_doc_worker.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Diagram Documentation Worker
+
+This script scans module directories under `include/` and `src/` and verifies
+that corresponding diagram documentation files exist under `docs/diagrams`.
+Missing or outdated files are reported for manual review.
+
+Usage:
+    python _sep/testbed/diagram_doc_worker.py
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def list_modules(base: Path) -> list[str]:
+    """Return directory names under *base* that represent modules."""
+    modules = []
+    for item in sorted(base.iterdir()):
+        if item.is_dir() and not item.is_symlink():
+            modules.append(item.name)
+    return modules
+
+
+def collect_docs(doc_dir: Path, prefix: str) -> dict[str, Path]:
+    """Return a mapping of module name to documentation path."""
+    docs = {}
+    for doc in doc_dir.glob(f"{prefix}-*.md"):
+        name = doc.stem[len(prefix) + 1 :]
+        docs[name] = doc
+    return docs
+
+
+def main() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    docs_dir = repo_root / "docs" / "diagrams"
+
+    include_modules = list_modules(repo_root / "include")
+    src_modules = list_modules(repo_root / "src")
+
+    include_docs = collect_docs(docs_dir, "include")
+    src_docs = collect_docs(docs_dir, "src")
+
+    missing = []
+    for name in include_modules:
+        if name not in include_docs:
+            missing.append(f"docs/diagrams/include-{name}.md")
+    for name in src_modules:
+        if name not in src_docs:
+            missing.append(f"docs/diagrams/src-{name}.md")
+
+    outdated = []
+    for name, path in include_docs.items():
+        if name not in include_modules:
+            outdated.append(str(path.relative_to(repo_root)))
+    for name, path in src_docs.items():
+        if name not in src_modules:
+            outdated.append(str(path.relative_to(repo_root)))
+
+    if not missing and not outdated:
+        print("Diagram documentation is up to date.")
+        return
+
+    if missing:
+        print("Missing diagram docs:")
+        for p in missing:
+            print(f"  {p}")
+
+    if outdated:
+        print("Outdated diagram docs:")
+        for p in outdated:
+            print(f"  {p}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/README.md
+++ b/docs/README.md
@@ -77,3 +77,13 @@ The script defines variables including `OPENVDB_INCLUDE_DIR`,
 on the system it automatically clones and builds version `v1.13.12.0` under
 `/sep/extern/osl`. After executing it you can build Cycles from `/sep/cycles-build`:
 
+
+## Diagram Documentation Worker
+
+Run the helper below whenever module folders change to verify that each one has a matching diagram markdown file.
+
+```bash
+python _sep/testbed/diagram_doc_worker.py
+```
+
+Missing or outdated files will be listed in the output so you can update `docs/diagrams` accordingly.


### PR DESCRIPTION
## Summary
- add a script that checks for module diagram docs
- document usage in docs/README

## Testing
- `python3 -m py_compile _sep/testbed/diagram_doc_worker.py`
- `python3 _sep/testbed/diagram_doc_worker.py | head`

------
https://chatgpt.com/codex/tasks/task_e_6866d03603a4832abc1e35c23fb0668d