### PR TITLE
Add drug discovery workbench demo

### DIFF
--- a/examples/workbench/CMakeLists.txt
+++ b/examples/workbench/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(sep_workbench
     demos/genesis_pattern.cpp
     demos/audio_visualizer.cpp
     demos/memory_garden.cpp
+    demos/drug_discovery_demo.cpp
 )
 
 # Set C++ standard

--- a/examples/workbench/config.cpp
+++ b/examples/workbench/config.cpp
@@ -90,6 +90,16 @@ bool Config::load(const std::filesystem::path& path) {
             }
         };
 
+        // Drug Discovery config
+        auto& drug = json["demos"]["drug_discovery"];
+        auto& opt = drug["optimizer"];
+        drug_discovery_ = {
+            {
+                opt["iterations"].get<int>(),
+                opt["mutation_rate"].get<float>()
+            }
+        };
+
         // Renderer config
         auto& renderer = json["renderer"];
         auto& cycles = renderer["cycles"];
@@ -173,6 +183,13 @@ bool Config::save(const std::filesystem::path& path) const {
                 {"show_connections", memory_garden_.visualization.show_connections},
                 {"connection_opacity", memory_garden_.visualization.connection_opacity},
                 {"pattern_scale", memory_garden_.visualization.pattern_scale}
+            }}
+        };
+
+        json["demos"]["drug_discovery"] = {
+            {"optimizer", {
+                {"iterations", drug_discovery_.optimizer.iterations},
+                {"mutation_rate", drug_discovery_.optimizer.mutation_rate}
             }}
         };
 

--- a/examples/workbench/config.hpp
+++ b/examples/workbench/config.hpp
@@ -65,6 +65,13 @@ struct MemoryGardenConfig {
     } visualization;
 };
 
+struct DrugDiscoveryConfig {
+    struct {
+        int iterations;
+        float mutation_rate;
+    } optimizer;
+};
+
 struct RendererConfig {
     struct {
         int samples;
@@ -88,6 +95,7 @@ public:
     const GenesisPatternConfig& genesis_pattern() const { return genesis_pattern_; }
     const AudioVisualizerConfig& audio_visualizer() const { return audio_visualizer_; }
     const MemoryGardenConfig& memory_garden() const { return memory_garden_; }
+    const DrugDiscoveryConfig& drug_discovery() const { return drug_discovery_; }
     const RendererConfig& renderer() const { return renderer_; }
 
 private:
@@ -98,6 +106,7 @@ private:
     GenesisPatternConfig genesis_pattern_;
     AudioVisualizerConfig audio_visualizer_;
     MemoryGardenConfig memory_garden_;
+    DrugDiscoveryConfig drug_discovery_;
     RendererConfig renderer_;
 };
 

--- a/examples/workbench/config.json
+++ b/examples/workbench/config.json
@@ -52,6 +52,12 @@
         "connection_opacity": 0.5,
         "pattern_scale": 1.0
       }
