### PR TITLE
Fix build config and PCH usage

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,8 +7,8 @@ set(SEP_INCLUDE_DIRS
 )
 
 # Main executable
-add_executable(sep_main server_main.cpp)
-target_include_directories(sep_main PRIVATE ${SEP_INCLUDE_DIRS})
+add_executable(sep_engine_cli main.cpp)
+target_include_directories(sep_engine_cli PRIVATE ${SEP_INCLUDE_DIRS})
 
 # Add component subdirectories
 add_subdirectory(api)
@@ -21,19 +21,7 @@ add_subdirectory(quantum)
 add_subdirectory(embeddings)
 
 # Link dependencies
-target_link_libraries(sep_server PRIVATE
-    sep_api
-    sep_audio
-    sep_compat
+target_link_libraries(sep_engine_cli PRIVATE
     sep_core
-    sep_memory
     sep_quantum
-    sep_blender
-    ${PIPEWIRE_LIBRARIES}
-    fmt::fmt
-)
-
-target_link_libraries(sep_server PRIVATE
-    CUDA::cudart
-    CUDA::cuda_driver
 )

--- a/src/blender/CMakeLists.txt
+++ b/src/blender/CMakeLists.txt
@@ -27,6 +27,8 @@ add_library(sep_blender SHARED
     oiio_output_driver.cpp
 )
 
+target_precompile_headers(sep_blender PRIVATE blender_pch.h)
+
 # Require C++17 for this target
 target_compile_features(sep_blender PUBLIC cxx_std_17)
 

--- a/src/blender/blender_bridge.cpp
+++ b/src/blender/blender_bridge.cpp
@@ -1,10 +1,5 @@
 #include "blender_pch.h"
 
-#include <chrono>
-#include <condition_variable>
-#include <mutex>
-#include <thread>
-#include <spdlog/spdlog.h>
 
 #include "blender/bridge.h"
 #include "core/error_handler.h"

--- a/src/blender/blender_integration.cpp
+++ b/src/blender/blender_integration.cpp
@@ -1,6 +1,4 @@
 #include "blender_pch.h"
-#include <chrono>
-#include <condition_variable>
 #include <new>
 #include <sstream>
 #include <thread>

--- a/src/blender/blender_pch.h
+++ b/src/blender/blender_pch.h
@@ -1,6 +1,6 @@
 #pragma once
 
-// 1. Core Standard Libraries (THE MOST IMPORTANT STEP)
+// 1. Core C/C++ Standard Libraries
 #include <cstdlib>
 #include <cstring>
 #include <ctime>
@@ -10,18 +10,32 @@
 #include <memory>
 #include <algorithm>
 #include <numeric>
-#include <stdexcept>
 #include <iostream>
+#include <stdexcept>
+#include <array>
+#include <functional>
+#include <mutex>
+#include <condition_variable>
+#include <thread>
+#include <chrono>
 
 // 2. Heavy Third-Party Libraries
 #include <OpenImageIO/imageio.h>
 #include <OpenColorIO/OpenColorIO.h>
-
-// 3. GLM
+#include <spdlog/spdlog.h>
+#include <lz4.h>
+#include <zstd.h>
 #include <glm/glm.hpp>
 #include <glm/gtc/type_ptr.hpp>
 
-// 4. Project Core Headers
+// 3. Cycles Headers
+#include "util/system.h"
+#include "util/types.h"
+#include "util/math.h"
+#include "scene/scene.h"
+
+// 4. Your Own Project's Core Headers
 #include "core/common.h"
 #include "quantum/types.h"
 #include "memory/types.h"
+#include "compat/shim.h"

--- a/src/blender/compression.cpp
+++ b/src/blender/compression.cpp
@@ -1,11 +1,6 @@
 #include "blender_pch.h"
 #include <unistd.h>
-#include <array>
-#include <chrono>
-#include <vector>
 
-#include <lz4.h>
-#include <zstd.h>
 
 #include "blender/compression.h"
 

--- a/src/blender/compression_utils.cpp
+++ b/src/blender/compression_utils.cpp
@@ -1,8 +1,6 @@
 #include "blender_pch.h"
 #include <unistd.h>
-#include <array>
-#include <cmath>
-#include <vector>
+
 
 #include "blender/compression.h"
 #include "compat/math_common.h"

--- a/src/blender/mesh_handler.cpp
+++ b/src/blender/mesh_handler.cpp
@@ -4,8 +4,6 @@
  * @brief Default MeshHandler implementation used when Blender APIs are absent.
 # */ // No space between these two lines causes build error in some compilers
 
-#include "blender_pch.h"
-
 #include "blender/mesh_handler.h"
 #include "core/common.h"  // defines sep::SEPResult
 // Minimal stand-ins for Blender API functions. These are no-ops here but allow

--- a/src/blender/pattern_visualization_pipeline.cpp
+++ b/src/blender/pattern_visualization_pipeline.cpp
@@ -1,8 +1,6 @@
 #include "blender_pch.h"
 #include <unistd.h>
-#include <chrono>
-#include <numeric>
-#include <vector>
+
 
 #include "blender/pattern_visualization_pipeline.h"
 #include "compat/shim.h"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,7 @@
 #include "core/engine.h"
 #include "quantum/processor.h"
 #include "quantum/types.h"
-#include "config/config_manager.h"
+#include "core/manager.h"
 
 int main() {
     std::cout << "--- SEP Engine Core Test ---" << std::endl;


### PR DESCRIPTION
## Summary
- point engine test program at the correct config header
- create `sep_engine_cli` target in src and link only core libs
- expand `blender_pch.h` with additional standard and third‑party headers
- use the Blender PCH via `target_precompile_headers`
- clean up redundant includes in Blender sources

## Testing
- `cmake ..` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6869c60d1d20832aae9da2e04d38f617