### PR TITLE
Add NeuralDemo and config

### DIFF
--- a/examples/workbench/CMakeLists.txt
+++ b/examples/workbench/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(sep_workbench
     demos/genesis_pattern.cpp
     demos/audio_visualizer.cpp
     demos/memory_garden.cpp
+    demos/neural_demo.cpp
 )
 
 # Set C++ standard

--- a/examples/workbench/config.cpp
+++ b/examples/workbench/config.cpp
@@ -90,6 +90,15 @@ bool Config::load(const std::filesystem::path& path) {
             }
         };
 
+        // Neural demo config
+        auto& neural = json["demos"]["neural"];
+        neural_ = {
+            neural["neuron_count"].get<int>(),
+            neural["threshold"].get<float>(),
+            neural["decay"].get<float>(),
+            neural["connection_weight"].get<float>()
+        };
+
         // Renderer config
         auto& renderer = json["renderer"];
         auto& cycles = renderer["cycles"];
@@ -174,6 +183,14 @@ bool Config::save(const std::filesystem::path& path) const {
                 {"connection_opacity", memory_garden_.visualization.connection_opacity},
                 {"pattern_scale", memory_garden_.visualization.pattern_scale}
             }}
+        };
+
+        // Neural demo config
+        json["demos"]["neural"] = {
+            {"neuron_count", neural_.neuron_count},
+            {"threshold", neural_.threshold},
+            {"decay", neural_.decay},
+            {"connection_weight", neural_.connection_weight}
         };
 
         // Renderer config

--- a/examples/workbench/config.hpp
+++ b/examples/workbench/config.hpp
@@ -65,6 +65,13 @@ struct MemoryGardenConfig {
     } visualization;
 };
 
+struct NeuralDemoConfig {
+    int neuron_count;
+    float threshold;
+    float decay;
+    float connection_weight;
+};
+
 struct RendererConfig {
     struct {
         int samples;
@@ -88,6 +95,7 @@ public:
     const GenesisPatternConfig& genesis_pattern() const { return genesis_pattern_; }
     const AudioVisualizerConfig& audio_visualizer() const { return audio_visualizer_; }
     const MemoryGardenConfig& memory_garden() const { return memory_garden_; }
+    const NeuralDemoConfig& neural() const { return neural_; }
     const RendererConfig& renderer() const { return renderer_; }
 
 private:
@@ -98,6 +106,7 @@ private:
     GenesisPatternConfig genesis_pattern_;
     AudioVisualizerConfig audio_visualizer_;
     MemoryGardenConfig memory_garden_;
+    NeuralDemoConfig neural_;
     RendererConfig renderer_;
 };
 

--- a/examples/workbench/config.json
+++ b/examples/workbench/config.json
@@ -52,6 +52,12 @@
         "connection_opacity": 0.5,
         "pattern_scale": 1.0
       }
