### PR TITLE
Add Drug Optimizer demo

### DIFF
--- a/examples/workbench/CMakeLists.txt
+++ b/examples/workbench/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(sep_workbench
     demos/audio_visualizer.cpp
     demos/memory_garden.cpp
     demos/annealing_demo.cpp
+    demos/drug_optimizer.cpp
 )
 
 # Set C++ standard

--- a/examples/workbench/demos/drug_optimizer.cpp
+++ b/examples/workbench/demos/drug_optimizer.cpp
@@ -1,0 +1,60 @@
+#include "drug_optimizer.hpp"
+#include <glm/gtx/norm.hpp>
+#include <cstdlib>
+
+namespace sep {
+namespace workbench {
+
+void DrugOptimizerDemo::init() {
+    poses_.resize(5);
+    for (auto& p : poses_) {
+        p.position = glm::vec3(static_cast<float>(std::rand()) / RAND_MAX,
+                               static_cast<float>(std::rand()) / RAND_MAX,
+                               static_cast<float>(std::rand()) / RAND_MAX);
+        p.orientation = glm::vec3(0.0f);
+        p.binding_affinity = computeBindingScore(p);
+    }
+}
+
+float DrugOptimizerDemo::computeBindingScore(const MoleculePose& pose) {
+#ifdef SEP_EXT_CHEM
+    // Placeholder for external chemistry library integration
+    return external_chemistry_score(pose.position.x, pose.position.y, pose.position.z);
+#else
+    return 1.0f / (1.0f + glm::length2(pose.position));
+#endif
+}
+
+void DrugOptimizerDemo::update(float) {
+    std::vector<sep::quantum::Pattern> patterns;
+    patterns.reserve(poses_.size());
+    for (const auto& p : poses_) {
+        sep::quantum::Pattern pattern;
+        pattern.position = glm::vec4(p.position, 1.0f);
+        pattern.quantum_state.coherence = p.binding_affinity;
+        patterns.push_back(pattern);
+    }
+
+    auto optimized = optimizer_.optimize(patterns);
+    for (size_t i = 0; i < poses_.size(); ++i) {
+        poses_[i].position = glm::vec3(optimized[i].position);
+        poses_[i].binding_affinity = optimized[i].quantum_state.coherence;
+    }
+}
+
+void DrugOptimizerDemo::render() {
+    if (!renderer_) return;
+    std::vector<glm::vec3> points;
+    for (const auto& p : poses_) points.push_back(p.position);
+    renderer_->renderPatternState(points);
+}
+
+void DrugOptimizerDemo::cleanup() {
+    poses_.clear();
+}
+
+void DrugOptimizerDemo::handleKeyboard(unsigned char) {}
+void DrugOptimizerDemo::handleMouse(int, int, int) {}
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/demos/drug_optimizer.hpp
+++ b/examples/workbench/demos/drug_optimizer.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "demo_manager.hpp"
+#include "quantum/quantum_manifold_optimizer.h"
+#include <glm/vec3.hpp>
+#include <vector>
+
+namespace sep {
+namespace workbench {
+
+struct MoleculePose {
+    glm::vec3 position{0.0f};
+    glm::vec3 orientation{0.0f};
+    float binding_affinity{0.0f};
+};
+
+class DrugOptimizerDemo : public Demo {
+public:
+    void init() override;
+    void update(float dt) override;
+    void render() override;
+    void cleanup() override;
+    void handleKeyboard(unsigned char key) override;
+    void handleMouse(int x, int y, int button) override;
+
+private:
+    float computeBindingScore(const MoleculePose& pose);
+
+    std::vector<MoleculePose> poses_;
+    sep::quantum::manifold::QuantumManifoldOptimizer optimizer_{};
+};
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/main.cpp
+++ b/examples/workbench/main.cpp
@@ -8,6 +8,7 @@
 // Include demo headers
 #include "demo_manager.hpp"
 #include "demos/annealing_demo.hpp"
+#include "demos/drug_optimizer.hpp"
 #include "demos/audio_visualizer.hpp"
 #include "demos/genesis_pattern.hpp"
 #include "demos/memory_garden.hpp"
@@ -130,6 +131,9 @@ void registerDemos() {
     });
     demo_manager.registerDemo("annealing", []() {
         return std::make_unique<AnnealingDemo>();
+    });
+    demo_manager.registerDemo("drug_opt", []() {
+        return std::make_unique<DrugOptimizerDemo>();
     });
 
   // Start with Genesis Pattern demo


### PR DESCRIPTION
## Summary
- implement new DrugOptimizerDemo showing QuantumManifoldOptimizer integration
- register demo in main.cpp and include in build

## Testing
- `cmake -S _sep/testbed -B _sep/testbed/build`
- `cmake --build _sep/testbed/build` *(failed: No rule to make target)*
- `ctest` *(no tests found)*
- `cmake -S examples/workbench -B examples/workbench/build`
- `cmake --build examples/workbench/build` *(failed: missing `nlohmann/json.hpp`)*


------
https://chatgpt.com/codex/tasks/task_e_6869b0d7d60c832a864ec3a3a8acc9bb