### PR TITLE
Fix server cpp preprocessor guards

### DIFF
--- a/src/api/server.cpp
+++ b/src/api/server.cpp
@@ -38,8 +38,8 @@
 #include "api/server.h"
 #include "quantum/cycles.h"
 #include "compat/types.h"
+#ifdef SEP_HAS_BLENDER
 #include "blender/cycles_renderer.h"
-
 #include "blender/api.h"
 #endif
 


### PR DESCRIPTION
## Summary
- add missing SEP_HAS_BLENDER guard around blender includes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6869cdff5174832a8b001682c5ea74f4