### PR TITLE
Fix build issues by adding missing C headers

### DIFF
--- a/src/audio/pipewire_capture.cpp
+++ b/src/audio/pipewire_capture.cpp
@@ -1,6 +1,8 @@
 #include "audio/pipewire_capture.h"
 #include "audio/types.h"
 #include "audio/capture.h"
+#include <string.h> // For strerror, strncmp, strstr
+#include <time.h>   // For CLOCK_MONOTONIC, nanosleep
 #include "audio/config.h"
 
 #ifdef SEP_HAS_AUDIO

--- a/src/audio/pipewire_capture.cpp
+++ b/src/audio/pipewire_capture.cpp
@@ -1,8 +1,8 @@
 #include "audio/pipewire_capture.h"
 #include "audio/types.h"
 #include "audio/capture.h"
-#include <string.h> // For strerror, strncmp, strstr
-#include <time.h>   // For CLOCK_MONOTONIC, nanosleep
+#include <string.h>
+#include <time.h>
 #include "audio/config.h"
 
 #ifdef SEP_HAS_AUDIO

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,8 +1,8 @@
 #include "core/manager.h"
 #include "core/engine.h"
 #include "core/common.h"
-#include <time.h>   // For nanosleep, CLOCK_MONOTONIC
-#include <unistd.h> // For nanosleep
+#include <time.h>
+#include <unistd.h>
 #include "core/logging.h"
 #include <curl/curl.h> 
 #include <cstring>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,8 @@
 #include "core/manager.h"
 #include "core/engine.h"
 #include "core/common.h"
+#include <time.h>   // For nanosleep, CLOCK_MONOTONIC
+#include <unistd.h> // For nanosleep
 #include "core/logging.h"
 #include <curl/curl.h> 
 #include <cstring>


### PR DESCRIPTION
## Summary
- include `<string.h>` and `<time.h>` for PipeWire capture
- include `<time.h>` and `<unistd.h>` in `main.cpp` for POSIX time support

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867f19a0184832aa1772add2b420a8a