### PR TITLE
Fix example builds with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,9 +115,8 @@ if(NOT EXISTS "${CMAKE_SOURCE_DIR}/lib/libcycles_device.a")
   add_subdirectory(extern/cycles)
 endif()
 
-# Include JSON processor build
-include(examples/json_processor_build.cmake)
-add_subdirectory(examples/workbench)
+# Build examples
+add_subdirectory(examples)
 
 # Main executable
 add_executable(sep_server src/server_main.cpp)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,34 @@
+cmake_minimum_required(VERSION 3.16)
+
+# Build JSON processor example
+add_executable(json_processor json_processor.cpp)
+
+# Include directories for engine and external dependencies
+# Allow sep_engine_wrapper.h to locate SEP headers
+target_include_directories(json_processor PRIVATE
+    ${PROJECT_SOURCE_DIR}/include
+    ${PROJECT_SOURCE_DIR}/extern/nlohmann
+    ${PROJECT_SOURCE_DIR}/extern/glm
+    ${PROJECT_SOURCE_DIR}/extern/cycles/src
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+# Enable C++17
+set_target_properties(json_processor PROPERTIES CXX_STANDARD 17)
+
+# Compile definitions for example build
+target_compile_definitions(json_processor PRIVATE SEP_HAS_CYCLES)
+
+# Link against SEP static libraries and pthread
+target_link_libraries(json_processor PRIVATE
+    sep_api
+    sep_audio
+    sep_quantum
+    sep_memory
+    sep_compat
+    sep_core
+    Threads::Threads
+)
+
+# Add other example subdirectories
+add_subdirectory(workbench)


### PR DESCRIPTION
## Summary
- build examples through a new `examples` CMakeLists
- link json_processor against SEP libraries
- hook examples directory into root build

## Testing
- `cmake -S . -B build-test -DCMAKE_BUILD_TYPE=Release` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6869b458c630832a990728840783559b