### PR TITLE
Fix headers and C string usage

### DIFF
--- a/include/compat/shim.h
+++ b/include/compat/shim.h
@@ -36,6 +36,8 @@
 #include <queue>
 #include <vector>
 #include <mutex>
+#include <cstring>
+#include <cstdlib>
 
 namespace sep {
 namespace shim {
@@ -50,11 +52,11 @@ namespace shim {
     string() : data_(nullptr), size_(0), capacity_(0) {}
     string(const char* s) : data_(nullptr), size_(0), capacity_(0) {
       if (s) {
-        size_ = std::strlen(s);
+        size_ = strlen(s);
         capacity_ = size_ + 1;
         data_ = static_cast<char*>(std::malloc(capacity_));
         if (data_) {
-          std::memcpy(data_, s, size_ + 1);
+          memcpy(data_, s, size_ + 1);
         } else {
           data_ = nullptr;
           size_ = capacity_ = 0;
@@ -72,7 +74,7 @@ namespace shim {
         capacity_ = size_ + 1;
         data_ = static_cast<char*>(std::malloc(capacity_));
         if (data_) {
-          std::memcpy(data_, other.data_, size_ + 1);
+          memcpy(data_, other.data_, size_ + 1);
         } else {
           size_ = capacity_ = 0;
         }
@@ -88,7 +90,7 @@ namespace shim {
           capacity_ = size_ + 1;
           data_ = static_cast<char*>(std::malloc(capacity_));
           if (data_) {
-            std::memcpy(data_, other.data_, size_ + 1);
+            memcpy(data_, other.data_, size_ + 1);
           } else {
             size_ = capacity_ = 0;
           }
@@ -101,11 +103,11 @@ namespace shim {
       data_ = nullptr;
       size_ = capacity_ = 0;
       if (s) {
-        size_ = std::strlen(s);
+        size_ = strlen(s);
         capacity_ = size_ + 1;
         data_ = static_cast<char*>(std::malloc(capacity_));
         if (data_) {
-          std::memcpy(data_, s, size_ + 1);
+          memcpy(data_, s, size_ + 1);
         } else {
           size_ = capacity_ = 0;
         }
@@ -162,7 +164,7 @@ namespace shim {
     // Comparison operators
     bool operator==(const char* s) const {
       if (!s) return size_ == 0;
-      return std::strcmp(c_str(), s) == 0;
+      return strcmp(c_str(), s) == 0;
     }
     bool operator!=(const char* s) const { return !(*this == s); }
     
@@ -184,7 +186,7 @@ namespace shim {
                         size_ - pos : count;
         char* temp = static_cast<char*>(std::malloc(rcount + 1));
         if (temp) {
-            std::memcpy(temp, data_ + pos, rcount);
+            memcpy(temp, data_ + pos, rcount);
             temp[rcount] = '\0';
             string result(temp);
             std::free(temp);
@@ -196,7 +198,7 @@ namespace shim {
     // Append operations
     string& append(const char* s) {
         if (s) {
-            size_t slen = std::strlen(s);
+            size_t slen = strlen(s);
             if (size_ + slen + 1 > capacity_) {
                 size_t new_cap = (size_ + slen + 1) * 2;
                 char* new_data = static_cast<char*>(std::realloc(data_, new_cap));
@@ -207,7 +209,7 @@ namespace shim {
                     return *this; // Failed to allocate
                 }
             }
-            std::memcpy(data_ + size_, s, slen + 1);
+            memcpy(data_ + size_, s, slen + 1);
             size_ += slen;
         }
         return *this;
@@ -226,7 +228,7 @@ namespace shim {
         if (size_ != other.size_) return false;
         if (!data_ && !other.data_) return true;
         if (!data_ || !other.data_) return false;
-        return std::memcmp(data_, other.data_, size_) == 0;
+        return memcmp(data_, other.data_, size_) == 0;
     }
 
     bool operator!=(const string& other) const {
@@ -236,7 +238,7 @@ namespace shim {
     bool operator<(const string& other) const {
         size_t min_size = (size_ < other.size_) ? size_ : other.size_;
         if (data_ && other.data_) {
-            int cmp = std::memcmp(data_, other.data_, min_size);
+            int cmp = memcmp(data_, other.data_, min_size);
             if (cmp != 0) return cmp < 0;
         }
         return size_ < other.size_;

--- a/src/api/server.cpp
+++ b/src/api/server.cpp
@@ -4,6 +4,8 @@
 #include <cstdio>
 #include <cstring> // For std::memcpy, std::strcmp etc.
 #include <cstring>
+#include <time.h>   // For CLOCK_MONOTONIC
+#include <unistd.h> // For nanosleep
 #include <memory>
 #include <string>
 #include <thread>

--- a/src/blender/blender_bridge.cpp
+++ b/src/blender/blender_bridge.cpp
@@ -2,6 +2,8 @@
 #include <string>  // For std::string
 #include <cstring> // For std::memcpy
 #include <ctime>   // For std::time (if needed, but chrono is preferred)
+#include <time.h>   // For CLOCK_MONOTONIC, timespec
+#include <unistd.h> // For nanosleep
 #include <thread>  // For std::thread
 #include <chrono>  // For std::chrono
 #include <condition_variable> // For std::condition_variable

--- a/src/blender/blender_integration.cpp
+++ b/src/blender/blender_integration.cpp
@@ -1,5 +1,7 @@
 #include <cstring> // For std::memcpy, std::memset, std::strlen, std::strcmp etc.
 #include <ctime>   // For C-style time functions
+#include <time.h>  // For CLOCK_MONOTONIC, timespec
+#include <unistd.h> // For nanosleep
 #include <string>  // For std::string
 #include "blender/pattern_bridge.h"
 #include <mutex>

--- a/src/compat/raii.cpp
+++ b/src/compat/raii.cpp
@@ -9,6 +9,8 @@
 #include <cstdio>
 #include <cstdlib>  // for memory allocation
 #include <cstring>  // For std::memcpy, std::memset
+#include <time.h>   // For CLOCK_MONOTONIC
+#include <unistd.h> // For nanosleep
 #if defined(_MSC_VER)
 #include <malloc.h>
 #endif


### PR DESCRIPTION
## Summary
- ensure shim includes `<cstring>` and `<cstdlib>` after `<mutex>`
- use global C string functions in shim implementation
- include `<time.h>` and `<unistd.h>` where needed

## Testing
- `cmake .. -DBUILD_TESTING=ON` *(fails: Cannot determine linker language for target "testbed_cuda_kernels")*

------
https://chatgpt.com/codex/tasks/task_e_6869963e6bc0832aab5c347d3e287467