### PR TITLE
Add digital physics demo example

### DIFF
--- a/examples/workbench/CMakeLists.txt
+++ b/examples/workbench/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(sep_workbench
     demos/genesis_pattern.cpp
     demos/audio_visualizer.cpp
     demos/memory_garden.cpp
+    demos/digital_physics_demo.cpp
 )
 
 # Set C++ standard

--- a/examples/workbench/config.cpp
+++ b/examples/workbench/config.cpp
@@ -90,6 +90,15 @@ bool Config::load(const std::filesystem::path& path) {
             }
         };
 
+        // Digital Physics config
+        auto& physics = json["demos"]["digital_physics"];
+        digital_physics_ = {
+            { physics["grid_size"][0].get<int>(), physics["grid_size"][1].get<int>() },
+            { physics["rules"]["birth"].get<int>(),
+              physics["rules"]["survive_min"].get<int>(),
+              physics["rules"]["survive_max"].get<int>() }
+        };
+
         // Renderer config
         auto& renderer = json["renderer"];
         auto& cycles = renderer["cycles"];
@@ -173,6 +182,16 @@ bool Config::save(const std::filesystem::path& path) const {
                 {"show_connections", memory_garden_.visualization.show_connections},
                 {"connection_opacity", memory_garden_.visualization.connection_opacity},
                 {"pattern_scale", memory_garden_.visualization.pattern_scale}
+            }}
+        };
+
+        // Digital Physics config
+        json["demos"]["digital_physics"] = {
+            {"grid_size", { digital_physics_.grid.width, digital_physics_.grid.height }},
+            {"rules", {
+                {"birth", digital_physics_.rules.birth},
+                {"survive_min", digital_physics_.rules.survive_min},
+                {"survive_max", digital_physics_.rules.survive_max}
             }}
         };
 

--- a/examples/workbench/config.hpp
+++ b/examples/workbench/config.hpp
@@ -65,6 +65,19 @@ struct MemoryGardenConfig {
     } visualization;
 };
 
+struct DigitalPhysicsConfig {
+    struct {
+        int width;
+        int height;
+    } grid;
+
+    struct {
+        int birth;
+        int survive_min;
+        int survive_max;
+    } rules;
+};
+
 struct RendererConfig {
     struct {
         int samples;
@@ -88,6 +101,7 @@ public:
     const GenesisPatternConfig& genesis_pattern() const { return genesis_pattern_; }
     const AudioVisualizerConfig& audio_visualizer() const { return audio_visualizer_; }
     const MemoryGardenConfig& memory_garden() const { return memory_garden_; }
+    const DigitalPhysicsConfig& digital_physics() const { return digital_physics_; }
     const RendererConfig& renderer() const { return renderer_; }
 
 private:
@@ -98,6 +112,7 @@ private:
     GenesisPatternConfig genesis_pattern_;
     AudioVisualizerConfig audio_visualizer_;
     MemoryGardenConfig memory_garden_;
+    DigitalPhysicsConfig digital_physics_;
     RendererConfig renderer_;
 };
 

--- a/examples/workbench/config.json
+++ b/examples/workbench/config.json
@@ -52,6 +52,14 @@
         "connection_opacity": 0.5,
         "pattern_scale": 1.0
       }
