### PR TITLE
Add Drug Discovery demo and optimizer config

### DIFF
--- a/examples/workbench/CMakeLists.txt
+++ b/examples/workbench/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(sep_workbench
     demos/genesis_pattern.cpp
     demos/audio_visualizer.cpp
     demos/memory_garden.cpp
+    demos/drug_discovery_demo.cpp
 )
 
 # Set C++ standard

--- a/examples/workbench/config.cpp
+++ b/examples/workbench/config.cpp
@@ -90,6 +90,13 @@ bool Config::load(const std::filesystem::path& path) {
             }
         };
 
+        // Drug Discovery config
+        auto& drug = json["demos"]["drug_discovery"];
+        drug_discovery_ = {
+            drug["iterations"].get<int>(),
+            drug["mutation_rate"].get<float>()
+        };
+
         // Renderer config
         auto& renderer = json["renderer"];
         auto& cycles = renderer["cycles"];
@@ -174,6 +181,12 @@ bool Config::save(const std::filesystem::path& path) const {
                 {"connection_opacity", memory_garden_.visualization.connection_opacity},
                 {"pattern_scale", memory_garden_.visualization.pattern_scale}
             }}
+        };
+
+        // Drug Discovery config
+        json["demos"]["drug_discovery"] = {
+            {"iterations", drug_discovery_.iterations},
+            {"mutation_rate", drug_discovery_.mutation_rate}
         };
 
         // Renderer config

--- a/examples/workbench/config.hpp
+++ b/examples/workbench/config.hpp
@@ -65,6 +65,11 @@ struct MemoryGardenConfig {
     } visualization;
 };
 
+struct DrugDiscoveryConfig {
+    int iterations;
+    float mutation_rate;
+};
+
 struct RendererConfig {
     struct {
         int samples;
@@ -88,6 +93,7 @@ public:
     const GenesisPatternConfig& genesis_pattern() const { return genesis_pattern_; }
     const AudioVisualizerConfig& audio_visualizer() const { return audio_visualizer_; }
     const MemoryGardenConfig& memory_garden() const { return memory_garden_; }
+    const DrugDiscoveryConfig& drug_discovery() const { return drug_discovery_; }
     const RendererConfig& renderer() const { return renderer_; }
 
 private:
@@ -98,6 +104,7 @@ private:
     GenesisPatternConfig genesis_pattern_;
     AudioVisualizerConfig audio_visualizer_;
     MemoryGardenConfig memory_garden_;
+    DrugDiscoveryConfig drug_discovery_;
     RendererConfig renderer_;
 };
 

--- a/examples/workbench/config.json
+++ b/examples/workbench/config.json
@@ -52,6 +52,10 @@
         "connection_opacity": 0.5,
         "pattern_scale": 1.0
       }
