### PR TITLE
Fix audio factory and blender link deps

### DIFF
--- a/src/audio/factory.cpp
+++ b/src/audio/factory.cpp
@@ -18,5 +18,10 @@ std::unique_ptr<AudioCapture> AudioCapture::create() {
 #endif
 }
 
+// Standalone factory function used by executables
+std::unique_ptr<AudioCapture> createAudioCapture() {
+    return AudioCapture::create();
+}
+
 } // namespace audio
 } // namespace sep

--- a/src/blender/CMakeLists.txt
+++ b/src/blender/CMakeLists.txt
@@ -128,7 +128,7 @@ link_directories(${CMAKE_SOURCE_DIR}/lib)
 # Link against Cycles libraries and required dependencies
 if(TARGET cycles_scene)
   # Linking against Cycles built from source
-  target_link_libraries(sep_blender PRIVATE
+  target_link_libraries(sep_blender PUBLIC
       cycles_device
       cycles_kernel
       cycles_util
@@ -158,7 +158,7 @@ if(TARGET cycles_scene)
 )
 else()
   # Fallback to precompiled static libraries
-  target_link_libraries(sep_blender PRIVATE
+  target_link_libraries(sep_blender PUBLIC
       cycles_device
       cycles_kernel
       cycles_util


### PR DESCRIPTION
## Summary
- export createAudioCapture factory
- expose cycles dependencies publicly for sep_blender

## Testing
- `cmake -B build -S .` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6869d6970d98832aaa61b06ba621fe2a