### PR TITLE
Inject CyclesRenderer via server_main

### DIFF
--- a/_sep/testbed/CMakeLists.txt
+++ b/_sep/testbed/CMakeLists.txt
@@ -21,6 +21,7 @@ target_link_libraries(testbed_tests PRIVATE
     sep_core
     sep_audio
     sep_api
+    sep_blender
     GTest::GTest
     GTest::Main
 )

--- a/_sep/testbed/api_makejsonresponse_test.cpp
+++ b/_sep/testbed/api_makejsonresponse_test.cpp
@@ -1,11 +1,13 @@
 #include "api/server.h"
 #include "config/api_config.h"
+#include "blender/cycles_renderer.h"
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>
 
 TEST(APIServerTest, MakeJsonResponseSuccess) {
     sep::config::APIConfig cfg{};
-    sep::api::SEPApiServer server(cfg);
+    sep::blender::ccl::CyclesRenderer renderer;
+    sep::api::SEPApiServer server(cfg, &renderer);
     auto resp = server.makeJsonResponse(200, "ok");
     EXPECT_EQ(resp->getCode(), 200);
     auto body = nlohmann::json::parse(resp->getBody());

--- a/examples/workbench/main.cpp
+++ b/examples/workbench/main.cpp
@@ -239,7 +239,9 @@ int main(int argc, char* argv[]) {
     engine.run();
 
     // Start API server after all components are initialized
-    sep::api::SEPApiServer server(config.getAPIConfig());
+    auto renderer = std::make_unique<sep::blender::ccl::CyclesRenderer>();
+    renderer->initialize();
+    sep::api::SEPApiServer server(config.getAPIConfig(), renderer.get());
     server.run();
     
     if (server_mode) {

--- a/include/api/server.h
+++ b/include/api/server.h
@@ -62,8 +62,10 @@ class SEPApiServer : public Server {
   /**
    * @brief Construct a new SEPApiServer
    * @param config The API configuration
+   * @param renderer Optional Cycles renderer dependency
    */
-  explicit SEPApiServer(const ::sep::config::APIConfig &config);
+  SEPApiServer(const ::sep::config::APIConfig &config,
+               sep::blender::ccl::CyclesRenderer *renderer);
 
   /**
    * @brief Destructor
@@ -223,7 +225,7 @@ class SEPApiServer : public Server {
 
   // Persistent processors for Blender routes
   std::unique_ptr<sep::pattern::PatternProcessor> pattern_processor_;
-  std::unique_ptr<sep::blender::ccl::CyclesRenderer> cycles_renderer_;
+  sep::blender::ccl::CyclesRenderer *cycles_renderer_{nullptr};
 };
 
 }  // namespace sep::api

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -24,7 +24,6 @@ target_link_libraries(sep_api
         ${CURL_LIBRARIES}
         sep_compat
         sep_embeddings
-        sep_blender
         sep_audio
         http_parser::http_parser
 )

--- a/src/api/server.cpp
+++ b/src/api/server.cpp
@@ -55,7 +55,8 @@ namespace sep::api {
 
 // Static instance for signal handling
 SEPApiServer* SEPApiServer::instance_ = nullptr;
-SEPApiServer::SEPApiServer(const ::sep::config::APIConfig& config)
+SEPApiServer::SEPApiServer(const ::sep::config::APIConfig& config,
+                           sep::blender::ccl::CyclesRenderer* renderer)
     : config_(config),
       logger_(nullptr),
       app_(nullptr),
@@ -66,7 +67,7 @@ SEPApiServer::SEPApiServer(const ::sep::config::APIConfig& config)
       metrics_mutex_(),
       ollama_client_(nullptr),
       pattern_processor_(std::make_unique<sep::pattern::PatternProcessor>()),
-      cycles_renderer_(std::make_unique<sep::blender::ccl::CyclesRenderer>()) {
+      cycles_renderer_(renderer) {
     instance_ = this;
 
     // Initialize the Crow app with middlewares
@@ -948,7 +949,7 @@ void SEPApiServer::setupBlenderRoutes() {
             auto cycles_config = json["cycles_config"];
 
             // Use persistent Cycles renderer
-            auto* renderer = cycles_renderer_.get();
+            auto* renderer = cycles_renderer_;
             if (!renderer) {
                 ::crow::response res;
                 res.body = "Cycles renderer unavailable";

--- a/src/api/server_main.cpp
+++ b/src/api/server_main.cpp
@@ -1,5 +1,6 @@
 #include "api/server.h"
 #include "core/manager.h"
+#include "blender/cycles_renderer.h"
 #include <memory>
 
 int main(int argc, char** argv) {
@@ -7,7 +8,10 @@ int main(int argc, char** argv) {
     cfg_manager.initialize(argc, argv);
     const auto& api_cfg = cfg_manager.getAPIConfig();
 
-    sep::api::SEPApiServer server(api_cfg);
+    auto renderer = std::make_unique<sep::blender::ccl::CyclesRenderer>();
+    renderer->initialize();
+
+    sep::api::SEPApiServer server(api_cfg, renderer.get());
     if (!server.run()) {
         return 1;
     }

--- a/src/server_main.cpp
+++ b/src/server_main.cpp
@@ -8,6 +8,8 @@
 #include "core/manager.h"
 #include "core/logging.h"
 #include "api/server.h"
+#include "blender/cycles_renderer.h"
+#include <memory>
 
 static std::atomic<bool> g_keep_running{true};
 
@@ -26,7 +28,10 @@ int main(int argc, char* argv[]) {
     auto& config = sep::config::ConfigManager::getInstance();
     config.initialize(argc, argv);
 
-    sep::api::SEPApiServer server(config.getAPIConfig());
+    auto renderer = std::make_unique<sep::blender::ccl::CyclesRenderer>();
+    renderer->initialize();
+
+    sep::api::SEPApiServer server(config.getAPIConfig(), renderer.get());
     server.run();
 
     while (g_keep_running.load()) {

--- a/tests/api/CMakeLists.txt
+++ b/tests/api/CMakeLists.txt
@@ -20,6 +20,7 @@ target_include_directories(api_tests PRIVATE
 
 target_link_libraries(api_tests PRIVATE
     sep_api
+    sep_blender
     ${HTTP_PARSER_LIBRARY}
     GTest::GTest
     GTest::Main

--- a/tests/api/health_endpoint_test.cpp
+++ b/tests/api/health_endpoint_test.cpp
@@ -1,6 +1,7 @@
 #include "api/client.h"
 #include "api/server.h"
 #include "api/types.h"
+#include "blender/cycles_renderer.h"
 #include <gtest/gtest.h>
 #include <chrono>
 #include <thread>
@@ -29,7 +30,8 @@ TEST(APIServer, HealthEndpoint) {
     auto cfg = sep::config::APIConfig{};
     cfg.port = port;
 
-    SEPApiServer server(cfg);
+    sep::blender::ccl::CyclesRenderer renderer;
+    SEPApiServer server(cfg, &renderer);
     server.setup_routes();
     auto resp = server.makeJsonResponse(200, "ok");
     EXPECT_EQ(resp->getCode(), 200);
@@ -43,7 +45,8 @@ class HealthServerTest : public ::testing::Test {};
 
 TEST_F(HealthServerTest, HealthEndpointReturnsOk) {
     uint16_t port = 23765; // fixed port for test
-    SEPApiServer server(createConfig(port));
+    sep::blender::ccl::CyclesRenderer renderer;
+    SEPApiServer server(createConfig(port), &renderer);
     std::thread server_thread([&](){ server.run(); });
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
 

--- a/tests/api/server_test.cpp
+++ b/tests/api/server_test.cpp
@@ -1,6 +1,7 @@
 #include "api/client.h"
 #include "api/server.h"
 #include "api/types.h"
+#include "blender/cycles_renderer.h"
 #include "compat/types.h"
 #ifdef BOOST_ASIO_DISABLE_RTTI
 #include "crow/asio_isolation.h"
@@ -163,7 +164,8 @@ protected:
   public:
     ServerGuard(uint16_t port) : port_(port) {
       config_ = createConfig(port);
-      server_ = std::make_unique<SEPApiServer>(config_);
+      renderer_ = std::make_unique<sep::blender::ccl::CyclesRenderer>();
+      server_ = std::make_unique<SEPApiServer>(config_, renderer_.get());
       running_ = std::make_shared<std::atomic<bool>>(true);
 
       // Start server in a separate thread
@@ -184,7 +186,8 @@ protected:
 
     ServerGuard(const sep::config::APIConfig &config)
         : port_(config.port), config_(config) {
-      server_ = std::make_unique<SEPApiServer>(config_);
+      renderer_ = std::make_unique<sep::blender::ccl::CyclesRenderer>();
+      server_ = std::make_unique<SEPApiServer>(config_, renderer_.get());
       running_ = std::make_shared<std::atomic<bool>>(true);
 
       // Start server in a separate thread
@@ -255,6 +258,7 @@ protected:
     uint16_t port_;
     sep::config::APIConfig config_;
     std::unique_ptr<SEPApiServer> server_;
+    std::unique_ptr<sep::blender::ccl::CyclesRenderer> renderer_;
     // running_ flag uses seq_cst semantics
     std::shared_ptr<std::atomic<bool>> running_;
     std::thread server_thread_;


### PR DESCRIPTION
## Summary
- refactor SEPApiServer constructor to accept CyclesRenderer pointer
- manage renderer lifetime in main and tests
- decouple sep_api from sep_blender

## Testing
- `cmake -B build -DBUILD_TESTING=ON` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6869d0fdfb00832a90da6406a6f6567e