### PR TITLE
Add Flocking demo

### DIFF
--- a/examples/workbench/CMakeLists.txt
+++ b/examples/workbench/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(sep_workbench
     demos/genesis_pattern.cpp
     demos/audio_visualizer.cpp
     demos/memory_garden.cpp
+    demos/flocking_demo.cpp
 )
 
 # Set C++ standard

--- a/examples/workbench/config.cpp
+++ b/examples/workbench/config.cpp
@@ -90,6 +90,14 @@ bool Config::load(const std::filesystem::path& path) {
             }
         };
 
+        // Flocking demo config
+        auto& flock = json["demos"]["flocking"];
+        flocking_ = {
+            flock["agent_count"].get<int>(),
+            flock["neighbor_radius"].get<float>(),
+            flock["max_speed"].get<float>()
+        };
+
         // Renderer config
         auto& renderer = json["renderer"];
         auto& cycles = renderer["cycles"];
@@ -174,6 +182,13 @@ bool Config::save(const std::filesystem::path& path) const {
                 {"connection_opacity", memory_garden_.visualization.connection_opacity},
                 {"pattern_scale", memory_garden_.visualization.pattern_scale}
             }}
+        };
+
+        // Flocking demo config
+        json["demos"]["flocking"] = {
+            {"agent_count", flocking_.agent_count},
+            {"neighbor_radius", flocking_.neighbor_radius},
+            {"max_speed", flocking_.max_speed}
         };
 
         // Renderer config

--- a/examples/workbench/config.hpp
+++ b/examples/workbench/config.hpp
@@ -65,6 +65,12 @@ struct MemoryGardenConfig {
     } visualization;
 };
 
+struct FlockingConfig {
+    int agent_count;
+    float neighbor_radius;
+    float max_speed;
+};
+
 struct RendererConfig {
     struct {
         int samples;
@@ -88,6 +94,7 @@ public:
     const GenesisPatternConfig& genesis_pattern() const { return genesis_pattern_; }
     const AudioVisualizerConfig& audio_visualizer() const { return audio_visualizer_; }
     const MemoryGardenConfig& memory_garden() const { return memory_garden_; }
+    const FlockingConfig& flocking() const { return flocking_; }
     const RendererConfig& renderer() const { return renderer_; }
 
 private:
@@ -98,6 +105,7 @@ private:
     GenesisPatternConfig genesis_pattern_;
     AudioVisualizerConfig audio_visualizer_;
     MemoryGardenConfig memory_garden_;
+    FlockingConfig flocking_;
     RendererConfig renderer_;
 };
 

--- a/examples/workbench/config.json
+++ b/examples/workbench/config.json
@@ -52,6 +52,11 @@
         "connection_opacity": 0.5,
         "pattern_scale": 1.0
       }
