### PR TITLE
Add Digital Physics demo

### DIFF
--- a/examples/workbench/CMakeLists.txt
+++ b/examples/workbench/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(sep_workbench
     demos/genesis_pattern.cpp
     demos/audio_visualizer.cpp
     demos/memory_garden.cpp
+    demos/digital_physics_demo.cpp
 )
 
 # Set C++ standard

--- a/examples/workbench/config.cpp
+++ b/examples/workbench/config.cpp
@@ -90,6 +90,15 @@ bool Config::load(const std::filesystem::path& path) {
             }
         };
 
+        // Digital Physics config
+        auto& phys = json["demos"]["digital_physics"];
+        auto& grid = phys["grid"];
+        auto& rules = phys["rules"];
+        digital_physics_ = {
+            { grid["width"].get<int>(), grid["height"].get<int>() },
+            { rules["birth"].get<std::vector<int>>(), rules["survival"].get<std::vector<int>>() }
+        };
+
         // Renderer config
         auto& renderer = json["renderer"];
         auto& cycles = renderer["cycles"];
@@ -173,6 +182,18 @@ bool Config::save(const std::filesystem::path& path) const {
                 {"show_connections", memory_garden_.visualization.show_connections},
                 {"connection_opacity", memory_garden_.visualization.connection_opacity},
                 {"pattern_scale", memory_garden_.visualization.pattern_scale}
+            }}
+        };
+
+        // Digital Physics config
+        json["demos"]["digital_physics"] = {
+            {"grid", {
+                {"width", digital_physics_.grid.width},
+                {"height", digital_physics_.grid.height}
+            }},
+            {"rules", {
+                {"birth", digital_physics_.rules.birth},
+                {"survival", digital_physics_.rules.survival}
             }}
         };
 

--- a/examples/workbench/config.hpp
+++ b/examples/workbench/config.hpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <memory>
 #include <filesystem>
+#include <vector>
 
 namespace sep {
 namespace workbench {
@@ -65,6 +66,18 @@ struct MemoryGardenConfig {
     } visualization;
 };
 
+struct DigitalPhysicsConfig {
+    struct {
+        int width;
+        int height;
+    } grid;
+
+    struct {
+        std::vector<int> birth;
+        std::vector<int> survival;
+    } rules;
+};
+
 struct RendererConfig {
     struct {
         int samples;
@@ -88,6 +101,7 @@ public:
     const GenesisPatternConfig& genesis_pattern() const { return genesis_pattern_; }
     const AudioVisualizerConfig& audio_visualizer() const { return audio_visualizer_; }
     const MemoryGardenConfig& memory_garden() const { return memory_garden_; }
+    const DigitalPhysicsConfig& digital_physics() const { return digital_physics_; }
     const RendererConfig& renderer() const { return renderer_; }
 
 private:
@@ -98,8 +112,9 @@ private:
     GenesisPatternConfig genesis_pattern_;
     AudioVisualizerConfig audio_visualizer_;
     MemoryGardenConfig memory_garden_;
+    DigitalPhysicsConfig digital_physics_;
     RendererConfig renderer_;
-};
+}; 
 
 } // namespace workbench
 } // namespace sep

--- a/examples/workbench/config.json
+++ b/examples/workbench/config.json
@@ -52,6 +52,16 @@
         "connection_opacity": 0.5,
         "pattern_scale": 1.0
       }
