### PR TITLE
Fix bare C calls

### DIFF
--- a/include/compat/shim.h
+++ b/include/compat/shim.h
@@ -215,7 +215,7 @@ namespace shim {
     // Append operations
     string& append(const char* s) {
         if (s) {
-            size_t slen = strlen(s);
+            size_t slen = std::strlen(s);
             if (size_ + slen + 1 > capacity_) {
                 size_t new_cap = (size_ + slen + 1) * 2;
                 char* new_data = static_cast<char*>(std::realloc(data_, new_cap));

--- a/tests/api/bridge_test.cpp
+++ b/tests/api/bridge_test.cpp
@@ -7,6 +7,7 @@
 #include <nlohmann/json.hpp>
 #include <string>
 #include <thread>
+#include <cstring>
 
 #include "api/bridge.hpp"
 #include "context/mock_processor.hpp"
@@ -135,7 +136,7 @@ TEST_F(BridgeTest, ErrorBufferHandling) {
   detail::setLastError("Long error message for testing buffer handling");
   char small_buffer[5];
   sep_bridge_get_last_error(small_buffer, sizeof(small_buffer));
-  EXPECT_EQ(strlen(small_buffer), 4);  // 4 chars + null terminator
+  EXPECT_EQ(std::strlen(small_buffer), 4);  // 4 chars + null terminator
 }
 
 // Configuration Tests

--- a/tests/blender/mesh_handler_test.cpp
+++ b/tests/blender/mesh_handler_test.cpp
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 #include <cmath>
 #include <memory>
+#include <cstring>
 #include "quantum/data.hpp"
 #include "quantum/types.h"
 #include "blender/mesh_handler.h"
@@ -29,7 +30,7 @@ class MeshHandlerTest : public ::testing::Test {
     float vertices[8][3] = {{-1, -1, -1}, {1, -1, -1}, {1, 1, -1}, {-1, 1, -1},
                             {-1, -1, 1},  {1, -1, 1},  {1, 1, 1},  {-1, 1, 1}};
     for (int i = 0; i < 8; ++i) {
-      memcpy(mesh_->mvert[i].co, vertices[i], sizeof(float) * 3);
+      std::memcpy(mesh_->mvert[i].co, vertices[i], sizeof(float) * 3);
     }
 
     // Initialize cube edges

--- a/third_party/crow/include/crow/TinySHA1.hpp
+++ b/third_party/crow/include/crow/TinySHA1.hpp
@@ -56,8 +56,8 @@ namespace sha1
         virtual ~SHA1() {}
         SHA1(const SHA1& s) { *this = s; }
         const SHA1& operator = (const SHA1& s) {
-            memcpy(m_digest, s.m_digest, 5 * sizeof(uint32_t));
-            memcpy(m_block, s.m_block, 64);
+            std::memcpy(m_digest, s.m_digest, 5 * sizeof(uint32_t));
+            std::memcpy(m_block, s.m_block, 64);
             m_blockByteIndex = s.m_blockByteIndex;
             m_byteCount = s.m_byteCount;
             return *this;
@@ -119,7 +119,7 @@ namespace sha1
             processByte( static_cast<unsigned char>((bitCount>>8 ) & 0xFF));
             processByte( static_cast<unsigned char>((bitCount)     & 0xFF));
 
-            memcpy(digest, m_digest, 5 * sizeof(uint32_t));
+            std::memcpy(digest, m_digest, 5 * sizeof(uint32_t));
             return digest;
         }
         const uint8_t* getDigestBytes(digest8_t digest) {

--- a/third_party/crow/include/crow/http_parser_merged.h
+++ b/third_party/crow/include/crow/http_parser_merged.h
@@ -1930,7 +1930,7 @@ inline void
   http_parser_init(http_parser* parser)
 {
   void *data = parser->data; /* preserve application data */
-  memset(parser, 0, sizeof(*parser));
+  std::memset(parser, 0, sizeof(*parser));
   parser->data = data;
   parser->state = s_start_req;
   parser->http_errno = CHPE_OK;

--- a/third_party/crow/include/crow/json.h
+++ b/third_party/crow/include/crow/json.h
@@ -1263,7 +1263,7 @@ namespace crow // NOTE: Already documented in "crow/app.h"
         inline rvalue load(const char* data, size_t size)
         {
             char* s = new char[size + 1];
-            memcpy(s, data, size);
+            std::memcpy(s, data, size);
             s[size] = 0;
             auto ret = load_nocopy_internal(s, size);
             if (ret)
@@ -1275,7 +1275,7 @@ namespace crow // NOTE: Already documented in "crow/app.h"
 
         inline rvalue load(const char* data)
         {
-            return load(data, strlen(data));
+            return load(data, std::strlen(data));
         }
 
         inline rvalue load(const std::string& str)

--- a/third_party/crow/include/crow/multipart.h
+++ b/third_party/crow/include/crow/multipart.h
@@ -3,6 +3,7 @@
 #include <string>
 #include <vector>
 #include <sstream>
+#include <cstring>
 
 #include "crow/http_request.h"
 #include "crow/returnable.h"
@@ -165,7 +166,7 @@ namespace crow
                 size_t found = header.find(boundary_text);
                 if (found != std::string::npos)
                 {
-                    std::string to_return(header.substr(found + strlen(boundary_text)));
+                    std::string to_return(header.substr(found + std::strlen(boundary_text)));
                     if (to_return[0] == '\"')
                     {
                         to_return = to_return.substr(1, to_return.length() - 2);

--- a/third_party/crow/include/crow/query_string.h
+++ b/third_party/crow/include/crow/query_string.h
@@ -175,7 +175,7 @@ inline char * qs_k2v(const char * key, char * const * qs_kv, size_t qs_kv_size, 
     size_t i;
     size_t key_len, skip;
 
-    key_len = strlen(key);
+    key_len = std::strlen(key);
 
 #ifdef _qsSORTING
 // TODO: binary search for key in the sorted qs_kv
@@ -205,7 +205,7 @@ inline std::unique_ptr<std::pair<std::string, std::string>> qs_dict_name2kv(cons
     size_t i;
     size_t name_len, skip_to_eq, skip_to_brace_open, skip_to_brace_close;
 
-    name_len = strlen(dict_name);
+    name_len = std::strlen(dict_name);
 
 #ifdef _qsSORTING
 // TODO: binary search for key in the sorted qs_kv
@@ -252,7 +252,7 @@ inline char * qs_scanvalue(const char * key, const char * qs, char * val, size_t
     if ( (tmp = strchr(qs, '?')) != NULL )
         qs = tmp + 1;
 
-    key_len = strlen(key);
+    key_len = std::strlen(key);
     while(qs[0] != '#' && qs[0] != '\0')
     {
         if ( qs_strncmp(key, qs, key_len) == 0 )

--- a/third_party/crow/tests/unittest.cpp
+++ b/third_party/crow/tests/unittest.cpp
@@ -8,6 +8,7 @@
 #include <thread>
 #include <type_traits>
 #include <regex>
+#include <cstring>
 
 #include "catch2/catch_all.hpp"
 #include "crow.h"
@@ -222,7 +223,7 @@ TEST_CASE("InvalidPathRouting")
     catch (std::exception& e)
     {
         auto expected_exception_text = "Internal error: Routes must start with a '/'";
-        CHECK(strcmp(expected_exception_text, e.what()) == 0);
+        CHECK(std::strcmp(expected_exception_text, e.what()) == 0);
     }
 } // InvalidPathRouting
 


### PR DESCRIPTION
## Summary
- prefix `strlen` with `std::` in shim implementation
- fix missing `<cstring>` and prefix memory ops in tests
- standardize C library calls in Crow third-party headers

## Testing
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6869f3a01b04832aa3bada4fe69367ef