+    },
+    "flocking": {
+      "agent_count": 50,
+      "neighbor_radius": 5.0,
+      "max_speed": 2.0
     }
   },
   "renderer": {

--- a/examples/workbench/demos/flocking_demo.cpp
+++ b/examples/workbench/demos/flocking_demo.cpp
@@ -1,0 +1,79 @@
+#include "flocking_demo.hpp"
+#include <cstdlib>
+#include <glm/glm.hpp>
+
+namespace sep {
+namespace workbench {
+
+void FlockingDemo::init() {
+#ifdef SEP_WORKBENCH_DEMO
+    std::size_t agent_count = 50;
+    max_speed_ = 2.0f;
+    neighbor_radius_ = 5.0f;
+#else
+    const auto& cfg = getConfigManager().getEngineConfig().flocking();
+    std::size_t agent_count = cfg.agent_count;
+    max_speed_ = cfg.max_speed;
+    neighbor_radius_ = cfg.neighbor_radius;
+#endif
+    agents_.resize(agent_count);
+    for (auto& a : agents_) {
+        float px = (static_cast<float>(std::rand()) / RAND_MAX - 0.5f) * 20.f;
+        float py = (static_cast<float>(std::rand()) / RAND_MAX - 0.5f) * 20.f;
+        float pz = (static_cast<float>(std::rand()) / RAND_MAX - 0.5f) * 20.f;
+        float vx = (static_cast<float>(std::rand()) / RAND_MAX - 0.5f) * 2.f;
+        float vy = (static_cast<float>(std::rand()) / RAND_MAX - 0.5f) * 2.f;
+        float vz = (static_cast<float>(std::rand()) / RAND_MAX - 0.5f) * 2.f;
+        a.position = glm::vec4(px, py, pz, 0.f);
+        a.velocity = glm::vec4(vx, vy, vz, 0.f);
+    }
+}
+
+void FlockingDemo::update(float dt) {
+    for (auto& agent : agents_) {
+        glm::vec3 cohesion(0.f);
+        glm::vec3 alignment(0.f);
+        glm::vec3 separation(0.f);
+        int neighbors = 0;
+        for (const auto& other : agents_) {
+            if (&agent == &other) continue;
+            glm::vec3 diff = glm::vec3(other.position) - glm::vec3(agent.position);
+            float dist = glm::length(diff);
+            if (dist < neighbor_radius_) {
+                cohesion += glm::vec3(other.position);
+                alignment += glm::vec3(other.velocity);
+                separation -= diff / (dist + 0.01f);
+                neighbors++;
+            }
+        }
+        if (neighbors > 0) {
+            cohesion = cohesion / static_cast<float>(neighbors) - glm::vec3(agent.position);
+            alignment = alignment / static_cast<float>(neighbors) - glm::vec3(agent.velocity);
+        }
+        agent.velocity += (cohesion + alignment + separation) * 0.01f;
+        if (glm::length(glm::vec3(agent.velocity)) > max_speed_) {
+            agent.velocity = glm::vec4(glm::normalize(glm::vec3(agent.velocity)) * max_speed_, 0.f);
+        }
+        agent.position += glm::vec4(glm::vec3(agent.velocity) * dt, 0.f);
+    }
+}
+
+void FlockingDemo::render() {
+    if (!renderer_) return;
+    std::vector<glm::vec3> points;
+    points.reserve(agents_.size());
+    for (const auto& a : agents_) {
+        points.emplace_back(a.position.x, a.position.y, a.position.z);
+    }
+    renderer_->renderPatternState(points);
+}
+
+void FlockingDemo::cleanup() {
+    agents_.clear();
+}
+
+void FlockingDemo::handleKeyboard(unsigned char) {}
+void FlockingDemo::handleMouse(int, int, int) {}
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/demos/flocking_demo.hpp
+++ b/examples/workbench/demos/flocking_demo.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "demo_manager.hpp"
+#include <vector>
+#include <glm/vec3.hpp>
+#include <quantum/data.hpp>
+
+namespace sep {
+namespace workbench {
+
+class FlockingDemo : public Demo {
+public:
+    void init() override;
+    void update(float dt) override;
+    void render() override;
+    void cleanup() override;
+    void handleKeyboard(unsigned char key) override;
+    void handleMouse(int x, int y, int button) override;
+
+private:
+    std::vector<pattern::PatternData> agents_;
+    float max_speed_{2.0f};
+    float neighbor_radius_{5.0f};
+};
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/main.cpp
+++ b/examples/workbench/main.cpp
@@ -10,6 +10,7 @@
 #include "demos/genesis_pattern.hpp"
 #include "demos/audio_visualizer.hpp"
 #include "demos/memory_garden.hpp"
+#include "demos/flocking_demo.hpp"
 
 using namespace sep;
 using namespace sep::workbench;
@@ -126,6 +127,9 @@ void registerDemos() {
     });
     demo_manager.registerDemo("memory", []() {
         return std::make_unique<MemoryGardenDemo>();
+    });
+    demo_manager.registerDemo("flocking", []() {
+        return std::make_unique<FlockingDemo>();
     });
 
     // Start with Genesis Pattern demo

--- a/include/workbench/CMakeLists.txt
+++ b/include/workbench/CMakeLists.txt
@@ -54,6 +54,7 @@ add_executable(sep_workbench
     demos/genesis_pattern.cpp
     demos/audio_visualizer.cpp
     demos/memory_garden.cpp
+    demos/flocking_demo.cpp
 )
 
 # Include directories

--- a/include/workbench/config.cpp
+++ b/include/workbench/config.cpp
@@ -90,6 +90,14 @@ bool Config::load(const std::filesystem::path& path) {
             }
         };
 
+        // Flocking demo config
+        auto& flock = json["demos"]["flocking"];
+        flocking_ = {
+            flock["agent_count"].get<int>(),
+            flock["neighbor_radius"].get<float>(),
+            flock["max_speed"].get<float>()
+        };
+
         // Renderer config
         auto& renderer = json["renderer"];
         auto& cycles = renderer["cycles"];
@@ -174,6 +182,13 @@ bool Config::save(const std::filesystem::path& path) const {
                 {"connection_opacity", memory_garden_.visualization.connection_opacity},
                 {"pattern_scale", memory_garden_.visualization.pattern_scale}
             }}
+        };
+
+        // Flocking demo config
+        json["demos"]["flocking"] = {
+            {"agent_count", flocking_.agent_count},
+            {"neighbor_radius", flocking_.neighbor_radius},
+            {"max_speed", flocking_.max_speed}
         };
 
         // Renderer config

--- a/include/workbench/config.hpp
+++ b/include/workbench/config.hpp
@@ -65,6 +65,12 @@ struct MemoryGardenConfig {
     } visualization;
 };
 
