### PR TITLE
Fix C headers and remove std namespace use

### DIFF
--- a/src/blender/api.cpp
+++ b/src/blender/api.cpp
@@ -1,10 +1,6 @@
-#include <string.h> // For memcmp, memcpy, memset
-#include <time.h>   // For C time functions
-#include <cstring> // Added for C string functions
-#include <ctime>   // Added for C time functions
-#include <string>  // Required for std::string
-
-using namespace std; // For string type
+#include <cstring> // For memcpy, memset, memcmp, strlen, etc.
+#include <ctime>   // For time-related functions
+#include <string>  // For std::string
 #include "compat/math_common.h"
 
 #include "blender/types.h"

--- a/src/blender/blender_bridge.cpp
+++ b/src/blender/blender_bridge.cpp
@@ -1,7 +1,5 @@
 #include "blender/bridge.h"
-#include <string> // Required for std::string
-
-using namespace std; // For string type
+#include <string>  // For std::string
 #include "core/error_handler.h"
 #include "core/metrics_collector.h"
 #include <spdlog/spdlog.h>

--- a/src/blender/blender_integration.cpp
+++ b/src/blender/blender_integration.cpp
@@ -1,10 +1,6 @@
-#include <string.h> // For memcmp, memcpy, memset
-#include <time.h>   // For C time functions
-#include <cstring> // Added for C string functions
-#include <ctime>   // Added for C time functions
-#include <string>  // Required for std::string
-
-using namespace std; // For string type
+#include <cstring> // For memcpy, memset, memcmp, strlen, etc.
+#include <ctime>   // For time-related functions
+#include <string>  // For std::string
 #include "blender/pattern_bridge.h"
 #include <thread>
 #include <chrono>

--- a/src/blender/compression.cpp
+++ b/src/blender/compression.cpp
@@ -1,10 +1,6 @@
-#include <string.h> // For memcmp, memcpy, memset
-#include <time.h>   // For C time functions
-#include <cstring> // Added for C string functions
-#include <ctime>   // Added for C time functions
-#include <string>  // Required for std::string
-
-using namespace std; // For string type
+#include <cstring> // For memcpy, memset, memcmp, strlen, etc.
+#include <ctime>   // For time-related functions
+#include <string>  // For std::string
 #include "blender/compression.h"
 
 #include <lz4.h>
