### PR TITLE
Add Flocking demo and config

### DIFF
--- a/examples/workbench/CMakeLists.txt
+++ b/examples/workbench/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(sep_workbench
     demos/genesis_pattern.cpp
     demos/audio_visualizer.cpp
     demos/memory_garden.cpp
+    demos/flocking_demo.cpp
 )
 
 # Set C++ standard

--- a/examples/workbench/config.json
+++ b/examples/workbench/config.json
@@ -52,6 +52,12 @@
         "connection_opacity": 0.5,
         "pattern_scale": 1.0
       }
+    },
+    "flocking": {
+      "agent_count": 50,
+      "neighbor_radius": 5.0,
+      "separation_distance": 1.0,
+      "max_speed": 2.0
     }
   },
   "renderer": {

--- a/examples/workbench/demos/flocking_demo.cpp
+++ b/examples/workbench/demos/flocking_demo.cpp
@@ -1,0 +1,81 @@
+#include "flocking_demo.hpp"
+#include "sep_engine_wrapper.h"
+#include <glm/gtx/norm.hpp>
+#include <glm/gtc/random.hpp>
+
+namespace sep {
+namespace workbench {
+
+void FlockingDemo::init() {
+    agents_.clear();
+    std::default_random_engine rng(static_cast<unsigned>(time(nullptr)));
+    std::uniform_real_distribution<float> pos(-10.f, 10.f);
+    std::uniform_real_distribution<float> vel(-1.f, 1.f);
+
+    const int count = 50; // Default agent count
+    for (int i = 0; i < count; ++i) {
+        sep::pattern::PatternData agent;
+        agent.position = glm::vec4(pos(rng), pos(rng), pos(rng), 1.0f);
+        agent.velocity = glm::vec4(vel(rng), vel(rng), vel(rng), 0.0f);
+        agents_.push_back(agent);
+    }
+}
+
+void FlockingDemo::update(float dt) {
+    for (auto& agent : agents_) {
+        glm::vec3 pos(agent.position);
+        glm::vec3 vel(agent.velocity);
+        glm::vec3 cohesion(0.0f);
+        glm::vec3 separation(0.0f);
+        glm::vec3 alignment(0.0f);
+        int neighbor_count = 0;
+
+        for (const auto& other : agents_) {
+            if (&agent == &other) continue;
+            glm::vec3 other_pos(other.position);
+            float dist = glm::distance(pos, other_pos);
+            if (dist < neighbor_radius_) {
+                cohesion += other_pos;
+                alignment += glm::vec3(other.velocity);
+                ++neighbor_count;
+                if (dist < separation_distance_) {
+                    separation -= (other_pos - pos) / (dist + 0.01f);
+                }
+            }
+        }
+
+        if (neighbor_count > 0) {
+            cohesion = (cohesion / static_cast<float>(neighbor_count)) - pos;
+            alignment /= static_cast<float>(neighbor_count);
+        }
+
+        glm::vec3 accel = cohesion + separation + alignment;
+        vel += accel * dt;
+        if (glm::length2(vel) > max_speed_ * max_speed_) {
+            vel = glm::normalize(vel) * max_speed_;
+        }
+        pos += vel * dt;
+
+        agent.position = glm::vec4(pos, 1.0f);
+        agent.velocity = glm::vec4(vel, 0.0f);
+    }
+}
+
+void FlockingDemo::render() {
+    if (!renderer_) return;
+    std::vector<glm::vec3> points;
+    for (const auto& a : agents_) {
+        points.emplace_back(a.position.x, a.position.y, a.position.z);
+    }
+    renderer_->renderPatternState(points);
+}
+
+void FlockingDemo::cleanup() {
+    agents_.clear();
+}
+
+void FlockingDemo::handleKeyboard(unsigned char) {}
+void FlockingDemo::handleMouse(int, int, int) {}
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/demos/flocking_demo.hpp
+++ b/examples/workbench/demos/flocking_demo.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "demo_manager.hpp"
+#include <vector>
+#include <glm/vec3.hpp>
+#include <random>
+#include <quantum/data.hpp>
+
+namespace sep {
+namespace workbench {
+
+class FlockingDemo : public Demo {
+public:
+    void init() override;
+    void update(float dt) override;
+    void render() override;
+    void cleanup() override;
+    void handleKeyboard(unsigned char key) override;
+    void handleMouse(int x, int y, int button) override;
+
+private:
+    std::vector<sep::pattern::PatternData> agents_;
+    float neighbor_radius_{5.0f};
+    float separation_distance_{1.0f};
+    float max_speed_{2.0f};
+};
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/main.cpp
+++ b/examples/workbench/main.cpp
@@ -10,6 +10,7 @@
 #include "demos/genesis_pattern.hpp"
 #include "demos/audio_visualizer.hpp"
 #include "demos/memory_garden.hpp"
+#include "demos/flocking_demo.hpp"
 
 using namespace sep;
 using namespace sep::workbench;
@@ -126,6 +127,9 @@ void registerDemos() {
     });
     demo_manager.registerDemo("memory", []() {
         return std::make_unique<MemoryGardenDemo>();
+    });
+    demo_manager.registerDemo("flocking", []() {
+        return std::make_unique<FlockingDemo>();
     });
 
     // Start with Genesis Pattern demo

--- a/include/workbench/config.cpp
+++ b/include/workbench/config.cpp
@@ -90,6 +90,15 @@ bool Config::load(const std::filesystem::path& path) {
             }
         };
 
+        // Flocking demo config
+        auto& flock = json["demos"]["flocking"];
+        flocking_ = {
+            flock["agent_count"].get<int>(),
+            flock["neighbor_radius"].get<float>(),
+            flock["separation_distance"].get<float>(),
+            flock["max_speed"].get<float>()
+        };
+
         // Renderer config
         auto& renderer = json["renderer"];
         auto& cycles = renderer["cycles"];
@@ -174,6 +183,14 @@ bool Config::save(const std::filesystem::path& path) const {
                 {"connection_opacity", memory_garden_.visualization.connection_opacity},
                 {"pattern_scale", memory_garden_.visualization.pattern_scale}
             }}
+        };
+
+        // Flocking demo config
+        json["demos"]["flocking"] = {
+            {"agent_count", flocking_.agent_count},
+            {"neighbor_radius", flocking_.neighbor_radius},
+            {"separation_distance", flocking_.separation_distance},
+            {"max_speed", flocking_.max_speed}
         };
 
         // Renderer config

--- a/include/workbench/config.hpp
+++ b/include/workbench/config.hpp
@@ -65,6 +65,13 @@ struct MemoryGardenConfig {
     } visualization;
 };
 
+struct FlockingConfig {
+    int agent_count;
+    float neighbor_radius;
+    float separation_distance;
+    float max_speed;
+};
+
 struct RendererConfig {
     struct {
         int samples;
@@ -88,6 +95,7 @@ public:
     const GenesisPatternConfig& genesis_pattern() const { return genesis_pattern_; }
     const AudioVisualizerConfig& audio_visualizer() const { return audio_visualizer_; }
     const MemoryGardenConfig& memory_garden() const { return memory_garden_; }
+    const FlockingConfig& flocking() const { return flocking_; }
     const RendererConfig& renderer() const { return renderer_; }
 
 private:
@@ -98,6 +106,7 @@ private:
     GenesisPatternConfig genesis_pattern_;
     AudioVisualizerConfig audio_visualizer_;
     MemoryGardenConfig memory_garden_;
+    FlockingConfig flocking_;
     RendererConfig renderer_;
 };
 


### PR DESCRIPTION
## Summary
- implement a new `FlockingDemo` with simple cohesion/separation/alignment
- register the demo in the workbench application
- build `flocking_demo.cpp` via CMake
- extend workbench config with flocking defaults
- parse new flocking options in workbench config library

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6869aa8a7238832ab56090d83a6059b3