### PR TITLE
Fix missing includes for crow json

### DIFF
--- a/extern/crow/include/crow/json.h
+++ b/extern/crow/include/crow/json.h
@@ -4,6 +4,7 @@
 //#define CROW_JSON_USE_MAP
 
 #include <string>
+#include <cstring>
 #ifdef CROW_JSON_USE_MAP
 #include <map>
 #else

--- a/third_party/crow/include/crow/json.h
+++ b/third_party/crow/include/crow/json.h
@@ -4,6 +4,7 @@
 //#define CROW_JSON_USE_MAP
 
 #include <string>
+#include <cstring>
 #ifdef CROW_JSON_USE_MAP
 #include <map>
 #else


### PR DESCRIPTION
## Summary
- add `<cstring>` include to Crow JSON headers to expose string/memory functions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6869a463b6a8832abd1954a217d9c7d2