### PR TITLE
Add annealing simulation workbench demo

### DIFF
--- a/examples/workbench/CMakeLists.txt
+++ b/examples/workbench/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(sep_workbench
     demos/audio_visualizer.cpp
     demos/memory_garden.cpp
     demos/annealing_demo.cpp
+    demos/annealing_sim.cpp
 )
 
 # Set C++ standard

--- a/examples/workbench/config.cpp
+++ b/examples/workbench/config.cpp
@@ -98,6 +98,14 @@ bool Config::load(const std::filesystem::path& path) {
             anneal["particle_count"].get<int>()
         };
 
+        if (json["demos"].contains("annealing_sim")) {
+            auto& sim = json["demos"]["annealing_sim"];
+            annealing_sim_.particle_count = sim["particle_count"].get<int>();
+            for (auto& t : sim["temperature_schedule"]) {
+                annealing_sim_.temperature_schedule.push_back(t.get<float>());
+            }
+        }
+
         // Renderer config
         auto& renderer = json["renderer"];
         auto& cycles = renderer["cycles"];
@@ -178,6 +186,14 @@ bool Config::load(const std::filesystem::path& path) {
                   anneal["initial_temperature"].get<float>(),
                   anneal["cooling_rate"].get<float>()};
 
+    if (json["demos"].contains("annealing_sim")) {
+        auto &sim = json["demos"]["annealing_sim"];
+        annealing_sim_.particle_count = sim["particle_count"].get<int>();
+        for (auto &t : sim["temperature_schedule"]) {
+            annealing_sim_.temperature_schedule.push_back(t.get<float>());
+        }
+    }
+
     // Renderer config
     auto &renderer = json["renderer"];
     auto &cycles = renderer["cycles"];
@@ -253,6 +269,11 @@ bool Config::save(const std::filesystem::path &path) const {
             {"initial_temperature", annealing_.initial_temperature},
             {"cooling_rate", annealing_.cooling_rate},
             {"particle_count", annealing_.particle_count}
+        };
+
+        json["demos"]["annealing_sim"] = {
+            {"temperature_schedule", annealing_sim_.temperature_schedule},
+            {"particle_count", annealing_sim_.particle_count}
         };
 
         // Cosmo demo config

--- a/examples/workbench/config.hpp
+++ b/examples/workbench/config.hpp
@@ -7,6 +7,7 @@
 #include <memory>
 #include <filesystem>
 #include <array>
