### PR TITLE
Adjust blender_pch and add http_parser finder

### DIFF
--- a/cmake/Findhttp_parser.cmake
+++ b/cmake/Findhttp_parser.cmake
@@ -1,0 +1,20 @@
+# Try to locate http_parser library
+
+find_path(http_parser_INCLUDE_DIR http_parser.h)
+find_library(http_parser_LIBRARY NAMES http_parser)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(http_parser DEFAULT_MSG
+    http_parser_LIBRARY http_parser_INCLUDE_DIR)
+
+if(http_parser_FOUND)
+    set(http_parser_LIBRARIES ${http_parser_LIBRARY})
+    set(http_parser_INCLUDE_DIRS ${http_parser_INCLUDE_DIR})
+    if(NOT TARGET http_parser::http_parser)
+        add_library(http_parser::http_parser UNKNOWN IMPORTED)
+        set_target_properties(http_parser::http_parser PROPERTIES
+            IMPORTED_LOCATION "${http_parser_LIBRARY}"
+            INTERFACE_INCLUDE_DIRECTORIES "${http_parser_INCLUDE_DIR}"
+        )
+    endif()
+endif()

--- a/src/blender/blender_pch.h
+++ b/src/blender/blender_pch.h
@@ -1,4 +1,3 @@
-#include <string.h>
 #pragma once
 
 // 1. ABSOLUTELY FIRST: C Standard Library Headers
@@ -6,11 +5,11 @@
 // global namespace. Using the <c...> variants ensures proper namespace
 // pollution avoidance with modern compilers.
 #include <cstring>
+#include <ctime>
 #include <cstdlib>
 #include <cmath>
 #include <cstdint>
 #include <cstdio>
-#include <ctime>
 #include <cassert>
 
 // 2. Core C++ Standard Library Headers


### PR DESCRIPTION
## Summary
- clean up includes in blender precompiled header
- add a simple CMake module to locate http_parser
- attempted to rebuild `sep_blender`; configuration failed due to missing OpenVDB

## Testing
- `python _sep/testbed/verify_blender_pch_order.py`
- `cmake -S . -B cmake-make` *(fails: Could NOT find OpenVDB)*


------
https://chatgpt.com/codex/tasks/task_e_6869f39c5b5c832aaf7582ea6a53de24