### PR TITLE
Add neural demo

### DIFF
--- a/examples/workbench/CMakeLists.txt
+++ b/examples/workbench/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(sep_workbench
     demos/genesis_pattern.cpp
     demos/audio_visualizer.cpp
     demos/memory_garden.cpp
+    demos/neural_demo.cpp
 )
 
 # Set C++ standard

--- a/examples/workbench/config.cpp
+++ b/examples/workbench/config.cpp
@@ -90,6 +90,14 @@ bool Config::load(const std::filesystem::path& path) {
             }
         };
 
+        // Neural demo config
+        auto& neural = json["demos"]["neural"];
+        neural_ = {
+            neural["neuron_count"].get<int>(),
+            neural["threshold"].get<float>(),
+            neural["decay"].get<float>()
+        };
+
         // Renderer config
         auto& renderer = json["renderer"];
         auto& cycles = renderer["cycles"];
@@ -174,6 +182,13 @@ bool Config::save(const std::filesystem::path& path) const {
                 {"connection_opacity", memory_garden_.visualization.connection_opacity},
                 {"pattern_scale", memory_garden_.visualization.pattern_scale}
             }}
+        };
+
+        // Neural demo config
+        json["demos"]["neural"] = {
+            {"neuron_count", neural_.neuron_count},
+            {"threshold", neural_.threshold},
+            {"decay", neural_.decay}
         };
 
         // Renderer config

--- a/examples/workbench/config.hpp
+++ b/examples/workbench/config.hpp
@@ -65,6 +65,12 @@ struct MemoryGardenConfig {
     } visualization;
 };
 
+struct NeuralConfig {
+    int neuron_count;
+    float threshold;
+    float decay;
+};
+
 struct RendererConfig {
     struct {
         int samples;
@@ -88,6 +94,7 @@ public:
     const GenesisPatternConfig& genesis_pattern() const { return genesis_pattern_; }
     const AudioVisualizerConfig& audio_visualizer() const { return audio_visualizer_; }
     const MemoryGardenConfig& memory_garden() const { return memory_garden_; }
+    const NeuralConfig& neural() const { return neural_; }
     const RendererConfig& renderer() const { return renderer_; }
 
 private:
@@ -98,6 +105,7 @@ private:
     GenesisPatternConfig genesis_pattern_;
     AudioVisualizerConfig audio_visualizer_;
     MemoryGardenConfig memory_garden_;
+    NeuralConfig neural_;
     RendererConfig renderer_;
 };
 

--- a/examples/workbench/config.json
+++ b/examples/workbench/config.json
@@ -52,6 +52,11 @@
         "connection_opacity": 0.5,
         "pattern_scale": 1.0
       }
