### PR TITLE
Fix memcpy usage

### DIFF
--- a/include/compat/memory.h
+++ b/include/compat/memory.h
@@ -115,7 +115,7 @@ bool copyToDevice(T* dst, const T* src, size_t count, Stream* stream  = nullptr)
     return error == cudaSuccess;
 #else
     (void)stream;
-    ::memcpy(dst, src, count * sizeof(T));
+    std::memcpy(dst, src, count * sizeof(T));
     return true;
 #endif
 }
@@ -127,7 +127,7 @@ bool copyToHost(T* dst, const T* src, size_t count, Stream* stream  = nullptr) {
     return error == cudaSuccess;
 #else
     (void)stream;
-    ::memcpy(dst, src, count * sizeof(T));
+    std::memcpy(dst, src, count * sizeof(T));
     return true;
 #endif
 }


### PR DESCRIPTION
## Summary
- switch to `std::memcpy` in memory utilities

## Testing
- `cmake ..` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6869a463b6a8832abd1954a217d9c7d2