### PR TITLE
Add Cosmo N-body demo

### DIFF
--- a/examples/workbench/CMakeLists.txt
+++ b/examples/workbench/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(sep_workbench
     demos/genesis_pattern.cpp
     demos/audio_visualizer.cpp
     demos/memory_garden.cpp
+    demos/cosmo_demo.cpp
 )
 
 # Set C++ standard

--- a/examples/workbench/config.cpp
+++ b/examples/workbench/config.cpp
@@ -90,6 +90,13 @@ bool Config::load(const std::filesystem::path& path) {
             }
         };
 
+        // Cosmo demo config
+        auto& cosmo = json["demos"]["cosmo"];
+        cosmo_ = {
+            cosmo["box_size"].get<float>(),
+            cosmo["timestep"].get<float>()
+        };
+
         // Renderer config
         auto& renderer = json["renderer"];
         auto& cycles = renderer["cycles"];
@@ -174,6 +181,12 @@ bool Config::save(const std::filesystem::path& path) const {
                 {"connection_opacity", memory_garden_.visualization.connection_opacity},
                 {"pattern_scale", memory_garden_.visualization.pattern_scale}
             }}
+        };
+
+        // Cosmo demo config
+        json["demos"]["cosmo"] = {
+            {"box_size", cosmo_.box_size},
+            {"timestep", cosmo_.timestep}
         };
 
         // Renderer config

--- a/examples/workbench/config.hpp
+++ b/examples/workbench/config.hpp
@@ -65,6 +65,11 @@ struct MemoryGardenConfig {
     } visualization;
 };
 
+struct CosmoConfig {
+    float box_size;
+    float timestep;
+};
+
 struct RendererConfig {
     struct {
         int samples;
@@ -88,6 +93,7 @@ public:
     const GenesisPatternConfig& genesis_pattern() const { return genesis_pattern_; }
     const AudioVisualizerConfig& audio_visualizer() const { return audio_visualizer_; }
     const MemoryGardenConfig& memory_garden() const { return memory_garden_; }
+    const CosmoConfig& cosmo() const { return cosmo_; }
     const RendererConfig& renderer() const { return renderer_; }
 
 private:
@@ -98,6 +104,7 @@ private:
     GenesisPatternConfig genesis_pattern_;
     AudioVisualizerConfig audio_visualizer_;
     MemoryGardenConfig memory_garden_;
+    CosmoConfig cosmo_;
     RendererConfig renderer_;
 };
 

--- a/examples/workbench/config.json
+++ b/examples/workbench/config.json
@@ -52,6 +52,10 @@
         "connection_opacity": 0.5,
         "pattern_scale": 1.0
       }
