### PR TITLE
Fix header include order in Blender module

### DIFF
--- a/src/blender/api.cpp
+++ b/src/blender/api.cpp
@@ -1,18 +1,21 @@
-#include <string.h>
 #include <cstring>
 #include <ctime>
+#include <cmath>
+#include <vector>
+#include <string>
+#include <memory>
+
+#include <string.h>
 #include <time.h>
 #include <unistd.h>
 #include <cstdlib>
 
-#include <string>  // For std::string
 #include "compat/math_common.h"
 
 // Forward declarations for Blender functions (minimal stubs)
 #include "blender/types.h"
 #include "blender/config.h"
 #include "blender/pattern_bridge.h"
-#include <memory>
 
 using sep::SEPBlenderBridge;
 

--- a/src/blender/blender_bridge.cpp
+++ b/src/blender/blender_bridge.cpp
@@ -1,14 +1,18 @@
-#include <string.h>
-#include <cstring> // For std::memcpy
-#include <ctime>   // For std::time
-#include <time.h>   // For CLOCK_MONOTONIC, timespec
-#include <unistd.h> // For nanosleep
+#include <cstring>
+#include <ctime>
+#include <cmath>
+#include <vector>
+#include <string>
+#include <memory>
 
-#include <string>  // For std::string
-#include <thread>  // For std::thread
-#include <chrono>  // For std::chrono
-#include <condition_variable> // For std::condition_variable
-#include <mutex> // For std::mutex, std::lock_guard, std::unique_lock
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <thread>
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
 
 #include "blender/bridge.h"
 

--- a/src/blender/blender_integration.cpp
+++ b/src/blender/blender_integration.cpp
@@ -1,23 +1,25 @@
+#include <cstring>
+#include <ctime>
+#include <cmath>
+#include <vector>
+#include <string>
+#include <memory>
+
 #include <string.h>
-#include <cstring> // For std::memcpy, std::memset, std::strlen, std::strcmp etc.
-#include <ctime>   // For C-style time functions
-#include <time.h>  // For CLOCK_MONOTONIC, timespec
-#include <unistd.h> // For nanosleep
+#include <time.h>
+#include <unistd.h>
 #include <cstdlib>
 
-#include <string>  // For std::string
-#include "blender/pattern_bridge.h"
 #include <mutex>
 #include <condition_variable>
 #include <thread>
 #include <chrono>
-
 #include <algorithm>
-#include <memory>
 #include <new>
 #include <sstream>
 #include <utility>
-#include <vector>
+
+#include "blender/pattern_bridge.h"
 
 #include "quantum/processor.h"  // Ensure PatternProcessor is complete
 #include "quantum/data.hpp"      // For PatternData/PatternConfig

--- a/src/blender/compression.cpp
+++ b/src/blender/compression.cpp
@@ -1,22 +1,23 @@
+#include <cstring>
+#include <ctime>
+#include <cmath>
+#include <vector>
+#include <string>
+#include <memory>
+
 #include <string.h>
-#include <cstring> // For std::memcpy, std::memset, std::memcmp
-#include <ctime>   // For C-style time functions (if needed)
 #include <time.h>
 #include <unistd.h>
 #include <cstdlib>
 
-#include <string>  // For std::string
-#include "blender/compression.h"
-#include <algorithm> // For std::min, std::clamp
-#include <chrono>    // For std::chrono
+#include <algorithm>
+#include <chrono>
+#include <array>
 
 #include <lz4.h>
 #include <zstd.h>
 
