### PR TITLE
Add simple neural network demo

### DIFF
--- a/examples/workbench/CMakeLists.txt
+++ b/examples/workbench/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(sep_workbench
     demos/genesis_pattern.cpp
     demos/audio_visualizer.cpp
     demos/memory_garden.cpp
+    demos/neural_demo.cpp
 )
 
 # Set C++ standard

--- a/examples/workbench/config.cpp
+++ b/examples/workbench/config.cpp
@@ -90,6 +90,22 @@ bool Config::load(const std::filesystem::path& path) {
             }
         };
 
+        // Neural Demo config
+        auto& neural = json["demos"]["neural_demo"];
+        auto& net = neural["network"];
+        auto& neu = neural["neuron"];
+        neural_demo_ = {
+            {
+                net["neuron_count"].get<int>(),
+                net["connection_prob"].get<float>()
+            },
+            {
+                neu["threshold"].get<float>(),
+                neu["decay"].get<float>(),
+                neu["input_strength"].get<float>()
+            }
+        };
+
         // Renderer config
         auto& renderer = json["renderer"];
         auto& cycles = renderer["cycles"];
@@ -173,6 +189,18 @@ bool Config::save(const std::filesystem::path& path) const {
                 {"show_connections", memory_garden_.visualization.show_connections},
                 {"connection_opacity", memory_garden_.visualization.connection_opacity},
                 {"pattern_scale", memory_garden_.visualization.pattern_scale}
+            }}
+        };
+
+        json["demos"]["neural_demo"] = {
+            {"network", {
+                {"neuron_count", neural_demo_.network.neuron_count},
+                {"connection_prob", neural_demo_.network.connection_prob}
+            }},
+            {"neuron", {
+                {"threshold", neural_demo_.neuron.threshold},
+                {"decay", neural_demo_.neuron.decay},
+                {"input_strength", neural_demo_.neuron.input_strength}
             }}
         };
 

--- a/examples/workbench/config.hpp
+++ b/examples/workbench/config.hpp
@@ -65,6 +65,18 @@ struct MemoryGardenConfig {
     } visualization;
 };
 
+struct NeuralDemoConfig {
+    struct {
+        int neuron_count;
+        float connection_prob;
+    } network;
+    struct {
+        float threshold;
+        float decay;
+        float input_strength;
+    } neuron;
+};
+
 struct RendererConfig {
     struct {
         int samples;
@@ -88,6 +100,7 @@ public:
     const GenesisPatternConfig& genesis_pattern() const { return genesis_pattern_; }
     const AudioVisualizerConfig& audio_visualizer() const { return audio_visualizer_; }
     const MemoryGardenConfig& memory_garden() const { return memory_garden_; }
+    const NeuralDemoConfig& neural_demo() const { return neural_demo_; }
     const RendererConfig& renderer() const { return renderer_; }
 
 private:
@@ -98,6 +111,7 @@ private:
     GenesisPatternConfig genesis_pattern_;
     AudioVisualizerConfig audio_visualizer_;
     MemoryGardenConfig memory_garden_;
+    NeuralDemoConfig neural_demo_;
     RendererConfig renderer_;
 };
 

--- a/examples/workbench/config.json
+++ b/examples/workbench/config.json
@@ -52,6 +52,17 @@
         "connection_opacity": 0.5,
         "pattern_scale": 1.0
       }
