### PR TITLE
Add flocking demo example

### DIFF
--- a/examples/workbench/CMakeLists.txt
+++ b/examples/workbench/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(sep_workbench
     demos/genesis_pattern.cpp
     demos/audio_visualizer.cpp
     demos/memory_garden.cpp
+    demos/flocking_demo.cpp
 )
 
 # Set C++ standard

--- a/examples/workbench/config.cpp
+++ b/examples/workbench/config.cpp
@@ -90,6 +90,17 @@ bool Config::load(const std::filesystem::path& path) {
             }
         };
 
+        // Flocking config
+        auto& flock = json["demos"]["flocking"];
+        flocking_ = {
+            flock["agent_count"].get<int>(),
+            flock["cohesion_weight"].get<float>(),
+            flock["separation_weight"].get<float>(),
+            flock["alignment_weight"].get<float>(),
+            flock["neighbor_radius"].get<float>(),
+            flock["max_speed"].get<float>()
+        };
+
         // Renderer config
         auto& renderer = json["renderer"];
         auto& cycles = renderer["cycles"];
@@ -174,6 +185,16 @@ bool Config::save(const std::filesystem::path& path) const {
                 {"connection_opacity", memory_garden_.visualization.connection_opacity},
                 {"pattern_scale", memory_garden_.visualization.pattern_scale}
             }}
+        };
+
+        // Flocking config
+        json["demos"]["flocking"] = {
+            {"agent_count", flocking_.agent_count},
+            {"cohesion_weight", flocking_.cohesion_weight},
+            {"separation_weight", flocking_.separation_weight},
+            {"alignment_weight", flocking_.alignment_weight},
+            {"neighbor_radius", flocking_.neighbor_radius},
+            {"max_speed", flocking_.max_speed}
         };
 
         // Renderer config

--- a/examples/workbench/config.hpp
+++ b/examples/workbench/config.hpp
@@ -65,6 +65,15 @@ struct MemoryGardenConfig {
     } visualization;
 };
 
+struct FlockingConfig {
+    int agent_count;
+    float cohesion_weight;
+    float separation_weight;
+    float alignment_weight;
+    float neighbor_radius;
+    float max_speed;
+};
+
 struct RendererConfig {
     struct {
         int samples;
@@ -88,6 +97,7 @@ public:
     const GenesisPatternConfig& genesis_pattern() const { return genesis_pattern_; }
     const AudioVisualizerConfig& audio_visualizer() const { return audio_visualizer_; }
     const MemoryGardenConfig& memory_garden() const { return memory_garden_; }
+    const FlockingConfig& flocking() const { return flocking_; }
     const RendererConfig& renderer() const { return renderer_; }
 
 private:
@@ -98,6 +108,7 @@ private:
     GenesisPatternConfig genesis_pattern_;
     AudioVisualizerConfig audio_visualizer_;
     MemoryGardenConfig memory_garden_;
+    FlockingConfig flocking_;
     RendererConfig renderer_;
 };
 

--- a/examples/workbench/config.json
+++ b/examples/workbench/config.json
@@ -52,6 +52,14 @@
         "connection_opacity": 0.5,
         "pattern_scale": 1.0
       }
