### PR TITLE
Add annealing demo

### DIFF
--- a/examples/workbench/CMakeLists.txt
+++ b/examples/workbench/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(sep_workbench
     demos/genesis_pattern.cpp
     demos/audio_visualizer.cpp
     demos/memory_garden.cpp
+    demos/annealing_demo.cpp
 )
 
 # Set C++ standard

--- a/examples/workbench/config.cpp
+++ b/examples/workbench/config.cpp
@@ -90,6 +90,14 @@ bool Config::load(const std::filesystem::path& path) {
             }
         };
 
+        // Annealing demo config
+        auto& anneal = json["demos"]["annealing"];
+        annealing_ = {
+            anneal["particle_count"].get<int>(),
+            anneal["initial_temperature"].get<float>(),
+            anneal["cooling_rate"].get<float>()
+        };
+
         // Renderer config
         auto& renderer = json["renderer"];
         auto& cycles = renderer["cycles"];
@@ -174,6 +182,12 @@ bool Config::save(const std::filesystem::path& path) const {
                 {"connection_opacity", memory_garden_.visualization.connection_opacity},
                 {"pattern_scale", memory_garden_.visualization.pattern_scale}
             }}
+        };
+
+        json["demos"]["annealing"] = {
+            {"particle_count", annealing_.particle_count},
+            {"initial_temperature", annealing_.initial_temperature},
+            {"cooling_rate", annealing_.cooling_rate}
         };
 
         // Renderer config

--- a/examples/workbench/config.hpp
+++ b/examples/workbench/config.hpp
@@ -62,7 +62,13 @@ struct MemoryGardenConfig {
         bool show_connections;
         float connection_opacity;
         float pattern_scale;
-    } visualization;
+} visualization;
+};
+
+struct AnnealingConfig {
+    int particle_count;
+    float initial_temperature;
+    float cooling_rate;
 };
 
 struct RendererConfig {
@@ -88,6 +94,7 @@ public:
     const GenesisPatternConfig& genesis_pattern() const { return genesis_pattern_; }
     const AudioVisualizerConfig& audio_visualizer() const { return audio_visualizer_; }
     const MemoryGardenConfig& memory_garden() const { return memory_garden_; }
+    const AnnealingConfig& annealing() const { return annealing_; }
     const RendererConfig& renderer() const { return renderer_; }
 
 private:
@@ -98,6 +105,7 @@ private:
     GenesisPatternConfig genesis_pattern_;
     AudioVisualizerConfig audio_visualizer_;
     MemoryGardenConfig memory_garden_;
+    AnnealingConfig annealing_;
     RendererConfig renderer_;
 };
 

--- a/examples/workbench/config.json
+++ b/examples/workbench/config.json
@@ -52,6 +52,11 @@
         "connection_opacity": 0.5,
         "pattern_scale": 1.0
       }
+    },
+    "annealing": {
+      "particle_count": 50,
+      "initial_temperature": 1.0,
+      "cooling_rate": 0.99
     }
   },
   "renderer": {

--- a/examples/workbench/demos/annealing_demo.cpp
+++ b/examples/workbench/demos/annealing_demo.cpp
@@ -1,0 +1,77 @@
+#include "annealing_demo.hpp"
+#include <config.hpp>
+#include <random>
+#include <glm/glm.hpp>
+
+namespace sep {
+namespace workbench {
+
+void AnnealingDemo::init() {
+#ifdef SEP_WORKBENCH_DEMO
+    int count = 50;
+    temperature_ = 1.0f;
+    cooling_rate_ = 0.99f;
+#else
+    const auto& cfg = sep::core::config::ConfigManager::getInstance().getEngineConfig().annealing();
+    int count = cfg.particle_count;
+    temperature_ = cfg.initial_temperature;
+    cooling_rate_ = cfg.cooling_rate;
+#endif
+
+    particles_.resize(count);
+    std::mt19937 rng{std::random_device{}()};
+    std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+    for (auto& p : particles_) {
+        p.position = {dist(rng), dist(rng), dist(rng)};
+        p.velocity = {0.0f, 0.0f, 0.0f};
+    }
+}
+
+void AnnealingDemo::applyForces(float dt) {
+    const float epsilon = 1.0f;
+    const float sigma = 1.0f;
+    for (size_t i = 0; i < particles_.size(); ++i) {
+        for (size_t j = i + 1; j < particles_.size(); ++j) {
+            glm::vec3 diff = particles_[j].position - particles_[i].position;
+            float r2 = glm::dot(diff, diff) + 1e-6f;
+            float inv_r6 = 1.0f / (r2 * r2 * r2);
+            float f = 24.0f * epsilon * inv_r6 * (2.0f * inv_r6 - 1.0f);
+            glm::vec3 force = f * diff;
+            particles_[i].velocity += force * dt;
+            particles_[j].velocity -= force * dt;
+        }
+    }
+
+    for (auto& p : particles_) {
+        p.position += p.velocity * dt;
+        p.velocity *= 0.99f;
+    }
+}
+
+void AnnealingDemo::coolSystem() {
+    temperature_ *= cooling_rate_;
+}
+
+void AnnealingDemo::update(float dt) {
+    applyForces(dt);
+    coolSystem();
+}
+
+void AnnealingDemo::render() {
+    if (!renderer_) return;
+    std::vector<glm::vec3> points;
+    for (const auto& p : particles_) {
+        points.push_back(p.position);
+    }
+    renderer_->renderPatternState(points);
+}
+
+void AnnealingDemo::cleanup() {
+    particles_.clear();
+}
+
+void AnnealingDemo::handleKeyboard(unsigned char) {}
+void AnnealingDemo::handleMouse(int, int, int) {}
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/demos/annealing_demo.hpp
+++ b/examples/workbench/demos/annealing_demo.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "demo_manager.hpp"
+#include <vector>
+#include <glm/vec3.hpp>
+
+namespace sep {
+namespace workbench {
+
+struct Particle {
+    glm::vec3 position;
+    glm::vec3 velocity;
+};
+
+class AnnealingDemo : public Demo {
+public:
+    void init() override;
+    void update(float dt) override;
+    void render() override;
+    void cleanup() override;
+    void handleKeyboard(unsigned char key) override;
+    void handleMouse(int x, int y, int button) override;
+
+private:
+    void applyForces(float dt);
+    void coolSystem();
+
+    std::vector<Particle> particles_;
+    float temperature_{1.0f};
+    float cooling_rate_{0.99f};
+};
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/main.cpp
+++ b/examples/workbench/main.cpp
@@ -10,6 +10,7 @@
 #include "demos/genesis_pattern.hpp"
 #include "demos/audio_visualizer.hpp"
 #include "demos/memory_garden.hpp"
+#include "demos/annealing_demo.hpp"
 
 using namespace sep;
 using namespace sep::workbench;
@@ -126,6 +127,9 @@ void registerDemos() {
     });
     demo_manager.registerDemo("memory", []() {
         return std::make_unique<MemoryGardenDemo>();
+    });
+    demo_manager.registerDemo("annealing", []() {
+        return std::make_unique<AnnealingDemo>();
     });
 
     // Start with Genesis Pattern demo


### PR DESCRIPTION
## Summary
- add `AnnealingDemo` with Lennard-Jones interactions
- wire into workbench build and registration
- extend config structures and default JSON

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bpy')*

------
https://chatgpt.com/codex/tasks/task_e_6869aa74735c832aa94131e5a9cd8b35