### PR TITLE
Add digital physics demo

### DIFF
--- a/examples/workbench/CMakeLists.txt
+++ b/examples/workbench/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(sep_workbench
     demos/genesis_pattern.cpp
     demos/audio_visualizer.cpp
     demos/memory_garden.cpp
+    demos/digital_physics_demo.cpp
 )
 
 # Set C++ standard

--- a/examples/workbench/config.cpp
+++ b/examples/workbench/config.cpp
@@ -90,6 +90,15 @@ bool Config::load(const std::filesystem::path& path) {
             }
         };
 
+        // Digital Physics config
+        auto& digital = json["demos"]["digital_physics"];
+        auto& grid = digital["grid"];
+        auto& rules = digital["rules"];
+        digital_physics_ = {
+            { grid["width"].get<int>(), grid["height"].get<int>() },
+            { rules["rule"].get<std::string>() }
+        };
+
         // Renderer config
         auto& renderer = json["renderer"];
         auto& cycles = renderer["cycles"];
@@ -173,6 +182,17 @@ bool Config::save(const std::filesystem::path& path) const {
                 {"show_connections", memory_garden_.visualization.show_connections},
                 {"connection_opacity", memory_garden_.visualization.connection_opacity},
                 {"pattern_scale", memory_garden_.visualization.pattern_scale}
+            }}
+        };
+
+        // Digital Physics config
+        json["demos"]["digital_physics"] = {
+            {"grid", {
+                {"width", digital_physics_.grid.width},
+                {"height", digital_physics_.grid.height}
+            }},
+            {"rules", {
+                {"rule", digital_physics_.rules.rule}
             }}
         };
 

--- a/examples/workbench/config.hpp
+++ b/examples/workbench/config.hpp
@@ -65,6 +65,16 @@ struct MemoryGardenConfig {
     } visualization;
 };
 
+struct DigitalPhysicsConfig {
+    struct {
+        int width;
+        int height;
+    } grid;
+    struct {
+        std::string rule;
+    } rules;
+};
+
 struct RendererConfig {
     struct {
         int samples;
@@ -88,6 +98,7 @@ public:
     const GenesisPatternConfig& genesis_pattern() const { return genesis_pattern_; }
     const AudioVisualizerConfig& audio_visualizer() const { return audio_visualizer_; }
     const MemoryGardenConfig& memory_garden() const { return memory_garden_; }
+    const DigitalPhysicsConfig& digital_physics() const { return digital_physics_; }
     const RendererConfig& renderer() const { return renderer_; }
 
 private:
@@ -98,6 +109,7 @@ private:
     GenesisPatternConfig genesis_pattern_;
     AudioVisualizerConfig audio_visualizer_;
     MemoryGardenConfig memory_garden_;
+    DigitalPhysicsConfig digital_physics_;
     RendererConfig renderer_;
 };
 

--- a/examples/workbench/config.json
+++ b/examples/workbench/config.json
@@ -52,6 +52,15 @@
         "connection_opacity": 0.5,
         "pattern_scale": 1.0
       }
