### PR TITLE
Add Flocking demo

### DIFF
--- a/examples/workbench/CMakeLists.txt
+++ b/examples/workbench/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(sep_workbench
     demos/genesis_pattern.cpp
     demos/audio_visualizer.cpp
     demos/memory_garden.cpp
+    demos/flocking_demo.cpp
 )
 
 # Set C++ standard

--- a/examples/workbench/config.cpp
+++ b/examples/workbench/config.cpp
@@ -90,6 +90,13 @@ bool Config::load(const std::filesystem::path& path) {
             }
         };
 
+        auto& flock = json["demos"]["flocking"];
+        flocking_ = {
+            flock["cohesion_weight"].get<float>(),
+            flock["separation_weight"].get<float>(),
+            flock["alignment_weight"].get<float>()
+        };
+
         // Renderer config
         auto& renderer = json["renderer"];
         auto& cycles = renderer["cycles"];
@@ -174,6 +181,12 @@ bool Config::save(const std::filesystem::path& path) const {
                 {"connection_opacity", memory_garden_.visualization.connection_opacity},
                 {"pattern_scale", memory_garden_.visualization.pattern_scale}
             }}
+        };
+
+        json["demos"]["flocking"] = {
+            {"cohesion_weight", flocking_.cohesion_weight},
+            {"separation_weight", flocking_.separation_weight},
+            {"alignment_weight", flocking_.alignment_weight}
         };
 
         // Renderer config

--- a/examples/workbench/config.hpp
+++ b/examples/workbench/config.hpp
@@ -65,6 +65,12 @@ struct MemoryGardenConfig {
     } visualization;
 };
 
+struct FlockingConfig {
+    float cohesion_weight;
+    float separation_weight;
+    float alignment_weight;
+};
+
 struct RendererConfig {
     struct {
         int samples;
@@ -88,6 +94,7 @@ public:
     const GenesisPatternConfig& genesis_pattern() const { return genesis_pattern_; }
     const AudioVisualizerConfig& audio_visualizer() const { return audio_visualizer_; }
     const MemoryGardenConfig& memory_garden() const { return memory_garden_; }
+    const FlockingConfig& flocking() const { return flocking_; }
     const RendererConfig& renderer() const { return renderer_; }
 
 private:
@@ -98,6 +105,7 @@ private:
     GenesisPatternConfig genesis_pattern_;
     AudioVisualizerConfig audio_visualizer_;
     MemoryGardenConfig memory_garden_;
+    FlockingConfig flocking_;
     RendererConfig renderer_;
 };
 

--- a/examples/workbench/config.json
+++ b/examples/workbench/config.json
@@ -52,6 +52,11 @@
         "connection_opacity": 0.5,
         "pattern_scale": 1.0
       }
