### PR TITLE
Implement Blender precompiled header and add core CLI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,16 @@ add_subdirectory(examples/workbench)
 
 # Main executable
 add_executable(sep_server src/server_main.cpp)
+# A minimal CLI to test the core engine logic
+add_executable(sep_engine_cli src/main.cpp)
+target_include_directories(sep_engine_cli PRIVATE ${CMAKE_SOURCE_DIR}/include)
+target_link_libraries(sep_engine_cli PRIVATE
+    sep_core
+    sep_memory
+    sep_quantum
+    sep_compat
+)
+
 
 set_target_properties(sep_server PROPERTIES
     CUDA_SEPARABLE_COMPILATION ON

--- a/src/blender/api.cpp
+++ b/src/blender/api.cpp
@@ -1,10 +1,5 @@
-#include <cstdlib>
-#include <cstring>
-#include <ctime>
-#include <string>
-#include <memory>
+#include "blender_pch.h"
 #include <unistd.h>
-
 #include "compat/math_common.h"
 
 // Forward declarations for Blender functions (minimal stubs)

--- a/src/blender/blender_bridge.cpp
+++ b/src/blender/blender_bridge.cpp
@@ -1,9 +1,7 @@
-#include <cstring>
-#include <ctime>
+#include "blender_pch.h"
 #include <chrono>
 #include <condition_variable>
 #include <mutex>
-#include <string>
 #include <thread>
 
 #include <spdlog/spdlog.h>

--- a/src/blender/blender_integration.cpp
+++ b/src/blender/blender_integration.cpp
@@ -1,16 +1,11 @@
-#include <cstdlib>
-#include <cstring>
-#include <ctime>
+#include "blender_pch.h"
 #include <algorithm>
 #include <chrono>
 #include <condition_variable>
-#include <memory>
 #include <new>
 #include <sstream>
-#include <string>
 #include <thread>
 #include <utility>
-#include <vector>
 #include <unistd.h>
 
 #include "blender/pattern_bridge.h"

--- a/src/blender/blender_pch.h
+++ b/src/blender/blender_pch.h
@@ -1,0 +1,27 @@
+#pragma once
+
+// 1. Core Standard Libraries (THE MOST IMPORTANT STEP)
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+#include <cmath>
+#include <vector>
+#include <string>
+#include <memory>
+#include <algorithm>
+#include <numeric>
+#include <stdexcept>
+#include <iostream>
+
+// 2. Heavy Third-Party Libraries
+#include <OpenImageIO/imageio.h>
+#include <OpenColorIO/OpenColorIO.h>
+
+// 3. GLM
+#include <glm/glm.hpp>
+#include <glm/gtc/type_ptr.hpp>
+
+// 4. Project Core Headers
+#include "core/common.h"
+#include "quantum/types.h"
+#include "memory/types.h"

--- a/src/blender/compression.cpp
+++ b/src/blender/compression.cpp
@@ -1,12 +1,8 @@
-#include <cstdlib>
-#include <cstring>
-#include <ctime>
+#include "blender_pch.h"
 #include <unistd.h>
 #include <array>
 #include <algorithm>
 #include <chrono>
-#include <string>
-#include <vector>
 
 #include <lz4.h>
 #include <zstd.h>

--- a/src/blender/compression_utils.cpp
+++ b/src/blender/compression_utils.cpp
@@ -1,12 +1,7 @@
-#include <cstdlib>
-#include <cstring>
-#include <ctime>
+#include "blender_pch.h"
 #include <unistd.h>
 #include <array>
 #include <cmath>
-#include <string>
-#include <vector>
-
 #include "blender/compression.h"
 #include "compat/math_common.h"
 

--- a/src/blender/cycles_renderer.cpp
+++ b/src/blender/cycles_renderer.cpp
@@ -1,13 +1,5 @@
-// Standard library headers
-#include <cstdlib>
-#include <cstring>
-#include <ctime>
-#include <algorithm>
-#include <cmath>
-#include <memory>
-#include <string>
+#include "blender_pch.h"
 #include <utility>
-#include <vector>
 
 // Define Cycles namespace macros
 #define CCL_NAMESPACE_BEGIN namespace ccl {

--- a/src/blender/factory.cpp
+++ b/src/blender/factory.cpp
@@ -1,8 +1,4 @@
-#include <cstdlib>
-#include <cstring>
-#include <ctime>
-#include <string>
-#include <memory>
+#include "blender_pch.h"
 #include <unistd.h>
 
 #include "blender/factory.h"

--- a/src/blender/gpu_context.cpp
+++ b/src/blender/gpu_context.cpp
@@ -1,15 +1,7 @@
-// 1. C Standard Library Headers
-#include <cstdlib>
-#include <cstring>
-#include <ctime>
-#include <string>
+#include "blender_pch.h"
 #include <new>
 #include <sys/stat.h>
 #include <unistd.h>
-
-#include <new>
-#include <string>
-
 #include "blender/gpu_context.h"
 
 namespace sep {

--- a/src/blender/mesh_handler.cpp
+++ b/src/blender/mesh_handler.cpp
@@ -3,15 +3,10 @@
  * @brief Default MeshHandler implementation used when Blender APIs are absent.
 # */ // No space between these two lines causes build error in some compilers
 
-#include <cstdlib>
-#include <cstring>
-#include <ctime>
-
-#include <string>
+#include "blender_pch.h"
 
 #include "blender/mesh_handler.h"
 #include "core/common.h"  // defines sep::SEPResult
-
 // Minimal stand-ins for Blender API functions. These are no-ops here but allow
 // the library to link without the real Blender environment.
 extern "C" {

--- a/src/blender/oiio_output_driver.cpp
+++ b/src/blender/oiio_output_driver.cpp
@@ -1,16 +1,5 @@
-#include <cstdlib>
-#include <cstring>
-#include <ctime>
+#include "blender_pch.h"
 #include <unistd.h>
-#include <vector>
-
-#include <vector>
-
-#include <vector>
-
-#include <vector>
-
-// Define Cycles namespace macros
 #define CCL_NAMESPACE_BEGIN namespace ccl {
 #define CCL_NAMESPACE_END }
 

--- a/src/blender/pattern_visualization_pipeline.cpp
+++ b/src/blender/pattern_visualization_pipeline.cpp
@@ -1,13 +1,8 @@
-#include <cstdlib>
-#include <cstring>
-#include <ctime>
+#include "blender_pch.h"
 #include <unistd.h>
 #include <algorithm>
 #include <chrono>
 #include <numeric>
-#include <string>
-#include <vector>
-
 #include "blender/pattern_visualization_pipeline.h"
 #include "compat/shim.h"
 #include "core/common.h"  // defines sep::SEPResult

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,48 @@
+#include <iostream>
+#include <vector>
+#include "core/engine.h"
+#include "quantum/processor.h"
+#include "quantum/types.h"
+#include "config/config_manager.h"
+
+int main() {
+    std::cout << "--- SEP Engine Core Test ---" << std::endl;
+
+    try {
+        sep::config::ConfigManager::getInstance().initialize(0, nullptr);
+        auto& engine = sep::core::Engine::instance();
+        engine.init({});
+
+        auto q_processor = sep::quantum::createProcessor({});
+
+        sep::quantum::Pattern p;
+        p.id = "genesis_pattern_1";
+        p.quantum_state.coherence = 0.5f;
+        p.quantum_state.stability = 0.5f;
+        p.quantum_state.entropy = 0.1f;
+
+        q_processor->addPattern(p);
+
+        std::cout << "Initial Pattern State:" << std::endl;
+        std::cout << "  Coherence: " << p.quantum_state.coherence << std::endl;
+        std::cout << "  Stability: " << p.quantum_state.stability << std::endl;
+
+        std::cout << "\nEvolving pattern..." << std::endl;
+        for (int i = 0; i < 10; ++i) {
+            q_processor->processPattern(p.id);
+        }
+
+        sep::quantum::Pattern final_pattern = q_processor->getPattern(p.id);
+
+        std::cout << "\n--- MEANINGFUL RESULT ---" << std::endl;
+        std::cout << "Final Pattern State after 10 evolutions:" << std::endl;
+        std::cout << "  Coherence: " << final_pattern.quantum_state.coherence << std::endl;
+        std::cout << "  Stability: " << final_pattern.quantum_state.stability << std::endl;
+        std::cout << "-------------------------" << std::endl;
+    } catch (const std::exception& e) {
+        std::cerr << "An error occurred: " << e.what() << std::endl;
+        return 1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- create `blender_pch.h` with stable include order
- include the PCH in all Blender source files
- add minimal CLI executable using engine core
- wire the CLI target into the root CMake

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6869b5038d90832a822e9dd618afd514