### PR TITLE
Fix header inclusion order

### DIFF
--- a/src/api/client.cpp
+++ b/src/api/client.cpp
@@ -1,11 +1,11 @@
-#include "api/client.h"
+#include <string.h>
 #include <cstring> // Ensure C string functions available before curl headers
-#include "curl/curl.h"
 #include <memory>
 #include <string>
-
 #include <stdexcept>
 #include <utility>
+#include "api/client.h"
+#include "curl/curl.h"
 
 
 #include "core/error_handler.h"  // For sep::ErrorCode

--- a/src/api/curl_http_client.cpp
+++ b/src/api/curl_http_client.cpp
@@ -1,10 +1,10 @@
-#include "api/client.h"
-#include "core/error_handler.h"
+#include <string.h>
+#include <cstring> // For std::memcpy
 #include <chrono>
 #include <stdexcept>
-#include <cstring> // For std::memcpy
 #include <string>
-#include <cstring>
+#include "api/client.h"
+#include "core/error_handler.h"
 
 namespace sep::api {
 

--- a/src/audio/pipewire_capture.cpp
+++ b/src/audio/pipewire_capture.cpp
@@ -1,12 +1,11 @@
+#include <string.h> // For strerror, memcpy, etc.
+#include <cstring>
+#include <ctime>
+#include <time.h>   // For timespec and nanosleep
+#include <unistd.h>
 #include "audio/pipewire_capture.h"
 #include "audio/types.h"
 #include "audio/capture.h"
-#include <cstring>
-#include <ctime>
-#include <string.h> // For strerror, memcpy, etc.
-#include <cstring>
-#include <time.h>   // For timespec and nanosleep
-#include <ctime>
 #include "audio/config.h"
 
 #ifdef SEP_HAS_AUDIO

--- a/src/blender/blender_bridge.cpp
+++ b/src/blender/blender_bridge.cpp
@@ -1,9 +1,10 @@
-#include "blender/bridge.h"
-#include <string>  // For std::string
+#include <string.h>
 #include <cstring> // For std::memcpy
 #include <ctime>   // For std::time (if needed, but chrono is preferred)
 #include <time.h>   // For CLOCK_MONOTONIC, timespec
 #include <unistd.h> // For nanosleep
+#include <string>  // For std::string
+#include "blender/bridge.h"
 #include <thread>  // For std::thread
 #include <chrono>  // For std::chrono
 #include <condition_variable> // For std::condition_variable

--- a/src/blender/mesh_handler.cpp
+++ b/src/blender/mesh_handler.cpp
@@ -7,17 +7,9 @@
 #include <cstring>
 #include <time.h>
 #include <ctime>
+#include <string>  // For std::string
 #include "blender/mesh_handler.h"
 #include "core/common.h"  // defines sep::SEPResult
-
-// Standard library includes
-#include <cstring>
-#include <ctime>
-#include <string.h>
-#include <cstring>
-#include <time.h>
-#include <ctime>
-#include <string>  // For std::string
 
 // Minimal stand-ins for Blender API functions. These are no-ops here but allow
 // the library to link without the real Blender environment.


### PR DESCRIPTION
## Summary
- ensure C headers appear before project headers in several source files
- tweak audio capture includes for nanosleep and reorder
- clean redundant includes in mesh handler

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6869a1d1d6fc832a899747c22e70602c