### PR TITLE
Fix C string calls and add missing POSIX headers

### DIFF
--- a/include/compat/shim.h
+++ b/include/compat/shim.h
@@ -8,7 +8,6 @@
 #include <time.h>    // For time, clock, difftime, mktime, etc.
 #include <unistd.h>  // For nanosleep, getpid, etc.
 // Ensure C++ wrappers of the C headers are also available
-#include <cstring> // C++ wrapper for memcpy, strcmp, etc.
 #include <ctime>
 #include <stdlib.h>  // For malloc, free, getenv, etc.
 #include <stdio.h>   // For snprintf, fprintf, etc.
@@ -21,8 +20,6 @@
 
 // Now include C++ headers that depend on C functions being in global namespace
 #include <string>
-#include <cstring>
-#include <cstdlib>
 #include <cstdio>
 #include <cstdint>
 #include <cstddef>
@@ -36,6 +33,8 @@
 #include <queue>
 #include <vector>
 #include <mutex>
+#include <cstring>
+#include <cstdlib>
 
 namespace sep {
 namespace shim {
@@ -50,11 +49,11 @@ namespace shim {
     string() : data_(nullptr), size_(0), capacity_(0) {}
     string(const char* s) : data_(nullptr), size_(0), capacity_(0) {
       if (s) {
-        size_ = std::strlen(s);
+        size_ = strlen(s);
         capacity_ = size_ + 1;
         data_ = static_cast<char*>(std::malloc(capacity_));
         if (data_) {
-          std::memcpy(data_, s, size_ + 1);
+          memcpy(data_, s, size_ + 1);
         } else {
           data_ = nullptr;
           size_ = capacity_ = 0;
@@ -72,7 +71,7 @@ namespace shim {
         capacity_ = size_ + 1;
         data_ = static_cast<char*>(std::malloc(capacity_));
         if (data_) {
-          std::memcpy(data_, other.data_, size_ + 1);
+          memcpy(data_, other.data_, size_ + 1);
         } else {
           size_ = capacity_ = 0;
         }
@@ -88,7 +87,7 @@ namespace shim {
           capacity_ = size_ + 1;
           data_ = static_cast<char*>(std::malloc(capacity_));
           if (data_) {
-            std::memcpy(data_, other.data_, size_ + 1);
+            memcpy(data_, other.data_, size_ + 1);
           } else {
             size_ = capacity_ = 0;
           }
@@ -101,11 +100,11 @@ namespace shim {
       data_ = nullptr;
       size_ = capacity_ = 0;
       if (s) {
-        size_ = std::strlen(s);
+        size_ = strlen(s);
         capacity_ = size_ + 1;
         data_ = static_cast<char*>(std::malloc(capacity_));
         if (data_) {
-          std::memcpy(data_, s, size_ + 1);
+          memcpy(data_, s, size_ + 1);
         } else {
           size_ = capacity_ = 0;
         }
@@ -162,7 +161,7 @@ namespace shim {
     // Comparison operators
     bool operator==(const char* s) const {
       if (!s) return size_ == 0;
-      return std::strcmp(c_str(), s) == 0;
+      return strcmp(c_str(), s) == 0;
     }
     bool operator!=(const char* s) const { return !(*this == s); }
     
@@ -184,7 +183,7 @@ namespace shim {
                         size_ - pos : count;
         char* temp = static_cast<char*>(std::malloc(rcount + 1));
         if (temp) {
-            std::memcpy(temp, data_ + pos, rcount);
+            memcpy(temp, data_ + pos, rcount);
             temp[rcount] = '\0';
             string result(temp);
             std::free(temp);
@@ -196,7 +195,7 @@ namespace shim {
     // Append operations
     string& append(const char* s) {
         if (s) {
-            size_t slen = std::strlen(s);
+            size_t slen = strlen(s);
             if (size_ + slen + 1 > capacity_) {
                 size_t new_cap = (size_ + slen + 1) * 2;
                 char* new_data = static_cast<char*>(std::realloc(data_, new_cap));
@@ -207,7 +206,7 @@ namespace shim {
                     return *this; // Failed to allocate
                 }
             }
-            std::memcpy(data_ + size_, s, slen + 1);
+            memcpy(data_ + size_, s, slen + 1);
             size_ += slen;
         }
         return *this;
@@ -226,7 +225,7 @@ namespace shim {
         if (size_ != other.size_) return false;
         if (!data_ && !other.data_) return true;
         if (!data_ || !other.data_) return false;
-        return std::memcmp(data_, other.data_, size_) == 0;
+        return memcmp(data_, other.data_, size_) == 0;
     }
 
     bool operator!=(const string& other) const {
@@ -236,7 +235,7 @@ namespace shim {
     bool operator<(const string& other) const {
         size_t min_size = (size_ < other.size_) ? size_ : other.size_;
         if (data_ && other.data_) {
-            int cmp = std::memcmp(data_, other.data_, min_size);
+            int cmp = memcmp(data_, other.data_, min_size);
             if (cmp != 0) return cmp < 0;
         }
         return size_ < other.size_;

--- a/src/api/server.cpp
+++ b/src/api/server.cpp
@@ -7,6 +7,8 @@
 #include <memory>
 #include <string>
 #include <thread>
+#include <time.h>
+#include <unistd.h>
 
 // Compatibility layer includes
 #include "compat/shim.h"

--- a/src/blender/blender_bridge.cpp
+++ b/src/blender/blender_bridge.cpp
@@ -6,6 +6,8 @@
 #include <chrono>  // For std::chrono
 #include <condition_variable> // For std::condition_variable
 #include <mutex> // For std::mutex, std::lock_guard, std::unique_lock
+#include <time.h>
+#include <unistd.h>
 #include "core/error_handler.h"
 #include "core/metrics_collector.h"
 #include <spdlog/spdlog.h>

--- a/src/blender/blender_integration.cpp
+++ b/src/blender/blender_integration.cpp
@@ -6,6 +6,8 @@
 #include <condition_variable>
 #include <thread>
 #include <chrono>
+#include <time.h>
+#include <unistd.h>
 
 #include <algorithm>
 #include <memory>

--- a/src/compat/raii.cpp
+++ b/src/compat/raii.cpp
@@ -9,6 +9,8 @@
 #include <cstdio>
 #include <cstdlib>  // for memory allocation
 #include <cstring>  // For std::memcpy, std::memset
+#include <time.h>
+#include <unistd.h>
 #if defined(_MSC_VER)
 #include <malloc.h>
 #endif


### PR DESCRIPTION
## Summary
- include <cstring> and <cstdlib> after `<mutex>` in shim.h
- use global C string functions in shim implementation
- include <time.h> and <unistd.h> where nanosleep or CLOCK_MONOTONIC may be used

## Testing
- `cmake ..` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6869963e6bc0832aab5c347d3e287467