### PR TITLE
Add DrugDiscoveryDemo example

### DIFF
--- a/examples/workbench/CMakeLists.txt
+++ b/examples/workbench/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(sep_workbench
     demos/genesis_pattern.cpp
     demos/audio_visualizer.cpp
     demos/memory_garden.cpp
+    demos/drug_discovery_demo.cpp
 )
 
 # Set C++ standard

--- a/examples/workbench/config.cpp
+++ b/examples/workbench/config.cpp
@@ -90,6 +90,16 @@ bool Config::load(const std::filesystem::path& path) {
             }
         };
 
+        // Drug Discovery config
+        auto& drug = json["demos"]["drug_discovery"];
+        auto& optim = drug["optimizer"];
+        drug_discovery_ = {
+            {
+                optim["iterations"].get<int>(),
+                optim["mutation_rate"].get<float>()
+            }
+        };
+
         // Renderer config
         auto& renderer = json["renderer"];
         auto& cycles = renderer["cycles"];
@@ -173,6 +183,14 @@ bool Config::save(const std::filesystem::path& path) const {
                 {"show_connections", memory_garden_.visualization.show_connections},
                 {"connection_opacity", memory_garden_.visualization.connection_opacity},
                 {"pattern_scale", memory_garden_.visualization.pattern_scale}
+            }}
+        };
+
+        // Drug Discovery config
+        json["demos"]["drug_discovery"] = {
+            {"optimizer", {
+                {"iterations", drug_discovery_.optimizer.iterations},
+                {"mutation_rate", drug_discovery_.optimizer.mutation_rate}
             }}
         };
 

--- a/examples/workbench/config.hpp
+++ b/examples/workbench/config.hpp
@@ -65,6 +65,13 @@ struct MemoryGardenConfig {
     } visualization;
 };
 
+struct DrugDiscoveryConfig {
+    struct {
+        int iterations;
+        float mutation_rate;
+    } optimizer;
+};
+
 struct RendererConfig {
     struct {
         int samples;
@@ -88,6 +95,7 @@ public:
     const GenesisPatternConfig& genesis_pattern() const { return genesis_pattern_; }
     const AudioVisualizerConfig& audio_visualizer() const { return audio_visualizer_; }
     const MemoryGardenConfig& memory_garden() const { return memory_garden_; }
+    const DrugDiscoveryConfig& drug_discovery() const { return drug_discovery_; }
     const RendererConfig& renderer() const { return renderer_; }
 
 private:
@@ -98,6 +106,7 @@ private:
     GenesisPatternConfig genesis_pattern_;
     AudioVisualizerConfig audio_visualizer_;
     MemoryGardenConfig memory_garden_;
+    DrugDiscoveryConfig drug_discovery_;
     RendererConfig renderer_;
 };
 

--- a/examples/workbench/config.json
+++ b/examples/workbench/config.json
@@ -52,6 +52,12 @@
         "connection_opacity": 0.5,
         "pattern_scale": 1.0
       }
