### PR TITLE
Add NeuroSim demo with spiking/learning logic

### DIFF
--- a/examples/workbench/CMakeLists.txt
+++ b/examples/workbench/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(sep_workbench
     demos/audio_visualizer.cpp
     demos/memory_garden.cpp
     demos/annealing_demo.cpp
+    demos/neuro_sim.cpp
 )
 
 # Set C++ standard

--- a/examples/workbench/demos/neuro_sim.cpp
+++ b/examples/workbench/demos/neuro_sim.cpp
@@ -1,0 +1,96 @@
+#include "neuro_sim.hpp"
+#include <config.hpp>
+#include <algorithm>
+#include <glm/glm.hpp>
+#include "quantum/evolution.h"
+
+namespace sep {
+namespace workbench {
+
+void NeuroSimDemo::init() {
+#ifdef SEP_WORKBENCH_DEMO
+    std::size_t neuron_count = 10;
+    threshold_ = 1.f;
+    decay_ = 0.1f;
+    input_strength_ = 0.5f;
+    connection_prob_ = 0.2f;
+#else
+    const auto& cfg = sep::core::config::ConfigManager::getInstance().getEngineConfig().neural_demo();
+    std::size_t neuron_count = cfg.network.neuron_count;
+    threshold_ = cfg.neuron.threshold;
+    decay_ = cfg.neuron.decay;
+    input_strength_ = cfg.neuron.input_strength;
+    connection_prob_ = cfg.network.connection_prob;
+#endif
+    memory_manager_ = std::make_unique<memory::MemoryTierManager>();
+    auto& dag = memory_manager_->getDagGraph();
+
+    neurons_.resize(neuron_count);
+    for (std::size_t i = 0; i < neuron_count; ++i) {
+        auto& n = neurons_[i];
+        n.pattern.id = std::to_string(i);
+        n.pattern.coherence = 0.f;
+        n.pattern.stability = 0.5f;
+        n.pattern.memory_tier = memory::MemoryTierEnum::STM;
+        n.pattern.position = glm::vec4(static_cast<float>(i), 0.f, 0.f, 1.f);
+        memory_manager_->registerPattern(i, n.pattern);
+        n.node_id = dag.addNode(glm::vec3(n.pattern.position), n.pattern.coherence, {});
+    }
+
+    std::uniform_real_distribution<float> dist(0.f, 1.f);
+    for (std::size_t j = 0; j < neurons_.size(); ++j) {
+        for (std::size_t i = 0; i < neurons_.size(); ++i) {
+            if (i == j) continue;
+            if (dist(rng_) < connection_prob_) {
+                auto parents = dag.getParents(neurons_[j].node_id);
+                parents.push_back(neurons_[i].node_id);
+                dag.updateNodeParents(neurons_[j].node_id, parents);
+            }
+        }
+    }
+}
+
+void NeuroSimDemo::update(float dt) {
+    auto& dag = memory_manager_->getDagGraph();
+    for (auto& n : neurons_) {
+        quantum::evolution::applySpike(n.pattern, input_strength_ * dt, decay_ * dt, threshold_);
+        if (n.pattern.quantum_state.coherence >= 1.0f) {
+            for (auto& tgt : neurons_) {
+                auto parents = dag.getParents(tgt.node_id);
+                if (std::find(parents.begin(), parents.end(), n.node_id) != parents.end()) {
+                    tgt.pattern.quantum_state.coherence = glm::clamp(tgt.pattern.quantum_state.coherence + 0.5f, 0.f, 1.f);
+                    quantum::evolution::hebbianUpdate(n.pattern, tgt.pattern, learning_rate_);
+                }
+            }
+            n.pattern.quantum_state.coherence = 0.f;
+        }
+
+        auto tier = memory_manager_->determineTier(n.pattern.quantum_state.coherence,
+                                                   n.pattern.quantum_state.stability,
+                                                   n.pattern.quantum_state.generation);
+        n.pattern.memory_tier = static_cast<memory::MemoryTierEnum>(tier->getType());
+        dag.updateCoherence(n.node_id, n.pattern.quantum_state.coherence);
+        memory_manager_->registerPattern(std::stoull(n.pattern.id), n.pattern);
+    }
+}
+
+void NeuroSimDemo::render() {
+    if (!renderer_) return;
+    std::vector<glm::vec3> pts;
+    pts.reserve(neurons_.size());
+    for (const auto& n : neurons_) {
+        pts.emplace_back(n.pattern.position.x, n.pattern.position.y, n.pattern.position.z);
+    }
+    renderer_->renderPatternState(pts);
+}
+
+void NeuroSimDemo::cleanup() {
+    neurons_.clear();
+    memory_manager_.reset();
+}
+
+void NeuroSimDemo::handleKeyboard(unsigned char) {}
+void NeuroSimDemo::handleMouse(int, int, int) {}
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/demos/neuro_sim.hpp
+++ b/examples/workbench/demos/neuro_sim.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "demo_manager.hpp"
+#include "sep_engine_wrapper.h"
+#include <memory>
+#include <random>
+#include <vector>
+
+namespace sep {
+namespace workbench {
+
+class NeuroSimDemo : public Demo {
+public:
+    void init() override;
+    void update(float dt) override;
+    void render() override;
+    void cleanup() override;
+    void handleKeyboard(unsigned char key) override;
+    void handleMouse(int x, int y, int button) override;
+
+private:
+    struct Neuron {
+        quantum::Pattern pattern;
+        float potential{0.f};
+        uint64_t node_id{0};
+    };
+
+    std::unique_ptr<memory::MemoryTierManager> memory_manager_;
+    std::vector<Neuron> neurons_;
+    std::mt19937 rng_{std::random_device{}()};
+
+    float threshold_{1.f};
+    float decay_{0.1f};
+    float input_strength_{0.5f};
+    float learning_rate_{0.05f};
+    float connection_prob_{0.2f};
+};
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/main.cpp
+++ b/examples/workbench/main.cpp
@@ -12,6 +12,7 @@
 #include "demos/genesis_pattern.hpp"
 #include "demos/memory_garden.hpp"
 #include "demos/annealing_demo.hpp"
+#include "demos/neuro_sim.hpp"
 
 using namespace sep;
 using namespace sep::workbench;
@@ -130,6 +131,9 @@ void registerDemos() {
     });
     demo_manager.registerDemo("annealing", []() {
         return std::make_unique<AnnealingDemo>();
+    });
+    demo_manager.registerDemo("neuro_sim", []() {
+        return std::make_unique<NeuroSimDemo>();
     });
 
   // Start with Genesis Pattern demo

--- a/include/quantum/evolution.h
+++ b/include/quantum/evolution.h
@@ -63,6 +63,8 @@ namespace evolution {
     float stabilityFitness(const Pattern& pattern);
     float complexityFitness(const Pattern& pattern);
     std::vector<Pattern> createRandomPopulation(size_t size);
+    void applySpike(Pattern& neuron, float input, float decay, float threshold);
+    void hebbianUpdate(const Pattern& pre, Pattern& post, float rate);
 }
 
 } // namespace sep::quantum

--- a/src/quantum/evolution.cpp
+++ b/src/quantum/evolution.cpp
@@ -385,6 +385,21 @@ std::vector<Pattern> createRandomPopulation(size_t size) {
     return population;
 }
 
+void applySpike(Pattern& neuron, float input, float decay, float threshold) {
+    float& c = neuron.quantum_state.coherence;
+    c += input;
+    c -= decay * c;
+    if (c >= threshold) {
+        c = 1.0f;
+    }
+    c = glm::clamp(c, 0.0f, 1.0f);
+}
+
+void hebbianUpdate(const Pattern& pre, Pattern& post, float rate) {
+    float delta = rate * pre.quantum_state.coherence * post.quantum_state.coherence;
+    post.quantum_state.stability = glm::clamp(post.quantum_state.stability + delta, 0.0f, 1.0f);
+}
+
 } // namespace evolution
 
 } // namespace sep::quantum


### PR DESCRIPTION
## Summary
- implement new demo `NeuroSimDemo` that uses `DagGraph` and `MemoryTierManager`
- add simple spiking and Hebbian learning utilities in `evolution` module
- register demo in workbench app and build system

## Testing
- `cmake -S . -B build -DBUILD_TESTING=ON` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6869b0d1668c832a8090e37194e938dd