+    },
+    "digital_physics": {
+      "grid": {
+        "width": 16,
+        "height": 16
+      },
+      "rules": {
+        "birth": [3],
+        "survival": [2,3]
+      }
     }
   },
   "renderer": {

--- a/examples/workbench/demos/digital_physics_demo.cpp
+++ b/examples/workbench/demos/digital_physics_demo.cpp
@@ -1,0 +1,93 @@
+#include "digital_physics_demo.hpp"
+#include <config.hpp>
+#include <glm/vec3.hpp>
+#include <cstdlib>
+
+namespace sep {
+namespace workbench {
+
+void DigitalPhysicsDemo::init() {
+#ifdef SEP_WORKBENCH_DEMO
+    width_ = 16;
+    height_ = 16;
+    birth_rules_ = {3};
+    survival_rules_ = {2,3};
+#else
+    const auto& cfg = getConfigManager().getEngineConfig().digital_physics();
+    width_ = static_cast<std::size_t>(cfg.grid.width);
+    height_ = static_cast<std::size_t>(cfg.grid.height);
+    birth_rules_ = cfg.rules.birth;
+    survival_rules_ = cfg.rules.survival;
+#endif
+
+    grid_.resize(width_ * height_);
+    for (std::size_t y = 0; y < height_; ++y) {
+        for (std::size_t x = 0; x < width_; ++x) {
+            auto& cell = grid_[index(x, y)];
+            cell.position = glm::vec4(static_cast<float>(x), 0.f, static_cast<float>(y), 1.f);
+            cell.attributes.x = static_cast<float>(std::rand() % 2);
+        }
+    }
+}
+
+void DigitalPhysicsDemo::update(float) {
+    std::vector<pattern::PatternData> next = grid_;
+
+    auto alive = [&](int x, int y) -> bool {
+        if (x < 0) x += static_cast<int>(width_);
+        if (y < 0) y += static_cast<int>(height_);
+        if (x >= static_cast<int>(width_)) x -= static_cast<int>(width_);
+        if (y >= static_cast<int>(height_)) y -= static_cast<int>(height_);
+        return grid_[index(static_cast<std::size_t>(x), static_cast<std::size_t>(y))].attributes.x > 0.5f;
+    };
+
+    for (std::size_t y = 0; y < height_; ++y) {
+        for (std::size_t x = 0; x < width_; ++x) {
+            int count = 0;
+            for (int dy = -1; dy <= 1; ++dy)
+                for (int dx = -1; dx <= 1; ++dx)
+                    if (dx || dy)
+                        count += alive(static_cast<int>(x) + dx, static_cast<int>(y) + dy) ? 1 : 0;
+
+            bool current = grid_[index(x, y)].attributes.x > 0.5f;
+            bool next_state;
+            if (current) {
+                next_state = std::find(survival_rules_.begin(), survival_rules_.end(), count) != survival_rules_.end();
+            } else {
+                next_state = std::find(birth_rules_.begin(), birth_rules_.end(), count) != birth_rules_.end();
+            }
+            next[index(x, y)].attributes.x = next_state ? 1.0f : 0.0f;
+        }
+    }
+
+    grid_.swap(next);
+}
+
+void DigitalPhysicsDemo::render() {
+    if (!renderer_) return;
+    std::vector<glm::vec3> points;
+    points.reserve(width_ * height_);
+    for (const auto& cell : grid_) {
+        if (cell.attributes.x > 0.5f) {
+            points.emplace_back(cell.position.x, cell.position.y, cell.position.z);
+        }
+    }
+    renderer_->renderPatternState(points);
+}
+
+void DigitalPhysicsDemo::cleanup() {
+    grid_.clear();
+}
+
+void DigitalPhysicsDemo::handleKeyboard(unsigned char key) {
+    if (key == 'r') {
+        for (auto& cell : grid_) {
+            cell.attributes.x = static_cast<float>(std::rand() % 2);
+        }
+    }
+}
+
+void DigitalPhysicsDemo::handleMouse(int, int, int) {}
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/demos/digital_physics_demo.hpp
+++ b/examples/workbench/demos/digital_physics_demo.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "demo_manager.hpp"
+#include "sep_engine_wrapper.h"
+#include <vector>
+#include <algorithm>
+
+namespace sep {
+namespace workbench {
+
+class DigitalPhysicsDemo : public Demo {
+public:
+    void init() override;
+    void update(float dt) override;
+    void render() override;
+    void cleanup() override;
+    void handleKeyboard(unsigned char key) override;
+    void handleMouse(int x, int y, int button) override;
+
+private:
+    std::size_t width_{0};
+    std::size_t height_{0};
+    std::vector<sep::pattern::PatternData> grid_;
+    std::vector<int> birth_rules_;
+    std::vector<int> survival_rules_;
+
+    std::size_t index(std::size_t x, std::size_t y) const { return y * width_ + x; }
+};
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/main.cpp
+++ b/examples/workbench/main.cpp
@@ -10,6 +10,7 @@
 #include "demos/genesis_pattern.hpp"
 #include "demos/audio_visualizer.hpp"
 #include "demos/memory_garden.hpp"
+#include "demos/digital_physics_demo.hpp"
 
 using namespace sep;
 using namespace sep::workbench;
@@ -126,6 +127,9 @@ void registerDemos() {
     });
     demo_manager.registerDemo("memory", []() {
         return std::make_unique<MemoryGardenDemo>();
+    });
+    demo_manager.registerDemo("digital_physics", []() {
+        return std::make_unique<DigitalPhysicsDemo>();
     });
 
     // Start with Genesis Pattern demo

--- a/include/workbench/CMakeLists.txt
+++ b/include/workbench/CMakeLists.txt
@@ -54,6 +54,7 @@ add_executable(sep_workbench
     demos/genesis_pattern.cpp
     demos/audio_visualizer.cpp
     demos/memory_garden.cpp
+    demos/digital_physics_demo.cpp
 )
 
 # Include directories

--- a/include/workbench/config.cpp
+++ b/include/workbench/config.cpp
@@ -90,6 +90,15 @@ bool Config::load(const std::filesystem::path& path) {
             }
         };
 
+        // Digital Physics config
+        auto& phys = json["demos"]["digital_physics"];
+        auto& grid = phys["grid"];
+        auto& rules = phys["rules"];
+        digital_physics_ = {
+            { grid["width"].get<int>(), grid["height"].get<int>() },
+            { rules["birth"].get<std::vector<int>>(), rules["survival"].get<std::vector<int>>() }
+        };
+
         // Renderer config
         auto& renderer = json["renderer"];
         auto& cycles = renderer["cycles"];
@@ -173,6 +182,18 @@ bool Config::save(const std::filesystem::path& path) const {
                 {"show_connections", memory_garden_.visualization.show_connections},
                 {"connection_opacity", memory_garden_.visualization.connection_opacity},
                 {"pattern_scale", memory_garden_.visualization.pattern_scale}
+            }}
+        };
+
+        // Digital Physics config
+        json["demos"]["digital_physics"] = {
+            {"grid", {
+                {"width", digital_physics_.grid.width},
+                {"height", digital_physics_.grid.height}
+            }},
+            {"rules", {
+                {"birth", digital_physics_.rules.birth},
+                {"survival", digital_physics_.rules.survival}
             }}
         };
 

--- a/include/workbench/config.hpp
+++ b/include/workbench/config.hpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <memory>
 #include <filesystem>
+#include <vector>
 
 namespace sep {
 namespace workbench {
@@ -65,6 +66,18 @@ struct MemoryGardenConfig {
     } visualization;
 };
 
+struct DigitalPhysicsConfig {
+    struct {
+        int width;
+        int height;
+    } grid;
+
+    struct {
+        std::vector<int> birth;
+        std::vector<int> survival;
+    } rules;
+};
+
 struct RendererConfig {
     struct {
         int samples;
@@ -88,6 +101,7 @@ public:
     const GenesisPatternConfig& genesis_pattern() const { return genesis_pattern_; }
     const AudioVisualizerConfig& audio_visualizer() const { return audio_visualizer_; }
     const MemoryGardenConfig& memory_garden() const { return memory_garden_; }
+    const DigitalPhysicsConfig& digital_physics() const { return digital_physics_; }
     const RendererConfig& renderer() const { return renderer_; }
 
 private:
@@ -98,6 +112,7 @@ private:
     GenesisPatternConfig genesis_pattern_;
     AudioVisualizerConfig audio_visualizer_;
     MemoryGardenConfig memory_garden_;
+    DigitalPhysicsConfig digital_physics_;
     RendererConfig renderer_;
 };
 

--- a/include/workbench/demos/digital_physics_demo.cpp
+++ b/include/workbench/demos/digital_physics_demo.cpp
@@ -1,0 +1,86 @@
+#include "digital_physics_demo.hpp"
+#include "config.hpp"
+#include <glm/vec3.hpp>
+#include <cstdlib>
+
+namespace sep {
+namespace workbench {
+
+void DigitalPhysicsDemo::init() {
+    const auto& cfg = Config::getInstance().digital_physics();
+    width_ = static_cast<std::size_t>(cfg.grid.width);
+    height_ = static_cast<std::size_t>(cfg.grid.height);
+    birth_rules_ = cfg.rules.birth;
+    survival_rules_ = cfg.rules.survival;
+
+    grid_.resize(width_ * height_);
+    for (std::size_t y = 0; y < height_; ++y) {
+        for (std::size_t x = 0; x < width_; ++x) {
+            auto& cell = grid_[index(x, y)];
+            cell.position = glm::vec4(static_cast<float>(x), 0.f, static_cast<float>(y), 1.f);
+            cell.attributes.x = static_cast<float>(std::rand() % 2);
+        }
+    }
+}
+
+void DigitalPhysicsDemo::update(float) {
+    std::vector<pattern::PatternData> next = grid_;
+
+    auto alive = [&](int x, int y) -> bool {
+        if (x < 0) x += static_cast<int>(width_);
+        if (y < 0) y += static_cast<int>(height_);
+        if (x >= static_cast<int>(width_)) x -= static_cast<int>(width_);
+        if (y >= static_cast<int>(height_)) y -= static_cast<int>(height_);
+        return grid_[index(static_cast<std::size_t>(x), static_cast<std::size_t>(y))].attributes.x > 0.5f;
+    };
+
+    for (std::size_t y = 0; y < height_; ++y) {
+        for (std::size_t x = 0; x < width_; ++x) {
+            int count = 0;
+            for (int dy = -1; dy <= 1; ++dy)
+                for (int dx = -1; dx <= 1; ++dx)
+                    if (dx || dy)
+                        count += alive(static_cast<int>(x) + dx, static_cast<int>(y) + dy) ? 1 : 0;
+
+            bool current = grid_[index(x, y)].attributes.x > 0.5f;
+            bool next_state;
+            if (current) {
+                next_state = std::find(survival_rules_.begin(), survival_rules_.end(), count) != survival_rules_.end();
+            } else {
+                next_state = std::find(birth_rules_.begin(), birth_rules_.end(), count) != birth_rules_.end();
+            }
+            next[index(x, y)].attributes.x = next_state ? 1.0f : 0.0f;
+        }
+    }
+
+    grid_.swap(next);
+}
+
+void DigitalPhysicsDemo::render() {
+    if (!renderer_) return;
+    std::vector<glm::vec3> points;
+    points.reserve(width_ * height_);
+    for (const auto& cell : grid_) {
+        if (cell.attributes.x > 0.5f) {
+            points.emplace_back(cell.position.x, cell.position.y, cell.position.z);
+        }
+    }
+    renderer_->renderPatternState(points);
+}
+
+void DigitalPhysicsDemo::cleanup() {
+    grid_.clear();
+}
+
+void DigitalPhysicsDemo::handleKeyboard(unsigned char key) {
+    if (key == 'r') {
+        for (auto& cell : grid_) {
+            cell.attributes.x = static_cast<float>(std::rand() % 2);
+        }
+    }
+}
+
+void DigitalPhysicsDemo::handleMouse(int, int, int) {}
+
+} // namespace workbench
+} // namespace sep

--- a/include/workbench/demos/digital_physics_demo.hpp
+++ b/include/workbench/demos/digital_physics_demo.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "demo_manager.hpp"
+#include <vector>
+#include <algorithm>
+
+namespace sep {
+namespace workbench {
+
+class DigitalPhysicsDemo : public Demo {
+public:
+    void init() override;
+    void update(float dt) override;
+    void render() override;
+    void cleanup() override;
+    void handleKeyboard(unsigned char key) override;
+    void handleMouse(int x, int y, int button) override;
+
+private:
+    std::size_t width_{0};
+    std::size_t height_{0};
+    std::vector<sep::pattern::PatternData> grid_;
+    std::vector<int> birth_rules_;
+    std::vector<int> survival_rules_;
+
+    std::size_t index(std::size_t x, std::size_t y) const { return y * width_ + x; }
+};
+
+} // namespace workbench
+} // namespace sep


### PR DESCRIPTION
## Summary
- implement DigitalPhysicsDemo with CA-style update rules
- support new digital_physics config section
- register the demo and include in build

## Testing
- `ctest --output-on-failure` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_6869aa844534832ab7429e40be798d3b