### PR TITLE
Fix missing c headers

### DIFF
--- a/src/api/server.cpp
+++ b/src/api/server.cpp
@@ -4,6 +4,7 @@
 #include <cstdio>
 #include <cstring> // For std::memcpy, std::strcmp etc.
 #include <cstring>
+#include <ctime>
 #include <time.h>   // For CLOCK_MONOTONIC
 #include <unistd.h> // For nanosleep
 #include <memory>

--- a/src/audio/pipewire_capture.cpp
+++ b/src/audio/pipewire_capture.cpp
@@ -1,6 +1,8 @@
 #include "audio/pipewire_capture.h"
 #include "audio/types.h"
 #include "audio/capture.h"
+#include <cstring>
+#include <ctime>
 #include <string.h> // For strerror, memcpy, etc.
 #include <time.h>   // For timespec and nanosleep
 #include "audio/config.h"

--- a/src/blender/api.cpp
+++ b/src/blender/api.cpp
@@ -1,3 +1,5 @@
+#include <cstring>
+#include <ctime>
 #include <string.h>
 #include <time.h>
 #include <string>  // For std::string

--- a/src/blender/gpu_context.cpp
+++ b/src/blender/gpu_context.cpp
@@ -1,5 +1,6 @@
 #include <string.h>
 #include <cstring>  // For std::memcpy
+#include <ctime>
 #include <time.h>
 #include <cstring>  // For std::memcpy
 #include <string>   // For std::string

--- a/src/blender/mesh_handler.cpp
+++ b/src/blender/mesh_handler.cpp
@@ -7,6 +7,8 @@
 #include "core/common.h"  // defines sep::SEPResult
 
 // Standard library includes
+#include <cstring>
+#include <ctime>
 #include <string.h>
 #include <time.h>
 #include <string>  // For std::string

--- a/src/blender/oiio_output_driver.cpp
+++ b/src/blender/oiio_output_driver.cpp
@@ -1,5 +1,6 @@
 #include <string.h>
 #include <cstring> // For std::memcpy if needed
+#include <ctime>
 #include <time.h>
 #include <cstring>  // For std::memcpy if needed
 

--- a/src/blender/pattern_visualization_pipeline.cpp
+++ b/src/blender/pattern_visualization_pipeline.cpp
@@ -1,3 +1,5 @@
+#include <cstring>
+#include <ctime>
 #include <string.h>
 #include <time.h>
 #include <string>  // For std::string

--- a/src/compat/raii.cpp
+++ b/src/compat/raii.cpp
@@ -9,6 +9,7 @@
 #include <cstdio>
 #include <cstdlib>  // for memory allocation
 #include <cstring>  // For std::memcpy, std::memset
+#include <ctime>
 #include <time.h>   // For CLOCK_MONOTONIC
 #include <unistd.h> // For nanosleep
 #if defined(_MSC_VER)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,7 @@
 #include "core/manager.h"
 #include "core/engine.h"
 #include "core/common.h"
+#include <ctime>
 #include <time.h>   // For std::tm, nanosleep
 #include <unistd.h> // For POSIX-specific APIs
 #include "core/logging.h"


### PR DESCRIPTION
## Summary
- ensure clang/gcc can find C string and time functions
- add `<cstring>` and `<ctime>` across blender and API files

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68699f0e19b4832a9dfa1c34fe527dd6