### PR TITLE
Add examples build configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,9 +115,8 @@ if(NOT EXISTS "${CMAKE_SOURCE_DIR}/lib/libcycles_device.a")
   add_subdirectory(extern/cycles)
 endif()
 
-# Include JSON processor build
-include(examples/json_processor_build.cmake)
-add_subdirectory(examples/workbench)
+# Include examples
+add_subdirectory(examples)
 
 # Main executable
 add_executable(sep_server src/server_main.cpp)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.16)
+
+# JSON processor example
+add_executable(json_processor json_processor.cpp)
+
+# Include directories so sep_engine_wrapper.h finds headers
+# The examples directory is added for the wrapper itself
+# Project include directory exposes the real engine headers
+# External dependencies are expected to be resolved globally
+# (e.g. nlohmann_json, glm)
+target_include_directories(json_processor
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}/include
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+# Link against core engine libraries
+# Only the minimal set required for the processor is linked
+# Additional libraries can be added here if needed
+
+target_link_libraries(json_processor
+    PRIVATE
+        sep_core
+        sep_quantum
+        sep_compat
+)
+
+# Build the workbench demo
+add_subdirectory(workbench)


### PR DESCRIPTION
## Summary
- add `examples/CMakeLists.txt` to build demo programs
- hook examples into main build

## Testing
- `cmake -S . -B _sep/testbed/build_examples` *(fails: Could not find nvcc, please set CUDAToolkit_ROOT)*

------
https://chatgpt.com/codex/tasks/task_e_6869b458c630832a990728840783559b