+    },
+    "flocking": {
+      "agent_count": 50,
+      "cohesion_weight": 1.0,
+      "separation_weight": 1.2,
+      "alignment_weight": 1.0,
+      "neighbor_radius": 5.0,
+      "max_speed": 1.0
     }
   },
   "renderer": {

--- a/examples/workbench/demos/flocking_demo.cpp
+++ b/examples/workbench/demos/flocking_demo.cpp
@@ -1,0 +1,95 @@
+#include "flocking_demo.hpp"
+#include <config.hpp>
+#include <cstdlib>
+#include <glm/glm.hpp>
+#include <glm/gtc/random.hpp>
+
+namespace sep {
+namespace workbench {
+
+void FlockingDemo::init() {
+#ifdef SEP_WORKBENCH_DEMO
+    // Default parameters
+    cohesion_weight_ = 1.0f;
+    separation_weight_ = 1.2f;
+    alignment_weight_ = 1.0f;
+    neighbor_radius_ = 5.0f;
+    max_speed_ = 1.0f;
+    initializeAgents();
+#else
+    const auto& cfg = Config::getInstance().flocking();
+    cohesion_weight_ = cfg.cohesion_weight;
+    separation_weight_ = cfg.separation_weight;
+    alignment_weight_ = cfg.alignment_weight;
+    neighbor_radius_ = cfg.neighbor_radius;
+    max_speed_ = cfg.max_speed;
+    agents_.resize(cfg.agent_count);
+    initializeAgents();
+#endif
+}
+
+void FlockingDemo::initializeAgents() {
+    if (agents_.empty()) {
+#ifdef SEP_WORKBENCH_DEMO
+        agents_.resize(50);
+#endif
+    }
+    for (auto& a : agents_) {
+        a.position = glm::linearRand(glm::vec3(-10.0f), glm::vec3(10.0f));
+        a.velocity = glm::sphericalRand(1.0f);
+    }
+}
+
+void FlockingDemo::update(float dt) {
+    for (size_t i = 0; i < agents_.size(); ++i) {
+        glm::vec3 cohesion{0.0f};
+        glm::vec3 separation{0.0f};
+        glm::vec3 alignment{0.0f};
+        int count = 0;
+        for (size_t j = 0; j < agents_.size(); ++j) {
+            if (i == j) continue;
+            glm::vec3 diff = agents_[j].position - agents_[i].position;
+            float dist = glm::length(diff);
+            if (dist < neighbor_radius_) {
+                cohesion += agents_[j].position;
+                alignment += agents_[j].velocity;
+                separation -= diff / (dist + 0.001f);
+                ++count;
+            }
+        }
+        if (count > 0) {
+            cohesion = (cohesion / static_cast<float>(count)) - agents_[i].position;
+            alignment = (alignment / static_cast<float>(count)) - agents_[i].velocity;
+        }
+        agents_[i].velocity += cohesion * cohesion_weight_ +
+                               separation * separation_weight_ +
+                               alignment * alignment_weight_;
+        float speed = glm::length(agents_[i].velocity);
+        if (speed > max_speed_) {
+            agents_[i].velocity = (agents_[i].velocity / speed) * max_speed_;
+        }
+    }
+
+    for (auto& a : agents_) {
+        a.position += a.velocity * dt;
+    }
+}
+
+void FlockingDemo::render() {
+    if (!renderer_) return;
+    std::vector<glm::vec3> points;
+    for (const auto& a : agents_) {
+        points.push_back(a.position);
+    }
+    renderer_->renderPatternState(points);
+}
+
+void FlockingDemo::cleanup() {
+    agents_.clear();
+}
+
+void FlockingDemo::handleKeyboard(unsigned char) {}
+void FlockingDemo::handleMouse(int, int, int) {}
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/demos/flocking_demo.hpp
+++ b/examples/workbench/demos/flocking_demo.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "demo_manager.hpp"
+#include <glm/vec3.hpp>
+#include <glm/gtc/random.hpp>
+#include <vector>
+
+namespace sep {
+namespace workbench {
+
+struct PatternData {
+    glm::vec3 position;
+    glm::vec3 velocity;
+};
+
+class FlockingDemo : public Demo {
+public:
+    void init() override;
+    void update(float dt) override;
+    void render() override;
+    void cleanup() override;
+    void handleKeyboard(unsigned char key) override;
+    void handleMouse(int x, int y, int button) override;
+
+private:
+    void initializeAgents();
+
+    std::vector<PatternData> agents_;
+    float cohesion_weight_{1.0f};
+    float separation_weight_{1.0f};
+    float alignment_weight_{1.0f};
+    float neighbor_radius_{5.0f};
+    float max_speed_{1.0f};
+};
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/main.cpp
+++ b/examples/workbench/main.cpp
@@ -10,6 +10,7 @@
 #include "demos/genesis_pattern.hpp"
 #include "demos/audio_visualizer.hpp"
 #include "demos/memory_garden.hpp"
+#include "demos/flocking_demo.hpp"
 
 using namespace sep;
 using namespace sep::workbench;
@@ -126,6 +127,9 @@ void registerDemos() {
     });
     demo_manager.registerDemo("memory", []() {
         return std::make_unique<MemoryGardenDemo>();
+    });
+    demo_manager.registerDemo("flocking", []() {
+        return std::make_unique<FlockingDemo>();
     });
 
     // Start with Genesis Pattern demo

--- a/include/workbench/config.cpp
+++ b/include/workbench/config.cpp
@@ -90,6 +90,17 @@ bool Config::load(const std::filesystem::path& path) {
             }
         };
 
+        // Flocking config
+        auto& flock = json["demos"]["flocking"];
+        flocking_ = {
+            flock["agent_count"].get<int>(),
+            flock["cohesion_weight"].get<float>(),
+            flock["separation_weight"].get<float>(),
+            flock["alignment_weight"].get<float>(),
+            flock["neighbor_radius"].get<float>(),
+            flock["max_speed"].get<float>()
+        };
+
         // Renderer config
         auto& renderer = json["renderer"];
         auto& cycles = renderer["cycles"];
@@ -174,6 +185,16 @@ bool Config::save(const std::filesystem::path& path) const {
                 {"connection_opacity", memory_garden_.visualization.connection_opacity},
                 {"pattern_scale", memory_garden_.visualization.pattern_scale}
             }}
+        };
+
+        // Flocking config
+        json["demos"]["flocking"] = {
+            {"agent_count", flocking_.agent_count},
+            {"cohesion_weight", flocking_.cohesion_weight},
+            {"separation_weight", flocking_.separation_weight},
+            {"alignment_weight", flocking_.alignment_weight},
+            {"neighbor_radius", flocking_.neighbor_radius},
+            {"max_speed", flocking_.max_speed}
         };
 
         // Renderer config

--- a/include/workbench/config.hpp
+++ b/include/workbench/config.hpp
@@ -65,6 +65,15 @@ struct MemoryGardenConfig {
     } visualization;
 };
 
+struct FlockingConfig {
+    int agent_count;
+    float cohesion_weight;
+    float separation_weight;
+    float alignment_weight;
+    float neighbor_radius;
+    float max_speed;
+};
+
 struct RendererConfig {
     struct {
         int samples;
@@ -88,6 +97,7 @@ public:
     const GenesisPatternConfig& genesis_pattern() const { return genesis_pattern_; }
     const AudioVisualizerConfig& audio_visualizer() const { return audio_visualizer_; }
     const MemoryGardenConfig& memory_garden() const { return memory_garden_; }
+    const FlockingConfig& flocking() const { return flocking_; }
     const RendererConfig& renderer() const { return renderer_; }
 
 private:
@@ -98,6 +108,7 @@ private:
     GenesisPatternConfig genesis_pattern_;
     AudioVisualizerConfig audio_visualizer_;
     MemoryGardenConfig memory_garden_;
+    FlockingConfig flocking_;
     RendererConfig renderer_;
 };
 


### PR DESCRIPTION
## Summary
- implement a simple `FlockingDemo`
- wire the new demo into `main.cpp`
- compile `flocking_demo.cpp`
- extend workbench configuration to support flocking agents

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6869aa8a7238832ab56090d83a6059b3