### PR TITLE
Fix compile errors due to missing cstring includes

### DIFF
--- a/include/api/client.h
+++ b/include/api/client.h
@@ -3,6 +3,7 @@
 
 #include "api/types.h"
 #include "api/ollama_types.h"
+#include <cstring> // Ensure mem* functions are available before curl headers
 #include "curl/curl.h"
 #include "core/common.h"
 

--- a/include/compat/shim.h
+++ b/include/compat/shim.h
@@ -26,6 +26,7 @@
 #include <cstddef>
 #include <ctime>
 #include <cmath>
+#include <chrono>
 
 // Additional C++ headers
 #include <functional>

--- a/src/api/client.cpp
+++ b/src/api/client.cpp
@@ -1,10 +1,11 @@
 #include "api/client.h"
+#include <cstring> // Ensure C string functions available before curl headers
 #include "curl/curl.h"
 #include <memory>
 #include <string>
+
 #include <stdexcept>
 #include <utility>
-#include <cstring>
 
 
 #include "core/error_handler.h"  // For sep::ErrorCode

--- a/src/api/crow_adapter.cpp
+++ b/src/api/crow_adapter.cpp
@@ -14,6 +14,9 @@
 #include "crow/http_request.h"
 #include "crow/http_response.h"
 
+// Ensure C string functions are available for any API headers using them
+#include <cstring>
+
 // Include our API headers
 #include "api/crow_adapter.h"
 #include "api/json_helpers.h"
@@ -23,7 +26,6 @@
 #include "core/types.h"  // For sep::config::APIConfig
 #include "core/manager.h" // For sep::config::ConfigManager
 #include "memory/memory_tier_manager.hpp"
-#include <cstring>
 
 // Include standard headers
 #include <memory>

--- a/src/api/sep_engine.cpp
+++ b/src/api/sep_engine.cpp
@@ -11,6 +11,8 @@
 #include <atomic>
 #include <thread>
 #include <vector>
+#include <cstring>  // For std::memcpy, std::memcmp, etc.
+#include <ctime>    // For CLOCK_MONOTONIC on some platforms
 
 // GLM includes
 

--- a/src/core/engine.cpp
+++ b/src/core/engine.cpp
@@ -39,6 +39,7 @@
 #include <algorithm>
 #include <cstdio>
 #include <exception>
+#include <cstring>  // For std::memcpy, std::memcmp if used in headers
 #include <numeric>
 
 // Define namespace alias for clarity


### PR DESCRIPTION
## Summary
- ensure curl clients include `<cstring>` before `curl/curl.h`
- add `<chrono>` to shim header for clock constants
- include `<cstring>` in various implementation files and move the include earlier in crow adapter
- add missing includes to SEP engine and core engine implementations

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867eed707c8832aaee9d4653db65d8c