### PR TITLE
Fix missing time includes

### DIFF
--- a/include/compat/shim.h
+++ b/include/compat/shim.h
@@ -16,6 +16,7 @@
 #include <stddef.h>  // For size_t, ptrdiff_t
 #include <math.h>    // For math functions
 #include <setjmp.h>  // For __jmp_buf
+#include <chrono>    // For CLOCK_MONOTONIC and chrono utilities
 
 // Now include C++ headers that depend on C functions being in global namespace
 #include <string>

--- a/src/api/sep_engine.cpp
+++ b/src/api/sep_engine.cpp
@@ -2,6 +2,7 @@
 
 // Standard includes first
 #include <chrono>
+#include <time.h>
 #include <iomanip>
 #include <iostream>
 #include <memory>


### PR DESCRIPTION
## Summary
- ensure `shim.h` provides chrono utilities by including `<chrono>`
- include `<time.h>` in `sep_engine.cpp`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6867eed707c8832aaee9d4653db65d8c