### PR TITLE
Fix includes for GPU and OIIO

### DIFF
--- a/src/blender/gpu_context.cpp
+++ b/src/blender/gpu_context.cpp
@@ -1,4 +1,5 @@
 #include <string.h>
+#include <cstring>  // For std::memcpy
 #include <time.h>
 #include <string>  // For std::string
 #include <sys/stat.h> // For stat

--- a/src/blender/oiio_output_driver.cpp
+++ b/src/blender/oiio_output_driver.cpp
@@ -1,4 +1,5 @@
 #include <string.h>
+#include <cstring> // For std::memcpy if needed
 #include <time.h>
 
 // Define Cycles namespace macros


### PR DESCRIPTION
## Summary
- add `<cstring>` to GPU context and OIIO output driver

## Testing
- `cmake ..` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_68699d27f75c832ab8b3339d7db1d1c3