### PR TITLE
Inject renderer via DI in SEPApiServer

### DIFF
--- a/include/api/server.h
+++ b/include/api/server.h
@@ -62,8 +62,10 @@ class SEPApiServer : public Server {
   /**
    * @brief Construct a new SEPApiServer
    * @param config The API configuration
+   * @param renderer Optional Cycles renderer
    */
-  explicit SEPApiServer(const ::sep::config::APIConfig &config);
+  explicit SEPApiServer(const ::sep::config::APIConfig &config,
+                        blender::ccl::CyclesRenderer *renderer);
 
   /**
    * @brief Destructor
@@ -223,7 +225,7 @@ class SEPApiServer : public Server {
 
   // Persistent processors for Blender routes
   std::unique_ptr<sep::pattern::PatternProcessor> pattern_processor_;
-  std::unique_ptr<sep::blender::ccl::CyclesRenderer> cycles_renderer_;
+  sep::blender::ccl::CyclesRenderer* cycles_renderer_;
 };
 
 }  // namespace sep::api

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -24,7 +24,6 @@ target_link_libraries(sep_api
         ${CURL_LIBRARIES}
         sep_compat
         sep_embeddings
-        sep_blender
         sep_audio
         http_parser::http_parser
 )

--- a/src/api/server.cpp
+++ b/src/api/server.cpp
@@ -55,7 +55,8 @@ namespace sep::api {
 
 // Static instance for signal handling
 SEPApiServer* SEPApiServer::instance_ = nullptr;
-SEPApiServer::SEPApiServer(const ::sep::config::APIConfig& config)
+SEPApiServer::SEPApiServer(const ::sep::config::APIConfig& config,
+                           blender::ccl::CyclesRenderer* renderer)
     : config_(config),
       logger_(nullptr),
       app_(nullptr),
@@ -66,7 +67,7 @@ SEPApiServer::SEPApiServer(const ::sep::config::APIConfig& config)
       metrics_mutex_(),
       ollama_client_(nullptr),
       pattern_processor_(std::make_unique<sep::pattern::PatternProcessor>()),
-      cycles_renderer_(std::make_unique<sep::blender::ccl::CyclesRenderer>()) {
+      cycles_renderer_(renderer) {
     instance_ = this;
 
     // Initialize the Crow app with middlewares
@@ -82,9 +83,7 @@ SEPApiServer::SEPApiServer(const ::sep::config::APIConfig& config)
         (void)pattern_processor_->init(nullptr);
     }
 #ifdef SEP_HAS_BLENDER
-    if (cycles_renderer_) {
-        (void)cycles_renderer_->initialize();
-    }
+    // Renderer lifetime managed externally
 #endif
 }
 
@@ -948,7 +947,7 @@ void SEPApiServer::setupBlenderRoutes() {
             auto cycles_config = json["cycles_config"];
 
             // Use persistent Cycles renderer
-            auto* renderer = cycles_renderer_.get();
+            auto* renderer = cycles_renderer_;
             if (!renderer) {
                 ::crow::response res;
                 res.body = "Cycles renderer unavailable";

--- a/src/api/server_main.cpp
+++ b/src/api/server_main.cpp
@@ -1,5 +1,6 @@
 #include "api/server.h"
 #include "core/manager.h"
+#include "blender/cycles_renderer.h"
 #include <memory>
 
 int main(int argc, char** argv) {
@@ -7,7 +8,10 @@ int main(int argc, char** argv) {
     cfg_manager.initialize(argc, argv);
     const auto& api_cfg = cfg_manager.getAPIConfig();
 
-    sep::api::SEPApiServer server(api_cfg);
+    auto renderer = std::make_unique<sep::blender::ccl::CyclesRenderer>();
+    renderer->initialize();
+
+    sep::api::SEPApiServer server(api_cfg, renderer.get());
     if (!server.run()) {
         return 1;
     }

--- a/src/server_main.cpp
+++ b/src/server_main.cpp
@@ -8,6 +8,8 @@
 #include "core/manager.h"
 #include "core/logging.h"
 #include "api/server.h"
+#include "blender/cycles_renderer.h"
+#include <memory>
 
 static std::atomic<bool> g_keep_running{true};
 
@@ -26,7 +28,10 @@ int main(int argc, char* argv[]) {
     auto& config = sep::config::ConfigManager::getInstance();
     config.initialize(argc, argv);
 
-    sep::api::SEPApiServer server(config.getAPIConfig());
+    auto renderer = std::make_unique<sep::blender::ccl::CyclesRenderer>();
+    renderer->initialize();
+
+    sep::api::SEPApiServer server(config.getAPIConfig(), renderer.get());
     server.run();
 
     while (g_keep_running.load()) {


### PR DESCRIPTION
## Summary
- refactor `SEPApiServer` to receive a `CyclesRenderer` pointer
- instantiate and initialize renderer in server main
- pass renderer when constructing server in both main programs
- remove ownership of renderer from `SEPApiServer`
- drop `sep_blender` link from `sep_api`

## Testing
- `cmake .. -DSEP_BUILD_TESTS=ON` *(fails: Could not find nvcc)*
- `make -j$(nproc)` *(fails: No targets specified)*
- `ctest --output-on-failure` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6869d0fdfb00832a90da6406a6f6567e