### PR TITLE
Fix header order for standard includes

### DIFF
--- a/src/api/bridge_c.cpp
+++ b/src/api/bridge_c.cpp
@@ -1,11 +1,15 @@
-#include <string.h> // For snprintf (used below), memset (not used directly here but good for C-style functions)
+#include <string.h> // For snprintf, memset
 #include <cstring>
+#include <ctime>
+#include <time.h>
+#include <unistd.h>
+#include <cstdlib>
+
 #include <cstdio>
 #include <memory>
 #include <mutex>
 #include <string>
 #include <algorithm>
-#include <cstdlib>
 #include <nlohmann/json.hpp>
 
 #include "api/bridge.h"

--- a/src/audio/pipewire_capture.cpp
+++ b/src/audio/pipewire_capture.cpp
@@ -1,12 +1,13 @@
+#include <string.h> // For strerror, memcpy, etc.
+#include <cstring>
+#include <ctime>
+#include <time.h>   // For timespec and nanosleep
+#include <unistd.h>
+#include <cstdlib>
+
 #include "audio/pipewire_capture.h"
 #include "audio/types.h"
 #include "audio/capture.h"
-#include <cstring>
-#include <ctime>
-#include <string.h> // For strerror, memcpy, etc.
-#include <cstring>
-#include <time.h>   // For timespec and nanosleep
-#include <ctime>
 #include "audio/config.h"
 
 #ifdef SEP_HAS_AUDIO

--- a/src/blender/api.cpp
+++ b/src/blender/api.cpp
@@ -1,9 +1,10 @@
-#include <cstring>
-#include <ctime>
 #include <string.h>
 #include <cstring>
-#include <time.h>
 #include <ctime>
+#include <time.h>
+#include <unistd.h>
+#include <cstdlib>
+
 #include <string>  // For std::string
 #include "compat/math_common.h"
 

--- a/src/blender/blender_bridge.cpp
+++ b/src/blender/blender_bridge.cpp
@@ -1,13 +1,17 @@
-#include "blender/bridge.h"
+#include <string.h>
+#include <cstring>
+#include <ctime>
+#include <time.h>
+#include <unistd.h>
+#include <cstdlib>
+
 #include <string>  // For std::string
-#include <cstring> // For std::memcpy
-#include <ctime>   // For std::time (if needed, but chrono is preferred)
-#include <time.h>   // For CLOCK_MONOTONIC, timespec
-#include <unistd.h> // For nanosleep
 #include <thread>  // For std::thread
 #include <chrono>  // For std::chrono
 #include <condition_variable> // For std::condition_variable
 #include <mutex> // For std::mutex, std::lock_guard, std::unique_lock
+
+#include "blender/bridge.h"
 
 #include "core/error_handler.h"
 #include "core/metrics_collector.h"

--- a/src/blender/blender_integration.cpp
+++ b/src/blender/blender_integration.cpp
@@ -1,7 +1,10 @@
+#include <string.h>
 #include <cstring> // For std::memcpy, std::memset, std::strlen, std::strcmp etc.
 #include <ctime>   // For C-style time functions
 #include <time.h>  // For CLOCK_MONOTONIC, timespec
 #include <unistd.h> // For nanosleep
+#include <cstdlib>
+
 #include <string>  // For std::string
 #include "blender/pattern_bridge.h"
 #include <mutex>

--- a/src/blender/compression.cpp
+++ b/src/blender/compression.cpp
@@ -1,5 +1,10 @@
+#include <string.h>
 #include <cstring> // For std::memcpy, std::memset, std::memcmp
 #include <ctime>   // For C-style time functions (if needed)
+#include <time.h>
+#include <unistd.h>
+#include <cstdlib>
+
 #include <string>  // For std::string
 #include "blender/compression.h"
 #include <algorithm> // For std::min, std::clamp

