### PR TITLE
Fix engine init and blender include

### DIFF
--- a/src/api/server.cpp
+++ b/src/api/server.cpp
@@ -38,10 +38,10 @@
 #include "api/server.h"
 #include "quantum/cycles.h"
 #include "compat/types.h"
+#include "blender/cycles_renderer.h"
 
 #ifdef SEP_HAS_BLENDER
 #include "blender/api.h"
-#include "blender/cycles_renderer.h"
 #endif
 
 namespace sep::api {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,7 +10,7 @@ int main() {
 
     try {
         sep::config::ConfigManager::getInstance().initialize(0, nullptr);
-        auto& engine = sep::core::Engine::instance();
+        sep::core::Engine engine;
         engine.init({});
 
         auto q_processor = sep::quantum::createProcessor({});


### PR DESCRIPTION
## Summary
- include `blender/cycles_renderer.h` directly in `server.cpp`
- instantiate `sep::core::Engine` directly in `main.cpp`

## Testing
- `cmake .. -DSEP_ENABLE_AUDIO=OFF -DBUILD_TESTING=ON` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6869ca2d4244832a866640a485d3f098