### PR TITLE
Add diagrams for embeddings and cycles

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -192,6 +192,12 @@ Each module is built as a self-contained static library, providing a clear and r
 *   **Key Files**: `memory_tier_manager.cpp`, `memory_tier.cpp`, `redis_manager.cpp`.
 *   **Dependencies**: `core`.
 
+### `embeddings` - Text Embedding Utilities
+*   **Purpose**: Supplies lightweight text embeddings for pattern generation and testing.
+*   **Key Files**: `simple_embedding_model.cpp`, `simple_embedding_model.h`.
+*   **Dependencies**: None.
+*   **Diagrams**: [include-embeddings.md](diagrams/include-embeddings.md), [src-embeddings.md](diagrams/src-embeddings.md).
+
 ### `api` - The Public Interface
 *   **Purpose**: Exposes the engine's functionality to the outside world via an HTTP server (Crow) and a stable C-style bridge.
 *   **Key Files**: `server.cpp`, `sep_engine.cpp` (facade), `bridge_c.cpp`, `rate_limit_middleware.cpp`.
@@ -205,6 +211,7 @@ Each module is built as a self-contained static library, providing a clear and r
 *   **Dependencies**: `core`, `quantum`, `memory`.
 *   **Rationale**: Keeping these integrations as separate modules prevents their specific dependencies (e.g., Blender headers, PipeWire) from polluting the core engine build.
 *   **Cycles Integration**: The `cycles_renderer.cpp` provides pattern-driven rendering through Blender's Cycles renderer when `SEP_HAS_CYCLES` is enabled.
+*   **Cycles Source**: Headers are accessed via the `include/cycles_src` symlink. See [include-cycles_src.md](diagrams/include-cycles_src.md) for details.
 
 ## 4. Detailed Interaction and Data Flows
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,9 @@ This folder contains notes and references for navigating and maintaining the SEP
 - **`THESIS.md`** — Background theory behind the project.
 - **`vscodium.md`** — Notes on the development environment setup.
 - **`CONFIG_OPTIONS.md`** — Description of configurable runtime parameters.
+- **`diagrams/include-embeddings.md`** — Header map for the embeddings module.
+- **`diagrams/src-embeddings.md`** — Implementation flow for embeddings.
+- **`diagrams/include-cycles_src.md`** — Notes on the Cycles source symlink.
 
 Most documentation assumes the code has already been built with CUDA support and that `sep_engine` runs. See below for a refresher on building and running.
 

--- a/docs/diagrams/include-cycles_src.md
+++ b/docs/diagrams/include-cycles_src.md
@@ -1,0 +1,11 @@
+# Cycles Source Symlink
+
+`include/cycles_src` is a convenience link to the Blender Cycles source tree. It allows the engine's `blender` module to reference Cycles headers without hardcoding absolute paths.
+
+```mermaid
+flowchart TD
+    CyclesSrc[/include/cycles_src/] --> CyclesExtern[/extern/cycles/src/]
+    CyclesSrc --> BlenderRenderer[cycles_renderer.cpp]
+```
+
+The symlink mirrors `extern/cycles/src` so that files like `src/blender/cycles_renderer.cpp` can include headers such as `kernel/kernel.h` when `SEP_HAS_CYCLES` is enabled.

--- a/docs/diagrams/include-embeddings.md
+++ b/docs/diagrams/include-embeddings.md
@@ -1,0 +1,13 @@
+# Embedding Headers Overview
+
+This document summarizes the header files under `include/embeddings/` and how they are used throughout the engine.
+
+```mermaid
+classDiagram
+    class SimpleEmbeddingModel {
+        +compute(text: string) std::vector<double>
+        -weights_[5] : double
+    }
+```
+
+`SimpleEmbeddingModel` provides a tiny, deterministic embedding implementation used primarily for tests and simple pattern generation. The header is included by the API layer to compute embeddings from incoming text requests.

--- a/docs/diagrams/src-embeddings.md
+++ b/docs/diagrams/src-embeddings.md
@@ -1,0 +1,13 @@
+# Embedding Source Flow
+
+The `src/embeddings` folder currently contains a single implementation file providing a toy text embedding model.
+
+```mermaid
+flowchart TD
+    A[text input] --> B{iterate chars}
+    B --> C[accumulate weighted sum]
+    C --> D[normalize vector]
+    D --> E[return embedding]
+```
+
+`simple_embedding_model.cpp` multiplies each character code by a constant weight vector and normalizes the result. The function is deterministic and serves as a placeholder until a real model is integrated.


### PR DESCRIPTION
## Summary
- document embedding headers and sources
- explain the `cycles_src` symlink
- link new diagrams from README and ARCHITECTURE

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6866d04828c0832ab2dc14e2ff000fad