### PR TITLE
Fix build header issues and inline registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,4 @@ blender
 !src/blender/cycles_renderer.cpp
 !sep_engine/
 !examples/json_processor_build.cmake
+package-lock.json

--- a/include/memory/spdlog_isolation.h
+++ b/include/memory/spdlog_isolation.h
@@ -243,7 +243,7 @@ namespace details {
 class registry
 {
 public:
-    static registry& instance()
+    inline static registry& instance()
     {
         static registry instance;
         static bool     initialized = false;
@@ -304,7 +304,7 @@ namespace details {
 class registry
 {
 public:
-    static registry& instance()
+    inline static registry& instance()
     {
         static registry inst;
         return inst;

--- a/src/blender/blender_pch.h
+++ b/src/blender/blender_pch.h
@@ -1,27 +1,25 @@
 #pragma once
 
-// 1. ABSOLUTELY FIRST: Core C/C++ Standard Library Headers
-// These provide the fundamental functions (memcpy, strlen, time, etc.)
-// that other libraries expect to be available in the global namespace.
-#include <string.h>
-#include <time.h>
-#include <unistd.h>
-#include <stdlib.h>
-#include <stdio.h>
-#include <stdint.h>
-#include <stddef.h>
-#include <math.h>
-
+// 1. ABSOLUTELY FIRST: C Standard Library Headers
+// These provide fundamental functions (memcpy, strlen, etc.) in the
+// global namespace. Using the <c...> variants ensures proper namespace
+// pollution avoidance with modern compilers.
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <ctime>
-#include <cmath>
-#include <vector>
+
+// 2. Core C++ Standard Library Headers
 #include <string>
+#include <vector>
 #include <memory>
 #include <algorithm>
 #include <stdexcept>
 
-// 2. Heavy Third-Party Libraries (Alphabetical)
+// 3. Heavy Third-Party Libraries (Alphabetical)
 // These often include their own complex set of headers.
 #include <OpenColorIO/OpenColorIO.h>
 #include <OpenImageIO/imageio.h>
@@ -31,13 +29,13 @@
 #include <spdlog/spdlog.h>
 #include <zstd.h>
 
-// 3. Cycles Headers (Essential ones)
+// 4. Cycles Headers (Essential ones)
 #include "util/system.h"
 #include "util/types.h"
 #include "util/math.h"
 #include "scene/scene.h"
 
-// 4. Project Core Headers (Your own stable headers)
+// 5. Project Core Headers (Your own stable headers)
 #include "core/common.h"
 #include "quantum/types.h"
 #include "memory/types.h"


### PR DESCRIPTION
## Summary
- fix include order for blender precompiled header
- mark `details::registry::instance()` inline in spdlog isolation
- ignore `package-lock.json`

## Testing
- `npm install`
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6869e8ca2768832abfcb6cc4928286d4