### PR TITLE
Add main entrypoint and update build

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,7 +17,7 @@ add_subdirectory(embeddings)
 
 # --- CORRECTED EXECUTABLE TARGET ---
 add_executable(sep_engine
-    api/server.cpp
+    main.cpp
 )
 
 set_target_properties(sep_engine PROPERTIES CXX_STANDARD 17)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,20 @@
+#include "api/server.h"
+#include "core/manager.h"
+#include "blender/cycles_renderer.h"
+#include <memory>
+
+int main(int argc, char** argv) {
+    auto& cfg_manager = sep::config::ConfigManager::getInstance();
+    cfg_manager.initialize(argc, argv);
+    const auto& api_cfg = cfg_manager.getAPIConfig();
+
+    auto renderer = std::make_unique<sep::blender::ccl::CyclesRenderer>();
+    renderer->initialize();
+
+    sep::api::SEPApiServer server(api_cfg, renderer.get());
+    if (!server.run()) {
+        return 1;
+    }
+    server.waitForShutdown();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add `src/main.cpp` that initializes the config manager, creates a `CyclesRenderer` and runs `SEPApiServer`
- adjust `src/CMakeLists.txt` so `sep_engine` builds from `main.cpp`

## Testing
- `cmake -S . -B build -DBUILD_TESTING=OFF` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6869f3a46db8832ab930db775f43b1e3