### PR TITLE
Fix linking issues and expose audio factory

### DIFF
--- a/_sep/testbed/CMakeLists.txt
+++ b/_sep/testbed/CMakeLists.txt
@@ -7,6 +7,7 @@ find_package(GTest REQUIRED)
 add_library(testbed_tests STATIC
     core_error_handler_test.cpp
     audio_pipeline_test.cpp
+    audio_factory_test.cpp
     api_makejsonresponse_test.cpp
     neuro_spike_test.cpp
 )

--- a/_sep/testbed/audio_factory_test.cpp
+++ b/_sep/testbed/audio_factory_test.cpp
@@ -1,0 +1,8 @@
+#include "audio/factory.h"
+#include <gtest/gtest.h>
+
+TEST(AudioFactoryTest, CreateAudioCaptureCompiles) {
+    auto capture = sep::audio::createAudioCapture();
+    (void)capture;
+    SUCCEED();
+}

--- a/src/audio/factory.cpp
+++ b/src/audio/factory.cpp
@@ -18,5 +18,9 @@ std::unique_ptr<AudioCapture> AudioCapture::create() {
 #endif
 }
 
+std::unique_ptr<AudioCapture> createAudioCapture() {
+    return AudioCapture::create();
+}
+
 } // namespace audio
 } // namespace sep

--- a/src/blender/CMakeLists.txt
+++ b/src/blender/CMakeLists.txt
@@ -128,7 +128,7 @@ link_directories(${CMAKE_SOURCE_DIR}/lib)
 # Link against Cycles libraries and required dependencies
 if(TARGET cycles_scene)
   # Linking against Cycles built from source
-  target_link_libraries(sep_blender PRIVATE
+  target_link_libraries(sep_blender PUBLIC
       cycles_device
       cycles_kernel
       cycles_util
@@ -158,7 +158,7 @@ if(TARGET cycles_scene)
 )
 else()
   # Fallback to precompiled static libraries
-  target_link_libraries(sep_blender PRIVATE
+  target_link_libraries(sep_blender PUBLIC
       cycles_device
       cycles_kernel
       cycles_util


### PR DESCRIPTION
## Summary
- propagate Blender library dependencies to consumers
- expose `createAudioCapture` helper
- cover audio factory with a basic test

## Testing
- `cmake .. -DBUILD_TESTING=ON` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6869d6970d98832aaa61b06ba621fe2a