### PR TITLE
Fix API include paths and re-enable blender

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,7 +13,7 @@ target_include_directories(sep_engine_cli PRIVATE ${SEP_INCLUDE_DIRS})
 # Add component subdirectories
 add_subdirectory(api)
 add_subdirectory(audio)
-# add_subdirectory(blender) # Temporarily disabled to isolate build issues
+add_subdirectory(blender)
 add_subdirectory(compat)
 add_subdirectory(core)
 add_subdirectory(memory)

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -36,6 +36,7 @@ target_include_directories(sep_api
     PRIVATE
         $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src>
         $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/third_party/crow/include>
+        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/extern/cycles/src>
 )
 
 # Link external dependencies when available

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,7 @@
 #include <iostream>
 #include <vector>
+#include <chrono>
+#include <thread>
 #include "core/engine.h"
 #include "quantum/processor.h"
 #include "quantum/types.h"
@@ -39,6 +41,18 @@ int main() {
         std::cout << "  Coherence: " << final_pattern.quantum_state.coherence << std::endl;
         std::cout << "  Stability: " << final_pattern.quantum_state.stability << std::endl;
         std::cout << "-------------------------" << std::endl;
+
+        std::cout << "\n--- EVOLUTION LOOP ---" << std::endl;
+        for (int i = 0; i < 50; ++i) {
+            q_processor->processPattern(p.id);
+            sep::quantum::Pattern current_pattern = q_processor->getPattern(p.id);
+            printf("Step %02d -> Coherence: %f, Stability: %f\n",
+                   i + 1,
+                   current_pattern.quantum_state.coherence,
+                   current_pattern.quantum_state.stability);
+            std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        }
+        std::cout << "----------------------" << std::endl;
     } catch (const std::exception& e) {
         std::cerr << "An error occurred: " << e.what() << std::endl;
         return 1;


### PR DESCRIPTION
## Summary
- re-enable blender module in main CMake configuration
- ensure API target can locate Cycles headers
- expand sep_engine_cli demo with an evolution loop

## Testing
- `cmake -S . -B build` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6869cbd6b874832ab492c17d3446d3e3