### PR TITLE
Fix engine creation in CLI and always include cycles renderer

### DIFF
--- a/src/api/server.cpp
+++ b/src/api/server.cpp
@@ -39,10 +39,8 @@
 #include "quantum/cycles.h"
 #include "compat/types.h"
 
-#ifdef SEP_HAS_BLENDER
 #include "blender/api.h"
 #include "blender/cycles_renderer.h"
-#endif
 
 namespace sep::api {
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,7 +10,7 @@ int main() {
 
     try {
         sep::config::ConfigManager::getInstance().initialize(0, nullptr);
-        auto& engine = sep::core::Engine::instance();
+        sep::core::Engine engine;
         engine.init({});
 
         auto q_processor = sep::quantum::createProcessor({});


### PR DESCRIPTION
## Summary
- fix main CLI to instantiate `Engine` directly instead of calling an undefined `instance()`
- always include `blender/cycles_renderer.h` in server implementation to avoid incomplete type errors

## Testing
- `cmake ../src -DBUILD_TESTING=OFF` *(fails: Package 'fftw3f', required by 'virtual:world', not found)*
- `cmake .. -DBUILD_TESTING=ON` *(fails: Could not find nvcc, please set CUDAToolkit_ROOT)*

------
https://chatgpt.com/codex/tasks/task_e_6869ca2d4244832a866640a485d3f098