### PR TITLE
Implement cosmological demo and config

### DIFF
--- a/examples/workbench/CMakeLists.txt
+++ b/examples/workbench/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(sep_workbench
     demos/genesis_pattern.cpp
     demos/audio_visualizer.cpp
     demos/memory_garden.cpp
+    demos/cosmo_demo.cpp
 )
 
 # Set C++ standard

--- a/examples/workbench/config.cpp
+++ b/examples/workbench/config.cpp
@@ -90,6 +90,13 @@ bool Config::load(const std::filesystem::path& path) {
             }
         };
 
+        // Cosmo demo config
+        auto& cosmo = json["demos"]["cosmo"];
+        cosmo_ = {
+            cosmo["box_size"].get<float>(),
+            cosmo["time_step"].get<float>()
+        };
+
         // Renderer config
         auto& renderer = json["renderer"];
         auto& cycles = renderer["cycles"];
@@ -174,6 +181,12 @@ bool Config::save(const std::filesystem::path& path) const {
                 {"connection_opacity", memory_garden_.visualization.connection_opacity},
                 {"pattern_scale", memory_garden_.visualization.pattern_scale}
             }}
+        };
+
+        // Cosmo demo config
+        json["demos"]["cosmo"] = {
+            {"box_size", cosmo_.box_size},
+            {"time_step", cosmo_.time_step}
         };
 
         // Renderer config

--- a/examples/workbench/config.hpp
+++ b/examples/workbench/config.hpp
@@ -62,7 +62,12 @@ struct MemoryGardenConfig {
         bool show_connections;
         float connection_opacity;
         float pattern_scale;
-    } visualization;
+} visualization;
+};
+
+struct CosmoDemoConfig {
+    float box_size;
+    float time_step;
 };
 
 struct RendererConfig {
@@ -88,6 +93,7 @@ public:
     const GenesisPatternConfig& genesis_pattern() const { return genesis_pattern_; }
     const AudioVisualizerConfig& audio_visualizer() const { return audio_visualizer_; }
     const MemoryGardenConfig& memory_garden() const { return memory_garden_; }
+    const CosmoDemoConfig& cosmo() const { return cosmo_; }
     const RendererConfig& renderer() const { return renderer_; }
 
 private:
@@ -98,6 +104,7 @@ private:
     GenesisPatternConfig genesis_pattern_;
     AudioVisualizerConfig audio_visualizer_;
     MemoryGardenConfig memory_garden_;
+    CosmoDemoConfig cosmo_;
     RendererConfig renderer_;
 };
 

--- a/examples/workbench/config.json
+++ b/examples/workbench/config.json
@@ -52,6 +52,10 @@
         "connection_opacity": 0.5,
         "pattern_scale": 1.0
       }
