### PR TITLE
Disable blender module to build CLI cleanly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,8 @@ set(SEP_HAS_CUDA 1)
 add_compile_definitions(SEP_HAS_CUDA=1)
 
 # Blender integration is always built
-set(SEP_HAS_BLENDER 1)
+# Blender integration is disabled for the console workbench
+set(SEP_HAS_BLENDER 0)
 
 # Ensure our custom Crow wrappers take precedence over the third-party headers
 include_directories(BEFORE
@@ -102,7 +103,7 @@ if(SEP_ENABLE_AUDIO)
     add_subdirectory(src/audio)
     add_compile_definitions(SEP_HAS_AUDIO=1)
 endif()
-add_subdirectory(src/blender)
+# add_subdirectory(src/blender) # Temporarily disabled to isolate build issues
 add_subdirectory(extern/cycles/third_party/cuew)
 add_subdirectory(extern/cycles/third_party/hipew)
 add_subdirectory(extern/cycles/third_party/sky)
@@ -148,7 +149,6 @@ install(TARGETS
     sep_quantum
     sep_embeddings
     sep_audio
-    sep_blender
     sep_api
     EXPORT sep-targets
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,7 +13,7 @@ target_include_directories(sep_engine_cli PRIVATE ${SEP_INCLUDE_DIRS})
 # Add component subdirectories
 add_subdirectory(api)
 add_subdirectory(audio)
-add_subdirectory(blender)
+# add_subdirectory(blender) # Temporarily disabled to isolate build issues
 add_subdirectory(compat)
 add_subdirectory(core)
 add_subdirectory(memory)


### PR DESCRIPTION
## Summary
- stop building blender integration by default
- update CMake to reflect blender deactivation

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6869c89267a8832a94760ce6f7879342