### PR TITLE
Fix PCH order for Blender build

### DIFF
--- a/src/blender/blender_pch.h
+++ b/src/blender/blender_pch.h
@@ -1,13 +1,15 @@
 #pragma once
 
-// 1. Core C/C++ Standard Libraries
-#include <cstring> // For memcpy, memset, etc.
-#include <ctime>   // For time_t, etc.
-#include <cstdlib>
-#include <cmath>   // For math functions
+// 1. ABSOLUTE FIRST: Core C/C++ Standard Libraries
+#include <cstring>   // For memcpy, memset, strcmp, strlen
+#include <ctime>     // For time_t, clock_gettime, etc.
+#include <cmath>     // For math functions
 #include <vector>
 #include <string>
 #include <memory>
+#include <cstdlib>
+#include <cstdio>
+#include <cstdint>
 #include <algorithm>
 #include <numeric>
 #include <iostream>


### PR DESCRIPTION
## Summary
- enforce C and C++ standard library headers as first includes in `blender_pch.h`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6869dc598514832a86ab90d12a4a1d14