### PR TITLE
Add digital physics demo with config-driven rules

### DIFF
--- a/examples/workbench/CMakeLists.txt
+++ b/examples/workbench/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(sep_workbench
     demos/genesis_pattern.cpp
     demos/audio_visualizer.cpp
     demos/memory_garden.cpp
+    demos/digital_physics_demo.cpp
 )
 
 # Set C++ standard

--- a/examples/workbench/config.cpp
+++ b/examples/workbench/config.cpp
@@ -90,6 +90,15 @@ bool Config::load(const std::filesystem::path& path) {
             }
         };
 
+        // Digital Physics config
+        auto& dp = json["demos"]["digital_physics"];
+        auto& grid = dp["grid"];
+        auto& rules = dp["rules"];
+        digital_physics_ = {
+            { grid["width"].get<int>(), grid["height"].get<int>() },
+            { rules["birth"].get<std::vector<int>>(), rules["survive"].get<std::vector<int>>() }
+        };
+
         // Renderer config
         auto& renderer = json["renderer"];
         auto& cycles = renderer["cycles"];
@@ -173,6 +182,18 @@ bool Config::save(const std::filesystem::path& path) const {
                 {"show_connections", memory_garden_.visualization.show_connections},
                 {"connection_opacity", memory_garden_.visualization.connection_opacity},
                 {"pattern_scale", memory_garden_.visualization.pattern_scale}
+            }}
+        };
+
+        // Digital Physics config
+        json["demos"]["digital_physics"] = {
+            {"grid", {
+                {"width", digital_physics_.grid.width},
+                {"height", digital_physics_.grid.height}
+            }},
+            {"rules", {
+                {"birth", digital_physics_.rules.birth},
+                {"survive", digital_physics_.rules.survive}
             }}
         };
 

--- a/examples/workbench/config.hpp
+++ b/examples/workbench/config.hpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <memory>
 #include <filesystem>
