### PR TITLE
Fix include ordering and split server build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,19 +118,22 @@ endif()
 # Include JSON processor build
 include(examples/json_processor_build.cmake)
 
-# Main executable
-add_executable(sep_engine src/main.cpp)
+# Build the interactive workbench example
+add_subdirectory(examples/workbench)
 
-set_target_properties(sep_engine PROPERTIES
+# Main server executable
+add_executable(sep_server src/server_main.cpp)
+
+set_target_properties(sep_server PROPERTIES
     CUDA_SEPARABLE_COMPILATION ON
     CUDA_RESOLVE_DEVICE_SYMBOLS ON
 )
-target_include_directories(sep_engine
+target_include_directories(sep_server
     PUBLIC
         ${CMAKE_SOURCE_DIR}/include
 )
 
-target_link_libraries(sep_engine
+target_link_libraries(sep_server
     PRIVATE
         # 1. High-level SEP Engine static libraries
         sep_api
@@ -213,7 +216,7 @@ install(TARGETS
 )
 
 # Install executable separately
-install(TARGETS sep_engine
+install(TARGETS sep_server
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 

--- a/examples/workbench/CMakeLists.txt
+++ b/examples/workbench/CMakeLists.txt
@@ -18,10 +18,9 @@ set_target_properties(sep_workbench PROPERTIES CXX_STANDARD 17)
 # Add include directories for the main engine and dependencies
 target_include_directories(sep_workbench PUBLIC
     ${PROJECT_SOURCE_DIR}/include
-    /sep/include
     ${CMAKE_CURRENT_SOURCE_DIR}
-    /sep/extern/cycles/src
-    /sep/extern/glm
+    ${PROJECT_SOURCE_DIR}/extern/cycles/src
+    ${PROJECT_SOURCE_DIR}/extern/glm
 )
 
 # Define preprocessor macros
@@ -31,32 +30,14 @@ target_compile_definitions(sep_workbench PRIVATE
 )
 
 # Add library search paths
-link_directories(
-    /sep/src
-    /sep/src/core
-    /sep/src/quantum
-    /sep/src/memory
-    /sep/src/audio
-    /sep/src/blender
-    /sep/src/compat
-    /sep/build/lib
-    /sep/cmake-make/src/core
-    /sep/cmake-make/src/quantum
-    /sep/cmake-make/src/memory
-    /sep/cmake-make/src/audio
-    /sep/cmake-make/src/blender
-    /sep/cmake-make/src/compat
-)
-
-# Link against the SEP libraries using full paths
+# Link against SEP targets
 target_link_libraries(sep_workbench PRIVATE
-    # SEP Engine Libraries with full paths
-    /sep/src/core/libsep_core.a
-    /sep/src/quantum/libsep_quantum.a
-    /sep/src/memory/libsep_memory.a
-    /sep/src/audio/libsep_audio.a
-    /sep/src/blender/libsep_blender.a
-    /sep/src/compat/libsep_compat.a
+    sep_core
+    sep_quantum
+    sep_memory
+    sep_audio
+    sep_blender
+    sep_compat
 )
 
 # Add this subdirectory to your root CMakeLists.txt:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,9 +6,9 @@ set(SEP_INCLUDE_DIRS
     ${PIPEWIRE_INCLUDE_DIRS}
 )
 
-# Main executable
-add_executable(sep_main main.cpp)
-target_include_directories(sep_main PRIVATE ${SEP_INCLUDE_DIRS})
+# Server executable
+add_executable(sep_server server_main.cpp)
+target_include_directories(sep_server PRIVATE ${SEP_INCLUDE_DIRS})
 
 # Add component subdirectories
 add_subdirectory(api)
@@ -21,7 +21,7 @@ add_subdirectory(quantum)
 add_subdirectory(embeddings)
 
 # Link dependencies
-target_link_libraries(sep_main PRIVATE
+target_link_libraries(sep_server PRIVATE
     sep_api
     sep_audio
     sep_compat
@@ -33,7 +33,7 @@ target_link_libraries(sep_main PRIVATE
     fmt::fmt
 )
 
-target_link_libraries(sep_main PRIVATE
+target_link_libraries(sep_server PRIVATE
     CUDA::cudart
     CUDA::cuda_driver
 )

--- a/src/blender/api.cpp
+++ b/src/blender/api.cpp
@@ -1,6 +1,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <ctime>
+
 #include <memory>
 #include <string>
 #include <unistd.h>

--- a/src/blender/blender_bridge.cpp
+++ b/src/blender/blender_bridge.cpp
@@ -1,7 +1,9 @@
-#include <chrono>
-#include <condition_variable>
+#include <cstdlib>
 #include <cstring>
 #include <ctime>
+
+#include <chrono>
+#include <condition_variable>
 #include <mutex>
 #include <string>
 #include <thread>

--- a/src/blender/blender_integration.cpp
+++ b/src/blender/blender_integration.cpp
@@ -1,8 +1,10 @@
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+
 #include <algorithm>
 #include <chrono>
 #include <condition_variable>
-#include <cstring>
-#include <ctime>
 #include <memory>
 #include <new>
 #include <sstream>
@@ -10,12 +12,7 @@
 #include <thread>
 #include <utility>
 #include <vector>
-#include <cstdlib>
 #include <unistd.h>
-
-#include "blender/pattern_bridge.h"
-
-#include "blender/pattern_bridge.h"
 
 #include "blender/pattern_bridge.h"
 #include "quantum/processor.h"

--- a/src/blender/compression.cpp
+++ b/src/blender/compression.cpp
@@ -1,11 +1,12 @@
-#include <array>
 #include <cstdlib>
 #include <cstring>
 #include <ctime>
+
+#include <algorithm>
+#include <array>
+#include <chrono>
 #include <string>
 #include <vector>
-#include <chrono>
-#include <algorithm>
 #include <unistd.h>
 
 #include <lz4.h>

--- a/src/blender/compression_utils.cpp
+++ b/src/blender/compression_utils.cpp
@@ -1,8 +1,9 @@
-#include <array>
-#include <cmath>
 #include <cstdlib>
 #include <cstring>
 #include <ctime>
+
+#include <array>
+#include <cmath>
 #include <string>
 #include <vector>
 #include <unistd.h>

--- a/src/blender/cycles_renderer.cpp
+++ b/src/blender/cycles_renderer.cpp
@@ -1,9 +1,10 @@
 // Standard library headers
-#include <algorithm>
-#include <cmath>
 #include <cstdlib>
 #include <cstring>
 #include <ctime>
+
+#include <algorithm>
+#include <cmath>
 #include <memory>
 #include <string>
 #include <utility>

--- a/src/blender/factory.cpp
+++ b/src/blender/factory.cpp
@@ -1,6 +1,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <ctime>
+
 #include <memory>
 #include <string>
 #include <unistd.h>

--- a/src/blender/gpu_context.cpp
+++ b/src/blender/gpu_context.cpp
@@ -1,6 +1,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <ctime>
+
 #include <new>
 #include <string>
 #include <sys/stat.h>

--- a/src/blender/mesh_handler.cpp
+++ b/src/blender/mesh_handler.cpp
@@ -3,8 +3,10 @@
  * @brief Default MeshHandler implementation used when Blender APIs are absent.
 # */ // No space between these two lines causes build error in some compilers
 
+#include <cstdlib>
 #include <cstring>
 #include <ctime>
+
 #include <string>
 
 #include "blender/mesh_handler.h"

--- a/src/blender/oiio_output_driver.cpp
+++ b/src/blender/oiio_output_driver.cpp
@@ -1,6 +1,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <ctime>
+
 #include <vector>
 #include <unistd.h>
 

--- a/src/blender/pattern_visualization_pipeline.cpp
+++ b/src/blender/pattern_visualization_pipeline.cpp
@@ -1,8 +1,9 @@
-#include <algorithm>
-#include <chrono>
 #include <cstdlib>
 #include <cstring>
 #include <ctime>
+
+#include <algorithm>
+#include <chrono>
 #include <numeric>
 #include <string>
 #include <vector>

--- a/src/server_main.cpp
+++ b/src/server_main.cpp
@@ -1,24 +1,29 @@
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+#include <csignal>
+
+#include <atomic>
+#include <exception>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <time.h>   // For std::tm, nanosleep
+#include <unistd.h> // For POSIX-specific APIs
+
+#include <curl/curl.h>
+#include <spdlog/spdlog.h>
+#include <nlohmann/json.hpp>
+
+#include <thread>
+#include <chrono>
+
 #include "core/manager.h"
 #include "core/engine.h"
 #include "core/common.h"
-#include <ctime>
-#include <time.h>   // For std::tm, nanosleep
-#include <ctime>
-#include <unistd.h> // For POSIX-specific APIs
 #include "core/logging.h"
-#include <curl/curl.h> 
-#include <cstring>
-#include <exception>
-#include <iostream>
-#include <fstream>
-#include <spdlog/spdlog.h>
 #include "api/server.h"
 #include "blender/cycles_renderer.h"
-#include "quantum/data.hpp"
-#include <atomic>
-#include <string>
-#include <csignal>
-#include <nlohmann/json.hpp>
 #include "quantum/data.hpp"
 #include "audio/capture.h"
 #include "audio/config.h"
@@ -26,8 +31,6 @@
 #include "blender/factory.h"
 #include "blender/types.h"
 #include "blender/bridge.h"
-#include <thread>
-#include <chrono>
 
 #ifndef SEP_HAS_EXCEPTIONS
 #    if defined(__cpp_exceptions) || defined(__EXCEPTIONS) || defined(_CPPUNWIND)


### PR DESCRIPTION
## Summary
- reorder standard headers across Blender sources
- move main server entry to `server_main.cpp`
- build the workbench using target dependencies
- expose the new `sep_server` target in CMake and install it

## Testing
- `cmake -S _sep/testbed -B _sep/testbed/build -DBUILD_TESTING=ON` *(fails: Cannot determine link language)*

------
https://chatgpt.com/codex/tasks/task_e_6869b0747fbc832aa86005f213583470