### PR TITLE
Fix POSIX defines and std namespace usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ cmake_minimum_required(VERSION 3.15)
 # Enable POSIX features for popen/pclose
 add_definitions(-D_POSIX_C_SOURCE=200809L)
 add_definitions(-D_GNU_SOURCE)
+# Also propagate POSIX feature macros to all targets
+add_compile_definitions(_POSIX_C_SOURCE=200809L)
 
 # Load CUDA toolchain file before project declaration
 set(CMAKE_TOOLCHAIN_FILE ${CMAKE_SOURCE_DIR}/cmake/cuda-toolchain.cmake)

--- a/include/blender/mesh_handler.h
+++ b/include/blender/mesh_handler.h
@@ -107,10 +107,10 @@ class MeshHandler {
 
     CustomDataLayer(const CustomDataLayer& other)
         : type(other.type), data(nullptr), size(other.size), active(other.active) {
-      memcpy(name, other.name, sizeof(name));
+      std::memcpy(name, other.name, sizeof(name));
       if (other.data && other.size > 0) {
         data = std::make_unique<char[]>(other.size);
-        memcpy(data.get(), other.data.get(), other.size);
+        std::memcpy(data.get(), other.data.get(), other.size);
       }
     }
 
@@ -120,10 +120,10 @@ class MeshHandler {
         type = other.type;
         size = other.size;
         active = other.active;
-        memcpy(name, other.name, sizeof(name));
+        std::memcpy(name, other.name, sizeof(name));
         if (other.data && other.size > 0) {
           data = std::make_unique<char[]>(other.size);
-          memcpy(data.get(), other.data.get(), other.size);
+          std::memcpy(data.get(), other.data.get(), other.size);
         }
       }
       return *this;
@@ -131,7 +131,7 @@ class MeshHandler {
 
     CustomDataLayer(CustomDataLayer&& other) noexcept
         : type(other.type), data(std::move(other.data)), size(other.size), active(other.active) {
-      memcpy(name, other.name, sizeof(name));
+      std::memcpy(name, other.name, sizeof(name));
       other.data.reset();
     }
 
@@ -142,7 +142,7 @@ class MeshHandler {
         data = std::move(other.data);
         size = other.size;
         active = other.active;
-        memcpy(name, other.name, sizeof(name));
+        std::memcpy(name, other.name, sizeof(name));
       }
       return *this;
     }

--- a/include/compat/shim.h
+++ b/include/compat/shim.h
@@ -69,11 +69,11 @@ namespace shim {
     string() : data_(nullptr), size_(0), capacity_(0) {}
     string(const char* s) : data_(nullptr), size_(0), capacity_(0) {
       if (s) {
-        size_ = strlen(s);
+        size_ = std::strlen(s);
         capacity_ = size_ + 1;
-        data_ = static_cast<char*>(malloc(capacity_));
+        data_ = static_cast<char*>(std::malloc(capacity_));
         if (data_) {
-          memcpy(data_, s, size_ + 1);
+          std::memcpy(data_, s, size_ + 1);
         } else {
           data_ = nullptr;
           size_ = capacity_ = 0;
@@ -89,9 +89,9 @@ namespace shim {
       if (other.data_) {
         size_ = other.size_;
         capacity_ = size_ + 1;
-        data_ = static_cast<char*>(malloc(capacity_));
+        data_ = static_cast<char*>(std::malloc(capacity_));
         if (data_) {
-          memcpy(data_, other.data_, size_ + 1);
+          std::memcpy(data_, other.data_, size_ + 1);
         } else {
           size_ = capacity_ = 0;
         }
@@ -105,9 +105,9 @@ namespace shim {
         if (other.data_) {
           size_ = other.size_;
           capacity_ = size_ + 1;
-          data_ = static_cast<char*>(malloc(capacity_));
+          data_ = static_cast<char*>(std::malloc(capacity_));
           if (data_) {
-            memcpy(data_, other.data_, size_ + 1);
+            std::memcpy(data_, other.data_, size_ + 1);
           } else {
             size_ = capacity_ = 0;
           }
@@ -120,11 +120,11 @@ namespace shim {
       data_ = nullptr;
       size_ = capacity_ = 0;
       if (s) {
-        size_ = strlen(s);
+        size_ = std::strlen(s);
         capacity_ = size_ + 1;
-        data_ = static_cast<char*>(malloc(capacity_));
+        data_ = static_cast<char*>(std::malloc(capacity_));
         if (data_) {
-          memcpy(data_, s, size_ + 1);
+          std::memcpy(data_, s, size_ + 1);
         } else {
           size_ = capacity_ = 0;
         }
@@ -181,7 +181,7 @@ namespace shim {
     // Comparison operators
     bool operator==(const char* s) const {
       if (!s) return size_ == 0;
-      return strcmp(c_str(), s) == 0;
+      return std::strcmp(c_str(), s) == 0;
     }
     bool operator!=(const char* s) const { return !(*this == s); }
     
@@ -201,9 +201,9 @@ namespace shim {
         if (pos >= size_) return string();
         size_t rcount = (count == npos || pos + count > size_) ?
                         size_ - pos : count;
-        char* temp = static_cast<char*>(malloc(rcount + 1));
+        char* temp = static_cast<char*>(std::malloc(rcount + 1));
         if (temp) {
-            memcpy(temp, data_ + pos, rcount);
+            std::memcpy(temp, data_ + pos, rcount);
             temp[rcount] = '\0';
             string result(temp);
             free(temp);
@@ -218,7 +218,7 @@ namespace shim {
             size_t slen = strlen(s);
             if (size_ + slen + 1 > capacity_) {
                 size_t new_cap = (size_ + slen + 1) * 2;
-                char* new_data = static_cast<char*>(realloc(data_, new_cap));
+                char* new_data = static_cast<char*>(std::realloc(data_, new_cap));
                 if (new_data) {
                     data_ = new_data;
                     capacity_ = new_cap;
@@ -226,7 +226,7 @@ namespace shim {
                     return *this; // Failed to allocate
                 }
             }
-            memcpy(data_ + size_, s, slen + 1);
+            std::memcpy(data_ + size_, s, slen + 1);
             size_ += slen;
         }
         return *this;
@@ -245,7 +245,7 @@ namespace shim {
         if (size_ != other.size_) return false;
         if (!data_ && !other.data_) return true;
         if (!data_ || !other.data_) return false;
-        return memcmp(data_, other.data_, size_) == 0;
+        return std::memcmp(data_, other.data_, size_) == 0;
     }
 
     bool operator!=(const string& other) const {
@@ -255,7 +255,7 @@ namespace shim {
     bool operator<(const string& other) const {
         size_t min_size = (size_ < other.size_) ? size_ : other.size_;
         if (data_ && other.data_) {
-            int cmp = memcmp(data_, other.data_, min_size);
+            int cmp = std::memcmp(data_, other.data_, min_size);
             if (cmp != 0) return cmp < 0;
         }
         return size_ < other.size_;
@@ -442,7 +442,7 @@ namespace shim {
   // Memory management - minimal implementations
   inline void* aligned_alloc(size_t alignment, size_t size) {
     (void)alignment;  // alignment parameter unused in fallback implementation
-    return malloc(size); // Not properly aligned but simple fallback
+    return std::malloc(size); // Not properly aligned but simple fallback
   }
   
   // Smart pointer helpers were previously defined here when the standard


### PR DESCRIPTION
## Summary
- propagate `_POSIX_C_SOURCE` to all targets
- use `std::` qualified C memory functions in shim
- update mesh handler to use `std::memcpy`

## Testing
- `bash tests/blender/run_tests.sh` *(fails: Could not find nvcc, please set CUDAToolkit_ROOT)*

------
https://chatgpt.com/codex/tasks/task_e_6869a7903b88832ab5b942fc22777354