+#include <vector>
 
 namespace sep {
 namespace workbench {
@@ -72,6 +73,11 @@ struct AnnealingConfig {
     float initial_temperature;
     float cooling_rate;
     int particle_count;
+};
+
+struct AnnealingSimConfig {
+    std::vector<float> temperature_schedule;
+    int particle_count{0};
 };
 
 struct DrugDiscoveryConfig {
@@ -264,6 +270,7 @@ public:
     const AudioVisualizerConfig& audio_visualizer() const { return audio_visualizer_; }
     const MemoryGardenConfig& memory_garden() const { return memory_garden_; }
     const AnnealingConfig& annealing() const { return annealing_; }
+    const AnnealingSimConfig& annealing_sim() const { return annealing_sim_; }
     const RendererConfig& renderer() const { return renderer_; }
     const OptimizerConfig& optimizer() const { return optimizer_; }
 
@@ -276,6 +283,7 @@ private:
     AudioVisualizerConfig audio_visualizer_;
     MemoryGardenConfig memory_garden_;
     AnnealingConfig annealing_;
+    AnnealingSimConfig annealing_sim_;
     RendererConfig renderer_;
     OptimizerConfig optimizer_;
 };

--- a/examples/workbench/config.json
+++ b/examples/workbench/config.json
@@ -57,6 +57,10 @@
       "initial_temperature": 1.0,
       "cooling_rate": 0.99,
       "particle_count": 10
+    },
+    "annealing_sim": {
+      "temperature_schedule": [1.0, 0.8, 0.6, 0.4],
+      "particle_count": 20
     }
   },
   "renderer": {

--- a/examples/workbench/demos/annealing_sim.cpp
+++ b/examples/workbench/demos/annealing_sim.cpp
@@ -1,0 +1,76 @@
+#include "annealing_sim.hpp"
+#include "sep_engine_wrapper.h"
+#include <glm/gtc/random.hpp>
+#include <cmath>
+
+namespace sep {
+namespace workbench {
+
+void AnnealingSimDemo::init() {
+    const auto& cfg = getConfigManager().annealing_sim();
+    temperature_schedule_ = cfg.temperature_schedule;
+    if (temperature_schedule_.empty()) temperature_schedule_.push_back(1.0f);
+    particles_.resize(static_cast<std::size_t>(cfg.particle_count));
+    for (auto& p : particles_) {
+        p.position = glm::linearRand(glm::vec3(-1.f), glm::vec3(1.f));
+        p.velocity = glm::vec3(0.f);
+        p.color = glm::vec3(1.f);
+    }
+    processor_ = std::make_unique<PatternProcessor>(engine_);
+    coherence_mgr_ = std::make_unique<QuantumCoherenceManager>();
+}
+
+void AnnealingSimDemo::update(float dt) {
+    if (paused_ || particles_.empty()) return;
+    float temperature = temperature_schedule_[current_step_ % temperature_schedule_.size()];
+    const float eps = 1e-3f;
+    for (size_t i = 0; i < particles_.size(); ++i) {
+        for (size_t j = i + 1; j < particles_.size(); ++j) {
+            glm::vec3 diff = particles_[j].position - particles_[i].position;
+            float dist = glm::length(diff) + eps;
+            glm::vec3 dir = diff / dist;
+            float invDist6 = 1.0f / std::pow(dist, 6);
+            float fmag = 24.0f * invDist6 * (2.0f * invDist6 - 1.0f) / dist;
+            glm::vec3 force = dir * fmag * temperature;
+            particles_[i].velocity += force * dt;
+            particles_[j].velocity -= force * dt;
+        }
+    }
+    for (auto& p : particles_) {
+        p.position += p.velocity * dt;
+    }
+    for (const auto& p : particles_) {
+        std::vector<float> data = {p.position.x, p.position.y, p.position.z};
+        processor_->processPattern(data);
+    }
+    auto result = processor_->evolvePatterns(dt);
+    coherence_mgr_->updateCoherence(result);
+    float coherence = coherence_mgr_->getAverageCoherence();
+    glm::vec3 bright(1.f, 1.f, 0.2f);
+    glm::vec3 dark(0.2f, 0.2f, 0.5f);
+    glm::vec3 col = glm::mix(dark, bright, coherence);
+    for (auto& p : particles_) p.color = col;
+    if (current_step_ + 1 < temperature_schedule_.size()) ++current_step_;
+}
+
+void AnnealingSimDemo::render() {
+    if (!renderer_) return;
+    std::vector<glm::vec3> points;
+    for (const auto& p : particles_) points.push_back(p.position);
+    renderer_->renderPatternState(points);
+}
+
+void AnnealingSimDemo::cleanup() {
+    particles_.clear();
+    processor_.reset();
+    coherence_mgr_.reset();
+}
+
+void AnnealingSimDemo::handleKeyboard(unsigned char key) {
+    if (key == 'p') paused_ = !paused_;
+}
+
+void AnnealingSimDemo::handleMouse(int, int, int) {}
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/demos/annealing_sim.hpp
+++ b/examples/workbench/demos/annealing_sim.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "demo_manager.hpp"
+#include <memory>
+#include <vector>
+#include <glm/vec3.hpp>
+
+namespace sep {
+namespace workbench {
+
+class PatternProcessor;
+class QuantumCoherenceManager;
+
+class AnnealingSimDemo : public Demo {
+public:
+    void init() override;
+    void update(float dt) override;
+    void render() override;
+    void cleanup() override;
+    void handleKeyboard(unsigned char key) override;
+    void handleMouse(int x, int y, int button) override;
+
+private:
+    struct Particle {
+        glm::vec3 position{0.0f};
+        glm::vec3 velocity{0.0f};
+        glm::vec3 color{1.0f};
+    };
+
+    std::unique_ptr<PatternProcessor> processor_;
+    std::unique_ptr<QuantumCoherenceManager> coherence_mgr_;
+    std::vector<Particle> particles_;
+    std::vector<float> temperature_schedule_;
+    std::size_t current_step_{0};
+    bool paused_{false};
+};
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/main.cpp
+++ b/examples/workbench/main.cpp
@@ -8,6 +8,7 @@
 // Include demo headers
 #include "demo_manager.hpp"
 #include "demos/annealing_demo.hpp"
+#include "demos/annealing_sim.hpp"
 #include "demos/audio_visualizer.hpp"
 #include "demos/genesis_pattern.hpp"
 #include "demos/memory_garden.hpp"
@@ -130,6 +131,9 @@ void registerDemos() {
     });
     demo_manager.registerDemo("annealing", []() {
         return std::make_unique<AnnealingDemo>();
+    });
+    demo_manager.registerDemo("annealing_sim", []() {
+        return std::make_unique<AnnealingSimDemo>();
     });
 
   // Start with Genesis Pattern demo


### PR DESCRIPTION
## Summary
- introduce `AnnealingSimDemo` using PatternProcessor
- track coherence with `QuantumCoherenceManager`
- hook the demo into the workbench and build
- extend configuration with new annealing_sim parameters

## Testing
- `cmake -S . -B build -D BUILD_TESTING=ON` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6869b0c14394832a8d397c179b23152e