### PR TITLE
Prefix std C string uses

### DIFF
--- a/include/compat/shim.h
+++ b/include/compat/shim.h
@@ -215,7 +215,7 @@ namespace shim {
     // Append operations
     string& append(const char* s) {
         if (s) {
-            size_t slen = strlen(s);
+            size_t slen = std::strlen(s);
             if (size_ + slen + 1 > capacity_) {
                 size_t new_cap = (size_ + slen + 1) * 2;
                 char* new_data = static_cast<char*>(std::realloc(data_, new_cap));

--- a/tests/api/bridge_test.cpp
+++ b/tests/api/bridge_test.cpp
@@ -1,6 +1,7 @@
 #include "api/bridge.h"
 
 #include <gtest/gtest.h>
+#include <cstring>
 
 #include <atomic>
 #include <memory>
@@ -135,7 +136,7 @@ TEST_F(BridgeTest, ErrorBufferHandling) {
   detail::setLastError("Long error message for testing buffer handling");
   char small_buffer[5];
   sep_bridge_get_last_error(small_buffer, sizeof(small_buffer));
-  EXPECT_EQ(strlen(small_buffer), 4);  // 4 chars + null terminator
+  EXPECT_EQ(std::strlen(small_buffer), 4);  // 4 chars + null terminator
 }
 
 // Configuration Tests

--- a/tests/blender/mesh_handler_test.cpp
+++ b/tests/blender/mesh_handler_test.cpp
@@ -1,6 +1,7 @@
 #include "blender/mesh_handler.h"
 
 #include <gtest/gtest.h>
+#include <cstring>
 #include <cmath>
 #include <memory>
 #include "quantum/data.hpp"
@@ -29,7 +30,7 @@ class MeshHandlerTest : public ::testing::Test {
     float vertices[8][3] = {{-1, -1, -1}, {1, -1, -1}, {1, 1, -1}, {-1, 1, -1},
                             {-1, -1, 1},  {1, -1, 1},  {1, 1, 1},  {-1, 1, 1}};
     for (int i = 0; i < 8; ++i) {
-      memcpy(mesh_->mvert[i].co, vertices[i], sizeof(float) * 3);
+      std::memcpy(mesh_->mvert[i].co, vertices[i], sizeof(float) * 3);
     }
 
     // Initialize cube edges


### PR DESCRIPTION
## Summary
- fix bare strlen in shim.h
- prefix C string calls in tests

## Testing
- `cmake --version`

------
https://chatgpt.com/codex/tasks/task_e_6869f3a01b04832aa3bada4fe69367ef