+#include <vector>
 
 namespace sep {
 namespace workbench {
@@ -65,6 +66,18 @@ struct MemoryGardenConfig {
     } visualization;
 };
 
+struct DigitalPhysicsConfig {
+    struct {
+        int width;
+        int height;
+    } grid;
+
+    struct {
+        std::vector<int> birth;
+        std::vector<int> survive;
+    } rules;
+};
+
 struct RendererConfig {
     struct {
         int samples;
@@ -88,6 +101,7 @@ public:
     const GenesisPatternConfig& genesis_pattern() const { return genesis_pattern_; }
     const AudioVisualizerConfig& audio_visualizer() const { return audio_visualizer_; }
     const MemoryGardenConfig& memory_garden() const { return memory_garden_; }
+    const DigitalPhysicsConfig& digital_physics() const { return digital_physics_; }
     const RendererConfig& renderer() const { return renderer_; }
 
 private:
@@ -98,6 +112,7 @@ private:
     GenesisPatternConfig genesis_pattern_;
     AudioVisualizerConfig audio_visualizer_;
     MemoryGardenConfig memory_garden_;
+    DigitalPhysicsConfig digital_physics_;
     RendererConfig renderer_;
 };
 

--- a/examples/workbench/config.json
+++ b/examples/workbench/config.json
@@ -52,6 +52,16 @@
         "connection_opacity": 0.5,
         "pattern_scale": 1.0
       }
+    },
+    "digital_physics": {
+      "grid": {
+        "width": 20,
+        "height": 20
+      },
+      "rules": {
+        "birth": [3],
+        "survive": [2, 3]
+      }
     }
   },
   "renderer": {

--- a/examples/workbench/demos/digital_physics_demo.cpp
+++ b/examples/workbench/demos/digital_physics_demo.cpp
@@ -1,0 +1,103 @@
+#include "digital_physics_demo.hpp"
+#include <config.hpp>
+#include <glm/vec3.hpp>
+#include <cstdlib>
+
+namespace sep {
+namespace workbench {
+
+void DigitalPhysicsDemo::init() {
+#ifdef SEP_WORKBENCH_DEMO
+    width_ = 20;
+    height_ = 20;
+    birth_ = {3};
+    survive_ = {2, 3};
+#else
+    const auto& cfg = sep::core::config::ConfigManager::getInstance().getEngineConfig().digital_physics();
+    width_ = cfg.grid.width;
+    height_ = cfg.grid.height;
+    birth_ = cfg.rules.birth;
+    survive_ = cfg.rules.survive;
+#endif
+
+    grid_.resize(width_ * height_);
+    next_.resize(width_ * height_);
+
+    for (int y = 0; y < height_; ++y) {
+        for (int x = 0; x < width_; ++x) {
+            grid_[index(x, y)].active = (std::rand() % 2) == 0;
+            grid_[index(x, y)].data.position = glm::vec4(x, 0.f, y, 1.f);
+        }
+    }
+}
+
+int DigitalPhysicsDemo::countNeighbors(int x, int y) const {
+    int count = 0;
+    for (int dy = -1; dy <= 1; ++dy) {
+        for (int dx = -1; dx <= 1; ++dx) {
+            if (dx == 0 && dy == 0) continue;
+            int nx = (x + dx + width_) % width_;
+            int ny = (y + dy + height_) % height_;
+            if (grid_[index(nx, ny)].active)
+                ++count;
+        }
+    }
+    return count;
+}
+
+void DigitalPhysicsDemo::step() {
+    for (int y = 0; y < height_; ++y) {
+        for (int x = 0; x < width_; ++x) {
+            int neighbors = countNeighbors(x, y);
+            bool alive = grid_[index(x, y)].active;
+            bool new_state = false;
+            if (alive) {
+                new_state = std::find(survive_.begin(), survive_.end(), neighbors) != survive_.end();
+            } else {
+                new_state = std::find(birth_.begin(), birth_.end(), neighbors) != birth_.end();
+            }
+            next_[index(x, y)] = grid_[index(x, y)];
+            next_[index(x, y)].active = new_state;
+        }
+    }
+    grid_.swap(next_);
+}
+
+void DigitalPhysicsDemo::update(float) {
+    step();
+}
+
+void DigitalPhysicsDemo::render() {
+    if (!renderer_) return;
+
+    std::vector<glm::vec3> points;
+    points.reserve(width_ * height_);
+    for (int y = 0; y < height_; ++y) {
+        for (int x = 0; x < width_; ++x) {
+            if (grid_[index(x, y)].active) {
+                points.emplace_back(static_cast<float>(x), 0.f, static_cast<float>(y));
+            }
+        }
+    }
+
+    renderer_->setColorMode("coherence");
+    renderer_->renderPatternState(points);
+}
+
+void DigitalPhysicsDemo::cleanup() {
+    grid_.clear();
+    next_.clear();
+}
+
+void DigitalPhysicsDemo::handleKeyboard(unsigned char key) {
+    if (key == 'r') {
+        for (auto& c : grid_) {
+            c.active = (std::rand() % 2) == 0;
+        }
+    }
+}
+
+void DigitalPhysicsDemo::handleMouse(int, int, int) {}
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/demos/digital_physics_demo.hpp
+++ b/examples/workbench/demos/digital_physics_demo.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "demo_manager.hpp"
+#include <vector>
+#include <algorithm>
+#include <quantum/data.hpp>
+
+namespace sep {
+namespace workbench {
+
+class DigitalPhysicsDemo : public Demo {
+public:
+    void init() override;
+    void update(float dt) override;
+    void render() override;
+    void cleanup() override;
+    void handleKeyboard(unsigned char key) override;
+    void handleMouse(int x, int y, int button) override;
+
+private:
+    struct Cell {
+        pattern::PatternData data;
+        bool active{false};
+    };
+
+    int width_{0};
+    int height_{0};
+    std::vector<Cell> grid_;
+    std::vector<Cell> next_;
+
+    std::vector<int> birth_;
+    std::vector<int> survive_;
+
+    int index(int x, int y) const { return y * width_ + x; }
+    int countNeighbors(int x, int y) const;
+    void step();
+};
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/main.cpp
+++ b/examples/workbench/main.cpp
@@ -10,6 +10,7 @@
 #include "demos/genesis_pattern.hpp"
 #include "demos/audio_visualizer.hpp"
 #include "demos/memory_garden.hpp"
+#include "demos/digital_physics_demo.hpp"
 
 using namespace sep;
 using namespace sep::workbench;
@@ -126,6 +127,9 @@ void registerDemos() {
     });
     demo_manager.registerDemo("memory", []() {
         return std::make_unique<MemoryGardenDemo>();
+    });
+    demo_manager.registerDemo("digital_physics", []() {
+        return std::make_unique<DigitalPhysicsDemo>();
     });
 
     // Start with Genesis Pattern demo


### PR DESCRIPTION
## Summary
- implement new `DigitalPhysicsDemo` providing a simple cellular automaton using `PatternData`
- register new demo and include it in the build
- extend configuration to describe digital physics grid and rules

## Testing
- `cmake -S _sep/testbed -B _sep/testbed/build`
- `cmake --build _sep/testbed/build`

------
https://chatgpt.com/codex/tasks/task_e_6869aa844534832ab7429e40be798d3b