### PR TITLE
Fix missing std headers

### DIFF
--- a/src/api/sep_engine.cpp
+++ b/src/api/sep_engine.cpp
@@ -11,6 +11,8 @@
 #include <atomic>
 #include <thread>
 #include <vector>
+#include <cstring>
+#include <ctime>
 
 // GLM includes
 

--- a/src/core/engine.cpp
+++ b/src/core/engine.cpp
@@ -38,6 +38,7 @@
 #include <cstdint>
 #include <algorithm>
 #include <cstdio>
+#include <cstring>
 #include <exception>
 #include <numeric>
 


### PR DESCRIPTION
## Summary
- include `<cstring>` and `<ctime>` in `sep_engine.cpp`
- include `<cstring>` in `core/engine.cpp`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867eed707c8832aaee9d4653db65d8c