+    },
+    "cosmo": {
+      "box_size": 50.0,
+      "timestep": 0.01
     }
   },
   "renderer": {

--- a/examples/workbench/demos/cosmo_demo.cpp
+++ b/examples/workbench/demos/cosmo_demo.cpp
@@ -1,0 +1,81 @@
+#include "cosmo_demo.hpp"
+#include <config.hpp>
+#include "sep_engine_wrapper.h"
+#include <cmath>
+#include <cstdlib>
+
+namespace sep {
+namespace workbench {
+
+void CosmoDemo::init() {
+#ifdef SEP_WORKBENCH_DEMO
+    const auto& cfg = Config::getInstance().cosmo();
+    box_size_ = cfg.box_size;
+    timestep_ = cfg.timestep;
+#else
+    const auto& cfg = getConfigManager().getEngineConfig().cosmo();
+    box_size_ = cfg.box_size;
+    timestep_ = cfg.timestep;
+#endif
+    parcels_.clear();
+    const int count = 32;
+    for (int i = 0; i < count; ++i) {
+        MassParcel m;
+        float half = box_size_ * 0.5f;
+        m.position = glm::vec3(
+            static_cast<float>(rand()) / RAND_MAX * box_size_ - half,
+            static_cast<float>(rand()) / RAND_MAX * box_size_ - half,
+            static_cast<float>(rand()) / RAND_MAX * box_size_ - half);
+        m.velocity = glm::vec3(0.0f);
+        parcels_.push_back(m);
+    }
+}
+
+void CosmoDemo::update(float dt) {
+    const float G = 1.0f;
+    size_t n = parcels_.size();
+    std::vector<glm::vec3> acc(n, glm::vec3(0.0f));
+    for (size_t i = 0; i < n; ++i) {
+        for (size_t j = 0; j < n; ++j) {
+            if (i == j) continue;
+            glm::vec3 r = parcels_[j].position - parcels_[i].position;
+            float dist2 = glm::dot(r, r) + 1e-5f;
+            float invDist3 = 1.0f / (std::sqrt(dist2) * dist2);
+            acc[i] += G * parcels_[j].mass * r * invDist3;
+        }
+    }
+    float step = timestep_ * dt;
+    for (size_t i = 0; i < n; ++i) {
+        parcels_[i].velocity += acc[i] * step;
+        parcels_[i].position += parcels_[i].velocity * step;
+        float half = box_size_ * 0.5f;
+        for (int k=0;k<3;++k) {
+            if (parcels_[i].position[k] > half) parcels_[i].position[k] -= box_size_;
+            if (parcels_[i].position[k] < -half) parcels_[i].position[k] += box_size_;
+        }
+    }
+}
+
+void CosmoDemo::render() {
+    if (!renderer_) return;
+    renderer_->setColorMode(show_density_ ? "density" : "potential");
+    std::vector<glm::vec3> pts;
+    pts.reserve(parcels_.size());
+    for (const auto& p : parcels_) pts.push_back(p.position);
+    renderer_->renderPatternState(pts);
+}
+
+void CosmoDemo::cleanup() {
+    parcels_.clear();
+}
+
+void CosmoDemo::handleKeyboard(unsigned char key) {
+    if (key == 'v') {
+        show_density_ = !show_density_;
+    }
+}
+
+void CosmoDemo::handleMouse(int, int, int) {}
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/demos/cosmo_demo.hpp
+++ b/examples/workbench/demos/cosmo_demo.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "demo_manager.hpp"
+#include <vector>
+#include <glm/vec3.hpp>
+
+namespace sep {
+namespace workbench {
+
+class CosmoDemo : public Demo {
+public:
+    void init() override;
+    void update(float dt) override;
+    void render() override;
+    void cleanup() override;
+    void handleKeyboard(unsigned char key) override;
+    void handleMouse(int x, int y, int button) override;
+
+private:
+    struct MassParcel {
+        glm::vec3 position;
+        glm::vec3 velocity;
+        float mass{1.0f};
+    };
+
+    std::vector<MassParcel> parcels_;
+    float box_size_{100.0f};
+    float timestep_{0.01f};
+    bool show_density_{true};
+};
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/main.cpp
+++ b/examples/workbench/main.cpp
@@ -10,6 +10,7 @@
 #include "demos/genesis_pattern.hpp"
 #include "demos/audio_visualizer.hpp"
 #include "demos/memory_garden.hpp"
+#include "demos/cosmo_demo.hpp"
 
 using namespace sep;
 using namespace sep::workbench;
@@ -126,6 +127,9 @@ void registerDemos() {
     });
     demo_manager.registerDemo("memory", []() {
         return std::make_unique<MemoryGardenDemo>();
+    });
+    demo_manager.registerDemo("cosmo", []() {
+        return std::make_unique<CosmoDemo>();
     });
 
     // Start with Genesis Pattern demo


### PR DESCRIPTION
## Summary
- implement a simple N-body cosmology demo
- expose box_size and timestep in workbench config
- register the new demo in the workbench and build files

## Testing
- `python _sep/testbed/diagram_sync_worker.py`
- `g++ -std=c++17 -c examples/workbench/demos/cosmo_demo.cpp -I examples/workbench -I extern/glm -I include` *(fails: `nlohmann/json.hpp` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869aa799040832abda23230bf49f240