### PR TITLE
Fix header include order in blender sources

### DIFF
--- a/src/blender/api.cpp
+++ b/src/blender/api.cpp
@@ -1,11 +1,12 @@
-#include <string.h>
 #include <cstring>
 #include <ctime>
+#include <cstdlib>
+#include <string>
+#include <memory>
+#include <string.h>
 #include <time.h>
 #include <unistd.h>
-#include <cstdlib>
 
-#include <string>  // For std::string
 #include "compat/math_common.h"
 
 // Forward declarations for Blender functions (minimal stubs)

--- a/src/blender/blender_bridge.cpp
+++ b/src/blender/blender_bridge.cpp
@@ -1,20 +1,19 @@
+#include <cstring>
+#include <ctime>
+#include <string>
+#include <thread>
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
 #include <string.h>
-#include <cstring> // For std::memcpy
-#include <ctime>   // For std::time
-#include <time.h>   // For CLOCK_MONOTONIC, timespec
-#include <unistd.h> // For nanosleep
+#include <time.h>
+#include <unistd.h>
 
-#include <string>  // For std::string
-#include <thread>  // For std::thread
-#include <chrono>  // For std::chrono
-#include <condition_variable> // For std::condition_variable
-#include <mutex> // For std::mutex, std::lock_guard, std::unique_lock
+#include <spdlog/spdlog.h>
 
 #include "blender/bridge.h"
-
 #include "core/error_handler.h"
 #include "core/metrics_collector.h"
