### PR TITLE
Fix server include path and audio types for workbench

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,7 +132,10 @@ target_link_libraries(sep_engine_cli PRIVATE
 
 # Full server executable using API server
 add_executable(sep_engine_server src/api/server_main.cpp)
-target_include_directories(sep_engine_server PRIVATE ${CMAKE_SOURCE_DIR}/include)
+target_include_directories(sep_engine_server PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/extern/cycles/src
+)
 target_link_libraries(sep_engine_server PRIVATE
     sep_api
     sep_blender

--- a/examples/workbench/main.cpp
+++ b/examples/workbench/main.cpp
@@ -25,8 +25,9 @@
 #include "api/server.h"
 #include "blender/cycles_renderer.h"
 #include "quantum/data.hpp"
+#include "audio/types.h"   // Defines AudioError
+#include "audio/config.h"  // Defines AudioConfig
 #include "audio/capture.h"
-#include "audio/config.h"
 #include "audio/factory.h"
 #include "blender/factory.h"
 #include "blender/types.h"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,7 +31,10 @@ target_link_libraries(sep_engine_cli PRIVATE
 # Full server executable
 add_executable(sep_engine_server
     server_main.cpp)
-target_include_directories(sep_engine_server PRIVATE ${SEP_INCLUDE_DIRS})
+target_include_directories(sep_engine_server PRIVATE
+    ${SEP_INCLUDE_DIRS}
+    ${CMAKE_SOURCE_DIR}/extern/cycles/src
+)
 target_link_libraries(sep_engine_server PRIVATE
     sep_api
     sep_blender
@@ -44,7 +47,10 @@ target_link_libraries(sep_engine_server PRIVATE
 
 # Full server executable
 add_executable(sep_engine_server api/server_main.cpp)
-target_include_directories(sep_engine_server PRIVATE ${SEP_INCLUDE_DIRS})
+target_include_directories(sep_engine_server PRIVATE
+    ${SEP_INCLUDE_DIRS}
+    ${CMAKE_SOURCE_DIR}/extern/cycles/src
+)
 target_link_libraries(sep_engine_server PRIVATE
     sep_api
     sep_blender


### PR DESCRIPTION
## Summary
- include `audio/types.h` for the workbench example
- add Cycles include directory to the main `sep_engine_server` target
- mirror the include path update in `src/CMakeLists.txt`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6869d3ff324c832aae1baf6d560f715e