### PR TITLE
Add cosmological simulation demo

### DIFF
--- a/examples/workbench/CMakeLists.txt
+++ b/examples/workbench/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(sep_workbench
     demos/audio_visualizer.cpp
     demos/memory_garden.cpp
     demos/annealing_demo.cpp
+    demos/cosmo_sim.cpp
 )
 
 # Set C++ standard

--- a/examples/workbench/config.json
+++ b/examples/workbench/config.json
@@ -57,6 +57,11 @@
       "initial_temperature": 1.0,
       "cooling_rate": 0.99,
       "particle_count": 10
+    },
+    "cosmo_sim": {
+      "box_size": 50.0,
+      "time_step": 0.01,
+      "particle_count": 100
     }
   },
   "renderer": {

--- a/examples/workbench/demos/cosmo_sim.cpp
+++ b/examples/workbench/demos/cosmo_sim.cpp
@@ -1,0 +1,113 @@
+#include "cosmo_sim.hpp"
+#include <cstdlib>
+#include <glm/glm.hpp>
+#include <glm/gtx/norm.hpp>
+
+namespace sep {
+namespace workbench {
+
+void CosmoSim::init() {
+#ifdef SEP_WORKBENCH_DEMO
+    box_size_ = 50.0f;
+    time_step_ = 0.01f;
+    particle_count_ = 100;
+#else
+    // When integrated with full engine config, load cosmo_sim settings
+    const auto& cfg = getConfigManager().getEngineConfig().cosmo();
+    box_size_ = cfg.box_size;
+    time_step_ = cfg.time_step;
+#endif
+    initBodies();
+}
+
+void CosmoSim::initBodies() {
+    bodies_.clear();
+    bodies_.resize(particle_count_);
+    for (auto& b : bodies_) {
+        b.position = glm::vec4(static_cast<float>(std::rand()) / RAND_MAX * box_size_,
+                               static_cast<float>(std::rand()) / RAND_MAX * box_size_,
+                               static_cast<float>(std::rand()) / RAND_MAX * box_size_,
+                               1.0f);
+        b.velocity = glm::vec4(0.0f);
+        b.attributes.x = 1.0f; // mass
+        b.coherence = 1.0f;
+    }
+}
+
+void CosmoSim::integrate(float dt) {
+    const float G = 1.0f;
+    std::vector<glm::vec3> acc(bodies_.size(), glm::vec3(0.0f));
+
+    for (std::size_t i = 0; i < bodies_.size(); ++i) {
+        for (std::size_t j = i + 1; j < bodies_.size(); ++j) {
+            glm::vec3 diff = glm::vec3(bodies_[j].position) - glm::vec3(bodies_[i].position);
+            float dist2 = glm::dot(diff, diff) + 1e-5f;
+            glm::vec3 force = G * bodies_[i].attributes.x * bodies_[j].attributes.x /
+                              (dist2 * glm::sqrt(dist2)) * diff;
+            acc[i] += force / bodies_[i].attributes.x;
+            acc[j] -= force / bodies_[j].attributes.x;
+        }
+    }
+
+    for (std::size_t i = 0; i < bodies_.size(); ++i) {
+        glm::vec3 vel = glm::vec3(bodies_[i].velocity) + acc[i] * dt;
+        glm::vec3 pos = glm::vec3(bodies_[i].position) + vel * dt;
+        for (int k = 0; k < 3; ++k) {
+            if (pos[k] < 0.0f)
+                pos[k] += box_size_;
+            else if (pos[k] > box_size_)
+                pos[k] -= box_size_;
+        }
+        bodies_[i].velocity = glm::vec4(vel, 0.0f);
+        bodies_[i].position = glm::vec4(pos, 1.0f);
+    }
+
+    // Compute center of mass
+    glm::vec3 com(0.0f);
+    float total_mass = 0.0f;
+    for (const auto& b : bodies_) {
+        com += glm::vec3(b.position) * b.attributes.x;
+        total_mass += b.attributes.x;
+    }
+    if (total_mass > 0.0f) com /= total_mass;
+
+    // Update coherence and temperature (speed)
+    for (auto& b : bodies_) {
+        glm::vec3 pos = glm::vec3(b.position);
+        glm::vec3 vel = glm::vec3(b.velocity);
+        float radius = glm::length(pos - com) + 1e-5f;
+        float vesc2 = 2.f * G * total_mass / radius;
+        float speed2 = glm::length2(vel);
+        b.coherence = speed2 < vesc2 ? 1.0f : 0.0f;
+        b.attributes.y = glm::sqrt(speed2); // temperature proxy
+    }
+}
+
+void CosmoSim::update(float) {
+    integrate(time_step_);
+}
+
+void CosmoSim::render() {
+    if (!renderer_) return;
+    renderer_->setColorMode("density");
+    renderer_->setEmissionMode("temperature");
+    std::vector<glm::vec3> points;
+    points.reserve(bodies_.size());
+    for (const auto& b : bodies_) {
+        points.emplace_back(glm::vec3(b.position) / box_size_);
+    }
+    renderer_->renderPatternState(points);
+}
+
+void CosmoSim::cleanup() {
+    bodies_.clear();
+}
+
+void CosmoSim::handleKeyboard(unsigned char key) {
+    if (key == 'r') initBodies();
+}
+
+void CosmoSim::handleMouse(int, int, int) {}
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/demos/cosmo_sim.hpp
+++ b/examples/workbench/demos/cosmo_sim.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "demo_manager.hpp"
+#include <vector>
+#include <quantum/data.hpp>
+#include <glm/vec3.hpp>
+
+namespace sep {
+namespace workbench {
+
+class CosmoSim : public Demo {
+public:
+    void init() override;
+    void update(float dt) override;
+    void render() override;
+    void cleanup() override;
+    void handleKeyboard(unsigned char key) override;
+    void handleMouse(int x, int y, int button) override;
+
+private:
+    std::vector<pattern::PatternData> bodies_;
+    float box_size_{100.0f};
+    float time_step_{0.01f};
+    std::size_t particle_count_{100};
+
+    void initBodies();
+    void integrate(float dt);
+};
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/main.cpp
+++ b/examples/workbench/main.cpp
@@ -12,6 +12,7 @@
 #include "demos/genesis_pattern.hpp"
 #include "demos/memory_garden.hpp"
 #include "demos/annealing_demo.hpp"
+#include "demos/cosmo_sim.hpp"
 
 using namespace sep;
 using namespace sep::workbench;
@@ -130,6 +131,9 @@ void registerDemos() {
     });
     demo_manager.registerDemo("annealing", []() {
         return std::make_unique<AnnealingDemo>();
+    });
+    demo_manager.registerDemo("cosmo_sim", []() {
+        return std::make_unique<CosmoSim>();
     });
 
   // Start with Genesis Pattern demo


### PR DESCRIPTION
## Summary
- implement a new N-body gravity demo `cosmo_sim`
- render particles using density/temperature modes
- hook the demo into workbench build and registration
- ship default settings in config

## Testing
- `true` (no automated tests present)

------
https://chatgpt.com/codex/tasks/task_e_6869b0c9ae18832ab017412bb02f9b6b