### PR TITLE
Fix duplicate cleanup, modernize shim

### DIFF
--- a/include/blender/bridge.h
+++ b/include/blender/bridge.h
@@ -121,7 +121,6 @@ class BlenderBridge {
   ObjectState* getObjectState(sep::pattern::ObjectHandle handle);
   void cleanup();
   void cleanupObject(sep::pattern::ObjectHandle handle);
-  void cleanup();
 
   void updateResourceStats();
   float calculateResourceUtilization(sep::pattern::ResourceType type) const;

--- a/include/compat/shim.h
+++ b/include/compat/shim.h
@@ -50,11 +50,11 @@ namespace shim {
     string() : data_(nullptr), size_(0), capacity_(0) {}
     string(const char* s) : data_(nullptr), size_(0), capacity_(0) {
       if (s) {
-        size_ = ::strlen(s);
+        size_ = std::strlen(s);
         capacity_ = size_ + 1;
-        data_ = static_cast<char*>(malloc(capacity_));
+        data_ = static_cast<char*>(std::malloc(capacity_));
         if (data_) {
-          ::memcpy(data_, s, size_ + 1);
+          std::memcpy(data_, s, size_ + 1);
         } else {
           data_ = nullptr;
           size_ = capacity_ = 0;
@@ -70,9 +70,9 @@ namespace shim {
       if (other.data_) {
         size_ = other.size_;
         capacity_ = size_ + 1;
-        data_ = static_cast<char*>(malloc(capacity_));
+        data_ = static_cast<char*>(std::malloc(capacity_));
         if (data_) {
-          ::memcpy(data_, other.data_, size_ + 1);
+          std::memcpy(data_, other.data_, size_ + 1);
         } else {
           size_ = capacity_ = 0;
         }
@@ -80,15 +80,15 @@ namespace shim {
     }
     string& operator=(const string& other) {
       if (this != &other) {
-        if (data_) free(data_);
+        if (data_) std::free(data_);
         data_ = nullptr;
         size_ = capacity_ = 0;
         if (other.data_) {
           size_ = other.size_;
           capacity_ = size_ + 1;
-          data_ = static_cast<char*>(malloc(capacity_));
+          data_ = static_cast<char*>(std::malloc(capacity_));
           if (data_) {
-            ::memcpy(data_, other.data_, size_ + 1);
+            std::memcpy(data_, other.data_, size_ + 1);
           } else {
             size_ = capacity_ = 0;
           }
@@ -97,15 +97,15 @@ namespace shim {
       return *this;
     }
     string& operator=(const char* s) {
-      if (data_) free(data_);
+      if (data_) std::free(data_);
       data_ = nullptr;
       size_ = capacity_ = 0;
       if (s) {
-        size_ = ::strlen(s);
+        size_ = std::strlen(s);
         capacity_ = size_ + 1;
-        data_ = static_cast<char*>(malloc(capacity_));
+        data_ = static_cast<char*>(std::malloc(capacity_));
         if (data_) {
-          ::memcpy(data_, s, size_ + 1);
+          std::memcpy(data_, s, size_ + 1);
         } else {
           size_ = capacity_ = 0;
         }
@@ -126,7 +126,7 @@ namespace shim {
     operator std::string() const { return std::string(c_str()); }
     ~string() {
       if (data_) {
-        free(data_);
+        std::free(data_);
         data_ = nullptr;
       }
     }
@@ -162,7 +162,7 @@ namespace shim {
     // Comparison operators
     bool operator==(const char* s) const {
       if (!s) return size_ == 0;
-      return ::strcmp(c_str(), s) == 0;
+      return std::strcmp(c_str(), s) == 0;
     }
     bool operator!=(const char* s) const { return !(*this == s); }
     
@@ -182,12 +182,12 @@ namespace shim {
         if (pos >= size_) return string();
         size_t rcount = (count == npos || pos + count > size_) ?
                         size_ - pos : count;
-        char* temp = static_cast<char*>(malloc(rcount + 1));
+        char* temp = static_cast<char*>(std::malloc(rcount + 1));
         if (temp) {
-            ::memcpy(temp, data_ + pos, rcount);
+            std::memcpy(temp, data_ + pos, rcount);
             temp[rcount] = '\0';
             string result(temp);
-            free(temp);
+            std::free(temp);
             return result;
         }
         return string();
@@ -196,10 +196,10 @@ namespace shim {
     // Append operations
     string& append(const char* s) {
         if (s) {
-            size_t slen = ::strlen(s);
+            size_t slen = std::strlen(s);
             if (size_ + slen + 1 > capacity_) {
                 size_t new_cap = (size_ + slen + 1) * 2;
-                char* new_data = static_cast<char*>(realloc(data_, new_cap));
+                char* new_data = static_cast<char*>(std::realloc(data_, new_cap));
                 if (new_data) {
                     data_ = new_data;
                     capacity_ = new_cap;
@@ -207,7 +207,7 @@ namespace shim {
                     return *this; // Failed to allocate
                 }
             }
-            ::memcpy(data_ + size_, s, slen + 1);
+            std::memcpy(data_ + size_, s, slen + 1);
             size_ += slen;
         }
         return *this;
@@ -226,7 +226,7 @@ namespace shim {
         if (size_ != other.size_) return false;
         if (!data_ && !other.data_) return true;
         if (!data_ || !other.data_) return false;
-        return ::memcmp(data_, other.data_, size_) == 0;
+        return std::memcmp(data_, other.data_, size_) == 0;
     }
 
     bool operator!=(const string& other) const {
@@ -236,7 +236,7 @@ namespace shim {
     bool operator<(const string& other) const {
         size_t min_size = (size_ < other.size_) ? size_ : other.size_;
         if (data_ && other.data_) {
-            int cmp = ::memcmp(data_, other.data_, min_size);
+            int cmp = std::memcmp(data_, other.data_, min_size);
             if (cmp != 0) return cmp < 0;
         }
         return size_ < other.size_;
@@ -423,7 +423,7 @@ namespace shim {
   // Memory management - minimal implementations
   inline void* aligned_alloc(size_t alignment, size_t size) {
     (void)alignment;  // alignment parameter unused in fallback implementation
-    return ::malloc(size); // Not properly aligned but simple fallback
+    return std::malloc(size); // Not properly aligned but simple fallback
   }
   
   // Smart pointer helpers were previously defined here when the standard

--- a/src/blender/blender_bridge.cpp
+++ b/src/blender/blender_bridge.cpp
@@ -28,13 +28,6 @@ void BlenderBridge::cleanup() {
     // For now, this is a placeholder.
 }
 
-mutable std::mutex objects_mutex_;
-
-void BlenderBridge::cleanup() {
-    // Perform any necessary cleanup, e.g., deallocating memory.
-    // For now, this is a placeholder.
-}
-
 sep::SEPResult BlenderBridge::init(::sep::GPUContext* ctx) {
     std::lock_guard<std::mutex> lock(objects_mutex_);
     


### PR DESCRIPTION
## Summary
- remove duplicate cleanup declarations/definitions in BlenderBridge
- modernize `compat/shim.h` to use `std::` memory/string functions

## Testing
- `cmake .. -DSEP_BUILD_TESTS=ON` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_68698cebcd5c832a8be459a967785461