+    },
+    "digital_physics": {
+      "grid": {
+        "width": 50,
+        "height": 50
+      },
+      "rules": {
+        "rule": "B3/S23"
+      }
     }
   },
   "renderer": {

--- a/examples/workbench/demos/digital_physics_demo.cpp
+++ b/examples/workbench/demos/digital_physics_demo.cpp
@@ -1,0 +1,135 @@
+#include "digital_physics_demo.hpp"
+#include <config.hpp>
+#include <random>
+#include <glm/vec3.hpp>
+
+namespace sep {
+namespace workbench {
+
+void DigitalPhysicsDemo::parseRule(const std::string& rule) {
+    birth_rules_.clear();
+    survive_rules_.clear();
+
+    auto b_pos = rule.find('B');
+    auto s_pos = rule.find('S');
+    if (b_pos == std::string::npos || s_pos == std::string::npos) {
+        // default to B3/S23
+        birth_rules_ = {3};
+        survive_rules_ = {2,3};
+        return;
+    }
+    auto parseNums = [&](std::size_t start, std::size_t end, std::vector<int>& out){
+        for (std::size_t i = start; i < end; ++i) {
+            if (std::isdigit(rule[i])) out.push_back(rule[i]-'0');
+        }
+    };
+    if (b_pos < s_pos) {
+        parseNums(b_pos+1, s_pos, birth_rules_);
+        parseNums(s_pos+1, rule.size(), survive_rules_);
+    } else {
+        parseNums(s_pos+1, b_pos, survive_rules_);
+        parseNums(b_pos+1, rule.size(), birth_rules_);
+    }
+    if (birth_rules_.empty()) birth_rules_.push_back(3);
+    if (survive_rules_.empty()) { survive_rules_.push_back(2); survive_rules_.push_back(3); }
+}
+
+void DigitalPhysicsDemo::init() {
+#ifdef SEP_WORKBENCH_DEMO
+    width_ = 50;
+    height_ = 50;
+    rule_string_ = "B3/S23";
+#else
+    const auto& cfg = getConfigManager().getEngineConfig().digital_physics();
+    width_ = cfg.grid.width;
+    height_ = cfg.grid.height;
+    rule_string_ = cfg.rules.rule;
+#endif
+
+    parseRule(rule_string_);
+    grid_.resize(width_ * height_);
+    std::mt19937 rng{std::random_device{}()};
+    std::uniform_int_distribution<int> dist(0,1);
+    for (auto& cell : grid_) {
+        cell.alive = dist(rng) == 1;
+    }
+}
+
+int DigitalPhysicsDemo::neighborCount(int x, int y) const {
+    int count = 0;
+    for (int dy = -1; dy <=1; ++dy) {
+        for (int dx = -1; dx <=1; ++dx) {
+            if (dx==0 && dy==0) continue;
+            int nx = (x + dx + width_) % width_;
+            int ny = (y + dy + height_) % height_;
+            if (grid_[index(nx,ny)].alive) ++count;
+        }
+    }
+    return count;
+}
+
+void DigitalPhysicsDemo::step() {
+    std::vector<Cell> next = grid_;
+    for (int y=0; y<height_; ++y) {
+        for (int x=0; x<width_; ++x) {
+            int n = neighborCount(x,y);
+            bool alive = grid_[index(x,y)].alive;
+            if (alive) {
+                bool survive = std::find(survive_rules_.begin(), survive_rules_.end(), n) != survive_rules_.end();
+                next[index(x,y)].alive = survive;
+            } else {
+                bool birth = std::find(birth_rules_.begin(), birth_rules_.end(), n) != birth_rules_.end();
+                next[index(x,y)].alive = birth;
+            }
+        }
+    }
+    grid_.swap(next);
+}
+
+void DigitalPhysicsDemo::update(float) {
+    step();
+}
+
+void DigitalPhysicsDemo::render() {
+#ifdef SEP_WORKBENCH_DEMO
+    if (renderer_) {
+        std::vector<glm::vec3> points;
+        for (int y=0; y<height_; ++y) {
+            for (int x=0; x<width_; ++x) {
+                if (grid_[index(x,y)].alive) {
+                    points.emplace_back((float)x/width_, 0.0f, (float)y/height_);
+                }
+            }
+        }
+        renderer_->renderPatternState(points);
+    }
+#else
+    if (!renderer_) return;
+    std::vector<glm::vec3> points;
+    for (int y=0; y<height_; ++y) {
+        for (int x=0; x<width_; ++x) {
+            if (grid_[index(x,y)].alive) {
+                points.emplace_back((float)x/width_, 0.0f, (float)y/height_);
+            }
+        }
+    }
+    renderer_->renderPatternState(points);
+#endif
+}
+
+void DigitalPhysicsDemo::cleanup() {
+    grid_.clear();
+}
+
+void DigitalPhysicsDemo::handleKeyboard(unsigned char key) {
+    if (key == 'r') {
+        std::mt19937 rng{std::random_device{}()};
+        std::uniform_int_distribution<int> dist(0,1);
+        for (auto& cell : grid_) cell.alive = dist(rng)==1;
+    }
+}
+
+void DigitalPhysicsDemo::handleMouse(int, int, int) {}
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/demos/digital_physics_demo.hpp
+++ b/examples/workbench/demos/digital_physics_demo.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "demo_manager.hpp"
+#include <vector>
+#include <string>
+
+namespace sep {
+namespace workbench {
+
+class DigitalPhysicsDemo : public Demo {
+public:
+    void init() override;
+    void update(float dt) override;
+    void render() override;
+    void cleanup() override;
+    void handleKeyboard(unsigned char key) override;
+    void handleMouse(int x, int y, int button) override;
+
+private:
+    struct Cell {
+        pattern::PatternData data;
+        bool alive{false};
+    };
+
+    std::vector<Cell> grid_;
+    int width_{0};
+    int height_{0};
+    std::vector<int> birth_rules_;
+    std::vector<int> survive_rules_;
+    std::string rule_string_{"B3/S23"};
+
+    int index(int x, int y) const { return y * width_ + x; }
+    int neighborCount(int x, int y) const;
+    void parseRule(const std::string& rule);
+    void step();
+};
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/main.cpp
+++ b/examples/workbench/main.cpp
@@ -10,6 +10,7 @@
 #include "demos/genesis_pattern.hpp"
 #include "demos/audio_visualizer.hpp"
 #include "demos/memory_garden.hpp"
+#include "demos/digital_physics_demo.hpp"
 
 using namespace sep;
 using namespace sep::workbench;
@@ -126,6 +127,9 @@ void registerDemos() {
     });
     demo_manager.registerDemo("memory", []() {
         return std::make_unique<MemoryGardenDemo>();
+    });
+    demo_manager.registerDemo("digital_physics", []() {
+        return std::make_unique<DigitalPhysicsDemo>();
     });
 
     // Start with Genesis Pattern demo


### PR DESCRIPTION
## Summary
- implement the `DigitalPhysicsDemo` cellular automaton
- hook new demo into main workbench build and registration
- extend configuration structures with `digital_physics` options
- provide example rules and grid size in config

## Testing
- `cmake -S . -B build -DBUILD_TESTING=OFF` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6869aa844534832ab7429e40be798d3b