### PR TITLE
Add standard library includes for Linux build

### DIFF
--- a/include/compat/shim.h
+++ b/include/compat/shim.h
@@ -6,6 +6,7 @@
 
 #include <string.h>  // For memcpy, memset, memcmp, strlen, etc.
 #include <time.h>    // For time, clock, difftime, mktime, etc.
+#include <unistd.h>  // For nanosleep, getpid, etc.
 // Ensure C++ wrappers of the C headers are also available
 #include <cstring>
 #include <ctime>

--- a/src/audio/pipewire_capture.cpp
+++ b/src/audio/pipewire_capture.cpp
@@ -1,8 +1,8 @@
 #include "audio/pipewire_capture.h"
 #include "audio/types.h"
 #include "audio/capture.h"
-#include <string.h>
-#include <time.h>
+#include <string.h> // For strerror, memcpy, etc.
+#include <time.h>   // For timespec and nanosleep
 #include "audio/config.h"
 
 #ifdef SEP_HAS_AUDIO

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,8 +1,8 @@
 #include "core/manager.h"
 #include "core/engine.h"
 #include "core/common.h"
-#include <time.h>
-#include <unistd.h>
+#include <time.h>   // For std::tm, nanosleep
+#include <unistd.h> // For POSIX-specific APIs
 #include "core/logging.h"
 #include <curl/curl.h> 
 #include <cstring>


### PR DESCRIPTION
## Summary
- fix missing headers by adding `unistd.h` to `compat/shim.h`
- clarify `string.h` and `time.h` usage in PipeWire capture
- document POSIX includes in `main.cpp`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6867f7287598832a883382783344a388