### PR TITLE
Add annealing_sim example using QuantumProcessor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,7 @@ endif()
 
 # Include JSON processor build
 include(examples/json_processor_build.cmake)
+include(examples/annealing_sim_build.cmake)
 add_subdirectory(examples/workbench)
 
 # Main executable

--- a/examples/annealing_sim.cpp
+++ b/examples/annealing_sim.cpp
@@ -1,0 +1,73 @@
+#include "sep_engine_wrapper.h"
+#include "quantum/qfh.h"
+#include "quantum/quantum_processor.h"
+#include <glm/gtc/random.hpp>
+#include <iostream>
+#include <vector>
+#include <cmath>
+#include <cstring>
+
+int main() {
+    const std::size_t particle_count = 20;
+    std::vector<sep::pattern::PatternData> particles(particle_count);
+
+    for (auto &p : particles) {
+        glm::vec3 pos = glm::linearRand(glm::vec3(-1.f), glm::vec3(1.f));
+        p.position = glm::vec4(pos, 1.0f);
+        p.velocity = glm::vec4(0.0f);
+        p.attributes.x = 1.0f; // mass
+    }
+
+    sep::quantum::QuantumProcessor::Config cfg;
+    auto processor = sep::quantum::createQuantumProcessor(cfg);
+    sep::quantum::QFHBasedProcessor qfh_analyzer;
+
+    const float dt = 0.01f;
+    const float eps = 1e-3f;
+    for (int step = 0; step < 100; ++step) {
+        for (std::size_t i = 0; i < particles.size(); ++i) {
+            for (std::size_t j = i + 1; j < particles.size(); ++j) {
+                glm::vec3 diff = glm::vec3(particles[j].position) - glm::vec3(particles[i].position);
+                float dist = glm::length(diff) + eps;
+                glm::vec3 dir = diff / dist;
+                float invDist6 = 1.0f / std::pow(dist, 6);
+                float fmag = 24.0f * invDist6 * (2.0f * invDist6 - 1.0f) / dist;
+                glm::vec3 force = dir * fmag;
+                particles[i].velocity += glm::vec4(force * dt, 0.0f);
+                particles[j].velocity -= glm::vec4(force * dt, 0.0f);
+            }
+        }
+
+        for (auto &p : particles) {
+            p.position += p.velocity * dt;
+            glm::vec3 data = glm::vec3(p.position);
+            processor->processPattern(data, &p - particles.data());
+        }
+
+        std::vector<uint32_t> raw_bits;
+        raw_bits.reserve(particles.size() * 3);
+        for (const auto &p : particles) {
+            uint32_t bx, by, bz;
+            std::memcpy(&bx, &p.position.x, sizeof(uint32_t));
+            std::memcpy(&by, &p.position.y, sizeof(uint32_t));
+            std::memcpy(&bz, &p.position.z, sizeof(uint32_t));
+            raw_bits.push_back(bx);
+            raw_bits.push_back(by);
+            raw_bits.push_back(bz);
+        }
+        auto bits = sep::quantum::QFHBasedProcessor::convertToBits(raw_bits);
+        auto result = qfh_analyzer.analyze(bits);
+
+        for (const auto &ev : result.events) {
+            if (ev.state == sep::quantum::QFHState::RUPTURE) {
+                std::cout << "[step " << step << "] rupture at index " << ev.index << "\n";
+            }
+        }
+        if (result.collapse_detected) {
+            std::cout << "[step " << step << "] collapse detected (ratio=" << result.rupture_ratio << ")\n";
+        }
+    }
+
+    return 0;
+}
+

--- a/examples/annealing_sim_build.cmake
+++ b/examples/annealing_sim_build.cmake
@@ -1,0 +1,33 @@
+add_executable(annealing_sim
+    examples/annealing_sim.cpp
+)
+
+set_target_properties(annealing_sim PROPERTIES CXX_STANDARD 17)
+
+target_include_directories(annealing_sim PUBLIC
+    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/extern/cycles/src
+    ${CMAKE_SOURCE_DIR}/extern/glm
+)
+
+link_directories(
+    /sep/src
+    /sep/src/core
+    /sep/src/quantum
+    /sep/src/memory
+    /sep/src/audio
+    /sep/src/blender
+    /sep/src/compat
+)
+
+target_link_libraries(annealing_sim PRIVATE
+    sep_core
+    sep_quantum
+    sep_memory
+    sep_audio
+    sep_blender
+    sep_compat
+    sep_api
+)
+
+


### PR DESCRIPTION
## Summary
- implement `examples/annealing_sim.cpp` demonstrating Lennard–Jones particle simulation
- analyze particle order using QFH and log rupture events
- provide CMake build script for the example
- include new example in the root build

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6869b426bacc832aa381f19eae5e2be9