### PR TITLE
Add physics_explorer example with new evolution utilities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,9 @@ endif()
 # Include JSON processor build
 include(examples/json_processor_build.cmake)
 add_subdirectory(examples/workbench)
+add_executable(physics_explorer examples/physics_explorer.cpp)
+target_include_directories(physics_explorer PUBLIC ${CMAKE_SOURCE_DIR}/include)
+target_link_libraries(physics_explorer PRIVATE sep_quantum sep_core sep_compat sep_memory)
 
 # Main executable
 add_executable(sep_server src/server_main.cpp)

--- a/examples/physics_explorer.cpp
+++ b/examples/physics_explorer.cpp
@@ -1,0 +1,55 @@
+#include <iostream>
+#include <vector>
+#include <glm/glm.hpp>
+
+#include "quantum/data.hpp"
+#include "quantum/evolution.h"
+#include "memory/types.h"
+
+using namespace sep;
+using namespace sep::pattern;
+using namespace sep::quantum;
+
+int main() {
+    const int grid = 10;
+    std::vector<PatternData> patterns;
+    patterns.reserve(grid * grid);
+
+    for (int x = 0; x < grid; ++x) {
+        for (int y = 0; y < grid; ++y) {
+            PatternData p;
+            p.id = "p_" + std::to_string(x) + "_" + std::to_string(y);
+            p.position = glm::vec4(static_cast<float>(x), static_cast<float>(y), 0.0f, 1.0f);
+            p.coherence = 0.5f;
+            p.stability = 0.5f;
+            p.memory_tier = memory::MemoryTierEnum::STM;
+            patterns.push_back(p);
+        }
+    }
+
+    glm::vec3 center(grid / 2.0f, grid / 2.0f, 0.0f);
+
+    for (int step = 0; step < 50; ++step) {
+        for (auto &p : patterns) {
+            evolution::applyGravity(p, center, 0.02f);
+            evolution::randomPerturbation(p, 0.01f);
+
+            if (glm::length(glm::vec3(p.position) - center) < 0.5f) {
+                p.coherence = std::min(1.0f, p.coherence + 0.05f);
+                p.stability = std::min(1.0f, p.stability + 0.05f);
+                if (p.coherence > 0.9f && p.stability > 0.9f) {
+                    p.memory_tier = memory::MemoryTierEnum::LTM;
+                }
+            }
+        }
+    }
+
+    std::cout << "Stable LTM patterns:\n";
+    for (const auto &p : patterns) {
+        if (p.memory_tier == memory::MemoryTierEnum::LTM) {
+            std::cout << p.id << " at (" << p.position.x << ", " << p.position.y << ", " << p.position.z << ")\n";
+        }
+    }
+
+    return 0;
+}

--- a/include/quantum/evolution.h
+++ b/include/quantum/evolution.h
@@ -65,6 +65,8 @@ namespace evolution {
     std::vector<Pattern> createRandomPopulation(size_t size);
     void applySpike(Pattern& neuron, float input, float decay, float threshold);
     void hebbianUpdate(const Pattern& pre, Pattern& post, float rate);
+    void applyGravity(Pattern& pattern, const glm::vec3& center, float strength);
+    void randomPerturbation(Pattern& pattern, float amplitude);
 }
 
 } // namespace sep::quantum

--- a/src/quantum/evolution.cpp
+++ b/src/quantum/evolution.cpp
@@ -400,6 +400,18 @@ void hebbianUpdate(const Pattern& pre, Pattern& post, float rate) {
     post.quantum_state.stability = glm::clamp(post.quantum_state.stability + delta, 0.0f, 1.0f);
 }
 
+void applyGravity(Pattern& pattern, const glm::vec3& center, float strength) {
+    glm::vec3 pos = glm::vec3(pattern.position);
+    glm::vec3 dir = center - pos;
+    pattern.position += glm::vec4(dir * strength, 0.0f);
+}
+
+void randomPerturbation(Pattern& pattern, float amplitude) {
+    static uint64_t noise_state = 0;
+    auto rnd = [&]() { return deterministicNoise(noise_state) * 2.0f - 1.0f; };
+    pattern.position += glm::vec4(rnd() * amplitude, rnd() * amplitude, rnd() * amplitude, 0.0f);
+}
+
 } // namespace evolution
 
 } // namespace sep::quantum


### PR DESCRIPTION
## Summary
- implement example `physics_explorer.cpp` demonstrating grid-based pattern exploration
- add simple gravity and random perturbation utilities in `evolution`
- expose new functions in header
- build target `physics_explorer`

## Testing
- `cmake -S . -B build -DSEP_ENABLE_AUDIO=OFF -DBUILD_TESTING=ON` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6869b442d7e0832aa2932b16d342958f