### PR TITLE
Add simple cosmology demo

### DIFF
--- a/examples/workbench/CMakeLists.txt
+++ b/examples/workbench/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(sep_workbench
     demos/genesis_pattern.cpp
     demos/audio_visualizer.cpp
     demos/memory_garden.cpp
+    demos/cosmo_demo.cpp
 )
 
 # Set C++ standard

--- a/examples/workbench/config.cpp
+++ b/examples/workbench/config.cpp
@@ -90,6 +90,13 @@ bool Config::load(const std::filesystem::path& path) {
             }
         };
 
+        // Cosmo demo config
+        auto& cosmo = json["demos"]["cosmo"];
+        cosmo_ = {
+            cosmo["box_size"].get<float>(),
+            cosmo["time_step"].get<float>()
+        };
+
         // Renderer config
         auto& renderer = json["renderer"];
         auto& cycles = renderer["cycles"];
@@ -174,6 +181,12 @@ bool Config::save(const std::filesystem::path& path) const {
                 {"connection_opacity", memory_garden_.visualization.connection_opacity},
                 {"pattern_scale", memory_garden_.visualization.pattern_scale}
             }}
+        };
+
+        // Cosmo demo config
+        json["demos"]["cosmo"] = {
+            {"box_size", cosmo_.box_size},
+            {"time_step", cosmo_.time_step}
         };
 
         // Renderer config

--- a/examples/workbench/config.hpp
+++ b/examples/workbench/config.hpp
@@ -65,6 +65,11 @@ struct MemoryGardenConfig {
     } visualization;
 };
 
+struct CosmoConfig {
+    float box_size;
+    float time_step;
+};
+
 struct RendererConfig {
     struct {
         int samples;
@@ -88,6 +93,7 @@ public:
     const GenesisPatternConfig& genesis_pattern() const { return genesis_pattern_; }
     const AudioVisualizerConfig& audio_visualizer() const { return audio_visualizer_; }
     const MemoryGardenConfig& memory_garden() const { return memory_garden_; }
+    const CosmoConfig& cosmo() const { return cosmo_; }
     const RendererConfig& renderer() const { return renderer_; }
 
 private:
@@ -98,6 +104,7 @@ private:
     GenesisPatternConfig genesis_pattern_;
     AudioVisualizerConfig audio_visualizer_;
     MemoryGardenConfig memory_garden_;
+    CosmoConfig cosmo_;
     RendererConfig renderer_;
 };
 

--- a/examples/workbench/config.json
+++ b/examples/workbench/config.json
@@ -52,6 +52,10 @@
         "connection_opacity": 0.5,
         "pattern_scale": 1.0
       }