+    },
+    "drug_discovery": {
+      "optimizer": {
+        "iterations": 1,
+        "mutation_rate": 0.1
+      }
     }
   },
   "renderer": {

--- a/examples/workbench/demos/drug_discovery_demo.cpp
+++ b/examples/workbench/demos/drug_discovery_demo.cpp
@@ -1,0 +1,89 @@
+#include "drug_discovery_demo.hpp"
+#include <config.hpp>
+#include <glm/gtc/constants.hpp>
+#include <cstdlib>
+
+namespace sep {
+namespace workbench {
+
+void DrugDiscoveryDemo::init() {
+#ifdef SEP_WORKBENCH_DEMO
+    // Create a few placeholder poses
+    for (int i = 0; i < 5; ++i) {
+        Pose p;
+        p.position = glm::vec3(static_cast<float>(std::rand()%100) / 100.f,
+                               static_cast<float>(std::rand()%100) / 100.f,
+                               static_cast<float>(std::rand()%100) / 100.f);
+        p.orientation = glm::vec3(0.0f);
+        p.affinity = 0.0f;
+        poses_.push_back(p);
+    }
+#else
+    const auto& cfg = getConfigManager().getEngineConfig().drug_discovery();
+    optimizer_.iterations = cfg.optimizer.iterations;
+    optimizer_.mutation_rate = cfg.optimizer.mutation_rate;
+    // Initialize poses with dummy data
+    for (int i = 0; i < 5; ++i) {
+        Pose p;
+        p.position = glm::vec3(static_cast<float>(std::rand()%100) / 100.f,
+                               static_cast<float>(std::rand()%100) / 100.f,
+                               static_cast<float>(std::rand()%100) / 100.f);
+        poses_.push_back(p);
+    }
+#endif
+}
+
+void DrugDiscoveryDemo::update(float dt) {
+    // Placeholder optimization of molecular poses
+    for (auto& pose : poses_) {
+        for (int i = 0; i < optimizer_.iterations; ++i) {
+            // Randomly perturb position and orientation
+            pose.position += optimizer_.mutation_rate *
+                glm::vec3((std::rand()%200 - 100) / 100.0f) * dt;
+            pose.orientation += optimizer_.mutation_rate *
+                glm::vec3((std::rand()%200 - 100) / 100.0f) * dt;
+        }
+        // Mock binding affinity based on distance from origin
+        float dist = glm::length(pose.position);
+        pose.affinity = 1.0f - glm::clamp(dist, 0.0f, 1.0f);
+    }
+}
+
+void DrugDiscoveryDemo::render() {
+#ifdef SEP_WORKBENCH_DEMO
+    if (renderer_) {
+        std::vector<glm::vec3> points;
+        for (const auto& p : poses_) {
+            points.push_back(p.position);
+        }
+        renderer_->renderPatternState(points);
+    }
+#else
+    if (!renderer_) return;
+    std::vector<glm::vec3> points;
+    for (const auto& p : poses_) {
+        points.push_back(p.position);
+    }
+    renderer_->renderPatternState(points);
+#endif
+}
+
+void DrugDiscoveryDemo::cleanup() {
+    poses_.clear();
+}
+
+void DrugDiscoveryDemo::handleKeyboard(unsigned char key) {
+    switch (key) {
+        case '+':
+            optimizer_.mutation_rate += 0.05f;
+            break;
+        case '-':
+            optimizer_.mutation_rate = std::max(0.01f, optimizer_.mutation_rate - 0.05f);
+            break;
+    }
+}
+
+void DrugDiscoveryDemo::handleMouse(int, int, int) {}
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/demos/drug_discovery_demo.hpp
+++ b/examples/workbench/demos/drug_discovery_demo.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "demo_manager.hpp"
+#include "sep_engine_wrapper.h"
+#include <glm/vec3.hpp>
+#include <vector>
+#include <memory>
+
+namespace sep {
+namespace workbench {
+
+class DrugDiscoveryDemo : public Demo {
+public:
+    void init() override;
+    void update(float dt) override;
+    void render() override;
+    void cleanup() override;
+    void handleKeyboard(unsigned char key) override;
+    void handleMouse(int x, int y, int button) override;
+
+private:
+    struct Pose {
+        glm::vec3 position{0.0f};
+        glm::vec3 orientation{0.0f};
+        float affinity{0.0f}; // Mock binding affinity
+    };
+
+    std::vector<Pose> poses_;
+
+    struct OptimizerParams {
+        int iterations{1};
+        float mutation_rate{0.1f};
+    } optimizer_;
+};
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/main.cpp
+++ b/examples/workbench/main.cpp
@@ -10,6 +10,7 @@
 #include "demos/genesis_pattern.hpp"
 #include "demos/audio_visualizer.hpp"
 #include "demos/memory_garden.hpp"
+#include "demos/drug_discovery_demo.hpp"
 
 using namespace sep;
 using namespace sep::workbench;
@@ -126,6 +127,9 @@ void registerDemos() {
     });
     demo_manager.registerDemo("memory", []() {
         return std::make_unique<MemoryGardenDemo>();
+    });
+    demo_manager.registerDemo("drug_discovery", []() {
+        return std::make_unique<DrugDiscoveryDemo>();
     });
 
     // Start with Genesis Pattern demo


### PR DESCRIPTION
## Summary
- add a new `DrugDiscoveryDemo` example
- support optimizer config values
- register the new demo
- compile sources in CMake
- update default config with demo settings

## Testing
- `cmake -S examples/workbench -B build/workbench`
- `cmake --build build/testbed --target testbed_tests` *(fails: Cannot determine link language for target "testbed_cuda_kernels")*

------
https://chatgpt.com/codex/tasks/task_e_6869aa80e9cc832aa532f800ed0ce8a5