### PR TITLE
Add neural network demo

### DIFF
--- a/examples/workbench/CMakeLists.txt
+++ b/examples/workbench/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(sep_workbench
     demos/genesis_pattern.cpp
     demos/audio_visualizer.cpp
     demos/memory_garden.cpp
+    demos/neural_demo.cpp
 )
 
 # Set C++ standard

--- a/examples/workbench/config.cpp
+++ b/examples/workbench/config.cpp
@@ -90,6 +90,15 @@ bool Config::load(const std::filesystem::path& path) {
             }
         };
 
+        // Neural demo config
+        auto& neural = json["demos"]["neural"];
+        neural_ = {
+            neural["neuron_count"].get<int>(),
+            neural["threshold"].get<float>(),
+            neural["decay"].get<float>(),
+            neural["input_strength"].get<float>()
+        };
+
         // Renderer config
         auto& renderer = json["renderer"];
         auto& cycles = renderer["cycles"];
@@ -174,6 +183,14 @@ bool Config::save(const std::filesystem::path& path) const {
                 {"connection_opacity", memory_garden_.visualization.connection_opacity},
                 {"pattern_scale", memory_garden_.visualization.pattern_scale}
             }}
+        };
+
+        // Neural demo config
+        json["demos"]["neural"] = {
+            {"neuron_count", neural_.neuron_count},
+            {"threshold", neural_.threshold},
+            {"decay", neural_.decay},
+            {"input_strength", neural_.input_strength}
         };
 
         // Renderer config

--- a/examples/workbench/config.hpp
+++ b/examples/workbench/config.hpp
@@ -65,6 +65,13 @@ struct MemoryGardenConfig {
     } visualization;
 };
 
+struct NeuralConfig {
+    int neuron_count;
+    float threshold;
+    float decay;
+    float input_strength;
+};
+
 struct RendererConfig {
     struct {
         int samples;
@@ -88,6 +95,7 @@ public:
     const GenesisPatternConfig& genesis_pattern() const { return genesis_pattern_; }
     const AudioVisualizerConfig& audio_visualizer() const { return audio_visualizer_; }
     const MemoryGardenConfig& memory_garden() const { return memory_garden_; }
+    const NeuralConfig& neural() const { return neural_; }
     const RendererConfig& renderer() const { return renderer_; }
 
 private:
@@ -98,6 +106,7 @@ private:
     GenesisPatternConfig genesis_pattern_;
     AudioVisualizerConfig audio_visualizer_;
     MemoryGardenConfig memory_garden_;
+    NeuralConfig neural_;
     RendererConfig renderer_;
 };
 

--- a/examples/workbench/config.json
+++ b/examples/workbench/config.json
@@ -52,6 +52,12 @@
         "connection_opacity": 0.5,
         "pattern_scale": 1.0
       }