+    },
+    "cosmo": {
+      "box_size": 50.0,
+      "time_step": 0.01
     }
   },
   "renderer": {

--- a/examples/workbench/demos/cosmo_demo.cpp
+++ b/examples/workbench/demos/cosmo_demo.cpp
@@ -1,0 +1,87 @@
+#include "cosmo_demo.hpp"
+#include <config.hpp>
+#include <glm/gtc/random.hpp>
+#include <glm/gtx/norm.hpp>
+#include <cmath>
+
+namespace sep {
+namespace workbench {
+
+void CosmoDemo::init() {
+#ifdef SEP_WORKBENCH_DEMO
+    box_size_ = 50.0f;
+    time_step_ = 0.01f;
+#else
+    const auto& cfg = getConfigManager().getEngineConfig().cosmo_demo();
+    box_size_ = cfg.box_size;
+    time_step_ = cfg.time_step;
+#endif
+    initializeBodies();
+}
+
+void CosmoDemo::initializeBodies() {
+    bodies_.clear();
+    const int num_bodies = 10;
+    for (int i = 0; i < num_bodies; ++i) {
+        Body b;
+        b.position = glm::linearRand(glm::vec3(-box_size_ * 0.5f), glm::vec3(box_size_ * 0.5f));
+        b.velocity = glm::vec3(0.0f);
+        b.mass = 1.0f;
+        bodies_.push_back(b);
+    }
+}
+
+void CosmoDemo::integrate(float dt) {
+    std::vector<glm::vec3> forces(bodies_.size(), glm::vec3(0.0f));
+    for (size_t i = 0; i < bodies_.size(); ++i) {
+        for (size_t j = i + 1; j < bodies_.size(); ++j) {
+            glm::vec3 diff = bodies_[j].position - bodies_[i].position;
+            float dist2 = glm::length2(diff) + 1e-5f;
+            float inv_dist = 1.0f / std::sqrt(dist2);
+            glm::vec3 force = gravity_const_ * bodies_[i].mass * bodies_[j].mass * diff * inv_dist / dist2;
+            forces[i] += force;
+            forces[j] -= force;
+        }
+    }
+
+    for (size_t i = 0; i < bodies_.size(); ++i) {
+        bodies_[i].velocity += forces[i] / bodies_[i].mass * dt;
+        bodies_[i].position += bodies_[i].velocity * dt;
+        // Wrap around box boundaries
+        for (int c = 0; c < 3; ++c) {
+            if (bodies_[i].position[c] > box_size_ * 0.5f) bodies_[i].position[c] -= box_size_;
+            if (bodies_[i].position[c] < -box_size_ * 0.5f) bodies_[i].position[c] += box_size_;
+        }
+    }
+}
+
+void CosmoDemo::update(float dt) {
+    (void)dt; // dt provided by loop; we use configured timestep
+    integrate(time_step_);
+}
+
+void CosmoDemo::render() {
+    if (!renderer_) return;
+    renderer_->setColorMode("density");
+    renderer_->setEmissionMode("potential");
+    std::vector<glm::vec3> points;
+    for (const auto& b : bodies_) {
+        points.push_back(b.position);
+    }
+    renderer_->renderPatternState(points);
+}
+
+void CosmoDemo::cleanup() {
+    bodies_.clear();
+}
+
+void CosmoDemo::handleKeyboard(unsigned char key) {
+    if (key == 'r') {
+        initializeBodies();
+    }
+}
+
+void CosmoDemo::handleMouse(int, int, int) {}
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/demos/cosmo_demo.hpp
+++ b/examples/workbench/demos/cosmo_demo.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "demo_manager.hpp"
+#include "sep_engine_wrapper.h"
+#include <vector>
+#include <glm/vec3.hpp>
+
+namespace sep {
+namespace workbench {
+
+class CosmoDemo : public Demo {
+public:
+    void init() override;
+    void update(float dt) override;
+    void render() override;
+    void cleanup() override;
+    void handleKeyboard(unsigned char key) override;
+    void handleMouse(int x, int y, int button) override;
+
+private:
+    struct Body {
+        glm::vec3 position;
+        glm::vec3 velocity;
+        float mass;
+    };
+
+    std::vector<Body> bodies_;
+    float box_size_{100.0f};
+    float time_step_{0.01f};
+    float gravity_const_{1.0f};
+
+    void initializeBodies();
+    void integrate(float dt);
+};
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/main.cpp
+++ b/examples/workbench/main.cpp
@@ -10,6 +10,7 @@
 #include "demos/genesis_pattern.hpp"
 #include "demos/audio_visualizer.hpp"
 #include "demos/memory_garden.hpp"
+#include "demos/cosmo_demo.hpp"
 
 using namespace sep;
 using namespace sep::workbench;
@@ -126,6 +127,9 @@ void registerDemos() {
     });
     demo_manager.registerDemo("memory", []() {
         return std::make_unique<MemoryGardenDemo>();
+    });
+    demo_manager.registerDemo("cosmo", []() {
+        return std::make_unique<CosmoDemo>();
     });
 
     // Start with Genesis Pattern demo

--- a/include/workbench/CMakeLists.txt
+++ b/include/workbench/CMakeLists.txt
@@ -54,6 +54,7 @@ add_executable(sep_workbench
     demos/genesis_pattern.cpp
     demos/audio_visualizer.cpp
     demos/memory_garden.cpp
+    demos/cosmo_demo.cpp
 )
 
 # Include directories

--- a/include/workbench/config.cpp
+++ b/include/workbench/config.cpp
@@ -90,6 +90,13 @@ bool Config::load(const std::filesystem::path& path) {
             }
         };
 
+        // Cosmo demo config
+        auto& cosmo = json["demos"]["cosmo"];
+        cosmo_ = {
+            cosmo["box_size"].get<float>(),
+            cosmo["time_step"].get<float>()
+        };
+
         // Renderer config
         auto& renderer = json["renderer"];
         auto& cycles = renderer["cycles"];
@@ -174,6 +181,12 @@ bool Config::save(const std::filesystem::path& path) const {
                 {"connection_opacity", memory_garden_.visualization.connection_opacity},
                 {"pattern_scale", memory_garden_.visualization.pattern_scale}
             }}
+        };
+
+        // Cosmo demo config
+        json["demos"]["cosmo"] = {
+            {"box_size", cosmo_.box_size},
+            {"time_step", cosmo_.time_step}
         };
 
         // Renderer config

--- a/include/workbench/config.hpp
+++ b/include/workbench/config.hpp
@@ -65,6 +65,11 @@ struct MemoryGardenConfig {
     } visualization;
 };
 