-#include <algorithm> // For std::min, std::clamp
-#include <chrono>    // For std::chrono
-#include <array>
-#include <vector>
+#include "blender/compression.h"
 
 namespace blender {
 

--- a/src/blender/compression_utils.cpp
+++ b/src/blender/compression_utils.cpp
@@ -1,18 +1,18 @@
+#include <cstring>
+#include <ctime>
+#include <cmath>
+#include <vector>
+#include <string>
+#include <memory>
+
 #include <string.h>
-#include <cstring> // For std::memcpy, std::memset, std::memcmp, std::strlen etc.
-#include <ctime>   // For C-style time functions
 #include <time.h>
 #include <unistd.h>
 #include <cstdlib>
+#include <array>
 
-#include <string>  // For std::string
-#include <vector>  // Already included below, but ensuring early availability
-#include <cmath> // For std::log2
-#include <array>   // Already included below, but ensuring early availability
 #include "blender/compression.h"
 #include "compat/math_common.h"
-
-// Standard library includes
 
 
 namespace blender {

--- a/src/blender/cycles_renderer.cpp
+++ b/src/blender/cycles_renderer.cpp
@@ -1,17 +1,17 @@
 // Standard includes
+#include <cstring>
+#include <ctime>
+#include <cmath>
+#include <vector>
+#include <string>
+#include <memory>
+
 #include <string.h>
-#include <cstring> // For std::memcpy, std::memset, std::memcmp, std::strlen etc.
-#include <ctime>   // For C-style time functions
 #include <time.h>
 #include <unistd.h>
 #include <cstdlib>
-
-#include <string>  // For std::string
-#include <cmath>
-#include <memory>
 #include <utility>
-#include <vector>
-#include <algorithm> // For std::max
+#include <algorithm>
 
 // Define Cycles namespace macros
 #define CCL_NAMESPACE_BEGIN namespace ccl {

--- a/src/blender/factory.cpp
+++ b/src/blender/factory.cpp
@@ -1,12 +1,15 @@
+#include <cstring>
+#include <ctime>
+#include <cmath>
+#include <vector>
+#include <string>
+#include <memory>
+
 #include <string.h>
-#include <cstring> // For std::memcpy, std::memset, std::memcmp, std::strlen etc.
-#include <ctime>   // For C-style time functions
 #include <time.h>
 #include <unistd.h>
 #include <cstdlib>
 
-#include <string>  // For std::string
-#include <memory>
 #include "blender/factory.h"
 #include "blender/bridge.h"
 #include "blender/types.h"

--- a/src/blender/gpu_context.cpp
+++ b/src/blender/gpu_context.cpp
@@ -1,16 +1,17 @@
-#include <string.h>  // C string functions
-#include <cstring>   // std::memcpy, etc.
-#include <ctime>     // std::tm and friends
-#include <time.h>    // CLOCK_MONOTONIC
-#include <unistd.h>  // nanosleep
-#include <cstdlib>   // std::malloc, std::free
+#include <cstring>
+#include <ctime>
+#include <cmath>
+#include <vector>
+#include <string>
+#include <memory>
 
-#include <string>    // For std::string
-#include <sys/stat.h> // For stat
-#include <new>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+#include <cstdlib>
+#include <sys/stat.h>
 
 #include "blender/gpu_context.h"
-#include <new>
 
 namespace sep {
 

--- a/src/blender/mesh_handler.cpp
+++ b/src/blender/mesh_handler.cpp
@@ -3,10 +3,18 @@
  * @brief Default MeshHandler implementation used when Blender APIs are absent.
 # */ // No space between these two lines causes build error in some compilers
 
-#include <string.h>
 #include <cstring>
 #include <ctime>
-#include <string>  // For std::string
+#include <cmath>
+#include <vector>
+#include <string>
+#include <memory>
+
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+#include <cstdlib>
+
 #include "blender/mesh_handler.h"
 #include "core/common.h"  // defines sep::SEPResult
 

--- a/src/blender/oiio_output_driver.cpp
+++ b/src/blender/oiio_output_driver.cpp
@@ -1,6 +1,11 @@
-#include <string.h>
-#include <cstring> // For std::memcpy if needed
+#include <cstring>
 #include <ctime>
+#include <cmath>
+#include <vector>
+#include <string>
+#include <memory>
+
+#include <string.h>
 #include <time.h>
 #include <unistd.h>
 #include <cstdlib>

--- a/src/blender/pattern_visualization_pipeline.cpp
+++ b/src/blender/pattern_visualization_pipeline.cpp
@@ -1,20 +1,21 @@
-#include <string.h>
 #include <cstring>
 #include <ctime>
+#include <cmath>
+#include <vector>
+#include <string>
+#include <memory>
+
+#include <string.h>
 #include <time.h>
 #include <unistd.h>
 #include <cstdlib>
 
-#include <string>  // For std::string
-#include <string>  // For std::string
+#include <algorithm>
+#include <numeric>
+
 #include "blender/pattern_visualization_pipeline.h"
 #include "compat/shim.h"
 #include "core/common.h"  // defines sep::SEPResult
-#include <algorithm> // For std::min, std::max
-#include <numeric>   // For std::accumulate
-#include <vector>
-#include <algorithm> // For std::min, std::max
-#include <numeric>   // For std::accumulate
 
 namespace sep {
 namespace blender {


### PR DESCRIPTION
## Summary
- include standard headers before third-party and project headers in Blender sources
- add missing `<cmath>`, `<vector>`, and `<memory>` to ensure standard symbols

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6869aacfc0e4832a9a8b69be6eb31c04