### PR TITLE
Add drug optimizer example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,16 @@ endif()
 include(examples/json_processor_build.cmake)
 add_subdirectory(examples/workbench)
 
+# Simple drug optimizer example
+add_executable(drug_optimizer examples/drug_optimizer.cpp)
+target_include_directories(drug_optimizer PUBLIC ${CMAKE_SOURCE_DIR}/include)
+target_link_libraries(drug_optimizer PRIVATE
+    sep_quantum
+    sep_memory
+    sep_compat
+    sep_core
+)
+
 # Main executable
 add_executable(sep_server src/server_main.cpp)
 

--- a/examples/drug_optimizer.cpp
+++ b/examples/drug_optimizer.cpp
@@ -1,0 +1,60 @@
+#include <iostream>
+#include <vector>
+#include <random>
+#include <glm/vec3.hpp>
+#include <glm/gtx/norm.hpp>
+#include "quantum/data.hpp"
+#include "quantum/quantum_manifold_optimizer.h"
+
+using sep::pattern::PatternData;
+using sep::quantum::Pattern;
+using sep::quantum::manifold::QuantumManifoldOptimizer;
+
+struct LigandPose {
+    PatternData data;
+};
+
+static float computeBindingAffinity(const LigandPose& pose) {
+    glm::vec3 pos = glm::vec3(pose.data.position);
+    return 1.0f / (1.0f + glm::length2(pos));
+}
+
+int main() {
+    const int numPoses = 5;
+    std::mt19937 rng(42);
+    std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+
+    std::vector<LigandPose> poses(numPoses);
+    for (auto& p : poses) {
+        p.data.position = {dist(rng), dist(rng), dist(rng), 1.0f};
+        p.data.coherence = computeBindingAffinity(p);
+    }
+
+    QuantumManifoldOptimizer optimizer;
+    std::vector<Pattern> patterns;
+    patterns.reserve(numPoses);
+    for (const auto& p : poses) {
+        Pattern pat;
+        pat.position = p.data.position;
+        pat.quantum_state.coherence = p.data.coherence;
+        patterns.push_back(pat);
+    }
+
+    auto optimized = optimizer.optimize(patterns);
+
+    float bestAffinity = 0.0f;
+    float bestCoherence = 0.0f;
+    for (size_t i = 0; i < poses.size(); ++i) {
+        poses[i].data.position = optimized[i].position;
+        poses[i].data.coherence = optimized[i].quantum_state.coherence;
+        float aff = computeBindingAffinity(poses[i]);
+        if (aff > bestAffinity) {
+            bestAffinity = aff;
+            bestCoherence = poses[i].data.coherence;
+        }
+    }
+
+    std::cout << "Best binding affinity: " << bestAffinity
+              << " with coherence: " << bestCoherence << std::endl;
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add `drug_optimizer.cpp` example using `QuantumManifoldOptimizer`
- register new `drug_optimizer` executable in root CMake

## Testing
- `g++ -std=c++17 -Iinclude -I/usr/include -Iextern/glm examples/drug_optimizer.cpp -c -o /tmp/drug_optimizer.o`
- `g++ -std=c++17 /tmp/drug_optimizer.o -o /tmp/drug_optimizer` *(fails: undefined references)*


------
https://chatgpt.com/codex/tasks/task_e_6869b43c5634832a9be13234cbfca4b6