+    },
+    "cosmo": {
+      "box_size": 50.0,
+      "time_step": 0.01
     }
   },
   "renderer": {

--- a/examples/workbench/demos/cosmo_demo.cpp
+++ b/examples/workbench/demos/cosmo_demo.cpp
@@ -1,0 +1,92 @@
+#include "cosmo_demo.hpp"
+#include <config.hpp>
+#include <cstdlib>
+#include <glm/glm.hpp>
+#include <glm/gtc/constants.hpp>
+
+namespace sep {
+namespace workbench {
+
+void CosmoDemo::init() {
+#ifdef SEP_WORKBENCH_DEMO
+    // Default parameters
+    box_size_ = 50.0f;
+    time_step_ = 0.01f;
+#else
+    const auto& cfg = getConfigManager().getEngineConfig().cosmo();
+    box_size_ = cfg.box_size;
+    time_step_ = cfg.time_step;
+#endif
+    initParticles();
+}
+
+void CosmoDemo::initParticles() {
+    particles_.clear();
+    std::size_t count = 100;
+    particles_.reserve(count);
+    for (std::size_t i = 0; i < count; ++i) {
+        Particle p;
+        p.position = glm::vec3(
+            static_cast<float>(std::rand()) / RAND_MAX * box_size_,
+            static_cast<float>(std::rand()) / RAND_MAX * box_size_,
+            static_cast<float>(std::rand()) / RAND_MAX * box_size_);
+        p.velocity = glm::vec3(0.0f);
+        p.mass = 1.0f;
+        particles_.push_back(p);
+    }
+}
+
+void CosmoDemo::integrate(float dt) {
+    const float G = 1.0f;
+    std::vector<glm::vec3> accelerations(particles_.size(), glm::vec3(0.0f));
+    for (std::size_t i = 0; i < particles_.size(); ++i) {
+        for (std::size_t j = i + 1; j < particles_.size(); ++j) {
+            glm::vec3 diff = particles_[j].position - particles_[i].position;
+            float dist2 = glm::dot(diff, diff) + 1e-5f;
+            glm::vec3 force = G * particles_[i].mass * particles_[j].mass / (dist2 * glm::sqrt(dist2)) * diff;
+            accelerations[i] += force / particles_[i].mass;
+            accelerations[j] -= force / particles_[j].mass;
+        }
+    }
+
+    for (std::size_t i = 0; i < particles_.size(); ++i) {
+        particles_[i].velocity += accelerations[i] * dt;
+        particles_[i].position += particles_[i].velocity * dt;
+        // Wrap around box
+        for (int k = 0; k < 3; ++k) {
+            if (particles_[i].position[k] < 0.0f)
+                particles_[i].position[k] += box_size_;
+            else if (particles_[i].position[k] > box_size_)
+                particles_[i].position[k] -= box_size_;
+        }
+    }
+}
+
+void CosmoDemo::update(float dt) {
+    integrate(time_step_);
+}
+
+void CosmoDemo::render() {
+    if (!renderer_) return;
+    std::vector<glm::vec3> points;
+    points.reserve(particles_.size());
+    for (const auto& p : particles_) {
+        points.push_back(p.position / box_size_); // normalize to unit cube
+    }
+    renderer_->renderPatternState(points);
+}
+
+void CosmoDemo::cleanup() {
+    particles_.clear();
+}
+
+void CosmoDemo::handleKeyboard(unsigned char key) {
+    if (key == 'r') {
+        initParticles();
+    }
+}
+
+void CosmoDemo::handleMouse(int, int, int) {}
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/demos/cosmo_demo.hpp
+++ b/examples/workbench/demos/cosmo_demo.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "demo_manager.hpp"
+#include <vector>
+#include <glm/vec3.hpp>
+
+namespace sep {
+namespace workbench {
+
+class CosmoDemo : public Demo {
+public:
+    void init() override;
+    void update(float dt) override;
+    void render() override;
+    void cleanup() override;
+    void handleKeyboard(unsigned char key) override;
+    void handleMouse(int x, int y, int button) override;
+
+private:
+    struct Particle {
+        glm::vec3 position;
+        glm::vec3 velocity;
+        float mass;
+    };
+
+    std::vector<Particle> particles_;
+
+    float box_size_{50.0f};
+    float time_step_{0.01f};
+
+    void initParticles();
+    void integrate(float dt);
+};
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/main.cpp
+++ b/examples/workbench/main.cpp
@@ -10,6 +10,7 @@
 #include "demos/genesis_pattern.hpp"
 #include "demos/audio_visualizer.hpp"
 #include "demos/memory_garden.hpp"
+#include "demos/cosmo_demo.hpp"
 
 using namespace sep;
 using namespace sep::workbench;
@@ -126,6 +127,9 @@ void registerDemos() {
     });
     demo_manager.registerDemo("memory", []() {
         return std::make_unique<MemoryGardenDemo>();
+    });
+    demo_manager.registerDemo("cosmo", []() {
+        return std::make_unique<CosmoDemo>();
     });
 
     // Start with Genesis Pattern demo

--- a/include/workbench/CMakeLists.txt
+++ b/include/workbench/CMakeLists.txt
@@ -54,6 +54,7 @@ add_executable(sep_workbench
     demos/genesis_pattern.cpp
     demos/audio_visualizer.cpp
     demos/memory_garden.cpp
+    demos/cosmo_demo.cpp
 )
 
 # Include directories

--- a/include/workbench/config.cpp
+++ b/include/workbench/config.cpp
@@ -90,6 +90,13 @@ bool Config::load(const std::filesystem::path& path) {
             }
         };
 
+        // Cosmo demo config
+        auto& cosmo = json["demos"]["cosmo"];
+        cosmo_ = {
+            cosmo["box_size"].get<float>(),
+            cosmo["time_step"].get<float>()
+        };
+
         // Renderer config
         auto& renderer = json["renderer"];
         auto& cycles = renderer["cycles"];
@@ -174,6 +181,12 @@ bool Config::save(const std::filesystem::path& path) const {
                 {"connection_opacity", memory_garden_.visualization.connection_opacity},
                 {"pattern_scale", memory_garden_.visualization.pattern_scale}
             }}
+        };
+
+        // Cosmo demo config
+        json["demos"]["cosmo"] = {
+            {"box_size", cosmo_.box_size},
+            {"time_step", cosmo_.time_step}
         };
 
         // Renderer config

--- a/include/workbench/config.hpp
+++ b/include/workbench/config.hpp
@@ -62,7 +62,12 @@ struct MemoryGardenConfig {
         bool show_connections;
         float connection_opacity;
         float pattern_scale;
-    } visualization;
+} visualization;
+};
+
+struct CosmoDemoConfig {
+    float box_size;
+    float time_step;
 };
 
 struct RendererConfig {
@@ -88,6 +93,7 @@ public:
     const GenesisPatternConfig& genesis_pattern() const { return genesis_pattern_; }
     const AudioVisualizerConfig& audio_visualizer() const { return audio_visualizer_; }
     const MemoryGardenConfig& memory_garden() const { return memory_garden_; }
+    const CosmoDemoConfig& cosmo() const { return cosmo_; }
     const RendererConfig& renderer() const { return renderer_; }
 
 private:
@@ -98,6 +104,7 @@ private:
     GenesisPatternConfig genesis_pattern_;
     AudioVisualizerConfig audio_visualizer_;
     MemoryGardenConfig memory_garden_;
+    CosmoDemoConfig cosmo_;
     RendererConfig renderer_;
 };
 

