### PR TITLE
Fix missing header in crow json

### DIFF
--- a/extern/crow/include/crow/json.h
+++ b/extern/crow/include/crow/json.h
@@ -4,6 +4,7 @@
 //#define CROW_JSON_USE_MAP
 
 #include <string>
+#include <cstring> // for std::memchr, memcpy, etc.
 #ifdef CROW_JSON_USE_MAP
 #include <map>
 #else


### PR DESCRIPTION
## Summary
- include `<cstring>` in `crow/json.h` so memcpy and memchr are defined

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6869a463b6a8832abd1954a217d9c7d2