### PR TITLE
Fix bare C calls to use std namespace

### DIFF
--- a/examples/flocking_sim.cpp
+++ b/examples/flocking_sim.cpp
@@ -1,6 +1,8 @@
 #include <iostream>
 #include <vector>
 #include <random>
+#include <ctime>
+#include <time.h>
 #include <glm/vec3.hpp>
 #include <glm/gtx/norm.hpp>
 
@@ -16,7 +18,7 @@ int main() {
     constexpr float dt = 0.05f;
 
     std::vector<sep::pattern::PatternData> agents(kAgentCount);
-    std::default_random_engine rng(static_cast<unsigned>(time(nullptr)));
+    std::default_random_engine rng(static_cast<unsigned>(std::time(nullptr)));
     std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
 
     for (int i = 0; i < kAgentCount; ++i) {

--- a/examples/workbench/demos/flocking_demo.cpp
+++ b/examples/workbench/demos/flocking_demo.cpp
@@ -2,13 +2,15 @@
 #include "sep_engine_wrapper.h"
 #include <glm/gtx/norm.hpp>
 #include <glm/gtc/random.hpp>
+#include <ctime>
+#include <time.h>
 
 namespace sep {
 namespace workbench {
 
 void FlockingDemo::init() {
     agents_.clear();
-    std::default_random_engine rng(static_cast<unsigned>(time(nullptr)));
+    std::default_random_engine rng(static_cast<unsigned>(std::time(nullptr)));
     std::uniform_real_distribution<float> pos(-10.f, 10.f);
     std::uniform_real_distribution<float> vel(-1.f, 1.f);
 

--- a/include/compat/shim.h
+++ b/include/compat/shim.h
@@ -215,7 +215,7 @@ namespace shim {
     // Append operations
     string& append(const char* s) {
         if (s) {
-            size_t slen = strlen(s);
+            size_t slen = std::strlen(s);
             if (size_ + slen + 1 > capacity_) {
                 size_t new_cap = (size_ + slen + 1) * 2;
                 char* new_data = static_cast<char*>(std::realloc(data_, new_cap));

--- a/tests/api/bridge_test.cpp
+++ b/tests/api/bridge_test.cpp
@@ -7,6 +7,7 @@
 #include <nlohmann/json.hpp>
 #include <string>
 #include <thread>
+#include <cstring>
 
 #include "api/bridge.hpp"
 #include "context/mock_processor.hpp"
@@ -135,7 +136,7 @@ TEST_F(BridgeTest, ErrorBufferHandling) {
   detail::setLastError("Long error message for testing buffer handling");
   char small_buffer[5];
   sep_bridge_get_last_error(small_buffer, sizeof(small_buffer));
-  EXPECT_EQ(strlen(small_buffer), 4);  // 4 chars + null terminator
+  EXPECT_EQ(std::strlen(small_buffer), 4);  // 4 chars + null terminator
 }
 
 // Configuration Tests

--- a/tests/blender/mesh_handler_test.cpp
+++ b/tests/blender/mesh_handler_test.cpp
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 #include <cmath>
 #include <memory>
+#include <cstring>
 #include "quantum/data.hpp"
 #include "quantum/types.h"
 #include "blender/mesh_handler.h"
@@ -29,7 +30,7 @@ class MeshHandlerTest : public ::testing::Test {
     float vertices[8][3] = {{-1, -1, -1}, {1, -1, -1}, {1, 1, -1}, {-1, 1, -1},
                             {-1, -1, 1},  {1, -1, 1},  {1, 1, 1},  {-1, 1, 1}};
     for (int i = 0; i < 8; ++i) {
-      memcpy(mesh_->mvert[i].co, vertices[i], sizeof(float) * 3);
+      std::memcpy(mesh_->mvert[i].co, vertices[i], sizeof(float) * 3);
     }
 
     // Initialize cube edges

--- a/third_party/crow/include/crow/TinySHA1.hpp
+++ b/third_party/crow/include/crow/TinySHA1.hpp
@@ -56,8 +56,8 @@ namespace sha1
         virtual ~SHA1() {}
         SHA1(const SHA1& s) { *this = s; }
         const SHA1& operator = (const SHA1& s) {
-            memcpy(m_digest, s.m_digest, 5 * sizeof(uint32_t));
-            memcpy(m_block, s.m_block, 64);
+            std::memcpy(m_digest, s.m_digest, 5 * sizeof(uint32_t));
+            std::memcpy(m_block, s.m_block, 64);
             m_blockByteIndex = s.m_blockByteIndex;
             m_byteCount = s.m_byteCount;
             return *this;
@@ -119,7 +119,7 @@ namespace sha1
             processByte( static_cast<unsigned char>((bitCount>>8 ) & 0xFF));
             processByte( static_cast<unsigned char>((bitCount)     & 0xFF));
 
-            memcpy(digest, m_digest, 5 * sizeof(uint32_t));
+            std::memcpy(digest, m_digest, 5 * sizeof(uint32_t));
             return digest;
         }
         const uint8_t* getDigestBytes(digest8_t digest) {

--- a/third_party/crow/include/crow/http_parser_merged.h
+++ b/third_party/crow/include/crow/http_parser_merged.h
@@ -1930,7 +1930,7 @@ inline void
   http_parser_init(http_parser* parser)
 {
   void *data = parser->data; /* preserve application data */
-  memset(parser, 0, sizeof(*parser));
+  std::memset(parser, 0, sizeof(*parser));
   parser->data = data;
   parser->state = s_start_req;
   parser->http_errno = CHPE_OK;

--- a/third_party/crow/include/crow/http_server.h
+++ b/third_party/crow/include/crow/http_server.h
@@ -11,6 +11,8 @@
 #include <future>
 #include <memory>
 #include <vector>
+#include <ctime>
+#include <time.h>
 
 #include "crow/version.h"
 #include "crow/http_connection.h"
@@ -133,7 +135,7 @@ namespace crow // NOTE: Already documented in "crow/app.h"
 
                         std::string date_str;
                         auto update_date_str = [&] {
-                            auto last_time_t = time(0);
+                            auto last_time_t = std::time(0);
                             tm my_tm;
 
 #if defined(_MSC_VER) || defined(__MINGW32__)

--- a/third_party/crow/include/crow/json.h
+++ b/third_party/crow/include/crow/json.h
@@ -1263,7 +1263,7 @@ namespace crow // NOTE: Already documented in "crow/app.h"
         inline rvalue load(const char* data, size_t size)
         {
             char* s = new char[size + 1];
-            memcpy(s, data, size);
+            std::memcpy(s, data, size);
             s[size] = 0;
             auto ret = load_nocopy_internal(s, size);
             if (ret)
@@ -1275,7 +1275,7 @@ namespace crow // NOTE: Already documented in "crow/app.h"
 
         inline rvalue load(const char* data)
         {
-            return load(data, strlen(data));
+            return load(data, std::strlen(data));
         }
 
         inline rvalue load(const std::string& str)

--- a/third_party/crow/include/crow/logging.h
+++ b/third_party/crow/include/crow/logging.h
@@ -5,6 +5,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <ctime>
+#include <time.h>
 #include <iostream>
 #include <sstream>
 #include <string>
@@ -69,7 +70,7 @@ namespace crow
         static std::string timestamp()
         {
             char date[32];
-            time_t t = time(0);
+            time_t t = std::time(0);
 
             tm my_tm;
 

--- a/third_party/crow/include/crow/multipart.h
+++ b/third_party/crow/include/crow/multipart.h
@@ -3,6 +3,7 @@
 #include <string>
 #include <vector>
 #include <sstream>
+#include <cstring>
 
 #include "crow/http_request.h"
 #include "crow/returnable.h"
@@ -165,7 +166,7 @@ namespace crow
                 size_t found = header.find(boundary_text);
                 if (found != std::string::npos)
                 {
-                    std::string to_return(header.substr(found + strlen(boundary_text)));
+                    std::string to_return(header.substr(found + std::strlen(boundary_text)));
                     if (to_return[0] == '\"')
                     {
                         to_return = to_return.substr(1, to_return.length() - 2);

--- a/third_party/crow/include/crow/query_string.h
+++ b/third_party/crow/include/crow/query_string.h
@@ -175,7 +175,7 @@ inline char * qs_k2v(const char * key, char * const * qs_kv, size_t qs_kv_size, 
     size_t i;
     size_t key_len, skip;
 
-    key_len = strlen(key);
+    key_len = std::strlen(key);
 
 #ifdef _qsSORTING
 // TODO: binary search for key in the sorted qs_kv
@@ -205,7 +205,7 @@ inline std::unique_ptr<std::pair<std::string, std::string>> qs_dict_name2kv(cons
     size_t i;
     size_t name_len, skip_to_eq, skip_to_brace_open, skip_to_brace_close;
 
-    name_len = strlen(dict_name);
+    name_len = std::strlen(dict_name);
 
 #ifdef _qsSORTING
 // TODO: binary search for key in the sorted qs_kv
@@ -252,7 +252,7 @@ inline char * qs_scanvalue(const char * key, const char * qs, char * val, size_t
     if ( (tmp = strchr(qs, '?')) != NULL )
         qs = tmp + 1;
 
-    key_len = strlen(key);
+    key_len = std::strlen(key);
     while(qs[0] != '#' && qs[0] != '\0')
     {
         if ( qs_strncmp(key, qs, key_len) == 0 )

--- a/third_party/crow/tests/unittest.cpp
+++ b/third_party/crow/tests/unittest.cpp
@@ -8,6 +8,7 @@
 #include <thread>
 #include <type_traits>
 #include <regex>
+#include <cstring>
 
 #include "catch2/catch_all.hpp"
 #include "crow.h"
@@ -222,7 +223,7 @@ TEST_CASE("InvalidPathRouting")
     catch (std::exception& e)
     {
         auto expected_exception_text = "Internal error: Routes must start with a '/'";
-        CHECK(strcmp(expected_exception_text, e.what()) == 0);
+        CHECK(std::strcmp(expected_exception_text, e.what()) == 0);
     }
 } // InvalidPathRouting
 


### PR DESCRIPTION
## Summary
- use `std::strlen` in `shim.h`
- qualify C library calls with `std::` across the repo
- include `<cstring>` where needed
- prefix `std::time` usages and include `<ctime>`/`<time.h>`

## Testing
- `./build.sh` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6869f3a01b04832aa3bada4fe69367ef