### PR TITLE
Disable blender module to isolate build

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,7 +13,7 @@ target_include_directories(sep_engine_cli PRIVATE ${SEP_INCLUDE_DIRS})
 # Add component subdirectories
 add_subdirectory(api)
 add_subdirectory(audio)
-add_subdirectory(blender)
+# add_subdirectory(blender) # Temporarily disabled to isolate build issues
 add_subdirectory(compat)
 add_subdirectory(core)
 add_subdirectory(memory)


### PR DESCRIPTION
## Summary
- disable building the `blender` component in `src/CMakeLists.txt`

## Testing
- `cmake ..` (fails: `Could not find nvcc, please set CUDAToolkit_ROOT`)


------
https://chatgpt.com/codex/tasks/task_e_6869c89267a8832a94760ce6f7879342