### PR TITLE
Add skeleton demos for workbench

### DIFF
--- a/examples/workbench/CMakeLists.txt
+++ b/examples/workbench/CMakeLists.txt
@@ -5,6 +5,8 @@ add_executable(sep_workbench
     main.cpp
     demo_manager.cpp
     demos/genesis_pattern.cpp
+    demos/audio_visualizer.cpp
+    demos/memory_garden.cpp
 )
 
 # Include directories

--- a/examples/workbench/demos/audio_visualizer.cpp
+++ b/examples/workbench/demos/audio_visualizer.cpp
@@ -1,0 +1,53 @@
+#include "audio_visualizer.hpp"
+#include "config.hpp"
+#include "audio/capture.h"
+#include "audio/pipeline.h"
+#include <glm/vec3.hpp>
+
+namespace sep {
+namespace workbench {
+
+using namespace sep::audio;
+
+void AudioVisualizerDemo::init() {
+    const auto& cfg = Config::getInstance().audio_visualizer();
+    pipeline_ = std::make_unique<AudioPipeline>(cfg.input.sample_rate);
+    capture_ = AudioCapture::create();
+
+    AudioConfig acfg;
+    acfg.device = cfg.input.device;
+    acfg.sample_rate = cfg.input.sample_rate;
+    acfg.buffer_size = cfg.input.buffer_size;
+    acfg.channels = 2;
+
+    capture_->setCallback([this](const float* data, size_t len) {
+        std::vector<float> samples(data, data + len);
+        pipeline_->processAudioFrame(samples);
+        latest_patterns_ = pipeline_->getPatterns();
+    });
+    capture_->init(acfg);
+    capture_->start();
+}
+
+void AudioVisualizerDemo::update(float) {
+    // No-op, patterns updated in callback
+}
+
+void AudioVisualizerDemo::render() {
+    if (!renderer_) return;
+    renderer_->renderDebugPoints(latest_patterns_);
+}
+
+void AudioVisualizerDemo::cleanup() {
+    if (capture_) {
+        capture_->stop();
+    }
+    pipeline_.reset();
+    capture_.reset();
+}
+
+void AudioVisualizerDemo::handleKeyboard(unsigned char) {}
+void AudioVisualizerDemo::handleMouse(int, int, int) {}
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/demos/audio_visualizer.hpp
+++ b/examples/workbench/demos/audio_visualizer.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "examples/workbench/demo_manager.hpp"
+#include <memory>
+#include <vector>
+
+namespace sep {
+namespace workbench {
+
+namespace audio {
+class AudioCapture;
+class AudioPipeline;
+}
+
+class AudioVisualizerDemo : public Demo {
+public:
+    void init() override;
+    void update(float dt) override;
+    void render() override;
+    void cleanup() override;
+    void handleKeyboard(unsigned char key) override;
+    void handleMouse(int x, int y, int button) override;
+
+private:
+    std::unique_ptr<audio::AudioCapture> capture_;
+    std::unique_ptr<audio::AudioPipeline> pipeline_;
+    std::vector<glm::vec3> latest_patterns_;
+};
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/demos/genesis_pattern.hpp
+++ b/examples/workbench/demos/genesis_pattern.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "examples/workbench/demo_manager.hpp"
+#include <memory>
+
+namespace sep {
+namespace workbench {
+
+class PatternProcessor;
+class QuantumCoherenceManager;
+
+class GenesisPatternDemo : public Demo {
+public:
+    void init() override;
+    void update(float dt) override;
+    void render() override;
+    void cleanup() override;
+    void handleKeyboard(unsigned char key) override;
+    void handleMouse(int x, int y, int button) override;
+
+private:
+    void initializePatterns();
+    void evolvePatterns(float dt);
+    void updateVisualization();
+
+    struct ViewSettings {
+        float rotation{0.0f};
+        float zoom{1.0f};
+        bool wireframe{false};
+    } view_;
+
+    struct Metrics {
+        float coherence{0.f};
+        std::size_t pattern_count{0};
+        float evolution_rate{0.f};
+        std::size_t iterations{0};
+    } metrics_;
+
+    std::unique_ptr<PatternProcessor> pattern_processor_;
+    std::unique_ptr<QuantumCoherenceManager> coherence_manager_;
+
+    bool auto_evolve_{true};
+    float evolution_rate_{0.1f};
+    float coherence_threshold_{0.5f};
+};
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/demos/memory_garden.cpp
+++ b/examples/workbench/demos/memory_garden.cpp
@@ -1,0 +1,41 @@
+#include "memory_garden.hpp"
+#include "config.hpp"
+#include <glm/vec3.hpp>
+
+namespace sep {
+namespace workbench {
+
+void MemoryGardenDemo::init() {
+    const auto& cfg = Config::getInstance().memory_garden();
+    nodes_.resize(10);
+    for (std::size_t i = 0; i < nodes_.size(); ++i) {
+        nodes_[i].position = glm::vec3(i, 0.0f, 0.0f);
+        nodes_[i].coherence = 1.0f - static_cast<float>(i) / nodes_.size();
+    }
+}
+
+void MemoryGardenDemo::update(float) {
+    // Simple rotation for demonstration
+    for (auto& n : nodes_) {
+        n.position.y += 0.01f;
+    }
+}
+
+void MemoryGardenDemo::render() {
+    if (!renderer_) return;
+    std::vector<glm::vec3> points;
+    for (const auto& n : nodes_) {
+        points.push_back(n.position);
+    }
+    renderer_->renderDebugPoints(points);
+}
+
+void MemoryGardenDemo::cleanup() {
+    nodes_.clear();
+}
+
+void MemoryGardenDemo::handleKeyboard(unsigned char) {}
+void MemoryGardenDemo::handleMouse(int, int, int) {}
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/demos/memory_garden.hpp
+++ b/examples/workbench/demos/memory_garden.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "examples/workbench/demo_manager.hpp"
+#include <memory>
+#include <vector>
+
+namespace sep {
+namespace workbench {
+
+class MemoryGardenDemo : public Demo {
+public:
+    void init() override;
+    void update(float dt) override;
+    void render() override;
+    void cleanup() override;
+    void handleKeyboard(unsigned char key) override;
+    void handleMouse(int x, int y, int button) override;
+
+private:
+    struct Node {
+        glm::vec3 position;
+        float coherence{0.f};
+    };
+
+    std::vector<Node> nodes_;
+};
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/main.cpp
+++ b/examples/workbench/main.cpp
@@ -5,6 +5,8 @@
 #include "blender/cycles_renderer.hpp"
 #include "demo_manager.hpp"
 #include "demos/genesis_pattern.hpp"
+#include "demos/audio_visualizer.hpp"
+#include "demos/memory_garden.hpp"
 
 using namespace sep;
 using namespace sep::workbench;
@@ -82,6 +84,12 @@ void registerDemos() {
     // Register available demos
     demo_manager.registerDemo("genesis", []() {
         return std::make_unique<GenesisPatternDemo>();
+    });
+    demo_manager.registerDemo("audio", []() {
+        return std::make_unique<AudioVisualizerDemo>();
+    });
+    demo_manager.registerDemo("memory", []() {
+        return std::make_unique<MemoryGardenDemo>();
     });
 
     // Start with Genesis Pattern demo


### PR DESCRIPTION
## Summary
- provide demo headers for genesis pattern
- add audio visualizer and memory garden demo skeletons
- register new demos in the workbench
- compile sources by updating CMake configuration

## Testing
- `bash tests/blender/run_tests.sh` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6866d61a2514832a8294738a27885c25