### PR TITLE
Add CMake build for examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,9 +115,8 @@ if(NOT EXISTS "${CMAKE_SOURCE_DIR}/lib/libcycles_device.a")
   add_subdirectory(extern/cycles)
 endif()
 
-# Include JSON processor build
-include(examples/json_processor_build.cmake)
-add_subdirectory(examples/workbench)
+# Build example programs
+add_subdirectory(examples)
 
 # Main executable
 add_executable(sep_server src/server_main.cpp)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,40 @@
+cmake_minimum_required(VERSION 3.16)
+
+# Build the JSON processor example
+add_executable(json_processor json_processor.cpp)
+
+# Include directories so sep_engine_wrapper.h can locate engine headers
+# and third-party libraries used by the examples
+# PROJECT_SOURCE_DIR refers to the repository root where the include directory lives
+
+# Provide include paths for engine headers and third party deps
+# used by json_processor and the demos
+set(JSON_PROCESSOR_INCLUDES
+    ${PROJECT_SOURCE_DIR}/include
+    ${PROJECT_SOURCE_DIR}/extern/nlohmann
+    ${PROJECT_SOURCE_DIR}/extern/glm
+    ${PROJECT_SOURCE_DIR}/extern/cycles/src
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+target_include_directories(json_processor PRIVATE ${JSON_PROCESSOR_INCLUDES})
+
+target_compile_definitions(json_processor PRIVATE SEP_WORKBENCH_DEMO)
+
+# Link against the SEP Engine static libraries
+# The examples rely only on the core components
+
+set(JSON_PROCESSOR_LIBS
+    sep_api
+    sep_audio
+    sep_quantum
+    sep_memory
+    sep_compat
+    sep_core
+)
+
+target_link_libraries(json_processor PRIVATE ${JSON_PROCESSOR_LIBS})
+
+# Build the workbench demo application
+add_subdirectory(workbench)
+

--- a/examples/workbench/CMakeLists.txt
+++ b/examples/workbench/CMakeLists.txt
@@ -6,11 +6,20 @@ add_executable(sep_workbench
     main.cpp
     demo_manager.cpp
     config.cpp
+    # Demo sources
     demos/genesis_pattern.cpp
     demos/audio_visualizer.cpp
     demos/memory_garden.cpp
     demos/annealing_demo.cpp
     demos/drug_optimizer.cpp
+    demos/drug_discovery_demo.cpp
+    demos/digital_physics_demo.cpp
+    demos/flocking_demo.cpp
+    demos/cosmo_demo.cpp
+    demos/cosmo_sim.cpp
+    demos/annealing_sim.cpp
+    demos/neural_demo.cpp
+    demos/neuro_sim.cpp
 )
 
 # Set C++ standard


### PR DESCRIPTION
## Summary
- create examples/CMakeLists.txt to build JSON processor and workbench
- include all demo sources in the workbench build
- add examples to root build

## Testing
- `cmake ..` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6869b458c630832a990728840783559b