@@ -49,7 +45,7 @@ bool DeltaCompression::decompress(const std::vector<uint8_t>& compressed, void* 
   auto start = std::chrono::high_resolution_clock::now();
 
   if (previousBlock.empty()) {
-    ::memcpy(out, compressed.data(), outputSize);
+    std::memcpy(out, compressed.data(), outputSize);
   } else {
     for (size_t i = 0; i < outputSize; ++i) {
       uint8_t prev = previousBlock[i % previousBlock.size()];
@@ -187,7 +183,7 @@ std::vector<uint8_t> downsample(const void* data, size_t size, size_t factor) {
   size_t out_size = (size + factor - 1) / factor;
   std::vector<uint8_t> result(out_size);
   if (out_size > 0) {
-    ::memset(result.data(), 0, out_size);
+    std::memset(result.data(), 0, out_size);
   }
   for (size_t i = 0; i < out_size; ++i) {
     size_t begin = i * factor;

--- a/src/blender/compression_utils.cpp
+++ b/src/blender/compression_utils.cpp
@@ -1,11 +1,8 @@
-#include <string.h> // For memcmp, memcpy, memset
-#include <time.h>   // For C time functions
-#include <cstring> // Added for C string functions
-#include <ctime>   // Added for C time functions
-#include <string>  // Required for std::string
+#include <cstring> // For memcpy, memset, memcmp, strlen, etc.
+#include <ctime>   // For time-related functions
+#include <string>  // For std::string
 #include <vector>  // Already included below, but ensuring early availability
 #include <array>   // Already included below, but ensuring early availability
-using namespace std; // For string type and common C functions
 #include "blender/compression.h"
 #include "compat/math_common.h"
 

--- a/src/blender/cycles_renderer.cpp
+++ b/src/blender/cycles_renderer.cpp
@@ -1,10 +1,7 @@
 // Standard includes
-#include <string.h> // For memcmp, memcpy, memset
-#include <time.h>   // For C time functions
-#include <cstring> // Added for C string functions
-#include <ctime>   // Added for C time functions
-#include <string>  // Required for std::string
-using namespace std; // For string type and common C functions
+#include <cstring> // For memcpy, memset, memcmp, strlen, etc.
+#include <ctime>   // For time-related functions
+#include <string>  // For std::string
 #include <cmath>
 #include <memory>
 #include <utility>

--- a/src/blender/factory.cpp
+++ b/src/blender/factory.cpp
@@ -1,10 +1,6 @@
-#include <string.h> // For memcmp, memcpy, memset
-#include <time.h>   // For C time functions
-#include <cstring> // Added for C string functions
-#include <ctime>   // Added for C time functions
-#include <string> // Required for std::string
-
-using namespace std; // For string type
+#include <cstring> // For memcpy, memset, memcmp, strlen, etc.
+#include <ctime>   // For time-related functions
+#include <string>  // For std::string
 #include "blender/factory.h"
 #include "blender/bridge.h"
 #include "blender/types.h"

--- a/src/blender/gpu_context.cpp
+++ b/src/blender/gpu_context.cpp
@@ -1,10 +1,7 @@
-#include <string.h> // For memcmp, memcpy, memset
-#include <time.h>   // For C time functions
-#include <cstring> // Added for C string functions
-#include <ctime>   // Added for C time functions
-#include <string> // Required for std::string
+#include <cstring> // For memcpy, memset, memcmp, etc.
+#include <ctime>   // For time-related functions
+#include <string>  // For std::string
 
-using namespace std; // For string type
 #include "blender/gpu_context.h"
 #include <cstdlib>
 #include <new>
@@ -102,7 +99,7 @@ GpuBufferPtr GPUContext::createBuffer(size_t size, const void* data) {
     }
     buf->size = size;
     if (data) {
-        ::memcpy(buf->ptr, data, size);
+        std::memcpy(buf->ptr, data, size);
     }
     buf->mapped = false;
     return GpuBufferPtr(this, buf);

--- a/src/blender/mesh_handler.cpp
+++ b/src/blender/mesh_handler.cpp
@@ -7,13 +7,9 @@
 #include "core/common.h"  // defines sep::SEPResult
 
 // Standard library includes
-#include <string.h> // For memcmp, memcpy, memset
-#include <time.h>   // For C time functions
-#include <cstring> // Added for C string functions
-#include <ctime>   // Added for C time functions
-#include <string> // Required for std::string
-
-using namespace std; // For string type and common C functions
+#include <cstring> // For memcpy, memset, memcmp, strlen, etc.
+#include <ctime>   // For time-related functions
+#include <string>  // For std::string
 
 // Minimal stand-ins for Blender API functions. These are no-ops here but allow
 // the library to link without the real Blender environment.
@@ -94,7 +90,7 @@ sep::SEPResult MeshHandler::addCustomDataLayer(const char* name, int type) {
     return sep::SEPResult::INITIALIZATION_FAILED;
   }
 
-  if (!name || ::strlen(name) == 0) {
+  if (!name || std::strlen(name) == 0) {
     return sep::SEPResult::INVALID_ARGUMENT;
   }
 
@@ -108,7 +104,7 @@ sep::SEPResult MeshHandler::addCustomDataLayer(const char* name, int type) {
 
   CustomDataLayer layer;
   layer.type = type;
-  ::strncpy(layer.name, name, sizeof(layer.name) - 1);
+  std::strncpy(layer.name, name, sizeof(layer.name) - 1);
   layer.name[sizeof(layer.name) - 1] = '\0';
   size_t vert_count = static_cast<size_t>(mesh_ ? mesh_->totvert : 0);
   if (vert_count == 0)
@@ -117,7 +113,7 @@ sep::SEPResult MeshHandler::addCustomDataLayer(const char* name, int type) {
   layer.active = true;
 
   layer.data = std::make_unique<char[]>(layer.size);
-  ::memset(layer.data.get(), 0, layer.size);
+  std::memset(layer.data.get(), 0, layer.size);
 
   custom_layers_.push_back(layer);
   cache_.metrics_valid = false;
@@ -129,12 +125,12 @@ sep::SEPResult MeshHandler::removeCustomDataLayer(const char* name) {
     return sep::SEPResult::INITIALIZATION_FAILED;
   }
 
-  if (!name || ::strlen(name) == 0) {
+  if (!name || std::strlen(name) == 0) {
     return sep::SEPResult::INVALID_ARGUMENT;
   }
 
   for (auto it = custom_layers_.begin(); it != custom_layers_.end(); ++it) {
-    if (::strcmp(it->name, name) == 0) {
+    if (std::strcmp(it->name, name) == 0) {
       custom_layers_.erase(it);
       cache_.metrics_valid = false;
       return sep::SEPResult::SUCCESS;
@@ -145,12 +141,12 @@ sep::SEPResult MeshHandler::removeCustomDataLayer(const char* name) {
 }
 
 bool MeshHandler::hasCustomDataLayer(const char* name) const {
-  if (!initialized_ || !name || ::strlen(name) == 0) {
+  if (!initialized_ || !name || std::strlen(name) == 0) {
     return false;
   }
 
   for (const auto& layer : custom_layers_) {
-    if (::strcmp(layer.name, name) == 0) {
+    if (std::strcmp(layer.name, name) == 0) {
       return true;
     }
   }
@@ -162,12 +158,12 @@ sep::SEPResult MeshHandler::setUniformFloatLayer(const char* name, float value) 
     return sep::SEPResult::INITIALIZATION_FAILED;
   }
 
-  if (!name || ::strlen(name) == 0) {
+  if (!name || std::strlen(name) == 0) {
     return sep::SEPResult::INVALID_ARGUMENT;
   }
 
   for (auto& layer : custom_layers_) {
-    if (::strcmp(layer.name, name) == 0) {
+    if (std::strcmp(layer.name, name) == 0) {
       float* data = reinterpret_cast<float*>(layer.data.get());
       size_t count = layer.size / sizeof(float);
       for (size_t i = 0; i < count; ++i) {
@@ -343,7 +339,7 @@ void MeshHandler::ensureCustomDataCapacity(size_t vertex_count) {
     if (layer.size != required) {
       layer.data.reset();
       layer.data = std::make_unique<char[]>(required);
-      ::memset(layer.data.get(), 0, required);
+      std::memset(layer.data.get(), 0, required);
       layer.size = required;
     }
   }

--- a/src/blender/oiio_output_driver.cpp
+++ b/src/blender/oiio_output_driver.cpp
@@ -2,12 +2,9 @@
 #define CCL_NAMESPACE_BEGIN namespace ccl {
 #define CCL_NAMESPACE_END }
 
-#include <string.h> // For memcmp, memcpy, memset
-#include <time.h>   // For C time functions
-#include <cstring> // Added for C string functions
-#include <ctime>   // Added for C time functions
-#include <string> // Required for std::string
-using namespace std; // For string type and common C functions
+#include <cstring> // For memcpy, memset, memcmp, strlen, etc.
+#include <ctime>   // For time-related functions
+#include <string>  // For std::string
 #include "blender/oiio_output_driver.h"
 
 // Core Cycles includes
@@ -25,7 +22,6 @@ using namespace std; // For string type and common C functions
 
 // Standard includes
 #include <vector>
-#include <cstring>
 
 namespace OIIO = OpenImageIO_v2_5;
 

--- a/src/blender/pattern_visualization_pipeline.cpp
+++ b/src/blender/pattern_visualization_pipeline.cpp
@@ -1,10 +1,6 @@
-#include <string.h> // For memcmp, memcpy, memset
-#include <time.h>   // For C time functions
-#include <cstring> // Added for C string functions
-#include <ctime>   // Added for C time functions
-#include <string> // Required for std::string
-
-using namespace std; // For string type and common C functions
+#include <cstring> // For memcpy, memset, memcmp, strlen, etc.
+#include <ctime>   // For time-related functions
+#include <string>  // For std::string
 #include "blender/pattern_visualization_pipeline.h"
 #include "compat/shim.h"
 #include "core/common.h"  // defines sep::SEPResult


### PR DESCRIPTION
## Summary
- ensure standard C headers are included for Blender sources
- remove `using namespace std` to avoid namespace conflicts
- use `std::` qualifiers for C string functions

## Testing
- `bash tests/blender/run_tests.sh` *(fails: `Could not find nvcc`)*

------
https://chatgpt.com/codex/tasks/task_e_6867e3f59658832ab03b077e1b030a75