### PR TITLE
Fix header order & enforce C++17 in blender

### DIFF
--- a/src/blender/CMakeLists.txt
+++ b/src/blender/CMakeLists.txt
@@ -23,6 +23,9 @@ add_library(sep_blender SHARED
     oiio_output_driver.cpp
 )
 
+# Require C++17 for this target
+target_compile_features(sep_blender PUBLIC cxx_std_17)
+
 # Define required features
 target_compile_definitions(sep_blender
     PUBLIC

--- a/src/blender/gpu_context.cpp
+++ b/src/blender/gpu_context.cpp
@@ -1,6 +1,6 @@
 #include <string.h>
-#include <time.h>
 #include <string>  // For std::string
+#include <time.h>
 #include <sys/stat.h> // For stat
 
 #include "blender/gpu_context.h"

--- a/src/blender/oiio_output_driver.cpp
+++ b/src/blender/oiio_output_driver.cpp
@@ -1,11 +1,11 @@
 #include <string.h>
+#include <string> // For std::string
 #include <time.h>
 
 // Define Cycles namespace macros
 #define CCL_NAMESPACE_BEGIN namespace ccl {
 #define CCL_NAMESPACE_END }
 
-#include <string> // For std::string
 #include "blender/oiio_output_driver.h"
 
 // Core Cycles includes


### PR DESCRIPTION
## Summary
- fix include ordering for GPU context & OIIO driver
- require C++17 for `sep_blender` library

## Testing
- `cmake ..` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_68699d27f75c832ab8b3339d7db1d1c3