### PR TITLE
Fix C string and time header usage

### DIFF
--- a/src/memory/memory_tier.cpp
+++ b/src/memory/memory_tier.cpp
@@ -2,7 +2,6 @@
 #include <algorithm>
 #include <cassert>
 #include <cstdlib>
-#include <string.h>
 #include <cstring>
 #include <stdexcept>
 #include <vector>
@@ -307,7 +306,7 @@ bool MemoryTier::moveData(MemoryBlock *dst, const MemoryBlock *src) {
   std::size_t size = std::min(dst->size, src->size);
 
   if (config_.type == TierType::HOST) {
-    ::memcpy(dst->ptr, src->ptr, size);
+    std::memcpy(dst->ptr, src->ptr, size);
   } else {
 #if SEP_MEMORY_HAS_CUDA
     cudaError_t err =
@@ -326,7 +325,7 @@ bool MemoryTier::moveData(MemoryBlock *dst, const MemoryBlock *src) {
       return false;
     }
 #else
-    ::memcpy(dst->ptr, src->ptr, size);
+    std::memcpy(dst->ptr, src->ptr, size);
 #endif
   }
   return true;
@@ -438,7 +437,7 @@ bool MemoryTier::resize(std::size_t new_size) {
       sep::metrics::allocationFailures().value++;
       return false;
     }
-    ::memcpy(static_cast<char *>(new_pool) + offset, block.ptr, block.size);
+    std::memcpy(static_cast<char *>(new_pool) + offset, block.ptr, block.size);
     new_blocks.emplace_back(static_cast<char *>(new_pool) + offset, block.size,
                             offset, config_.type);
     MemoryBlock &nb = new_blocks.back();


### PR DESCRIPTION
## Summary
- drop `<string.h>` include from `memory_tier.cpp`
- rely on `<cstring>` and qualify memcpy calls with `std::`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867e69f7c64832aa42766e0379334b1