### PR TITLE
Fix build includes for blender components

### DIFF
--- a/src/blender/CMakeLists.txt
+++ b/src/blender/CMakeLists.txt
@@ -187,6 +187,8 @@ target_include_directories(sep_blender PRIVATE
 
 # Set library properties
 set_target_properties(sep_blender PROPERTIES
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED ON
     POSITION_INDEPENDENT_CODE ON
     CXX_VISIBILITY_PRESET default
     VISIBILITY_INLINES_HIDDEN OFF

--- a/src/blender/gpu_context.cpp
+++ b/src/blender/gpu_context.cpp
@@ -1,6 +1,7 @@
 #include <string.h>
 #include <time.h>
-#include <string>  // For std::string
+#include <cstring>  // For std::memcpy
+#include <string>   // For std::string
 #include <sys/stat.h> // For stat
 
 #include "blender/gpu_context.h"

--- a/src/blender/oiio_output_driver.cpp
+++ b/src/blender/oiio_output_driver.cpp
@@ -1,5 +1,6 @@
 #include <string.h>
 #include <time.h>
+#include <cstring>  // For std::memcpy if needed
 
 // Define Cycles namespace macros
 #define CCL_NAMESPACE_BEGIN namespace ccl {


### PR DESCRIPTION
## Summary
- add `<cstring>` to Blender integration sources to avoid std::memcpy errors
- enforce C++17 standard for `sep_blender` target in CMake

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68699d27f75c832ab8b3339d7db1d1c3