### PR TITLE
Add server executable and fix preprocessor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,19 @@ target_link_libraries(sep_engine_cli PRIVATE
     sep_compat
 )
 
+# Full server executable using API server
+add_executable(sep_engine_server src/api/server_main.cpp)
+target_include_directories(sep_engine_server PRIVATE ${CMAKE_SOURCE_DIR}/include)
+target_link_libraries(sep_engine_server PRIVATE
+    sep_api
+    sep_blender
+    sep_audio
+    sep_core
+    sep_memory
+    sep_quantum
+    sep_compat
+)
+
 # Export and install targets
 include(GNUInstallDirs)
 

--- a/src/api/server.cpp
+++ b/src/api/server.cpp
@@ -38,8 +38,9 @@
 #include "api/server.h"
 #include "quantum/cycles.h"
 #include "compat/types.h"
-#include "blender/cycles_renderer.h"
 
+#ifdef SEP_HAS_BLENDER
+#include "blender/cycles_renderer.h"
 #include "blender/api.h"
 #endif
 

--- a/src/api/server_main.cpp
+++ b/src/api/server_main.cpp
@@ -1,0 +1,16 @@
+#include "api/server.h"
+#include "core/manager.h"
+#include <memory>
+
+int main(int argc, char** argv) {
+    auto& cfg_manager = sep::config::ConfigManager::getInstance();
+    cfg_manager.initialize(argc, argv);
+    const auto& api_cfg = cfg_manager.getAPIConfig();
+
+    sep::api::SEPApiServer server(api_cfg);
+    if (!server.run()) {
+        return 1;
+    }
+    server.waitForShutdown();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add missing `#endif` guard for `SEP_HAS_BLENDER`
- create `server_main.cpp` to start `SEPApiServer`
- build new `sep_engine_server` executable

## Testing
- `cmake -S . -B build -DBUILD_TESTING=OFF` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6869cdff5174832a8b001682c5ea74f4