### PR TITLE
Fix C string function usage

### DIFF
--- a/include/compat/memory.h
+++ b/include/compat/memory.h
@@ -115,7 +115,7 @@ bool copyToDevice(T* dst, const T* src, size_t count, Stream* stream  = nullptr)
     return error == cudaSuccess;
 #else
     (void)stream;
-    std::memcpy(dst, src, count * sizeof(T));
+    ::memcpy(dst, src, count * sizeof(T));
     return true;
 #endif
 }
@@ -127,7 +127,7 @@ bool copyToHost(T* dst, const T* src, size_t count, Stream* stream  = nullptr) {
     return error == cudaSuccess;
 #else
     (void)stream;
-    std::memcpy(dst, src, count * sizeof(T));
+    ::memcpy(dst, src, count * sizeof(T));
     return true;
 #endif
 }

--- a/include/compat/shim.h
+++ b/include/compat/shim.h
@@ -45,11 +45,11 @@ namespace shim {
     string() : data_(nullptr), size_(0), capacity_(0) {}
     string(const char* s) : data_(nullptr), size_(0), capacity_(0) {
       if (s) {
-        size_ = strlen(s);
+        size_ = ::strlen(s);
         capacity_ = size_ + 1;
         data_ = static_cast<char*>(malloc(capacity_));
         if (data_) {
-          memcpy(data_, s, size_ + 1);
+          ::memcpy(data_, s, size_ + 1);
         } else {
           data_ = nullptr;
           size_ = capacity_ = 0;
@@ -67,7 +67,7 @@ namespace shim {
         capacity_ = size_ + 1;
         data_ = static_cast<char*>(malloc(capacity_));
         if (data_) {
-          memcpy(data_, other.data_, size_ + 1);
+          ::memcpy(data_, other.data_, size_ + 1);
         } else {
           size_ = capacity_ = 0;
         }
@@ -83,7 +83,7 @@ namespace shim {
           capacity_ = size_ + 1;
           data_ = static_cast<char*>(malloc(capacity_));
           if (data_) {
-            memcpy(data_, other.data_, size_ + 1);
+            ::memcpy(data_, other.data_, size_ + 1);
           } else {
             size_ = capacity_ = 0;
           }
@@ -96,11 +96,11 @@ namespace shim {
       data_ = nullptr;
       size_ = capacity_ = 0;
       if (s) {
-        size_ = strlen(s);
+        size_ = ::strlen(s);
         capacity_ = size_ + 1;
         data_ = static_cast<char*>(malloc(capacity_));
         if (data_) {
-          memcpy(data_, s, size_ + 1);
+          ::memcpy(data_, s, size_ + 1);
         } else {
           size_ = capacity_ = 0;
         }
@@ -157,7 +157,7 @@ namespace shim {
     // Comparison operators
     bool operator==(const char* s) const {
       if (!s) return size_ == 0;
-      return strcmp(c_str(), s) == 0;
+      return ::strcmp(c_str(), s) == 0;
     }
     bool operator!=(const char* s) const { return !(*this == s); }
     
@@ -179,7 +179,7 @@ namespace shim {
                         size_ - pos : count;
         char* temp = static_cast<char*>(malloc(rcount + 1));
         if (temp) {
-            memcpy(temp, data_ + pos, rcount);
+            ::memcpy(temp, data_ + pos, rcount);
             temp[rcount] = '\0';
             string result(temp);
             free(temp);
@@ -191,7 +191,7 @@ namespace shim {
     // Append operations
     string& append(const char* s) {
         if (s) {
-            size_t slen = strlen(s);
+            size_t slen = ::strlen(s);
             if (size_ + slen + 1 > capacity_) {
                 size_t new_cap = (size_ + slen + 1) * 2;
                 char* new_data = static_cast<char*>(realloc(data_, new_cap));
@@ -202,7 +202,7 @@ namespace shim {
                     return *this; // Failed to allocate
                 }
             }
-            memcpy(data_ + size_, s, slen + 1);
+            ::memcpy(data_ + size_, s, slen + 1);
             size_ += slen;
         }
         return *this;
@@ -221,7 +221,7 @@ namespace shim {
         if (size_ != other.size_) return false;
         if (!data_ && !other.data_) return true;
         if (!data_ || !other.data_) return false;
-        return memcmp(data_, other.data_, size_) == 0;
+        return ::memcmp(data_, other.data_, size_) == 0;
     }
 
     bool operator!=(const string& other) const {
@@ -231,7 +231,7 @@ namespace shim {
     bool operator<(const string& other) const {
         size_t min_size = (size_ < other.size_) ? size_ : other.size_;
         if (data_ && other.data_) {
-            int cmp = memcmp(data_, other.data_, min_size);
+            int cmp = ::memcmp(data_, other.data_, min_size);
             if (cmp != 0) return cmp < 0;
         }
         return size_ < other.size_;

--- a/src/blender/compression.cpp
+++ b/src/blender/compression.cpp
@@ -49,7 +49,7 @@ bool DeltaCompression::decompress(const std::vector<uint8_t>& compressed, void* 
   auto start = std::chrono::high_resolution_clock::now();
 
   if (previousBlock.empty()) {
-    std::memcpy(out, compressed.data(), outputSize);
+    ::memcpy(out, compressed.data(), outputSize);
   } else {
     for (size_t i = 0; i < outputSize; ++i) {
       uint8_t prev = previousBlock[i % previousBlock.size()];
@@ -187,7 +187,7 @@ std::vector<uint8_t> downsample(const void* data, size_t size, size_t factor) {
   size_t out_size = (size + factor - 1) / factor;
   std::vector<uint8_t> result(out_size);
   if (out_size > 0) {
-    std::memset(result.data(), 0, out_size);
+    ::memset(result.data(), 0, out_size);
   }
   for (size_t i = 0; i < out_size; ++i) {
     size_t begin = i * factor;

--- a/src/blender/gpu_context.cpp
+++ b/src/blender/gpu_context.cpp
@@ -102,7 +102,7 @@ GpuBufferPtr GPUContext::createBuffer(size_t size, const void* data) {
     }
     buf->size = size;
     if (data) {
-        std::memcpy(buf->ptr, data, size);
+        ::memcpy(buf->ptr, data, size);
     }
     buf->mapped = false;
     return GpuBufferPtr(this, buf);

--- a/src/blender/mesh_handler.cpp
+++ b/src/blender/mesh_handler.cpp
@@ -94,7 +94,7 @@ sep::SEPResult MeshHandler::addCustomDataLayer(const char* name, int type) {
     return sep::SEPResult::INITIALIZATION_FAILED;
   }
 
-  if (!name || std::strlen(name) == 0) {
+  if (!name || ::strlen(name) == 0) {
     return sep::SEPResult::INVALID_ARGUMENT;
   }
 
@@ -108,7 +108,7 @@ sep::SEPResult MeshHandler::addCustomDataLayer(const char* name, int type) {
 
   CustomDataLayer layer;
   layer.type = type;
-  std::strncpy(layer.name, name, sizeof(layer.name) - 1);
+  ::strncpy(layer.name, name, sizeof(layer.name) - 1);
   layer.name[sizeof(layer.name) - 1] = '\0';
   size_t vert_count = static_cast<size_t>(mesh_ ? mesh_->totvert : 0);
   if (vert_count == 0)
@@ -117,7 +117,7 @@ sep::SEPResult MeshHandler::addCustomDataLayer(const char* name, int type) {
   layer.active = true;
 
   layer.data = std::make_unique<char[]>(layer.size);
-  std::memset(layer.data.get(), 0, layer.size);
+  ::memset(layer.data.get(), 0, layer.size);
 
   custom_layers_.push_back(layer);
   cache_.metrics_valid = false;
@@ -129,12 +129,12 @@ sep::SEPResult MeshHandler::removeCustomDataLayer(const char* name) {
     return sep::SEPResult::INITIALIZATION_FAILED;
   }
 
-  if (!name || std::strlen(name) == 0) {
+  if (!name || ::strlen(name) == 0) {
     return sep::SEPResult::INVALID_ARGUMENT;
   }
 
   for (auto it = custom_layers_.begin(); it != custom_layers_.end(); ++it) {
-    if (std::strcmp(it->name, name) == 0) {
+    if (::strcmp(it->name, name) == 0) {
       custom_layers_.erase(it);
       cache_.metrics_valid = false;
       return sep::SEPResult::SUCCESS;
@@ -145,12 +145,12 @@ sep::SEPResult MeshHandler::removeCustomDataLayer(const char* name) {
 }
 
 bool MeshHandler::hasCustomDataLayer(const char* name) const {
-  if (!initialized_ || !name || std::strlen(name) == 0) {
+  if (!initialized_ || !name || ::strlen(name) == 0) {
     return false;
   }
 
   for (const auto& layer : custom_layers_) {
-    if (std::strcmp(layer.name, name) == 0) {
+    if (::strcmp(layer.name, name) == 0) {
       return true;
     }
   }
@@ -162,12 +162,12 @@ sep::SEPResult MeshHandler::setUniformFloatLayer(const char* name, float value) 
     return sep::SEPResult::INITIALIZATION_FAILED;
   }
 
-  if (!name || std::strlen(name) == 0) {
+  if (!name || ::strlen(name) == 0) {
     return sep::SEPResult::INVALID_ARGUMENT;
   }
 
   for (auto& layer : custom_layers_) {
-    if (std::strcmp(layer.name, name) == 0) {
+    if (::strcmp(layer.name, name) == 0) {
       float* data = reinterpret_cast<float*>(layer.data.get());
       size_t count = layer.size / sizeof(float);
       for (size_t i = 0; i < count; ++i) {
@@ -343,7 +343,7 @@ void MeshHandler::ensureCustomDataCapacity(size_t vertex_count) {
     if (layer.size != required) {
       layer.data.reset();
       layer.data = std::make_unique<char[]>(required);
-      std::memset(layer.data.get(), 0, required);
+      ::memset(layer.data.get(), 0, required);
       layer.size = required;
     }
   }

--- a/src/memory/memory_tier.cpp
+++ b/src/memory/memory_tier.cpp
@@ -2,6 +2,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cstdlib>
+#include <string.h>
 #include <cstring>
 #include <stdexcept>
 #include <vector>
@@ -205,7 +206,7 @@ sep::SEPResult MemoryTier::defragment() {
           return sep::SEPResult::CUDA_ERROR;
         }
 #else
-        std::memmove(new_location, block.ptr, block.size);
+        ::memmove(new_location, block.ptr, block.size);
 #endif
 
         block.ptr = new_location;
@@ -306,7 +307,7 @@ bool MemoryTier::moveData(MemoryBlock *dst, const MemoryBlock *src) {
   std::size_t size = std::min(dst->size, src->size);
 
   if (config_.type == TierType::HOST) {
-    std::memcpy(dst->ptr, src->ptr, size);
+    ::memcpy(dst->ptr, src->ptr, size);
   } else {
 #if SEP_MEMORY_HAS_CUDA
     cudaError_t err =
@@ -325,7 +326,7 @@ bool MemoryTier::moveData(MemoryBlock *dst, const MemoryBlock *src) {
       return false;
     }
 #else
-    std::memcpy(dst->ptr, src->ptr, size);
+    ::memcpy(dst->ptr, src->ptr, size);
 #endif
   }
   return true;
@@ -437,7 +438,7 @@ bool MemoryTier::resize(std::size_t new_size) {
       sep::metrics::allocationFailures().value++;
       return false;
     }
-    std::memcpy(static_cast<char *>(new_pool) + offset, block.ptr, block.size);
+    ::memcpy(static_cast<char *>(new_pool) + offset, block.ptr, block.size);
     new_blocks.emplace_back(static_cast<char *>(new_pool) + offset, block.size,
                             offset, config_.type);
     MemoryBlock &nb = new_blocks.back();

--- a/third_party/crow/include/crow/json.h
+++ b/third_party/crow/include/crow/json.h
@@ -11,6 +11,7 @@
 #endif
 #include <iostream>
 #include <algorithm>
+#include <string.h>
 #include <memory>
 #include <vector>
 #include <cmath>
@@ -749,9 +750,9 @@ namespace crow // NOTE: Already documented in "crow/app.h"
                 }
 
                 const std::size_t len = end_ - start_;
-                const bool has_minus = std::memchr(start_, '-', len) != nullptr;
-                const bool has_e = std::memchr(start_, 'e', len) != nullptr || std::memchr(start_, 'E', len) != nullptr;
-                const bool has_dec_sep = std::memchr(start_, '.', len) != nullptr;
+                const bool has_minus = ::memchr(start_, '-', len) != nullptr;
+                const bool has_e = ::memchr(start_, 'e', len) != nullptr || ::memchr(start_, 'E', len) != nullptr;
+                const bool has_dec_sep = ::memchr(start_, '.', len) != nullptr;
                 if (has_dec_sep || has_e)
                     nt_ = num_type::Floating_point;
                 else if (has_minus)


### PR DESCRIPTION
## Summary
- replace `std::memcpy`, `std::memset`, etc. with global namespace calls
- include `<string.h>` for headers that rely on C library functions
- update third_party Crow JSON implementation to use global `memchr`

## Testing
- `cmake -S _sep/testbed -B _sep/testbed/build`
- `cmake --build _sep/testbed/build --verbose`

------
https://chatgpt.com/codex/tasks/task_e_6867d47e7364832a976aa30b54f30c38