-#include <spdlog/spdlog.h>
 
 namespace sep {
 namespace pattern {

--- a/src/blender/blender_integration.cpp
+++ b/src/blender/blender_integration.cpp
@@ -1,27 +1,24 @@
-#include <string.h>
-#include <cstring> // For std::memcpy, std::memset, std::strlen, std::strcmp etc.
-#include <ctime>   // For C-style time functions
-#include <time.h>  // For CLOCK_MONOTONIC, timespec
-#include <unistd.h> // For nanosleep
+#include <cstring>
+#include <ctime>
 #include <cstdlib>
-
-#include <string>  // For std::string
-#include "blender/pattern_bridge.h"
+#include <string>
 #include <mutex>
 #include <condition_variable>
 #include <thread>
 #include <chrono>
-
 #include <algorithm>
 #include <memory>
 #include <new>
 #include <sstream>
 #include <utility>
 #include <vector>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
 
-#include "quantum/processor.h"  // Ensure PatternProcessor is complete
-#include "quantum/data.hpp"      // For PatternData/PatternConfig
-
+#include "blender/pattern_bridge.h"
+#include "quantum/processor.h"
+#include "quantum/data.hpp"
 #include "blender/pattern_observer.h"
 #include "quantum/types.h"
 #include "memory/types.h"

--- a/src/blender/compression.cpp
+++ b/src/blender/compression.cpp
@@ -1,22 +1,19 @@
+#include <cstring>
+#include <ctime>
+#include <cstdlib>
+#include <string>
+#include <algorithm>
+#include <chrono>
+#include <array>
+#include <vector>
 #include <string.h>
-#include <cstring> // For std::memcpy, std::memset, std::memcmp
-#include <ctime>   // For C-style time functions (if needed)
 #include <time.h>
 #include <unistd.h>
-#include <cstdlib>
-
-#include <string>  // For std::string
-#include "blender/compression.h"
-#include <algorithm> // For std::min, std::clamp
-#include <chrono>    // For std::chrono
 
 #include <lz4.h>
 #include <zstd.h>
 
-#include <algorithm> // For std::min, std::clamp
-#include <chrono>    // For std::chrono
-#include <array>
-#include <vector>
+#include "blender/compression.h"
 
 namespace blender {
 

--- a/src/blender/compression_utils.cpp
+++ b/src/blender/compression_utils.cpp
@@ -1,14 +1,14 @@
+#include <cstring>
+#include <ctime>
+#include <cstdlib>
+#include <string>
+#include <vector>
+#include <cmath>
+#include <array>
 #include <string.h>
-#include <cstring> // For std::memcpy, std::memset, std::memcmp, std::strlen etc.
-#include <ctime>   // For C-style time functions
 #include <time.h>
 #include <unistd.h>
-#include <cstdlib>
 
-#include <string>  // For std::string
-#include <vector>  // Already included below, but ensuring early availability
-#include <cmath> // For std::log2
-#include <array>   // Already included below, but ensuring early availability
 #include "blender/compression.h"
 #include "compat/math_common.h"
 

--- a/src/blender/cycles_renderer.cpp
+++ b/src/blender/cycles_renderer.cpp
@@ -1,33 +1,22 @@
-// Standard includes
-#include <string.h>
-#include <cstring> // For std::memcpy, std::memset, std::memcmp, std::strlen etc.
-#include <ctime>   // For C-style time functions
-#include <time.h>
-#include <unistd.h>
+#include <cstring>
+#include <ctime>
 #include <cstdlib>
-
-#include <string>  // For std::string
+#include <string>
 #include <cmath>
 #include <memory>
 #include <utility>
 #include <vector>
-#include <algorithm> // For std::max
+#include <algorithm>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
 
 // Define Cycles namespace macros
 #define CCL_NAMESPACE_BEGIN namespace ccl {
 #define CCL_NAMESPACE_END }
 
-// Core Cycles includes
 #include "util/system.h"
 #include "util/types.h"
-
-// SEP includes
-#include "blender/cycles_renderer.h"
-#include "core/error_handler.h"
-#include "core/types.h"
-#include "quantum/data.hpp"
-
-// Cycles core includes
 #include "device/device.h"
 #include "scene/camera.h"
 #include "scene/image.h"
@@ -35,9 +24,6 @@
 #include "scene/scene.h"
 #include "session/output_driver.h"
 #include "session/session.h"
-
-// Cycles utility includes
-#include "blender/oiio_output_driver.h"
 #include "util/array.h"
 #include "util/math_base.h"
 #include "util/param.h"
@@ -47,6 +33,13 @@
 #include "util/texture.h"
 #include "util/unique_ptr.h"
 #include "util/vector.h"
+
+// Project includes
+#include "blender/cycles_renderer.h"
+#include "blender/oiio_output_driver.h"
+#include "core/error_handler.h"
+#include "core/types.h"
+#include "quantum/data.hpp"
 
 namespace sep {
 namespace blender {

--- a/src/blender/factory.cpp
+++ b/src/blender/factory.cpp
@@ -1,12 +1,12 @@
+#include <cstring>
+#include <ctime>
+#include <cstdlib>
+#include <string>
+#include <memory>
 #include <string.h>
-#include <cstring> // For std::memcpy, std::memset, std::memcmp, std::strlen etc.
-#include <ctime>   // For C-style time functions
 #include <time.h>
 #include <unistd.h>
-#include <cstdlib>
 
-#include <string>  // For std::string
-#include <memory>
 #include "blender/factory.h"
 #include "blender/bridge.h"
 #include "blender/types.h"

--- a/src/blender/gpu_context.cpp
+++ b/src/blender/gpu_context.cpp
@@ -1,16 +1,14 @@
-#include <string.h>  // C string functions
-#include <cstring>   // std::memcpy, etc.
-#include <ctime>     // std::tm and friends
-#include <time.h>    // CLOCK_MONOTONIC
-#include <unistd.h>  // nanosleep
-#include <cstdlib>   // std::malloc, std::free
-
-#include <string>    // For std::string
-#include <sys/stat.h> // For stat
+#include <cstring>
+#include <ctime>
+#include <cstdlib>
+#include <string>
+#include <sys/stat.h>
 #include <new>
+#include <unistd.h>
+#include <time.h>
+#include <string.h>
 
 #include "blender/gpu_context.h"
-#include <new>
 
 namespace sep {
 

--- a/src/blender/mesh_handler.cpp
+++ b/src/blender/mesh_handler.cpp
@@ -3,10 +3,11 @@
  * @brief Default MeshHandler implementation used when Blender APIs are absent.
 # */ // No space between these two lines causes build error in some compilers
 
-#include <string.h>
 #include <cstring>
 #include <ctime>
-#include <string>  // For std::string
+#include <string>
+#include <string.h>
+
 #include "blender/mesh_handler.h"
 #include "core/common.h"  // defines sep::SEPResult
 

--- a/src/blender/oiio_output_driver.cpp
+++ b/src/blender/oiio_output_driver.cpp
@@ -1,40 +1,31 @@
-#include <string.h>
-#include <cstring> // For std::memcpy if needed
+#include <cstring>
 #include <ctime>
+#include <vector>
+#include <cstdlib>
+#include <string.h>
 #include <time.h>
 #include <unistd.h>
-#include <cstdlib>
 
 // Define Cycles namespace macros
 #define CCL_NAMESPACE_BEGIN namespace ccl {
 #define CCL_NAMESPACE_END }
 
-#include "blender/oiio_output_driver.h"
 
-// Core Cycles includes
+// Third-party includes
 #include "util/system.h"
 #include "util/types.h"
-
-// Scene includes
 #include "scene/colorspace.h"
 #include "util/image.h"
 #include "util/unique_ptr.h"
-
 #ifdef WITH_OCIO
 #  include <OpenColorIO/OpenColorIO.h>
 namespace OCIO = OCIO_NAMESPACE;
 #endif
-
-// OpenImageIO includes - full definitions first
 #include <OpenImageIO/imagebuf.h>
 #include <OpenImageIO/imagebufalgo.h>
-#ifdef WITH_OCIO
-#  include <OpenColorIO/OpenColorIO.h>
-namespace OCIO = OCIO_NAMESPACE;
-#endif
 
-// Standard includes
-#include <vector>
+// Project includes
+#include "blender/oiio_output_driver.h"
 
 namespace OIIO = OpenImageIO_v2_5;
 

--- a/src/blender/pattern_visualization_pipeline.cpp
+++ b/src/blender/pattern_visualization_pipeline.cpp
@@ -1,20 +1,17 @@
-#include <string.h>
 #include <cstring>
 #include <ctime>
+#include <cstdlib>
+#include <string>
+#include <algorithm>
+#include <numeric>
+#include <vector>
+#include <string.h>
 #include <time.h>
 #include <unistd.h>
-#include <cstdlib>
 
-#include <string>  // For std::string
-#include <string>  // For std::string
 #include "blender/pattern_visualization_pipeline.h"
 #include "compat/shim.h"
 #include "core/common.h"  // defines sep::SEPResult
-#include <algorithm> // For std::min, std::max
-#include <numeric>   // For std::accumulate
-#include <vector>
-#include <algorithm> // For std::min, std::max
-#include <numeric>   // For std::accumulate
 
 namespace sep {
 namespace blender {


### PR DESCRIPTION
## Summary
- reorder standard/third-party headers across blender modules
- ensure C and C++ headers appear before project includes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6869aacfc0e4832a9a8b69be6eb31c04