### PR TITLE
Add GNU headers to shim

### DIFF
--- a/include/compat/shim.h
+++ b/include/compat/shim.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#define _GNU_SOURCE // For POSIX functions like nanosleep, CLOCK_MONOTONIC
+#include <cstring>  // For memcpy, memset, strcmp, strlen, etc.
+#include <ctime>    // For time_t, tm struct, mktime, localtime, gmtime, etc.
+
 // When compiling without the standard library the build system defines
 // `SEP_NO_STDLIB`.  Default builds rely on the system standard library and
 // should not define this macro.


### PR DESCRIPTION
## Summary
- expose GNU extensions before including system headers
- include `<cstring>` and `<ctime>` early in `shim.h`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686998f52c4c832a9494cd65561f1a6e