### PR TITLE
Fix server header guard and add new server executable

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(SEP_INCLUDE_DIRS
     ${PIPEWIRE_INCLUDE_DIRS}
 )
 
-# Main executable
+# CLI executable for minimal engine test
 add_executable(sep_engine_cli main.cpp)
 target_include_directories(sep_engine_cli PRIVATE ${SEP_INCLUDE_DIRS})
 
@@ -24,4 +24,18 @@ add_subdirectory(embeddings)
 target_link_libraries(sep_engine_cli PRIVATE
     sep_core
     sep_quantum
+)
+
+# Full server executable
+add_executable(sep_engine_server api/server_main.cpp)
+target_include_directories(sep_engine_server PRIVATE ${SEP_INCLUDE_DIRS})
+target_link_libraries(sep_engine_server PRIVATE
+    sep_api
+    sep_blender
+    sep_audio
+    sep_embeddings
+    sep_core
+    sep_memory
+    sep_quantum
+    sep_compat
 )

--- a/src/api/server.cpp
+++ b/src/api/server.cpp
@@ -38,8 +38,9 @@
 #include "api/server.h"
 #include "quantum/cycles.h"
 #include "compat/types.h"
-#include "blender/cycles_renderer.h"
 
+#ifdef SEP_HAS_BLENDER
+#include "blender/cycles_renderer.h"
 #include "blender/api.h"
 #endif
 

--- a/src/api/server_main.cpp
+++ b/src/api/server_main.cpp
@@ -1,0 +1,14 @@
+#include "api/server.h"
+#include "core/manager.h"
+
+int main(int argc, char** argv) {
+    sep::config::ConfigManager::getInstance().initialize(argc, argv);
+    const auto& api_cfg = sep::config::ConfigManager::getInstance().getAPIConfig();
+
+    sep::api::SEPApiServer server(api_cfg);
+    if (!server.run()) {
+        return 1;
+    }
+    server.waitForShutdown();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- fix `SEP_HAS_BLENDER` include guard typo in `server.cpp`
- add `server_main.cpp` with a simple entry point for the HTTP server
- update build to produce two executables:
  - **sep_engine_cli** for minimal engine tests
  - **sep_engine_server** for the full API server

## Testing
- `cmake -S . -B build` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6869cdff5174832a8b001682c5ea74f4