--- a/src/blender/compression_utils.cpp
+++ b/src/blender/compression_utils.cpp
@@ -1,5 +1,10 @@
+#include <string.h>
 #include <cstring> // For std::memcpy, std::memset, std::memcmp, std::strlen etc.
 #include <ctime>   // For C-style time functions
+#include <time.h>
+#include <unistd.h>
+#include <cstdlib>
+
 #include <string>  // For std::string
 #include <vector>  // Already included below, but ensuring early availability
 #include <cmath> // For std::log2

--- a/src/blender/cycles_renderer.cpp
+++ b/src/blender/cycles_renderer.cpp
@@ -1,6 +1,11 @@
 // Standard includes
+#include <string.h>
 #include <cstring> // For std::memcpy, std::memset, std::memcmp, std::strlen etc.
 #include <ctime>   // For C-style time functions
+#include <time.h>
+#include <unistd.h>
+#include <cstdlib>
+
 #include <string>  // For std::string
 #include <cmath>
 #include <memory>

--- a/src/blender/factory.cpp
+++ b/src/blender/factory.cpp
@@ -1,5 +1,10 @@
+#include <string.h>
 #include <cstring> // For std::memcpy, std::memset, std::memcmp, std::strlen etc.
 #include <ctime>   // For C-style time functions
+#include <time.h>
+#include <unistd.h>
+#include <cstdlib>
+
 #include <string>  // For std::string
 #include <memory>
 #include "blender/factory.h"

--- a/src/blender/gpu_context.cpp
+++ b/src/blender/gpu_context.cpp
@@ -2,13 +2,14 @@
 #include <cstring>  // For std::memcpy
 #include <ctime>
 #include <time.h>
-#include <ctime>
+#include <unistd.h> // For nanosleep or other POSIX calls
+#include <cstdlib>
+
 #include <string>   // For std::string
 #include <sys/stat.h> // For stat
+#include <new>
 
 #include "blender/gpu_context.h"
-#include <cstdlib>
-#include <new>
 
 namespace sep {
 

--- a/src/blender/mesh_handler.cpp
+++ b/src/blender/mesh_handler.cpp
@@ -5,19 +5,15 @@
 
 #include <string.h>
 #include <cstring>
-#include <time.h>
 #include <ctime>
+#include <time.h>
+#include <unistd.h>
+#include <cstdlib>
+
+#include <string>  // For std::string
+
 #include "blender/mesh_handler.h"
 #include "core/common.h"  // defines sep::SEPResult
-
-// Standard library includes
-#include <cstring>
-#include <ctime>
-#include <string.h>
-#include <cstring>
-#include <time.h>
-#include <ctime>
-#include <string>  // For std::string
 
 // Minimal stand-ins for Blender API functions. These are no-ops here but allow
 // the library to link without the real Blender environment.

--- a/src/blender/oiio_output_driver.cpp
+++ b/src/blender/oiio_output_driver.cpp
@@ -2,7 +2,8 @@
 #include <cstring> // For std::memcpy if needed
 #include <ctime>
 #include <time.h>
-#include <ctime>
+#include <unistd.h>
+#include <cstdlib>
 
 // Define Cycles namespace macros
 #define CCL_NAMESPACE_BEGIN namespace ccl {

--- a/src/blender/pattern_visualization_pipeline.cpp
+++ b/src/blender/pattern_visualization_pipeline.cpp
@@ -1,9 +1,11 @@
-#include <cstring>
-#include <ctime>
 #include <string.h>
 #include <cstring>
-#include <time.h>
 #include <ctime>
+#include <time.h>
+#include <unistd.h>
+#include <cstdlib>
+
+#include <string>  // For std::string
 #include <string>  // For std::string
 #include "blender/pattern_visualization_pipeline.h"
 #include "compat/shim.h"


### PR DESCRIPTION
## Summary
- add C headers before project includes to avoid missing function declarations
- ensure POSIX headers like `<unistd.h>` and `<cstdlib>` are included consistently

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6869a1d1d6fc832a899747c22e70602c