+    },
+    "neural": {
+      "neuron_count": 3,
+      "threshold": 1.0,
+      "decay": 0.1,
+      "connection_weight": 0.5
     }
   },
   "renderer": {

--- a/examples/workbench/demos/neural_demo.cpp
+++ b/examples/workbench/demos/neural_demo.cpp
@@ -1,0 +1,91 @@
+#include "neural_demo.hpp"
+#include <config.hpp>
+#include <algorithm>
+
+namespace sep {
+namespace workbench {
+
+void NeuralDemo::init() {
+#ifdef SEP_WORKBENCH_DEMO
+    int count = 3;
+    threshold_ = 1.0f;
+    decay_ = 0.1f;
+    weight_ = 0.5f;
+#else
+    const auto& cfg = sep::core::config::ConfigManager::getInstance().getEngineConfig().neural();
+    int count = cfg.neuron_count;
+    threshold_ = cfg.threshold;
+    decay_ = cfg.decay;
+    weight_ = cfg.connection_weight;
+#endif
+
+    neurons_.clear();
+    graph_ = dag::DagGraph();
+    for (int i = 0; i < count; ++i) {
+        uint64_t id = graph_.addNode(glm::vec3(0.0f), 0.f, {});
+        neurons_.push_back({id, 0.f});
+        if (i > 0) {
+            graph_.updateNodeParents(neurons_[i].id, {neurons_[i-1].id});
+        }
+    }
+}
+
+void NeuralDemo::update(float dt) {
+    std::vector<float> inputs(neurons_.size(), 0.f);
+    for (size_t i = 0; i < neurons_.size(); ++i) {
+        auto parents = graph_.getParents(neurons_[i].id);
+        for (uint64_t pid : parents) {
+            auto it = std::find_if(neurons_.begin(), neurons_.end(), [pid](const Neuron& n){ return n.id == pid; });
+            if (it != neurons_.end()) {
+                inputs[i] += it->potential * weight_;
+            }
+        }
+    }
+
+    for (size_t i = 0; i < neurons_.size(); ++i) {
+        Neuron& n = neurons_[i];
+        n.potential += inputs[i];
+        n.potential -= decay_ * n.potential * dt;
+        if (n.potential >= threshold_) {
+            n.potential = 0.f;
+            for (size_t j = 0; j < neurons_.size(); ++j) {
+                auto parents = graph_.getParents(neurons_[j].id);
+                if (std::find(parents.begin(), parents.end(), n.id) != parents.end()) {
+                    neurons_[j].potential += 1.f;
+                }
+            }
+        }
+        graph_.updateCoherence(n.id, n.potential / threshold_);
+    }
+}
+
+void NeuralDemo::render() {
+#ifdef SEP_WORKBENCH_DEMO
+    if (!renderer_) return;
+    std::vector<glm::vec3> points;
+    for (size_t i = 0; i < neurons_.size(); ++i) {
+        float y = neurons_[i].potential / threshold_;
+        points.push_back(glm::vec3(static_cast<float>(i), y, 0.f));
+    }
+    renderer_->renderPatternState(points);
+#else
+    if (!renderer_) return;
+    std::vector<glm::vec3> points;
+    for (size_t i = 0; i < neurons_.size(); ++i) {
+        float y = neurons_[i].potential / threshold_;
+        points.push_back(glm::vec3(static_cast<float>(i), y, 0.f));
+    }
+    renderer_->renderPatternState(points);
+#endif
+}
+
+void NeuralDemo::cleanup() {
+    neurons_.clear();
+    graph_ = dag::DagGraph();
+}
+
+void NeuralDemo::handleKeyboard(unsigned char) {}
+void NeuralDemo::handleMouse(int, int, int) {}
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/demos/neural_demo.hpp
+++ b/examples/workbench/demos/neural_demo.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "demo_manager.hpp"
+#include "sep_engine_wrapper.h"
+#include <vector>
+
+namespace sep {
+namespace workbench {
+
+class NeuralDemo : public Demo {
+public:
+    void init() override;
+    void update(float dt) override;
+    void render() override;
+    void cleanup() override;
+    void handleKeyboard(unsigned char key) override;
+    void handleMouse(int x, int y, int button) override;
+
+private:
+    struct Neuron {
+        uint64_t id;
+        float potential{0.f};
+    };
+
+    std::vector<Neuron> neurons_;
+    dag::DagGraph graph_;
+    float threshold_{1.0f};
+    float decay_{0.1f};
+    float weight_{0.5f};
+};
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/main.cpp
+++ b/examples/workbench/main.cpp
@@ -10,6 +10,7 @@
 #include "demos/genesis_pattern.hpp"
 #include "demos/audio_visualizer.hpp"
 #include "demos/memory_garden.hpp"
+#include "demos/neural_demo.hpp"
 
 using namespace sep;
 using namespace sep::workbench;
@@ -126,6 +127,9 @@ void registerDemos() {
     });
     demo_manager.registerDemo("memory", []() {
         return std::make_unique<MemoryGardenDemo>();
+    });
+    demo_manager.registerDemo("neural", []() {
+        return std::make_unique<NeuralDemo>();
     });
 
     // Start with Genesis Pattern demo

--- a/include/workbench/CMakeLists.txt
+++ b/include/workbench/CMakeLists.txt
@@ -54,6 +54,7 @@ add_executable(sep_workbench
     demos/genesis_pattern.cpp
     demos/audio_visualizer.cpp
     demos/memory_garden.cpp
+    demos/neural_demo.cpp
 )
 
 # Include directories

--- a/include/workbench/config.cpp
+++ b/include/workbench/config.cpp
@@ -90,6 +90,15 @@ bool Config::load(const std::filesystem::path& path) {
             }
         };
 
+        // Neural demo config
+        auto& neural = json["demos"]["neural"];
+        neural_ = {
+            neural["neuron_count"].get<int>(),
+            neural["threshold"].get<float>(),
+            neural["decay"].get<float>(),
+            neural["connection_weight"].get<float>()
+        };
+
         // Renderer config
         auto& renderer = json["renderer"];
         auto& cycles = renderer["cycles"];
@@ -174,6 +183,14 @@ bool Config::save(const std::filesystem::path& path) const {
                 {"connection_opacity", memory_garden_.visualization.connection_opacity},
                 {"pattern_scale", memory_garden_.visualization.pattern_scale}
             }}
+        };
+
+        // Neural demo config
+        json["demos"]["neural"] = {
+            {"neuron_count", neural_.neuron_count},
+            {"threshold", neural_.threshold},
+            {"decay", neural_.decay},
+            {"connection_weight", neural_.connection_weight}
         };
 
         // Renderer config

--- a/include/workbench/config.hpp
+++ b/include/workbench/config.hpp
@@ -65,6 +65,13 @@ struct MemoryGardenConfig {
     } visualization;
 };
 
