### PR TITLE
Fix includes across Blender modules

### DIFF
--- a/src/api/server.cpp
+++ b/src/api/server.cpp
@@ -3,14 +3,12 @@
 #include <csignal>
 #include <cstdio>
 #include <cstring> // For std::memcpy, std::strcmp etc.
-#include <cstring>
 #include <time.h>   // For CLOCK_MONOTONIC
 #include <unistd.h> // For nanosleep
 #include <memory>
 #include <string>
 #include <thread>
-#include <time.h>
-#include <unistd.h>
+#include <ctime>
 
 // Compatibility layer includes
 #include "compat/shim.h"

--- a/src/blender/blender_bridge.cpp
+++ b/src/blender/blender_bridge.cpp
@@ -8,8 +8,7 @@
 #include <chrono>  // For std::chrono
 #include <condition_variable> // For std::condition_variable
 #include <mutex> // For std::mutex, std::lock_guard, std::unique_lock
-#include <time.h>
-#include <unistd.h>
+
 #include "core/error_handler.h"
 #include "core/metrics_collector.h"
 #include <spdlog/spdlog.h>

--- a/src/blender/blender_integration.cpp
+++ b/src/blender/blender_integration.cpp
@@ -8,8 +8,6 @@
 #include <condition_variable>
 #include <thread>
 #include <chrono>
-#include <time.h>
-#include <unistd.h>
 
 #include <algorithm>
 #include <memory>

--- a/src/blender/gpu_context.cpp
+++ b/src/blender/gpu_context.cpp
@@ -1,7 +1,7 @@
 #include <string.h>
 #include <cstring>  // For std::memcpy
 #include <time.h>
-#include <cstring>  // For std::memcpy
+#include <ctime>
 #include <string>   // For std::string
 #include <sys/stat.h> // For stat
 

--- a/src/blender/oiio_output_driver.cpp
+++ b/src/blender/oiio_output_driver.cpp
@@ -1,7 +1,7 @@
 #include <string.h>
 #include <cstring> // For std::memcpy if needed
 #include <time.h>
-#include <cstring>  // For std::memcpy if needed
+#include <ctime>
 
 // Define Cycles namespace macros
 #define CCL_NAMESPACE_BEGIN namespace ccl {


### PR DESCRIPTION
## Summary
- deduplicate and clean up headers for API server and blender modules
- include `<ctime>` for standard time types

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68699f0e19b4832a9dfa1c34fe527dd6