+    },
+    "digital_physics": {
+      "grid_size": [16, 16],
+      "rules": {
+        "birth": 3,
+        "survive_min": 2,
+        "survive_max": 3
+      }
     }
   },
   "renderer": {

--- a/examples/workbench/demos/digital_physics_demo.cpp
+++ b/examples/workbench/demos/digital_physics_demo.cpp
@@ -1,0 +1,117 @@
+#include "digital_physics_demo.hpp"
+#include <config.hpp>
+#include <glm/vec3.hpp>
+#include <cstdlib>
+
+namespace sep {
+namespace workbench {
+
+void DigitalPhysicsDemo::init() {
+#ifdef SEP_WORKBENCH_DEMO
+    width_ = 16;
+    height_ = 16;
+    rules_ = {3, 2, 3};
+#else
+    const auto& cfg = Config::getInstance().digital_physics();
+    width_ = cfg.grid.width;
+    height_ = cfg.grid.height;
+    rules_.birth = cfg.rules.birth;
+    rules_.survive_min = cfg.rules.survive_min;
+    rules_.survive_max = cfg.rules.survive_max;
+#endif
+    grid_.resize(width_ * height_);
+    for (auto& cell : grid_) {
+        cell.alive = (std::rand() % 2) == 0;
+        cell.data.coherence = cell.alive ? 1.f : 0.f;
+    }
+}
+
+int DigitalPhysicsDemo::countAliveNeighbors(int x, int y) const {
+    int count = 0;
+    for (int dy = -1; dy <= 1; ++dy) {
+        for (int dx = -1; dx <= 1; ++dx) {
+            if (dx == 0 && dy == 0) continue;
+            int nx = (x + dx + width_) % width_;
+            int ny = (y + dy + height_) % height_;
+            if (grid_[index(nx, ny)].alive) ++count;
+        }
+    }
+    return count;
+}
+
+void DigitalPhysicsDemo::step() {
+    std::vector<bool> next(grid_.size());
+    for (int y = 0; y < height_; ++y) {
+        for (int x = 0; x < width_; ++x) {
+            int neighbors = countAliveNeighbors(x, y);
+            bool alive = grid_[index(x, y)].alive;
+            bool new_alive = false;
+            if (alive) {
+                new_alive = neighbors >= rules_.survive_min && neighbors <= rules_.survive_max;
+            } else {
+                new_alive = neighbors == rules_.birth;
+            }
+            next[index(x, y)] = new_alive;
+        }
+    }
+    for (size_t i = 0; i < grid_.size(); ++i) {
+        grid_[i].alive = next[i];
+        grid_[i].data.coherence = next[i] ? 1.f : 0.f;
+    }
+}
+
+void DigitalPhysicsDemo::update(float) {
+    if (running_) {
+        step();
+    }
+}
+
+void DigitalPhysicsDemo::render() {
+#ifdef SEP_WORKBENCH_DEMO
+    if (renderer_) {
+        std::vector<glm::vec3> points;
+        for (int y = 0; y < height_; ++y) {
+            for (int x = 0; x < width_; ++x) {
+                if (grid_[index(x, y)].alive) {
+                    points.emplace_back(static_cast<float>(x), 0.f, static_cast<float>(y));
+                }
+            }
+        }
+        renderer_->renderPatternState(points);
+    }
+#else
+    if (!renderer_) return;
+    std::vector<glm::vec3> points;
+    for (int y = 0; y < height_; ++y) {
+        for (int x = 0; x < width_; ++x) {
+            if (grid_[index(x, y)].alive) {
+                points.emplace_back(static_cast<float>(x), 0.f, static_cast<float>(y));
+            }
+        }
+    }
+    renderer_->renderPatternState(points);
+#endif
+}
+
+void DigitalPhysicsDemo::cleanup() {
+    grid_.clear();
+}
+
+void DigitalPhysicsDemo::handleKeyboard(unsigned char key) {
+    switch (key) {
+        case ' ': // toggle running
+            running_ = !running_;
+            break;
+        case 'r': // randomize
+            for (auto& cell : grid_) {
+                cell.alive = (std::rand() % 2) == 0;
+                cell.data.coherence = cell.alive ? 1.f : 0.f;
+            }
+            break;
+    }
+}
+
+void DigitalPhysicsDemo::handleMouse(int, int, int) {}
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/demos/digital_physics_demo.hpp
+++ b/examples/workbench/demos/digital_physics_demo.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "demo_manager.hpp"
+#include <quantum/data.hpp>
+#include <vector>
+
+namespace sep {
+namespace workbench {
+
+class DigitalPhysicsDemo : public Demo {
+public:
+    void init() override;
+    void update(float dt) override;
+    void render() override;
+    void cleanup() override;
+    void handleKeyboard(unsigned char key) override;
+    void handleMouse(int x, int y, int button) override;
+
+private:
+    struct Cell {
+        pattern::PatternData data;
+        bool alive{false};
+    };
+
+    std::vector<Cell> grid_;
+    int width_{16};
+    int height_{16};
+    bool running_{true};
+
+    struct {
+        int birth{3};
+        int survive_min{2};
+        int survive_max{3};
+    } rules_;
+
+    int index(int x, int y) const { return y * width_ + x; }
+    int countAliveNeighbors(int x, int y) const;
+    void step();
+};
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/main.cpp
+++ b/examples/workbench/main.cpp
@@ -10,6 +10,7 @@
 #include "demos/genesis_pattern.hpp"
 #include "demos/audio_visualizer.hpp"
 #include "demos/memory_garden.hpp"
+#include "demos/digital_physics_demo.hpp"
 
 using namespace sep;
 using namespace sep::workbench;
@@ -126,6 +127,9 @@ void registerDemos() {
     });
     demo_manager.registerDemo("memory", []() {
         return std::make_unique<MemoryGardenDemo>();
+    });
+    demo_manager.registerDemo("digital_physics", []() {
+        return std::make_unique<DigitalPhysicsDemo>();
     });
 
     // Start with Genesis Pattern demo

--- a/examples/workbench/sep_engine_wrapper.h
+++ b/examples/workbench/sep_engine_wrapper.h
@@ -6,6 +6,8 @@
 #include <functional>
 #include <glm/vec3.hpp>
 #include <glm/gtc/constants.hpp> // For glm::pi
+#include <glm/geometric.hpp>
+#include <cmath>
 #include <array>
 
 #ifndef SEP_WORKBENCH_DEMO


### PR DESCRIPTION
## Summary
- implement simple digital physics demo
- hook demo into workbench build and registration
- extend configuration to support digital physics parameters
- include missing math headers for workbench wrapper

## Testing
- `cmake -B build/workbench -S examples/workbench` *(fails: nlohmann/json.hpp missing)*
- `npm run lint` *(fails: Missing script)*
- `ctest --output-on-failure` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6869aa844534832ab7429e40be798d3b