+    },
+    "neural": {
+      "neuron_count": 3,
+      "threshold": 1.0,
+      "decay": 0.1,
+      "input_strength": 0.5
     }
   },
   "renderer": {

--- a/examples/workbench/demos/neural_demo.cpp
+++ b/examples/workbench/demos/neural_demo.cpp
@@ -1,0 +1,96 @@
+#include "neural_demo.hpp"
+#include "config.hpp"
+#include <algorithm>
+
+namespace sep {
+namespace workbench {
+
+void NeuralDemo::init() {
+#ifdef SEP_WORKBENCH_DEMO
+    // Default parameters for demo build
+    threshold_ = 1.0f;
+    decay_ = 0.1f;
+    input_strength_ = 0.5f;
+#else
+    const auto& cfg = Config::getInstance().neural();
+    threshold_ = cfg.threshold;
+    decay_ = cfg.decay;
+    input_strength_ = cfg.input_strength;
+#endif
+
+    // Create a small feed-forward chain of three neurons
+    uint64_t n1 = graph_.addNode(glm::vec3(0.0f), 0.0f, {});
+    uint64_t n2 = graph_.addNode(glm::vec3(0.0f), 0.0f, {n1});
+    uint64_t n3 = graph_.addNode(glm::vec3(0.0f), 0.0f, {n2});
+
+    neurons_.push_back({n1, 0.0f});
+    neurons_.push_back({n2, 0.0f});
+    neurons_.push_back({n3, 0.0f});
+
+    visualize_.resize(neurons_.size(), glm::vec3(0.0f));
+}
+
+void NeuralDemo::update(float dt) {
+    if (neurons_.empty()) return;
+
+    // External input to first neuron
+    neurons_[0].potential += input_strength_ * dt;
+
+    // Integrate input from parents
+    for (size_t i = 1; i < neurons_.size(); ++i) {
+        float input = 0.f;
+        auto parents = graph_.getParents(neurons_[i].id);
+        for (auto p : parents) {
+            auto it = std::find_if(neurons_.begin(), neurons_.end(), [p](const Neuron& n){ return n.id == p; });
+            if (it != neurons_.end()) {
+                input += it->potential;
+            }
+        }
+        neurons_[i].potential += input * dt;
+    }
+
+    // Apply decay and fire
+    for (auto& n : neurons_) {
+        n.potential -= decay_ * dt;
+        if (n.potential < 0.f) n.potential = 0.f;
+
+        if (n.potential >= threshold_) {
+            n.potential = 0.f;
+            // Propagate spike to children
+            for (auto& target : neurons_) {
+                auto parents = graph_.getParents(target.id);
+                if (std::find(parents.begin(), parents.end(), n.id) != parents.end()) {
+                    target.potential += 1.0f;
+                }
+            }
+        }
+    }
+
+    // Update visualization patterns
+    for (size_t i = 0; i < neurons_.size(); ++i) {
+        visualize_[i] = glm::vec3(static_cast<float>(i), 0.0f, neurons_[i].potential);
+    }
+}
+
+void NeuralDemo::render() {
+#ifdef SEP_WORKBENCH_DEMO
+    if (renderer_) {
+        renderer_->renderPatternState(visualize_);
+    }
+#else
+    if (renderer_) {
+        renderer_->renderPatternState(visualize_);
+    }
+#endif
+}
+
+void NeuralDemo::cleanup() {
+    neurons_.clear();
+    visualize_.clear();
+}
+
+void NeuralDemo::handleKeyboard(unsigned char) {}
+void NeuralDemo::handleMouse(int, int, int) {}
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/demos/neural_demo.hpp
+++ b/examples/workbench/demos/neural_demo.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "demo_manager.hpp"
+#include "core/dag_graph.h"
+#include <vector>
+#include <glm/vec3.hpp>
+
+namespace sep {
+namespace workbench {
+
+class NeuralDemo : public Demo {
+public:
+    void init() override;
+    void update(float dt) override;
+    void render() override;
+    void cleanup() override;
+    void handleKeyboard(unsigned char key) override;
+    void handleMouse(int x, int y, int button) override;
+
+private:
+    dag::DagGraph graph_;
+
+    struct Neuron {
+        uint64_t id;
+        float potential{0.f};
+    };
+    std::vector<Neuron> neurons_;
+
+    float threshold_{1.0f};
+    float decay_{0.1f};
+    float input_strength_{0.5f};
+
+    std::vector<glm::vec3> visualize_;
+};
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/main.cpp
+++ b/examples/workbench/main.cpp
@@ -10,6 +10,7 @@
 #include "demos/genesis_pattern.hpp"
 #include "demos/audio_visualizer.hpp"
 #include "demos/memory_garden.hpp"
+#include "demos/neural_demo.hpp"
 
 using namespace sep;
 using namespace sep::workbench;
@@ -126,6 +127,9 @@ void registerDemos() {
     });
     demo_manager.registerDemo("memory", []() {
         return std::make_unique<MemoryGardenDemo>();
+    });
+    demo_manager.registerDemo("neural", []() {
+        return std::make_unique<NeuralDemo>();
     });
 
     // Start with Genesis Pattern demo

--- a/include/workbench/CMakeLists.txt
+++ b/include/workbench/CMakeLists.txt
@@ -54,6 +54,7 @@ add_executable(sep_workbench
     demos/genesis_pattern.cpp
     demos/audio_visualizer.cpp
     demos/memory_garden.cpp
+    demos/neural_demo.cpp
 )
 
 # Include directories

--- a/include/workbench/config.cpp
+++ b/include/workbench/config.cpp
@@ -90,6 +90,15 @@ bool Config::load(const std::filesystem::path& path) {
             }
         };
 
+        // Neural demo config
+        auto& neural = json["demos"]["neural"];
+        neural_ = {
+            neural["neuron_count"].get<int>(),
+            neural["threshold"].get<float>(),
+            neural["decay"].get<float>(),
+            neural["input_strength"].get<float>()
+        };
+
         // Renderer config
         auto& renderer = json["renderer"];
         auto& cycles = renderer["cycles"];
@@ -174,6 +183,14 @@ bool Config::save(const std::filesystem::path& path) const {
                 {"connection_opacity", memory_garden_.visualization.connection_opacity},
                 {"pattern_scale", memory_garden_.visualization.pattern_scale}
             }}
+        };
+
+        // Neural demo config
+        json["demos"]["neural"] = {
+            {"neuron_count", neural_.neuron_count},
+            {"threshold", neural_.threshold},
+            {"decay", neural_.decay},
+            {"input_strength", neural_.input_strength}
         };
 
         // Renderer config

--- a/include/workbench/config.hpp
+++ b/include/workbench/config.hpp
@@ -65,6 +65,13 @@ struct MemoryGardenConfig {
     } visualization;
 };
 