+struct CosmoConfig {
+    float box_size;
+    float time_step;
+};
+
 struct RendererConfig {
     struct {
         int samples;
@@ -88,6 +93,7 @@ public:
     const GenesisPatternConfig& genesis_pattern() const { return genesis_pattern_; }
     const AudioVisualizerConfig& audio_visualizer() const { return audio_visualizer_; }
     const MemoryGardenConfig& memory_garden() const { return memory_garden_; }
+    const CosmoConfig& cosmo() const { return cosmo_; }
     const RendererConfig& renderer() const { return renderer_; }
 
 private:
@@ -98,6 +104,7 @@ private:
     GenesisPatternConfig genesis_pattern_;
     AudioVisualizerConfig audio_visualizer_;
     MemoryGardenConfig memory_garden_;
+    CosmoConfig cosmo_;
     RendererConfig renderer_;
 };
 

--- a/include/workbench/config.json
+++ b/include/workbench/config.json
@@ -52,6 +52,10 @@
         "connection_opacity": 0.5,
         "pattern_scale": 1.0
       }
+    },
+    "cosmo": {
+      "box_size": 50.0,
+      "time_step": 0.01
     }
   },
   "renderer": {

--- a/include/workbench/demos/cosmo_demo.cpp
+++ b/include/workbench/demos/cosmo_demo.cpp
@@ -1,0 +1,81 @@
+#include "cosmo_demo.hpp"
+#include <config.hpp>
+#include <glm/gtc/random.hpp>
+#include <glm/gtx/norm.hpp>
+#include <cmath>
+
+namespace sep {
+namespace workbench {
+
+void CosmoDemo::init() {
+    const auto& cfg = Config::getInstance().cosmo();
+    box_size_ = cfg.box_size;
+    time_step_ = cfg.time_step;
+    initializeBodies();
+}
+
+void CosmoDemo::initializeBodies() {
+    bodies_.clear();
+    const int num_bodies = 10;
+    for (int i = 0; i < num_bodies; ++i) {
+        Body b;
+        b.position = glm::linearRand(glm::vec3(-box_size_ * 0.5f), glm::vec3(box_size_ * 0.5f));
+        b.velocity = glm::vec3(0.0f);
+        b.mass = 1.0f;
+        bodies_.push_back(b);
+    }
+}
+
+void CosmoDemo::integrate(float dt) {
+    std::vector<glm::vec3> forces(bodies_.size(), glm::vec3(0.0f));
+    for (size_t i = 0; i < bodies_.size(); ++i) {
+        for (size_t j = i + 1; j < bodies_.size(); ++j) {
+            glm::vec3 diff = bodies_[j].position - bodies_[i].position;
+            float dist2 = glm::length2(diff) + 1e-5f;
+            float inv_dist = 1.0f / std::sqrt(dist2);
+            glm::vec3 force = gravity_const_ * bodies_[i].mass * bodies_[j].mass * diff * inv_dist / dist2;
+            forces[i] += force;
+            forces[j] -= force;
+        }
+    }
+
+    for (size_t i = 0; i < bodies_.size(); ++i) {
+        bodies_[i].velocity += forces[i] / bodies_[i].mass * dt;
+        bodies_[i].position += bodies_[i].velocity * dt;
+        for (int c = 0; c < 3; ++c) {
+            if (bodies_[i].position[c] > box_size_ * 0.5f) bodies_[i].position[c] -= box_size_;
+            if (bodies_[i].position[c] < -box_size_ * 0.5f) bodies_[i].position[c] += box_size_;
+        }
+    }
+}
+
+void CosmoDemo::update(float dt) {
+    (void)dt;
+    integrate(time_step_);
+}
+
+void CosmoDemo::render() {
+    if (!renderer_) return;
+    renderer_->setColorMode("density");
+    renderer_->setEmissionMode("potential");
+    std::vector<glm::vec3> points;
+    for (const auto& b : bodies_) {
+        points.push_back(b.position);
+    }
+    renderer_->renderPatternState(points);
+}
+
+void CosmoDemo::cleanup() {
+    bodies_.clear();
+}
+
+void CosmoDemo::handleKeyboard(unsigned char key) {
+    if (key == 'r') {
+        initializeBodies();
+    }
+}
+
+void CosmoDemo::handleMouse(int, int, int) {}
+
+} // namespace workbench
+} // namespace sep

--- a/include/workbench/demos/cosmo_demo.hpp
+++ b/include/workbench/demos/cosmo_demo.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "demo_manager.hpp"
+#include <vector>
+#include <glm/vec3.hpp>
+
+namespace sep {
+namespace workbench {
+
+class CosmoDemo : public Demo {
+public:
+    void init() override;
+    void update(float dt) override;
+    void render() override;
+    void cleanup() override;
+    void handleKeyboard(unsigned char key) override;
+    void handleMouse(int x, int y, int button) override;
+
+private:
+    struct Body {
+        glm::vec3 position;
+        glm::vec3 velocity;
+        float mass;
+    };
+
+    std::vector<Body> bodies_;
+    float box_size_{50.0f};
+    float time_step_{0.01f};
+    float gravity_const_{1.0f};
+
+    void initializeBodies();
+    void integrate(float dt);
+};
+
+} // namespace workbench
+} // namespace sep

--- a/include/workbench/main.cpp
+++ b/include/workbench/main.cpp
@@ -5,6 +5,7 @@
 #include "demos/genesis_pattern.hpp"
 #include "demos/audio_visualizer.hpp"
 #include "demos/memory_garden.hpp"
+#include "demos/cosmo_demo.hpp"
 
 using namespace sep;
 using namespace sep::workbench;
@@ -88,6 +89,9 @@ void registerDemos() {
     });
     demo_manager.registerDemo("memory", []() {
         return std::make_unique<MemoryGardenDemo>();
+    });
+    demo_manager.registerDemo("cosmo", []() {
+        return std::make_unique<CosmoDemo>();
     });
 
     // Start with Genesis Pattern demo


### PR DESCRIPTION
## Summary
- implement cosmology demo with basic N‑body integration and Cycles placeholders
- register new demo and list its cpp in CMake
- support cosmology config with box size and time step

## Testing
- `cmake -S . -B build -DBUILD_TESTING=ON` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6869aa799040832abda23230bf49f240