### PR TITLE
Fix header order in blender pch

### DIFF
--- a/src/blender/blender_pch.h
+++ b/src/blender/blender_pch.h
@@ -1,4 +1,3 @@
-#include <string.h>
 #pragma once
 
 // 1. ABSOLUTELY FIRST: C Standard Library Headers
@@ -6,11 +5,11 @@
 // global namespace. Using the <c...> variants ensures proper namespace
 // pollution avoidance with modern compilers.
 #include <cstring>
+#include <ctime>
 #include <cstdlib>
 #include <cmath>
 #include <cstdint>
 #include <cstdio>
-#include <ctime>
 #include <cassert>
 
 // 2. Core C++ Standard Library Headers


### PR DESCRIPTION
## Summary
- clean up `blender_pch.h` includes

## Testing
- `cmake ..` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6869f39c5b5c832aaf7582ea6a53de24