### PR TITLE
Fix std namespace in Cycles time utilities

### DIFF
--- a/extern/cycles/src/util/time.cpp
+++ b/extern/cycles/src/util/time.cpp
@@ -66,7 +66,7 @@ void time_sleep(double t)
 
 /* Time in format "hours:minutes:seconds.hundreds" */
 
-string time_human_readable_from_seconds(const double seconds)
+std::string time_human_readable_from_seconds(const double seconds)
 {
   const int h = (((int)seconds) / (60 * 60));
   const int m = (((int)seconds) / 60) % 60;
@@ -79,7 +79,7 @@ string time_human_readable_from_seconds(const double seconds)
   return string_printf("%.2d:%.2d.%.2d", m, s, r);
 }
 
-double time_human_readable_to_seconds(const string &time_string)
+double time_human_readable_to_seconds(const std::string &time_string)
 {
   /* Those are multiplies of a corresponding token surrounded by : in the
    * time string, which denotes how to convert value to seconds.

--- a/extern/cycles/src/util/time.h
+++ b/extern/cycles/src/util/time.h
@@ -7,6 +7,7 @@
 #include <functional>
 
 #include "util/string.h"
+#include <string>
 
 CCL_NAMESPACE_BEGIN
 
@@ -69,7 +70,7 @@ class scoped_callback_timer {
 
 /* Make human readable string from time, compatible with Blender metadata. */
 
-string time_human_readable_from_seconds(const double seconds);
-double time_human_readable_to_seconds(const string &time_string);
+std::string time_human_readable_from_seconds(const double seconds);
+double time_human_readable_to_seconds(const std::string &time_string);
 
 CCL_NAMESPACE_END


### PR DESCRIPTION
## Summary
- include `<string>` in `cycles` time utilities
- use `std::string` explicitly in `time_human_readable_*` helpers

## Testing
- `tests/blender/run_all_tests.sh` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6867cfd5db44832ab1603412c2d5f421