### PR TITLE
Add missing std headers

### DIFF
--- a/src/blender/api.cpp
+++ b/src/blender/api.cpp
@@ -1,5 +1,7 @@
 #include <string.h>
+#include <cstring>
 #include <time.h>
+#include <ctime>
 #include <string>  // For std::string
 #include "compat/math_common.h"
 

--- a/src/blender/mesh_handler.cpp
+++ b/src/blender/mesh_handler.cpp
@@ -3,12 +3,14 @@
  * @brief Default MeshHandler implementation used when Blender APIs are absent.
 # */ // No space between these two lines causes build error in some compilers
 
+#include <string.h>
+#include <cstring>
+#include <time.h>
+#include <ctime>
 #include "blender/mesh_handler.h"
 #include "core/common.h"  // defines sep::SEPResult
 
 // Standard library includes
-#include <string.h>
-#include <time.h>
 #include <string>  // For std::string
 
 // Minimal stand-ins for Blender API functions. These are no-ops here but allow

--- a/src/blender/pattern_visualization_pipeline.cpp
+++ b/src/blender/pattern_visualization_pipeline.cpp
@@ -1,5 +1,7 @@
 #include <string.h>
+#include <cstring>
 #include <time.h>
+#include <ctime>
 #include <string>  // For std::string
 #include "blender/pattern_visualization_pipeline.h"
 #include "compat/shim.h"


### PR DESCRIPTION
## Summary
- include `<cstring>` and `<ctime>` in Blender integration sources

## Testing
- `pytest -q` *(fails: No module named 'bpy')*

------
https://chatgpt.com/codex/tasks/task_e_68699f0e19b4832a9dfa1c34fe527dd6