+    },
+    "drug_discovery": {
+      "optimizer": {
+        "iterations": 100,
+        "mutation_rate": 0.05
+      }
     }
   },
   "renderer": {

--- a/examples/workbench/demos/drug_discovery_demo.cpp
+++ b/examples/workbench/demos/drug_discovery_demo.cpp
@@ -1,0 +1,67 @@
+#include "drug_discovery_demo.hpp"
+#include <config.hpp>
+#include <glm/geometric.hpp>
+#include <cstdlib>
+
+namespace sep {
+namespace workbench {
+
+void DrugDiscoveryDemo::init() {
+#ifdef SEP_WORKBENCH_DEMO
+    iterations_ = 100;
+    mutation_rate_ = 0.05f;
+#else
+    const auto& cfg = getConfigManager().getEngineConfig().drug_discovery();
+    iterations_ = cfg.optimizer.iterations;
+    mutation_rate_ = cfg.optimizer.mutation_rate;
+#endif
+
+    // Initialize some candidate poses
+    for (int i = 0; i < 10; ++i) {
+        Pose p;
+        p.position = glm::vec3(static_cast<float>(std::rand()) / RAND_MAX,
+                               static_cast<float>(std::rand()) / RAND_MAX,
+                               static_cast<float>(std::rand()) / RAND_MAX);
+        p.orientation = glm::vec3(0.0f);
+        poses_.push_back(p);
+    }
+}
+
+void DrugDiscoveryDemo::runOptimizationStep() {
+    for (auto& p : poses_) {
+        glm::vec3 delta(
+            ((std::rand() % 100) / 100.0f - 0.5f) * mutation_rate_,
+            ((std::rand() % 100) / 100.0f - 0.5f) * mutation_rate_,
+            ((std::rand() % 100) / 100.0f - 0.5f) * mutation_rate_);
+        p.position += delta;
+        p.position = glm::clamp(p.position, glm::vec3(0.0f), glm::vec3(1.0f));
+
+        // Mock binding affinity: higher when closer to origin
+        p.binding_affinity = 1.0f / (1.0f + glm::length(p.position));
+    }
+}
+
+void DrugDiscoveryDemo::update(float) {
+    for (int i = 0; i < iterations_; ++i) {
+        runOptimizationStep();
+    }
+}
+
+void DrugDiscoveryDemo::render() {
+    if (!renderer_) return;
+    std::vector<glm::vec3> points;
+    for (const auto& p : poses_) {
+        points.push_back(p.position);
+    }
+    renderer_->renderPatternState(points);
+}
+
+void DrugDiscoveryDemo::cleanup() {
+    poses_.clear();
+}
+
+void DrugDiscoveryDemo::handleKeyboard(unsigned char) {}
+void DrugDiscoveryDemo::handleMouse(int, int, int) {}
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/demos/drug_discovery_demo.hpp
+++ b/examples/workbench/demos/drug_discovery_demo.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "demo_manager.hpp"
+#include <glm/vec3.hpp>
+#include <vector>
+
+namespace sep {
+namespace workbench {
+
+class DrugDiscoveryDemo : public Demo {
+public:
+    void init() override;
+    void update(float dt) override;
+    void render() override;
+    void cleanup() override;
+    void handleKeyboard(unsigned char key) override;
+    void handleMouse(int x, int y, int button) override;
+
+private:
+    struct Pose {
+        glm::vec3 position{0.f};
+        glm::vec3 orientation{0.f};
+        float binding_affinity{0.f};
+    };
+
+    std::vector<Pose> poses_;
+
+    int iterations_{100};
+    float mutation_rate_{0.05f};
+
+    void runOptimizationStep();
+};
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/main.cpp
+++ b/examples/workbench/main.cpp
@@ -10,6 +10,7 @@
 #include "demos/genesis_pattern.hpp"
 #include "demos/audio_visualizer.hpp"
 #include "demos/memory_garden.hpp"
+#include "demos/drug_discovery_demo.hpp"
 
 using namespace sep;
 using namespace sep::workbench;
@@ -126,6 +127,9 @@ void registerDemos() {
     });
     demo_manager.registerDemo("memory", []() {
         return std::make_unique<MemoryGardenDemo>();
+    });
+    demo_manager.registerDemo("drug_discovery", []() {
+        return std::make_unique<DrugDiscoveryDemo>();
     });
 
     // Start with Genesis Pattern demo

--- a/examples/workbench/sep_engine_wrapper.h
+++ b/examples/workbench/sep_engine_wrapper.h
@@ -6,6 +6,8 @@
 #include <functional>
 #include <glm/vec3.hpp>
 #include <glm/gtc/constants.hpp> // For glm::pi
+#include <glm/geometric.hpp>
+#include <cmath>
 #include <array>
 
 #ifndef SEP_WORKBENCH_DEMO


### PR DESCRIPTION
## Summary
- add a DrugDiscoveryDemo example with placeholder optimization
- register the demo in main and add it to the build
- extend workbench configuration for drug discovery parameters
- save/load the new configuration fields
- include additional headers in the engine wrapper
- provide default optimizer config in config.json

## Testing
- `./tests/blender/run_all_tests.sh` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6869aa80e9cc832aa532f800ed0ce8a5