### PR TITLE
Fix POSIX macro and memmove namespace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.15)
 
 # Enable POSIX features for popen/pclose
-add_definitions(-D_POSIX_C_SOURCE=200809L)
+add_compile_definitions(_POSIX_C_SOURCE=200809L)
 add_definitions(-D_GNU_SOURCE)
 
 # Load CUDA toolchain file before project declaration

--- a/src/memory/memory_tier.cpp
+++ b/src/memory/memory_tier.cpp
@@ -205,7 +205,7 @@ sep::SEPResult MemoryTier::defragment() {
           return sep::SEPResult::CUDA_ERROR;
         }
 #else
-        ::memmove(new_location, block.ptr, block.size);
+        std::memmove(new_location, block.ptr, block.size);
 #endif
 
         block.ptr = new_location;


### PR DESCRIPTION
## Summary
- ensure `_POSIX_C_SOURCE` is defined with `add_compile_definitions`
- use `std::memmove` in `MemoryTier`

## Testing
- `cmake -B build -S .` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6869a7903b88832ab5b942fc22777354