### PR TITLE
Fix order of standard headers in blender PCH

### DIFF
--- a/src/blender/blender_pch.h
+++ b/src/blender/blender_pch.h
@@ -1,13 +1,15 @@
 #pragma once
 
-// 1. Core C/C++ Standard Libraries
-#include <cstring> // For memcpy, memset, etc.
-#include <ctime>   // For time_t, etc.
-#include <cstdlib>
-#include <cmath>   // For math functions
+// 1. ABSOLUTE FIRST: Core C/C++ Standard Libraries
+#include <cstring>   // For memcpy, memset, strcmp, strlen
+#include <ctime>     // For time_t, clock_gettime, etc.
+#include <cmath>     // For math functions
 #include <vector>
 #include <string>
 #include <memory>
+
+// Additional standard utilities
+#include <cstdlib>
 #include <algorithm>
 #include <numeric>
 #include <iostream>


### PR DESCRIPTION
## Summary
- ensure C/C++ standard headers are the first inclusions in `blender_pch.h`

## Testing
- `n/a`

------
https://chatgpt.com/codex/tasks/task_e_6869dc598514832a86ab90d12a4a1d14