+    },
+    "drug_discovery": {
+      "iterations": 10,
+      "mutation_rate": 0.05
     }
   },
   "renderer": {

--- a/examples/workbench/demos/drug_discovery_demo.cpp
+++ b/examples/workbench/demos/drug_discovery_demo.cpp
@@ -1,0 +1,82 @@
+#include "drug_discovery_demo.hpp"
+#include <config.hpp>
+#include <glm/glm.hpp>
+#include <cstdlib>
+
+namespace sep {
+namespace workbench {
+
+void DrugDiscoveryDemo::init() {
+#ifdef SEP_WORKBENCH_DEMO
+    // Default parameters for demo mode
+    iterations_ = 10;
+    mutation_rate_ = 0.05f;
+#else
+    const auto& cfg = sep::core::config::ConfigManager::getInstance().getEngineConfig().drug_discovery();
+    iterations_ = cfg.iterations;
+    mutation_rate_ = cfg.mutation_rate;
+#endif
+
+    // Create a few initial poses
+    for (int i = 0; i < 5; ++i) {
+        Pose p;
+        p.position = glm::vec3((std::rand() % 100) * 0.01f);
+        p.orientation = glm::vec3(0.0f);
+        p.binding_affinity = 0.0f;
+        poses_.push_back(p);
+    }
+}
+
+void DrugDiscoveryDemo::optimizePoses() {
+    for (int it = 0; it < iterations_; ++it) {
+        for (auto& p : poses_) {
+            // Simple random mutation of pose variables
+            p.position += mutation_rate_ * glm::vec3(
+                ((std::rand() % 200) - 100) * 0.001f,
+                ((std::rand() % 200) - 100) * 0.001f,
+                ((std::rand() % 200) - 100) * 0.001f);
+            p.orientation += mutation_rate_ * glm::vec3(
+                ((std::rand() % 200) - 100) * 0.001f,
+                ((std::rand() % 200) - 100) * 0.001f,
+                ((std::rand() % 200) - 100) * 0.001f);
+
+            // Mock binding affinity computation
+            float dist = glm::length(p.position);
+            p.binding_affinity = glm::clamp(1.0f - dist, 0.0f, 1.0f);
+        }
+    }
+}
+
+void DrugDiscoveryDemo::update(float) {
+    optimizePoses();
+}
+
+void DrugDiscoveryDemo::render() {
+#ifdef SEP_WORKBENCH_DEMO
+    if (renderer_) {
+        std::vector<glm::vec3> points;
+        for (const auto& p : poses_) {
+            points.push_back(p.position);
+        }
+        renderer_->renderPatternState(points);
+    }
+#else
+    if (!renderer_) return;
+    std::vector<glm::vec3> points;
+    for (const auto& p : poses_) {
+        points.push_back(p.position);
+    }
+    renderer_->renderPatternState(points);
+#endif
+}
+
+void DrugDiscoveryDemo::cleanup() {
+    poses_.clear();
+}
+
+void DrugDiscoveryDemo::handleKeyboard(unsigned char) {}
+void DrugDiscoveryDemo::handleMouse(int, int, int) {}
+
+} // namespace workbench
+} // namespace sep
+

--- a/examples/workbench/demos/drug_discovery_demo.hpp
+++ b/examples/workbench/demos/drug_discovery_demo.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "demo_manager.hpp"
+#include "sep_engine_wrapper.h"
+#include <vector>
+#include <glm/vec3.hpp>
+
+namespace sep {
+namespace workbench {
+
+struct Pose {
+    glm::vec3 position{0.0f};
+    glm::vec3 orientation{0.0f};
+    float binding_affinity{0.0f};
+};
+
+class DrugDiscoveryDemo : public Demo {
+public:
+    void init() override;
+    void update(float dt) override;
+    void render() override;
+    void cleanup() override;
+    void handleKeyboard(unsigned char key) override;
+    void handleMouse(int x, int y, int button) override;
+
+private:
+    void optimizePoses();
+
+    std::vector<Pose> poses_;
+    int iterations_{10};
+    float mutation_rate_{0.05f};
+};
+
+} // namespace workbench
+} // namespace sep
+

--- a/examples/workbench/main.cpp
+++ b/examples/workbench/main.cpp
@@ -10,6 +10,7 @@
 #include "demos/genesis_pattern.hpp"
 #include "demos/audio_visualizer.hpp"
 #include "demos/memory_garden.hpp"
+#include "demos/drug_discovery_demo.hpp"
 
 using namespace sep;
 using namespace sep::workbench;
@@ -126,6 +127,9 @@ void registerDemos() {
     });
     demo_manager.registerDemo("memory", []() {
         return std::make_unique<MemoryGardenDemo>();
+    });
+    demo_manager.registerDemo("drug_discovery", []() {
+        return std::make_unique<DrugDiscoveryDemo>();
     });
 
     // Start with Genesis Pattern demo

--- a/include/workbench/CMakeLists.txt
+++ b/include/workbench/CMakeLists.txt
@@ -54,6 +54,7 @@ add_executable(sep_workbench
     demos/genesis_pattern.cpp
     demos/audio_visualizer.cpp
     demos/memory_garden.cpp
+    demos/drug_discovery_demo.cpp
 )
 
 # Include directories

