### PR TITLE
Fix header includes for compatibility

### DIFF
--- a/include/compat/shim.h
+++ b/include/compat/shim.h
@@ -4,7 +4,7 @@
 // `SEP_NO_STDLIB`.  Default builds rely on the system standard library and
 // should not define this macro.
 
-// Ensure C standard library functions are in the global namespace firstddddd
+// Ensure C standard library functions are in the global namespace first
 #include <cstring>  // For memcpy, memset, memcmp, strlen, etc.
 #include <ctime>    // For time, clock, difftime, mktime, etc.
 #include <stdlib.h>  // For malloc, free, getenv, etc.

--- a/src/blender/oiio_output_driver.cpp
+++ b/src/blender/oiio_output_driver.cpp
@@ -1,9 +1,9 @@
+#include <cstring> // For memcpy, memset, memcmp, strlen, etc.
+#include <ctime>   // For time-related functions
+
 // Define Cycles namespace macros
 #define CCL_NAMESPACE_BEGIN namespace ccl {
 #define CCL_NAMESPACE_END }
-
-#include <cstring> // For memcpy, memset, memcmp, strlen, etc.
-#include <ctime>   // For time-related functions
 #include <string>  // For std::string
 #include "blender/oiio_output_driver.h"
 


### PR DESCRIPTION
## Summary
- ensure C headers in shim don't have typo
- move cstring/ctime to top of oiio driver for clarity

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867e69f7c64832aa42766e0379334b1