+struct FlockingConfig {
+    int agent_count;
+    float neighbor_radius;
+    float max_speed;
+};
+
 struct RendererConfig {
     struct {
         int samples;
@@ -88,6 +94,7 @@ public:
     const GenesisPatternConfig& genesis_pattern() const { return genesis_pattern_; }
     const AudioVisualizerConfig& audio_visualizer() const { return audio_visualizer_; }
     const MemoryGardenConfig& memory_garden() const { return memory_garden_; }
+    const FlockingConfig& flocking() const { return flocking_; }
     const RendererConfig& renderer() const { return renderer_; }
 
 private:
@@ -98,6 +105,7 @@ private:
     GenesisPatternConfig genesis_pattern_;
     AudioVisualizerConfig audio_visualizer_;
     MemoryGardenConfig memory_garden_;
+    FlockingConfig flocking_;
     RendererConfig renderer_;
 };
 

--- a/include/workbench/config.json
+++ b/include/workbench/config.json
@@ -52,6 +52,11 @@
         "connection_opacity": 0.5,
         "pattern_scale": 1.0
       }
+    },
+    "flocking": {
+      "agent_count": 50,
+      "neighbor_radius": 5.0,
+      "max_speed": 2.0
     }
   },
   "renderer": {

--- a/include/workbench/demos/flocking_demo.cpp
+++ b/include/workbench/demos/flocking_demo.cpp
@@ -1,0 +1,79 @@
+#include "flocking_demo.hpp"
+#include <cstdlib>
+#include <glm/glm.hpp>
+
+namespace sep {
+namespace workbench {
+
+void FlockingDemo::init() {
+#ifdef SEP_WORKBENCH_DEMO
+    std::size_t agent_count = 50;
+    max_speed_ = 2.0f;
+    neighbor_radius_ = 5.0f;
+#else
+    const auto& cfg = getConfigManager().getEngineConfig().flocking();
+    std::size_t agent_count = cfg.agent_count;
+    max_speed_ = cfg.max_speed;
+    neighbor_radius_ = cfg.neighbor_radius;
+#endif
+    agents_.resize(agent_count);
+    for (auto& a : agents_) {
+        float px = (static_cast<float>(std::rand()) / RAND_MAX - 0.5f) * 20.f;
+        float py = (static_cast<float>(std::rand()) / RAND_MAX - 0.5f) * 20.f;
+        float pz = (static_cast<float>(std::rand()) / RAND_MAX - 0.5f) * 20.f;
+        float vx = (static_cast<float>(std::rand()) / RAND_MAX - 0.5f) * 2.f;
+        float vy = (static_cast<float>(std::rand()) / RAND_MAX - 0.5f) * 2.f;
+        float vz = (static_cast<float>(std::rand()) / RAND_MAX - 0.5f) * 2.f;
+        a.position = glm::vec4(px, py, pz, 0.f);
+        a.velocity = glm::vec4(vx, vy, vz, 0.f);
+    }
+}
+
+void FlockingDemo::update(float dt) {
+    for (auto& agent : agents_) {
+        glm::vec3 cohesion(0.f);
+        glm::vec3 alignment(0.f);
+        glm::vec3 separation(0.f);
+        int neighbors = 0;
+        for (const auto& other : agents_) {
+            if (&agent == &other) continue;
+            glm::vec3 diff = glm::vec3(other.position) - glm::vec3(agent.position);
+            float dist = glm::length(diff);
+            if (dist < neighbor_radius_) {
+                cohesion += glm::vec3(other.position);
+                alignment += glm::vec3(other.velocity);
+                separation -= diff / (dist + 0.01f);
+                neighbors++;
+            }
+        }
+        if (neighbors > 0) {
+            cohesion = cohesion / static_cast<float>(neighbors) - glm::vec3(agent.position);
+            alignment = alignment / static_cast<float>(neighbors) - glm::vec3(agent.velocity);
+        }
+        agent.velocity += (cohesion + alignment + separation) * 0.01f;
+        if (glm::length(glm::vec3(agent.velocity)) > max_speed_) {
+            agent.velocity = glm::vec4(glm::normalize(glm::vec3(agent.velocity)) * max_speed_, 0.f);
+        }
+        agent.position += glm::vec4(glm::vec3(agent.velocity) * dt, 0.f);
+    }
+}
+
+void FlockingDemo::render() {
+    if (!renderer_) return;
+    std::vector<glm::vec3> points;
+    points.reserve(agents_.size());
+    for (const auto& a : agents_) {
+        points.emplace_back(a.position.x, a.position.y, a.position.z);
+    }
+    renderer_->renderPatternState(points);
+}
+
+void FlockingDemo::cleanup() {
+    agents_.clear();
+}
+
+void FlockingDemo::handleKeyboard(unsigned char) {}
+void FlockingDemo::handleMouse(int, int, int) {}
+
+} // namespace workbench
+} // namespace sep

--- a/include/workbench/demos/flocking_demo.hpp
+++ b/include/workbench/demos/flocking_demo.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "demo_manager.hpp"
+#include <vector>
+#include <glm/vec3.hpp>
+#include <quantum/data.hpp>
+
+namespace sep {
+namespace workbench {
+
+class FlockingDemo : public Demo {
+public:
+    void init() override;
+    void update(float dt) override;
+    void render() override;
+    void cleanup() override;
+    void handleKeyboard(unsigned char key) override;
+    void handleMouse(int x, int y, int button) override;
+
+private:
+    std::vector<pattern::PatternData> agents_;
+    float max_speed_{2.0f};
+    float neighbor_radius_{5.0f};
+};
+
+} // namespace workbench
+} // namespace sep

--- a/include/workbench/main.cpp
+++ b/include/workbench/main.cpp
@@ -5,6 +5,7 @@
 #include "demos/genesis_pattern.hpp"
 #include "demos/audio_visualizer.hpp"
 #include "demos/memory_garden.hpp"
+#include "demos/flocking_demo.hpp"
 
 using namespace sep;
 using namespace sep::workbench;
@@ -88,6 +89,9 @@ void registerDemos() {
     });
     demo_manager.registerDemo("memory", []() {
         return std::make_unique<MemoryGardenDemo>();
+    });
+    demo_manager.registerDemo("flocking", []() {
+        return std::make_unique<FlockingDemo>();
     });
 
     // Start with Genesis Pattern demo


### PR DESCRIPTION
## Summary
- add `FlockingDemo` with simple flocking logic
- register demo in example main
- extend example configuration and parser with flocking options
- compile new source file in CMake

## Testing
- `g++ -std=c++17 -Iinclude -Iexamples/workbench -fsyntax-only examples/workbench/demos/flocking_demo.cpp` *(fails: nlohmann/json.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6869aa8a7238832ab56090d83a6059b3