+    },
+    "neural": {
+      "neuron_count": 10,
+      "threshold": 1.0,
+      "decay": 0.1
     }
   },
   "renderer": {

--- a/examples/workbench/demos/neural_demo.cpp
+++ b/examples/workbench/demos/neural_demo.cpp
@@ -1,0 +1,78 @@
+#include "neural_demo.hpp"
+#include <config.hpp>
+#include <glm/gtc/constants.hpp>
+
+namespace sep {
+namespace workbench {
+
+void NeuralDemo::init() {
+#ifdef SEP_WORKBENCH_DEMO
+    // Use default parameters
+    params_ = {10, 1.0f, 0.1f};
+#else
+    const auto& cfg = getConfigManager().getEngineConfig().neural();
+    params_.neuron_count = cfg.neuron_count;
+    params_.threshold = cfg.threshold;
+    params_.decay = cfg.decay;
+#endif
+
+    potentials_.assign(params_.neuron_count, 0.0f);
+    outputs_.assign(params_.neuron_count, 0.0f);
+    positions_.clear();
+
+    // Create simple ring connectivity
+    for (int i = 0; i < params_.neuron_count; ++i) {
+        int parent = (i == 0) ? params_.neuron_count - 1 : i - 1;
+        graph_.addNodeWithId(i, glm::vec3(0.0f), 0.0f, {static_cast<uint64_t>(parent)});
+        float angle = 2.0f * glm::pi<float>() * (static_cast<float>(i) / params_.neuron_count);
+        positions_.push_back(glm::vec3(std::cos(angle) * 5.0f, 0.0f, std::sin(angle) * 5.0f));
+    }
+}
+
+void NeuralDemo::update(float dt) {
+    std::vector<float> inputs(params_.neuron_count, 0.0f);
+
+    // Integrate inputs from parent spikes
+    for (int i = 0; i < params_.neuron_count; ++i) {
+        auto parents = graph_.getParents(i);
+        float sum = 0.0f;
+        for (auto p : parents) {
+            if (p < outputs_.size()) sum += outputs_[p];
+        }
+        inputs[i] = sum;
+    }
+
+    std::vector<float> new_outputs(params_.neuron_count, 0.0f);
+    for (int i = 0; i < params_.neuron_count; ++i) {
+        potentials_[i] += inputs[i] * dt;
+        potentials_[i] *= (1.0f - params_.decay * dt);
+        if (potentials_[i] >= params_.threshold) {
+            potentials_[i] = 0.0f;
+            new_outputs[i] = 1.0f;
+        }
+    }
+    outputs_ = std::move(new_outputs);
+}
+
+void NeuralDemo::render() {
+#ifdef SEP_WORKBENCH_DEMO
+    if (renderer_) {
+        renderer_->renderPatternState(positions_);
+    }
+#else
+    if (!renderer_) return;
+    renderer_->renderPatternState(positions_);
+#endif
+}
+
+void NeuralDemo::cleanup() {
+    potentials_.clear();
+    outputs_.clear();
+    positions_.clear();
+}
+
+void NeuralDemo::handleKeyboard(unsigned char) {}
+void NeuralDemo::handleMouse(int, int, int) {}
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/demos/neural_demo.hpp
+++ b/examples/workbench/demos/neural_demo.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "demo_manager.hpp"
+#include <core/dag_graph.h>
+#include <glm/vec3.hpp>
+#include <vector>
+
+namespace sep {
+namespace workbench {
+
+class NeuralDemo : public Demo {
+public:
+    void init() override;
+    void update(float dt) override;
+    void render() override;
+    void cleanup() override;
+    void handleKeyboard(unsigned char key) override;
+    void handleMouse(int x, int y, int button) override;
+
+private:
+    dag::DagGraph graph_;
+    std::vector<float> potentials_;
+    std::vector<float> outputs_;
+    std::vector<glm::vec3> positions_;
+
+    struct Params {
+        int neuron_count{10};
+        float threshold{1.0f};
+        float decay{0.1f};
+    } params_;
+};
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/main.cpp
+++ b/examples/workbench/main.cpp
@@ -10,6 +10,7 @@
 #include "demos/genesis_pattern.hpp"
 #include "demos/audio_visualizer.hpp"
 #include "demos/memory_garden.hpp"
+#include "demos/neural_demo.hpp"
 
 using namespace sep;
 using namespace sep::workbench;
@@ -126,6 +127,9 @@ void registerDemos() {
     });
     demo_manager.registerDemo("memory", []() {
         return std::make_unique<MemoryGardenDemo>();
+    });
+    demo_manager.registerDemo("neural", []() {
+        return std::make_unique<NeuralDemo>();
     });
 
     // Start with Genesis Pattern demo


### PR DESCRIPTION
## Summary
- introduce `NeuralDemo` example with integrate-and-fire loop
- register the new demo and compile it
- support neural demo options in config structures
- add defaults to `config.json`

## Testing
- `bash ./tests/blender/run_tests.sh` *(fails: Could not find nvcc)*
- `cmake --build /tmp/build --target sep_workbench -j $(nproc)` *(fails: missing nlohmann/json.hpp)*

------
https://chatgpt.com/codex/tasks/task_e_6869aa7d6d1c832a996d1cd8692ef677