+struct NeuralDemoConfig {
+    int neuron_count;
+    float threshold;
+    float decay;
+    float connection_weight;
+};
+
 struct RendererConfig {
     struct {
         int samples;
@@ -88,6 +95,7 @@ public:
     const GenesisPatternConfig& genesis_pattern() const { return genesis_pattern_; }
     const AudioVisualizerConfig& audio_visualizer() const { return audio_visualizer_; }
     const MemoryGardenConfig& memory_garden() const { return memory_garden_; }
+    const NeuralDemoConfig& neural() const { return neural_; }
     const RendererConfig& renderer() const { return renderer_; }
 
 private:
@@ -98,6 +106,7 @@ private:
     GenesisPatternConfig genesis_pattern_;
     AudioVisualizerConfig audio_visualizer_;
     MemoryGardenConfig memory_garden_;
+    NeuralDemoConfig neural_;
     RendererConfig renderer_;
 };
 

--- a/include/workbench/config.json
+++ b/include/workbench/config.json
@@ -52,6 +52,12 @@
         "connection_opacity": 0.5,
         "pattern_scale": 1.0
       }
+    },
+    "neural": {
+      "neuron_count": 3,
+      "threshold": 1.0,
+      "decay": 0.1,
+      "connection_weight": 0.5
     }
   },
   "renderer": {

--- a/include/workbench/demos/neural_demo.cpp
+++ b/include/workbench/demos/neural_demo.cpp
@@ -1,0 +1,91 @@
+#include "neural_demo.hpp"
+#include <config.hpp>
+#include <algorithm>
+
+namespace sep {
+namespace workbench {
+
+void NeuralDemo::init() {
+#ifdef SEP_WORKBENCH_DEMO
+    int count = 3;
+    threshold_ = 1.0f;
+    decay_ = 0.1f;
+    weight_ = 0.5f;
+#else
+    const auto& cfg = sep::core::config::ConfigManager::getInstance().getEngineConfig().neural();
+    int count = cfg.neuron_count;
+    threshold_ = cfg.threshold;
+    decay_ = cfg.decay;
+    weight_ = cfg.connection_weight;
+#endif
+
+    neurons_.clear();
+    graph_ = dag::DagGraph();
+    for (int i = 0; i < count; ++i) {
+        uint64_t id = graph_.addNode(glm::vec3(0.0f), 0.f, {});
+        neurons_.push_back({id, 0.f});
+        if (i > 0) {
+            graph_.updateNodeParents(neurons_[i].id, {neurons_[i-1].id});
+        }
+    }
+}
+
+void NeuralDemo::update(float dt) {
+    std::vector<float> inputs(neurons_.size(), 0.f);
+    for (size_t i = 0; i < neurons_.size(); ++i) {
+        auto parents = graph_.getParents(neurons_[i].id);
+        for (uint64_t pid : parents) {
+            auto it = std::find_if(neurons_.begin(), neurons_.end(), [pid](const Neuron& n){ return n.id == pid; });
+            if (it != neurons_.end()) {
+                inputs[i] += it->potential * weight_;
+            }
+        }
+    }
+
+    for (size_t i = 0; i < neurons_.size(); ++i) {
+        Neuron& n = neurons_[i];
+        n.potential += inputs[i];
+        n.potential -= decay_ * n.potential * dt;
+        if (n.potential >= threshold_) {
+            n.potential = 0.f;
+            for (size_t j = 0; j < neurons_.size(); ++j) {
+                auto parents = graph_.getParents(neurons_[j].id);
+                if (std::find(parents.begin(), parents.end(), n.id) != parents.end()) {
+                    neurons_[j].potential += 1.f;
+                }
+            }
+        }
+        graph_.updateCoherence(n.id, n.potential / threshold_);
+    }
+}
+
+void NeuralDemo::render() {
+#ifdef SEP_WORKBENCH_DEMO
+    if (!renderer_) return;
+    std::vector<glm::vec3> points;
+    for (size_t i = 0; i < neurons_.size(); ++i) {
+        float y = neurons_[i].potential / threshold_;
+        points.push_back(glm::vec3(static_cast<float>(i), y, 0.f));
+    }
+    renderer_->renderPatternState(points);
+#else
+    if (!renderer_) return;
+    std::vector<glm::vec3> points;
+    for (size_t i = 0; i < neurons_.size(); ++i) {
+        float y = neurons_[i].potential / threshold_;
+        points.push_back(glm::vec3(static_cast<float>(i), y, 0.f));
+    }
+    renderer_->renderPatternState(points);
+#endif
+}
+
+void NeuralDemo::cleanup() {
+    neurons_.clear();
+    graph_ = dag::DagGraph();
+}
+
+void NeuralDemo::handleKeyboard(unsigned char) {}
+void NeuralDemo::handleMouse(int, int, int) {}
+
+} // namespace workbench
+} // namespace sep

--- a/include/workbench/demos/neural_demo.hpp
+++ b/include/workbench/demos/neural_demo.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "demo_manager.hpp"
+#include "sep_engine_wrapper.h"
+#include <vector>
+
+namespace sep {
+namespace workbench {
+
+class NeuralDemo : public Demo {
+public:
+    void init() override;
+    void update(float dt) override;
+    void render() override;
+    void cleanup() override;
+    void handleKeyboard(unsigned char key) override;
+    void handleMouse(int x, int y, int button) override;
+
+private:
+    struct Neuron {
+        uint64_t id;
+        float potential{0.f};
+    };
+
+    std::vector<Neuron> neurons_;
+    dag::DagGraph graph_;
+    float threshold_{1.0f};
+    float decay_{0.1f};
+    float weight_{0.5f};
+};
+
+} // namespace workbench
+} // namespace sep

--- a/include/workbench/main.cpp
+++ b/include/workbench/main.cpp
@@ -5,6 +5,7 @@
 #include "demos/genesis_pattern.hpp"
 #include "demos/audio_visualizer.hpp"
 #include "demos/memory_garden.hpp"
+#include "demos/neural_demo.hpp"
 
 using namespace sep;
 using namespace sep::workbench;
@@ -88,6 +89,9 @@ void registerDemos() {
     });
     demo_manager.registerDemo("memory", []() {
         return std::make_unique<MemoryGardenDemo>();
+    });
+    demo_manager.registerDemo("neural", []() {
+        return std::make_unique<NeuralDemo>();
     });
 
     // Start with Genesis Pattern demo


### PR DESCRIPTION
## Summary
- introduce NeuralDemo example with integrate-and-fire logic
- register demo and add to build files
- extend workbench config with neural parameters
- set default neural settings in config.json

## Testing
- `cmake -S _sep/testbed -B _sep/testbed/build -DBUILD_TESTING=ON` *(fails: Cannot determine link language for target "testbed_cuda_kernels")*

------
https://chatgpt.com/codex/tasks/task_e_6869aa7d6d1c832a996d1cd8692ef677