### PR TITLE
Fix comment typo in shim header

### DIFF
--- a/include/compat/shim.h
+++ b/include/compat/shim.h
@@ -4,7 +4,7 @@
 // `SEP_NO_STDLIB`.  Default builds rely on the system standard library and
 // should not define this macro.
 
-// Ensure C standard library functions are in the global namespace firstddddd
+// Ensure C standard library functions are in the global namespace first
 #include <cstring>  // For memcpy, memset, memcmp, strlen, etc.
 #include <ctime>    // For time, clock, difftime, mktime, etc.
 #include <stdlib.h>  // For malloc, free, getenv, etc.


### PR DESCRIPTION
## Summary
- fix the typo in `include/compat/shim.h`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867e69f7c64832aa42766e0379334b1