--- a/include/workbench/config.json
+++ b/include/workbench/config.json
@@ -52,6 +52,10 @@
         "connection_opacity": 0.5,
         "pattern_scale": 1.0
       }
+    },
+    "cosmo": {
+      "box_size": 50.0,
+      "time_step": 0.01
     }
   },
   "renderer": {

--- a/include/workbench/demos/cosmo_demo.cpp
+++ b/include/workbench/demos/cosmo_demo.cpp
@@ -1,0 +1,84 @@
+#include "cosmo_demo.hpp"
+#include "config.hpp"
+#include <cstdlib>
+#include <glm/glm.hpp>
+
+namespace sep {
+namespace workbench {
+
+void CosmoDemo::init() {
+    const auto& cfg = Config::getInstance().cosmo();
+    box_size_ = cfg.box_size;
+    time_step_ = cfg.time_step;
+    initParticles();
+}
+
+void CosmoDemo::initParticles() {
+    particles_.clear();
+    std::size_t count = 100;
+    particles_.reserve(count);
+    for (std::size_t i = 0; i < count; ++i) {
+        Particle p;
+        p.position = glm::vec3(
+            static_cast<float>(std::rand()) / RAND_MAX * box_size_,
+            static_cast<float>(std::rand()) / RAND_MAX * box_size_,
+            static_cast<float>(std::rand()) / RAND_MAX * box_size_);
+        p.velocity = glm::vec3(0.0f);
+        p.mass = 1.0f;
+        particles_.push_back(p);
+    }
+}
+
+void CosmoDemo::integrate(float dt) {
+    const float G = 1.0f;
+    std::vector<glm::vec3> accelerations(particles_.size(), glm::vec3(0.0f));
+    for (std::size_t i = 0; i < particles_.size(); ++i) {
+        for (std::size_t j = i + 1; j < particles_.size(); ++j) {
+            glm::vec3 diff = particles_[j].position - particles_[i].position;
+            float dist2 = glm::dot(diff, diff) + 1e-5f;
+            glm::vec3 force = G * particles_[i].mass * particles_[j].mass / (dist2 * glm::sqrt(dist2)) * diff;
+            accelerations[i] += force / particles_[i].mass;
+            accelerations[j] -= force / particles_[j].mass;
+        }
+    }
+
+    for (std::size_t i = 0; i < particles_.size(); ++i) {
+        particles_[i].velocity += accelerations[i] * dt;
+        particles_[i].position += particles_[i].velocity * dt;
+        for (int k = 0; k < 3; ++k) {
+            if (particles_[i].position[k] < 0.0f)
+                particles_[i].position[k] += box_size_;
+            else if (particles_[i].position[k] > box_size_)
+                particles_[i].position[k] -= box_size_;
+        }
+    }
+}
+
+void CosmoDemo::update(float) {
+    integrate(time_step_);
+}
+
+void CosmoDemo::render() {
+    if (!renderer_) return;
+    std::vector<glm::vec3> points;
+    points.reserve(particles_.size());
+    for (const auto& p : particles_) {
+        points.push_back(p.position / box_size_);
+    }
+    renderer_->renderPatternState(points);
+}
+
+void CosmoDemo::cleanup() {
+    particles_.clear();
+}
+
+void CosmoDemo::handleKeyboard(unsigned char key) {
+    if (key == 'r') {
+        initParticles();
+    }
+}
+
+void CosmoDemo::handleMouse(int, int, int) {}
+
+} // namespace workbench
+} // namespace sep

--- a/include/workbench/demos/cosmo_demo.hpp
+++ b/include/workbench/demos/cosmo_demo.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "demo_manager.hpp"
+#include <vector>
+#include <glm/vec3.hpp>
+
+namespace sep {
+namespace workbench {
+
+class CosmoDemo : public Demo {
+public:
+    void init() override;
+    void update(float dt) override;
+    void render() override;
+    void cleanup() override;
+    void handleKeyboard(unsigned char key) override;
+    void handleMouse(int x, int y, int button) override;
+
+private:
+    struct Particle {
+        glm::vec3 position;
+        glm::vec3 velocity;
+        float mass;
+    };
+
+    std::vector<Particle> particles_;
+
+    float box_size_{50.0f};
+    float time_step_{0.01f};
+
+    void initParticles();
+    void integrate(float dt);
+};
+
+} // namespace workbench
+} // namespace sep

--- a/include/workbench/main.cpp
+++ b/include/workbench/main.cpp
@@ -5,6 +5,7 @@
 #include "demos/genesis_pattern.hpp"
 #include "demos/audio_visualizer.hpp"
 #include "demos/memory_garden.hpp"
+#include "demos/cosmo_demo.hpp"
 
 using namespace sep;
 using namespace sep::workbench;
@@ -88,6 +89,9 @@ void registerDemos() {
     });
     demo_manager.registerDemo("memory", []() {
         return std::make_unique<MemoryGardenDemo>();
+    });
+    demo_manager.registerDemo("cosmo", []() {
+        return std::make_unique<CosmoDemo>();
     });
 
     // Start with Genesis Pattern demo


### PR DESCRIPTION
## Summary
- implement new `CosmoDemo` N-body simulation
- expose cosmological settings in workbench configs
- register cosmo demo and update build files

## Testing
- `npm test` *(fails: Missing script)*
- `cmake --version`

------
https://chatgpt.com/codex/tasks/task_e_6869aa799040832abda23230bf49f240