+    },
+    "neural_demo": {
+      "network": {
+        "neuron_count": 5,
+        "connection_prob": 0.3
+      },
+      "neuron": {
+        "threshold": 1.0,
+        "decay": 0.1,
+        "input_strength": 0.5
+      }
     }
   },
   "renderer": {

--- a/examples/workbench/demos/neural_demo.cpp
+++ b/examples/workbench/demos/neural_demo.cpp
@@ -1,0 +1,69 @@
+#include "neural_demo.hpp"
+#include <config.hpp>
+#include <algorithm>
+
+namespace sep {
+namespace workbench {
+
+void NeuralDemo::init() {
+    const auto& cfg = sep::core::config::ConfigManager::getInstance().getEngineConfig().neural_demo();
+
+    decay_ = cfg.neuron.decay;
+    input_strength_ = cfg.neuron.input_strength;
+
+    neurons_.resize(cfg.network.neuron_count);
+    for (size_t i = 0; i < neurons_.size(); ++i) {
+        neurons_[i].threshold = cfg.neuron.threshold;
+        neurons_[i].id = graph_.addNode(glm::vec3(0.0f), 0.0f, {});
+    }
+
+    std::uniform_real_distribution<float> dist(0.0f, 1.0f);
+    for (size_t i = 0; i < neurons_.size(); ++i) {
+        for (size_t j = 0; j < neurons_.size(); ++j) {
+            if (i == j) continue;
+            if (dist(rng_) < cfg.network.connection_prob) {
+                auto parents = graph_.getParents(neurons_[j].id);
+                parents.push_back(neurons_[i].id);
+                graph_.updateNodeParents(neurons_[j].id, parents);
+            }
+        }
+    }
+}
+
+void NeuralDemo::update(float dt) {
+    for (auto& n : neurons_) {
+        n.potential += input_strength_ * dt;
+        n.potential -= decay_ * n.potential * dt;
+
+        if (n.potential >= n.threshold) {
+            n.potential = 0.f;
+            // propagate to connected neurons
+            for (auto& target : neurons_) {
+                auto parents = graph_.getParents(target.id);
+                if (std::find(parents.begin(), parents.end(), n.id) != parents.end()) {
+                    target.potential += 0.5f;
+                }
+            }
+        }
+    }
+}
+
+void NeuralDemo::render() {
+    if (!renderer_) return;
+
+    std::vector<glm::vec3> points;
+    for (const auto& n : neurons_) {
+        points.emplace_back(n.potential);
+    }
+    renderer_->renderPatternState(points);
+}
+
+void NeuralDemo::cleanup() {
+    neurons_.clear();
+}
+
+void NeuralDemo::handleKeyboard(unsigned char) {}
+void NeuralDemo::handleMouse(int, int, int) {}
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/demos/neural_demo.hpp
+++ b/examples/workbench/demos/neural_demo.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "demo_manager.hpp"
+#include <vector>
+#include <random>
+#include <core/dag_graph.h>
+#include <glm/vec3.hpp>
+
+namespace sep {
+namespace workbench {
+
+class NeuralDemo : public Demo {
+public:
+    void init() override;
+    void update(float dt) override;
+    void render() override;
+    void cleanup() override;
+    void handleKeyboard(unsigned char key) override;
+    void handleMouse(int x, int y, int button) override;
+
+private:
+    struct Neuron {
+        uint64_t id{0};
+        float potential{0.f};
+        float threshold{1.f};
+    };
+
+    dag::DagGraph graph_;
+    std::vector<Neuron> neurons_;
+    float decay_{0.1f};
+    float input_strength_{0.5f};
+    std::mt19937 rng_{std::random_device{}()};
+};
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/main.cpp
+++ b/examples/workbench/main.cpp
@@ -10,6 +10,7 @@
 #include "demos/genesis_pattern.hpp"
 #include "demos/audio_visualizer.hpp"
 #include "demos/memory_garden.hpp"
+#include "demos/neural_demo.hpp"
 
 using namespace sep;
 using namespace sep::workbench;
@@ -126,6 +127,9 @@ void registerDemos() {
     });
     demo_manager.registerDemo("memory", []() {
         return std::make_unique<MemoryGardenDemo>();
+    });
+    demo_manager.registerDemo("neural", []() {
+        return std::make_unique<NeuralDemo>();
     });
 
     // Start with Genesis Pattern demo


### PR DESCRIPTION
## Summary
- add NeuralDemo example showing integrate-and-fire neurons
- parse neural demo settings from config
- register the neural demo and build source

## Testing
- `cmake .. -D BUILD_TESTING=ON` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6869aa7d6d1c832a996d1cd8692ef677