--- a/include/workbench/config.cpp
+++ b/include/workbench/config.cpp
@@ -90,6 +90,13 @@ bool Config::load(const std::filesystem::path& path) {
             }
         };
 
+        // Drug Discovery config
+        auto& drug = json["demos"]["drug_discovery"];
+        drug_discovery_ = {
+            drug["iterations"].get<int>(),
+            drug["mutation_rate"].get<float>()
+        };
+
         // Renderer config
         auto& renderer = json["renderer"];
         auto& cycles = renderer["cycles"];
@@ -174,6 +181,12 @@ bool Config::save(const std::filesystem::path& path) const {
                 {"connection_opacity", memory_garden_.visualization.connection_opacity},
                 {"pattern_scale", memory_garden_.visualization.pattern_scale}
             }}
+        };
+
+        // Drug Discovery config
+        json["demos"]["drug_discovery"] = {
+            {"iterations", drug_discovery_.iterations},
+            {"mutation_rate", drug_discovery_.mutation_rate}
         };
 
         // Renderer config

--- a/include/workbench/config.hpp
+++ b/include/workbench/config.hpp
@@ -65,6 +65,11 @@ struct MemoryGardenConfig {
     } visualization;
 };
 
+struct DrugDiscoveryConfig {
+    int iterations;
+    float mutation_rate;
+};
+
 struct RendererConfig {
     struct {
         int samples;
@@ -88,6 +93,7 @@ public:
     const GenesisPatternConfig& genesis_pattern() const { return genesis_pattern_; }
     const AudioVisualizerConfig& audio_visualizer() const { return audio_visualizer_; }
     const MemoryGardenConfig& memory_garden() const { return memory_garden_; }
+    const DrugDiscoveryConfig& drug_discovery() const { return drug_discovery_; }
     const RendererConfig& renderer() const { return renderer_; }
 
 private:
@@ -98,6 +104,7 @@ private:
     GenesisPatternConfig genesis_pattern_;
     AudioVisualizerConfig audio_visualizer_;
     MemoryGardenConfig memory_garden_;
+    DrugDiscoveryConfig drug_discovery_;
     RendererConfig renderer_;
 };
 

--- a/include/workbench/config.json
+++ b/include/workbench/config.json
@@ -52,6 +52,10 @@
         "connection_opacity": 0.5,
         "pattern_scale": 1.0
       }
