### PR TITLE
Fix missing C headers for GCC 14

### DIFF
--- a/include/compat/shim.h
+++ b/include/compat/shim.h
@@ -4,9 +4,11 @@
 // `SEP_NO_STDLIB`.  Default builds rely on the system standard library and
 // should not define this macro.
 
-// Ensure C standard library functions are in the global namespace firstddddd
-#include <cstring>  // For memcpy, memset, memcmp, strlen, etc.
-#include <ctime>    // For time, clock, difftime, mktime, etc.
+#include <string.h>  // For memcpy, memset, memcmp, strlen, etc.
+#include <time.h>    // For time, clock, difftime, mktime, etc.
+// Ensure C++ wrappers of the C headers are also available
+#include <cstring>
+#include <ctime>
 #include <stdlib.h>  // For malloc, free, getenv, etc.
 #include <stdio.h>   // For snprintf, fprintf, etc.
 #include <stdint.h>  // For uint32_t, uint64_t etc.

--- a/src/api/bridge_c.cpp
+++ b/src/api/bridge_c.cpp
@@ -1,3 +1,4 @@
+#include <string.h>
 #include <cstring>
 #include <cstdio>
 #include <memory>
@@ -18,6 +19,7 @@
 #include "crow/socket_adaptors.h"
 #include <ios>
 #include <nlohmann/json.hpp>
+#include <string.h>
 #include <cstring>
 #include <cstdio>  // Required for snprintf
 #include <memory>

--- a/src/blender/api.cpp
+++ b/src/blender/api.cpp
@@ -1,5 +1,7 @@
-#include <cstring> // For memcpy, memset, memcmp, strlen, etc.
-#include <ctime>   // For time-related functions
+#include <string.h> // For memcpy, memset, memcmp, strlen, etc.
+#include <time.h>   // For time-related functions
+#include <cstring>  // C++ wrappers
+#include <ctime>
 #include <string>  // For std::string
 #include "compat/math_common.h"
 

--- a/src/blender/blender_bridge.cpp
+++ b/src/blender/blender_bridge.cpp
@@ -1,5 +1,9 @@
 #include "blender/bridge.h"
 #include <string>  // For std::string
+#include <string.h> // For memcpy, memset, memcmp, strlen, etc.
+#include <time.h>   // For time-related functions
+#include <cstring>
+#include <ctime>
 #include "core/error_handler.h"
 #include "core/metrics_collector.h"
 #include <spdlog/spdlog.h>

--- a/src/blender/blender_integration.cpp
+++ b/src/blender/blender_integration.cpp
@@ -1,5 +1,7 @@
-#include <cstring> // For memcpy, memset, memcmp, strlen, etc.
-#include <ctime>   // For time-related functions
+#include <string.h> // For memcpy, memset, memcmp, strlen, etc.
+#include <time.h>   // For time-related functions
+#include <cstring>
+#include <ctime>
 #include <string>  // For std::string
 #include "blender/pattern_bridge.h"
 #include <thread>

--- a/src/blender/compression.cpp
+++ b/src/blender/compression.cpp
@@ -1,5 +1,7 @@
-#include <cstring> // For memcpy, memset, memcmp, strlen, etc.
-#include <ctime>   // For time-related functions
+#include <string.h> // For memcpy, memset, memcmp, strlen, etc.
+#include <time.h>   // For time-related functions
+#include <cstring>
+#include <ctime>
 #include <string>  // For std::string
 #include "blender/compression.h"
 

--- a/src/blender/compression_utils.cpp
+++ b/src/blender/compression_utils.cpp
@@ -1,5 +1,7 @@
-#include <cstring> // For memcpy, memset, memcmp, strlen, etc.
-#include <ctime>   // For time-related functions
+#include <string.h> // For memcpy, memset, memcmp, strlen, etc.
+#include <time.h>   // For time-related functions
+#include <cstring>
+#include <ctime>
 #include <string>  // For std::string
 #include <vector>  // Already included below, but ensuring early availability
 #include <array>   // Already included below, but ensuring early availability

--- a/src/blender/cycles_renderer.cpp
+++ b/src/blender/cycles_renderer.cpp
@@ -1,6 +1,8 @@
 // Standard includes
-#include <cstring> // For memcpy, memset, memcmp, strlen, etc.
-#include <ctime>   // For time-related functions
+#include <string.h> // For memcpy, memset, memcmp, strlen, etc.
+#include <time.h>   // For time-related functions
+#include <cstring>
+#include <ctime>
 #include <string>  // For std::string
 #include <cmath>
 #include <memory>

--- a/src/blender/factory.cpp
+++ b/src/blender/factory.cpp
@@ -1,5 +1,7 @@
-#include <cstring> // For memcpy, memset, memcmp, strlen, etc.
-#include <ctime>   // For time-related functions
+#include <string.h> // For memcpy, memset, memcmp, strlen, etc.
+#include <time.h>   // For time-related functions
+#include <cstring>
+#include <ctime>
 #include <string>  // For std::string
 #include "blender/factory.h"
 #include "blender/bridge.h"

--- a/src/blender/gpu_context.cpp
+++ b/src/blender/gpu_context.cpp
@@ -1,5 +1,7 @@
-#include <cstring> // For memcpy, memset, memcmp, etc.
-#include <ctime>   // For time-related functions
+#include <string.h> // For memcpy, memset, memcmp, etc.
+#include <time.h>   // For time-related functions
+#include <cstring>
+#include <ctime>
 #include <string>  // For std::string
 
 #include "blender/gpu_context.h"

--- a/src/blender/mesh_handler.cpp
+++ b/src/blender/mesh_handler.cpp
@@ -7,8 +7,10 @@
 #include "core/common.h"  // defines sep::SEPResult
 
 // Standard library includes
-#include <cstring> // For memcpy, memset, memcmp, strlen, etc.
-#include <ctime>   // For time-related functions
+#include <string.h> // For memcpy, memset, memcmp, strlen, etc.
+#include <time.h>   // For time-related functions
+#include <cstring>
+#include <ctime>
 #include <string>  // For std::string
 
 // Minimal stand-ins for Blender API functions. These are no-ops here but allow

--- a/src/blender/oiio_output_driver.cpp
+++ b/src/blender/oiio_output_driver.cpp
@@ -2,8 +2,10 @@
 #define CCL_NAMESPACE_BEGIN namespace ccl {
 #define CCL_NAMESPACE_END }
 
-#include <cstring> // For memcpy, memset, memcmp, strlen, etc.
-#include <ctime>   // For time-related functions
+#include <string.h> // For memcpy, memset, memcmp, strlen, etc.
+#include <time.h>   // For time-related functions
+#include <cstring>
+#include <ctime>
 #include <string>  // For std::string
 #include "blender/oiio_output_driver.h"
 

--- a/src/blender/pattern_visualization_pipeline.cpp
+++ b/src/blender/pattern_visualization_pipeline.cpp
@@ -1,5 +1,7 @@
-#include <cstring> // For memcpy, memset, memcmp, strlen, etc.
-#include <ctime>   // For time-related functions
+#include <string.h> // For memcpy, memset, memcmp, strlen, etc.
+#include <time.h>   // For time-related functions
+#include <cstring>
+#include <ctime>
 #include <string>  // For std::string
 #include "blender/pattern_visualization_pipeline.h"
 #include "compat/shim.h"


### PR DESCRIPTION
## Summary
- ensure global C symbols are provided via `shim.h`
- include `<string.h>`/`<time.h>` in Blender sources and bridge C API

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867e69f7c64832aa42766e0379334b1