### PR TITLE
Fix missing cstring includes for blender modules

### DIFF
--- a/src/blender/CMakeLists.txt
+++ b/src/blender/CMakeLists.txt
@@ -11,6 +11,10 @@ find_package(OpenSubdiv REQUIRED)
 pkg_check_modules(OIIO REQUIRED OpenImageIO)
 pkg_check_modules(ZSTD REQUIRED libzstd)
 
+# Ensure consistent C++ standard across modules
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 add_library(sep_blender SHARED
     compression_utils.cpp
     gpu_context.cpp

--- a/src/blender/gpu_context.cpp
+++ b/src/blender/gpu_context.cpp
@@ -1,4 +1,5 @@
 #include <string.h>
+#include <cstring>  // For std::memcpy
 #include <time.h>
 #include <string>  // For std::string
 #include <sys/stat.h> // For stat

--- a/src/blender/oiio_output_driver.cpp
+++ b/src/blender/oiio_output_driver.cpp
@@ -1,4 +1,5 @@
 #include <string.h>
+#include <cstring>
 #include <time.h>
 
 // Define Cycles namespace macros


### PR DESCRIPTION
## Summary
- fix include order in `gpu_context.cpp`
- fix include order in `oiio_output_driver.cpp`
- enforce C++17 standard for the blender module

## Testing
- `g++ -c -std=c++17 src/blender/gpu_context.cpp -Iinclude`
- `g++ -c -std=c++17 src/blender/oiio_output_driver.cpp -Iinclude -Iextern/cycles/src -Iextern/cycles/src/util -Iextern/cycles/src/scene -Iextern/cycles/src/session -Iextern/cycles/third_party/hipew/include -Iextern/cycles/third_party/sky/include` *(fails: OpenImageIO/string_view.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68699d27f75c832ab8b3339d7db1d1c3