+struct NeuralConfig {
+    int neuron_count;
+    float threshold;
+    float decay;
+    float input_strength;
+};
+
 struct RendererConfig {
     struct {
         int samples;
@@ -88,6 +95,7 @@ public:
     const GenesisPatternConfig& genesis_pattern() const { return genesis_pattern_; }
     const AudioVisualizerConfig& audio_visualizer() const { return audio_visualizer_; }
     const MemoryGardenConfig& memory_garden() const { return memory_garden_; }
+    const NeuralConfig& neural() const { return neural_; }
     const RendererConfig& renderer() const { return renderer_; }
 
 private:
@@ -98,6 +106,7 @@ private:
     GenesisPatternConfig genesis_pattern_;
     AudioVisualizerConfig audio_visualizer_;
     MemoryGardenConfig memory_garden_;
+    NeuralConfig neural_;
     RendererConfig renderer_;
 };
 

--- a/include/workbench/config.json
+++ b/include/workbench/config.json
@@ -52,6 +52,12 @@
         "connection_opacity": 0.5,
         "pattern_scale": 1.0
       }
+    },
+    "neural": {
+      "neuron_count": 3,
+      "threshold": 1.0,
+      "decay": 0.1,
+      "input_strength": 0.5
     }
   },
   "renderer": {

--- a/include/workbench/demos/neural_demo.cpp
+++ b/include/workbench/demos/neural_demo.cpp
@@ -1,0 +1,96 @@
+#include "neural_demo.hpp"
+#include "config.hpp"
+#include <algorithm>
+
+namespace sep {
+namespace workbench {
+
+void NeuralDemo::init() {
+#ifdef SEP_WORKBENCH_DEMO
+    // Default parameters for demo build
+    threshold_ = 1.0f;
+    decay_ = 0.1f;
+    input_strength_ = 0.5f;
+#else
+    const auto& cfg = Config::getInstance().neural();
+    threshold_ = cfg.threshold;
+    decay_ = cfg.decay;
+    input_strength_ = cfg.input_strength;
+#endif
+
+    // Create a small feed-forward chain of three neurons
+    uint64_t n1 = graph_.addNode(glm::vec3(0.0f), 0.0f, {});
+    uint64_t n2 = graph_.addNode(glm::vec3(0.0f), 0.0f, {n1});
+    uint64_t n3 = graph_.addNode(glm::vec3(0.0f), 0.0f, {n2});
+
+    neurons_.push_back({n1, 0.0f});
+    neurons_.push_back({n2, 0.0f});
+    neurons_.push_back({n3, 0.0f});
+
+    visualize_.resize(neurons_.size(), glm::vec3(0.0f));
+}
+
+void NeuralDemo::update(float dt) {
+    if (neurons_.empty()) return;
+
+    // External input to first neuron
+    neurons_[0].potential += input_strength_ * dt;
+
+    // Integrate input from parents
+    for (size_t i = 1; i < neurons_.size(); ++i) {
+        float input = 0.f;
+        auto parents = graph_.getParents(neurons_[i].id);
+        for (auto p : parents) {
+            auto it = std::find_if(neurons_.begin(), neurons_.end(), [p](const Neuron& n){ return n.id == p; });
+            if (it != neurons_.end()) {
+                input += it->potential;
+            }
+        }
+        neurons_[i].potential += input * dt;
+    }
+
+    // Apply decay and fire
+    for (auto& n : neurons_) {
+        n.potential -= decay_ * dt;
+        if (n.potential < 0.f) n.potential = 0.f;
+
+        if (n.potential >= threshold_) {
+            n.potential = 0.f;
+            // Propagate spike to children
+            for (auto& target : neurons_) {
+                auto parents = graph_.getParents(target.id);
+                if (std::find(parents.begin(), parents.end(), n.id) != parents.end()) {
+                    target.potential += 1.0f;
+                }
+            }
+        }
+    }
+
+    // Update visualization patterns
+    for (size_t i = 0; i < neurons_.size(); ++i) {
+        visualize_[i] = glm::vec3(static_cast<float>(i), 0.0f, neurons_[i].potential);
+    }
+}
+
+void NeuralDemo::render() {
+#ifdef SEP_WORKBENCH_DEMO
+    if (renderer_) {
+        renderer_->renderPatternState(visualize_);
+    }
+#else
+    if (renderer_) {
+        renderer_->renderPatternState(visualize_);
+    }
+#endif
+}
+
+void NeuralDemo::cleanup() {
+    neurons_.clear();
+    visualize_.clear();
+}
+
+void NeuralDemo::handleKeyboard(unsigned char) {}
+void NeuralDemo::handleMouse(int, int, int) {}
+
+} // namespace workbench
+} // namespace sep

--- a/include/workbench/demos/neural_demo.hpp
+++ b/include/workbench/demos/neural_demo.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "demo_manager.hpp"
+#include "core/dag_graph.h"
+#include <vector>
+#include <glm/vec3.hpp>
+
+namespace sep {
+namespace workbench {
+
+class NeuralDemo : public Demo {
+public:
+    void init() override;
+    void update(float dt) override;
+    void render() override;
+    void cleanup() override;
+    void handleKeyboard(unsigned char key) override;
+    void handleMouse(int x, int y, int button) override;
+
+private:
+    dag::DagGraph graph_;
+
+    struct Neuron {
+        uint64_t id;
+        float potential{0.f};
+    };
+    std::vector<Neuron> neurons_;
+
+    float threshold_{1.0f};
+    float decay_{0.1f};
+    float input_strength_{0.5f};
+
+    std::vector<glm::vec3> visualize_;
+};
+
+} // namespace workbench
+} // namespace sep

--- a/include/workbench/main.cpp
+++ b/include/workbench/main.cpp
@@ -5,6 +5,7 @@
 #include "demos/genesis_pattern.hpp"
 #include "demos/audio_visualizer.hpp"
 #include "demos/memory_garden.hpp"
+#include "demos/neural_demo.hpp"
 
 using namespace sep;
 using namespace sep::workbench;
@@ -88,6 +89,9 @@ void registerDemos() {
     });
     demo_manager.registerDemo("memory", []() {
         return std::make_unique<MemoryGardenDemo>();
+    });
+    demo_manager.registerDemo("neural", []() {
+        return std::make_unique<NeuralDemo>();
     });
 
     // Start with Genesis Pattern demo


### PR DESCRIPTION
## Summary
- add NeuralDemo with simple integrate-and-fire loop
- register neural demo in workbench
- support neural demo config via config manager
- update configs and build files

## Testing
- `cmake -S _sep/testbed -B _sep/testbed/build`
- `cmake --build _sep/testbed/build`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6869aa7d6d1c832a996d1cd8692ef677