+    },
+    "flocking": {
+      "cohesion_weight": 1.0,
+      "separation_weight": 1.5,
+      "alignment_weight": 1.0
     }
   },
   "renderer": {

--- a/examples/workbench/demos/flocking_demo.cpp
+++ b/examples/workbench/demos/flocking_demo.cpp
@@ -1,0 +1,84 @@
+#include "flocking_demo.hpp"
+#include <glm/gtc/constants.hpp>
+#include <cstdlib>
+
+namespace sep {
+namespace workbench {
+
+void FlockingDemo::init() {
+    agents_.resize(50);
+    for (auto &a : agents_) {
+        a.position = glm::vec3(
+            static_cast<float>(std::rand() % 100) / 100.0f,
+            0.0f,
+            static_cast<float>(std::rand() % 100) / 100.0f);
+        a.velocity = glm::vec3(
+            static_cast<float>(std::rand() % 100 - 50) / 500.0f,
+            0.0f,
+            static_cast<float>(std::rand() % 100 - 50) / 500.0f);
+    }
+}
+
+void FlockingDemo::update(float dt) {
+    const float neighbor_radius = 0.1f;
+    const float separation_radius = 0.05f;
+
+    for (std::size_t i = 0; i < agents_.size(); ++i) {
+        glm::vec3 cohesion(0.0f);
+        glm::vec3 separation(0.0f);
+        glm::vec3 alignment(0.0f);
+        int neighbor_count = 0;
+
+        for (std::size_t j = 0; j < agents_.size(); ++j) {
+            if (i == j) continue;
+            glm::vec3 diff = agents_[j].position - agents_[i].position;
+            float dist = glm::length(diff);
+            if (dist < neighbor_radius && dist > 0.0001f) {
+                cohesion += agents_[j].position;
+                alignment += agents_[j].velocity;
+                if (dist < separation_radius) {
+                    separation -= diff / dist;
+                }
+                neighbor_count++;
+            }
+        }
+
+        if (neighbor_count > 0) {
+            cohesion = (cohesion / static_cast<float>(neighbor_count) - agents_[i].position) * cohesion_weight_;
+            alignment = (alignment / static_cast<float>(neighbor_count) - agents_[i].velocity) * alignment_weight_;
+        }
+
+        separation *= separation_weight_;
+        agents_[i].velocity += (cohesion + alignment + separation) * dt;
+    }
+
+    for (auto &a : agents_) {
+        a.position += a.velocity * dt;
+    }
+}
+
+void FlockingDemo::render() {
+#ifdef SEP_WORKBENCH_DEMO
+    if (renderer_) {
+        std::vector<glm::vec3> points;
+        for (const auto &a : agents_) points.push_back(a.position);
+        renderer_->renderPatternState(points);
+    }
+#endif
+}
+
+void FlockingDemo::cleanup() {
+    agents_.clear();
+}
+
+void FlockingDemo::handleKeyboard(unsigned char key) {
+    if (key == ' ') {
+        // reset positions
+        init();
+    }
+}
+
+void FlockingDemo::handleMouse(int, int, int) {}
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/demos/flocking_demo.hpp
+++ b/examples/workbench/demos/flocking_demo.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "demo_manager.hpp"
+#include <vector>
+#include <glm/vec3.hpp>
+
+namespace sep {
+namespace workbench {
+
+struct PatternData {
+    glm::vec3 position;
+    glm::vec3 velocity;
+};
+
+class FlockingDemo : public Demo {
+public:
+    void init() override;
+    void update(float dt) override;
+    void render() override;
+    void cleanup() override;
+    void handleKeyboard(unsigned char key) override;
+    void handleMouse(int x, int y, int button) override;
+
+private:
+    std::vector<PatternData> agents_;
+
+    float cohesion_weight_{1.0f};
+    float separation_weight_{1.5f};
+    float alignment_weight_{1.0f};
+};
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/main.cpp
+++ b/examples/workbench/main.cpp
@@ -10,6 +10,7 @@
 #include "demos/genesis_pattern.hpp"
 #include "demos/audio_visualizer.hpp"
 #include "demos/memory_garden.hpp"
+#include "demos/flocking_demo.hpp"
 
 using namespace sep;
 using namespace sep::workbench;
@@ -126,6 +127,9 @@ void registerDemos() {
     });
     demo_manager.registerDemo("memory", []() {
         return std::make_unique<MemoryGardenDemo>();
+    });
+    demo_manager.registerDemo("flocking", []() {
+        return std::make_unique<FlockingDemo>();
     });
 
     // Start with Genesis Pattern demo

--- a/include/workbench/config.cpp
+++ b/include/workbench/config.cpp
@@ -90,6 +90,14 @@ bool Config::load(const std::filesystem::path& path) {
             }
         };
 
+        // Flocking config
+        auto& flock = json["demos"]["flocking"];
+        flocking_ = {
+            flock["cohesion_weight"].get<float>(),
+            flock["separation_weight"].get<float>(),
+            flock["alignment_weight"].get<float>()
+        };
+
         // Renderer config
         auto& renderer = json["renderer"];
         auto& cycles = renderer["cycles"];
@@ -174,6 +182,12 @@ bool Config::save(const std::filesystem::path& path) const {
                 {"connection_opacity", memory_garden_.visualization.connection_opacity},
                 {"pattern_scale", memory_garden_.visualization.pattern_scale}
             }}
+        };
+
+        json["demos"]["flocking"] = {
+            {"cohesion_weight", flocking_.cohesion_weight},
+            {"separation_weight", flocking_.separation_weight},
+            {"alignment_weight", flocking_.alignment_weight}
         };
 
         // Renderer config

--- a/include/workbench/config.hpp
+++ b/include/workbench/config.hpp
@@ -65,6 +65,12 @@ struct MemoryGardenConfig {
     } visualization;
 };
 
+struct FlockingConfig {
+    float cohesion_weight;
+    float separation_weight;
+    float alignment_weight;
+};
+
 struct RendererConfig {
     struct {
         int samples;
@@ -88,6 +94,7 @@ public:
     const GenesisPatternConfig& genesis_pattern() const { return genesis_pattern_; }
     const AudioVisualizerConfig& audio_visualizer() const { return audio_visualizer_; }
     const MemoryGardenConfig& memory_garden() const { return memory_garden_; }
+    const FlockingConfig& flocking() const { return flocking_; }
     const RendererConfig& renderer() const { return renderer_; }
 
 private:
@@ -98,6 +105,7 @@ private:
     GenesisPatternConfig genesis_pattern_;
     AudioVisualizerConfig audio_visualizer_;
     MemoryGardenConfig memory_garden_;
+    FlockingConfig flocking_;
     RendererConfig renderer_;
 };
 


### PR DESCRIPTION
## Summary
- implement stubbed Flocking demo
- register new demo
- compile flocking demo in CMakeLists
- extend config structures and defaults for flocking

## Testing
- `ctest -R testbed_tests --output-on-failure` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_6869aa8a7238832ab56090d83a6059b3