+    },
+    "drug_discovery": {
+      "iterations": 10,
+      "mutation_rate": 0.05
     }
   },
   "renderer": {

--- a/include/workbench/demos/drug_discovery_demo.cpp
+++ b/include/workbench/demos/drug_discovery_demo.cpp
@@ -1,0 +1,82 @@
+#include "drug_discovery_demo.hpp"
+#include <config.hpp>
+#include <glm/glm.hpp>
+#include <cstdlib>
+
+namespace sep {
+namespace workbench {
+
+void DrugDiscoveryDemo::init() {
+#ifdef SEP_WORKBENCH_DEMO
+    // Default parameters for demo mode
+    iterations_ = 10;
+    mutation_rate_ = 0.05f;
+#else
+    const auto& cfg = sep::core::config::ConfigManager::getInstance().getEngineConfig().drug_discovery();
+    iterations_ = cfg.iterations;
+    mutation_rate_ = cfg.mutation_rate;
+#endif
+
+    // Create a few initial poses
+    for (int i = 0; i < 5; ++i) {
+        Pose p;
+        p.position = glm::vec3((std::rand() % 100) * 0.01f);
+        p.orientation = glm::vec3(0.0f);
+        p.binding_affinity = 0.0f;
+        poses_.push_back(p);
+    }
+}
+
+void DrugDiscoveryDemo::optimizePoses() {
+    for (int it = 0; it < iterations_; ++it) {
+        for (auto& p : poses_) {
+            // Simple random mutation of pose variables
+            p.position += mutation_rate_ * glm::vec3(
+                ((std::rand() % 200) - 100) * 0.001f,
+                ((std::rand() % 200) - 100) * 0.001f,
+                ((std::rand() % 200) - 100) * 0.001f);
+            p.orientation += mutation_rate_ * glm::vec3(
+                ((std::rand() % 200) - 100) * 0.001f,
+                ((std::rand() % 200) - 100) * 0.001f,
+                ((std::rand() % 200) - 100) * 0.001f);
+
+            // Mock binding affinity computation
+            float dist = glm::length(p.position);
+            p.binding_affinity = glm::clamp(1.0f - dist, 0.0f, 1.0f);
+        }
+    }
+}
+
+void DrugDiscoveryDemo::update(float) {
+    optimizePoses();
+}
+
+void DrugDiscoveryDemo::render() {
+#ifdef SEP_WORKBENCH_DEMO
+    if (renderer_) {
+        std::vector<glm::vec3> points;
+        for (const auto& p : poses_) {
+            points.push_back(p.position);
+        }
+        renderer_->renderPatternState(points);
+    }
+#else
+    if (!renderer_) return;
+    std::vector<glm::vec3> points;
+    for (const auto& p : poses_) {
+        points.push_back(p.position);
+    }
+    renderer_->renderPatternState(points);
+#endif
+}
+
+void DrugDiscoveryDemo::cleanup() {
+    poses_.clear();
+}
+
+void DrugDiscoveryDemo::handleKeyboard(unsigned char) {}
+void DrugDiscoveryDemo::handleMouse(int, int, int) {}
+
+} // namespace workbench
+} // namespace sep
+

--- a/include/workbench/demos/drug_discovery_demo.hpp
+++ b/include/workbench/demos/drug_discovery_demo.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "demo_manager.hpp"
+#include "sep_engine_wrapper.h"
+#include <vector>
+#include <glm/vec3.hpp>
+
+namespace sep {
+namespace workbench {
+
+struct Pose {
+    glm::vec3 position{0.0f};
+    glm::vec3 orientation{0.0f};
+    float binding_affinity{0.0f};
+};
+
+class DrugDiscoveryDemo : public Demo {
+public:
+    void init() override;
+    void update(float dt) override;
+    void render() override;
+    void cleanup() override;
+    void handleKeyboard(unsigned char key) override;
+    void handleMouse(int x, int y, int button) override;
+
+private:
+    void optimizePoses();
+
+    std::vector<Pose> poses_;
+    int iterations_{10};
+    float mutation_rate_{0.05f};
+};
+
+} // namespace workbench
+} // namespace sep
+

--- a/include/workbench/main.cpp
+++ b/include/workbench/main.cpp
@@ -5,6 +5,7 @@
 #include "demos/genesis_pattern.hpp"
 #include "demos/audio_visualizer.hpp"
 #include "demos/memory_garden.hpp"
+#include "demos/drug_discovery_demo.hpp"
 
 using namespace sep;
 using namespace sep::workbench;
@@ -88,6 +89,9 @@ void registerDemos() {
     });
     demo_manager.registerDemo("memory", []() {
         return std::make_unique<MemoryGardenDemo>();
+    });
+    demo_manager.registerDemo("drug_discovery", []() {
+        return std::make_unique<DrugDiscoveryDemo>();
     });
 
     // Start with Genesis Pattern demo


### PR DESCRIPTION
## Summary
- add DrugDiscoveryDemo implementation and header
- register the demo and extend cmake
- add DrugDiscoveryConfig with optimizer parameters
- parse/save optimizer parameters in configuration

## Testing
- `cmake .. -DCUDAToolkit_ROOT=/usr/local/cuda -DSEP_BUILD_TESTS=ON` *(fails: Could NOT find CUDAToolkit)*

------
https://chatgpt.com/codex/tasks/task_e_6869aa80e9cc832aa532f800ed0ce8a5