### PR TITLE
Add drug discovery demo example

### DIFF
--- a/examples/workbench/CMakeLists.txt
+++ b/examples/workbench/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(sep_workbench
     demos/genesis_pattern.cpp
     demos/audio_visualizer.cpp
     demos/memory_garden.cpp
+    demos/drug_discovery_demo.cpp
 )
 
 # Set C++ standard

--- a/examples/workbench/config.cpp
+++ b/examples/workbench/config.cpp
@@ -101,6 +101,12 @@ bool Config::load(const std::filesystem::path& path) {
             }
         };
 
+        auto& optimizer = json["optimizer"];
+        optimizer_ = {
+            optimizer["iterations"].get<int>(),
+            optimizer["mutation_rate"].get<float>()
+        };
+
         return true;
     }
     catch (const std::exception& e) {
@@ -183,6 +189,11 @@ bool Config::save(const std::filesystem::path& path) const {
                 {"denoising", renderer_.cycles.denoising},
                 {"device", renderer_.cycles.device}
             }}
+        };
+
+        json["optimizer"] = {
+            {"iterations", optimizer_.iterations},
+            {"mutation_rate", optimizer_.mutation_rate}
         };
 
         std::ofstream file(path);

--- a/examples/workbench/config.hpp
+++ b/examples/workbench/config.hpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <memory>
 #include <filesystem>
+#include <array>
 
 namespace sep {
 namespace workbench {
@@ -73,6 +74,11 @@ struct RendererConfig {
     } cycles;
 };
 
+struct OptimizerConfig {
+    int iterations;
+    float mutation_rate;
+};
+
 class Config {
 public:
     static Config& getInstance() {
@@ -89,6 +95,7 @@ public:
     const AudioVisualizerConfig& audio_visualizer() const { return audio_visualizer_; }
     const MemoryGardenConfig& memory_garden() const { return memory_garden_; }
     const RendererConfig& renderer() const { return renderer_; }
+    const OptimizerConfig& optimizer() const { return optimizer_; }
 
 private:
     Config() = default;
@@ -99,6 +106,7 @@ private:
     AudioVisualizerConfig audio_visualizer_;
     MemoryGardenConfig memory_garden_;
     RendererConfig renderer_;
+    OptimizerConfig optimizer_;
 };
 
 } // namespace workbench

--- a/examples/workbench/config.json
+++ b/examples/workbench/config.json
@@ -60,5 +60,9 @@
       "denoising": true,
       "device": "gpu"
     }
+  },
+  "optimizer": {
+    "iterations": 100,
+    "mutation_rate": 0.1
   }
 }

--- a/examples/workbench/demos/drug_discovery_demo.cpp
+++ b/examples/workbench/demos/drug_discovery_demo.cpp
@@ -1,0 +1,67 @@
+#include "drug_discovery_demo.hpp"
+#include <config.hpp>
+#include <glm/gtx/norm.hpp>
+#include <cstdlib>
+
+namespace sep {
+namespace workbench {
+
+void DrugDiscoveryDemo::init() {
+#ifdef SEP_WORKBENCH_DEMO
+    optimizer_iterations_ = 100;
+    mutation_rate_ = 0.1f;
+#else
+    const auto& cfg = getConfigManager().optimizer();
+    optimizer_iterations_ = cfg.iterations;
+    mutation_rate_ = cfg.mutation_rate;
+#endif
+
+    candidate_poses_.resize(5);
+    for (auto& pose : candidate_poses_) {
+        pose.position = glm::vec3(static_cast<float>(std::rand()) / RAND_MAX,
+                                  static_cast<float>(std::rand()) / RAND_MAX,
+                                  static_cast<float>(std::rand()) / RAND_MAX);
+        pose.orientation = glm::vec3(static_cast<float>(std::rand()) / RAND_MAX,
+                                     static_cast<float>(std::rand()) / RAND_MAX,
+                                     static_cast<float>(std::rand()) / RAND_MAX);
+        pose.binding_affinity = 0.0f;
+    }
+}
+
+void DrugDiscoveryDemo::update(float) {
+    for (int i = 0; i < optimizer_iterations_; ++i) {
+        for (auto& pose : candidate_poses_) {
+            glm::vec3 delta((std::rand() % 100 - 50) / 1000.0f * mutation_rate_,
+                            (std::rand() % 100 - 50) / 1000.0f * mutation_rate_,
+                            (std::rand() % 100 - 50) / 1000.0f * mutation_rate_);
+            pose.position += delta;
+            pose.orientation += delta * 0.5f;
+            pose.binding_affinity = 1.0f / (1.0f + glm::length2(pose.position));
+        }
+    }
+}
+
+void DrugDiscoveryDemo::render() {
+#ifdef SEP_WORKBENCH_DEMO
+    if (renderer_) {
+        std::vector<glm::vec3> pts;
+        for (const auto& p : candidate_poses_) pts.push_back(p.position);
+        renderer_->renderPatternState(pts);
+    }
+#else
+    if (!renderer_) return;
+    std::vector<glm::vec3> pts;
+    for (const auto& p : candidate_poses_) pts.push_back(p.position);
+    renderer_->renderPatternState(pts);
+#endif
+}
+
+void DrugDiscoveryDemo::cleanup() {
+    candidate_poses_.clear();
+}
+
+void DrugDiscoveryDemo::handleKeyboard(unsigned char) {}
+void DrugDiscoveryDemo::handleMouse(int, int, int) {}
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/demos/drug_discovery_demo.hpp
+++ b/examples/workbench/demos/drug_discovery_demo.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "demo_manager.hpp"
+#include <glm/vec3.hpp>
+#include <vector>
+
+namespace sep {
+namespace workbench {
+
+struct Pose {
+    glm::vec3 position{0.0f};
+    glm::vec3 orientation{0.0f};
+    float binding_affinity{0.0f};
+};
+
+class DrugDiscoveryDemo : public Demo {
+public:
+    void init() override;
+    void update(float dt) override;
+    void render() override;
+    void cleanup() override;
+    void handleKeyboard(unsigned char key) override;
+    void handleMouse(int x, int y, int button) override;
+
+private:
+    std::vector<Pose> candidate_poses_;
+    int optimizer_iterations_{100};
+    float mutation_rate_{0.1f};
+};
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/main.cpp
+++ b/examples/workbench/main.cpp
@@ -10,6 +10,7 @@
 #include "demos/genesis_pattern.hpp"
 #include "demos/audio_visualizer.hpp"
 #include "demos/memory_garden.hpp"
+#include "demos/drug_discovery_demo.hpp"
 
 using namespace sep;
 using namespace sep::workbench;
@@ -126,6 +127,9 @@ void registerDemos() {
     });
     demo_manager.registerDemo("memory", []() {
         return std::make_unique<MemoryGardenDemo>();
+    });
+    demo_manager.registerDemo("drug_discovery", []() {
+        return std::make_unique<DrugDiscoveryDemo>();
     });
 
     // Start with Genesis Pattern demo


### PR DESCRIPTION
## Summary
- add DrugDiscoveryDemo example with simple pose optimization
- register `drug_discovery` demo in main
- handle optimizer parameters in configuration
- include optimizer defaults in config file
- compile DrugDiscoveryDemo via CMake

## Testing
- `npm test` *(fails: Missing script)*
- `cmake -S examples/workbench -B build_example`
- `cmake --build build_example` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6869aa80e9cc832aa532f800ed0ce8a5