### PR TITLE
Fix manifold config types

### DIFF
--- a/include/quantum/manifold_config.h
+++ b/include/quantum/manifold_config.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include "quantum/quantum_manifold_optimizer.h"
+#include "core/types.h"
 
 namespace sep::quantum::manifold {
-    extern MemoryConfig memory;
-    extern QuantumConfig quantum;
+    extern ::sep::config::MemoryThresholdConfig memory;
+    extern ::sep::config::QuantumThresholdConfig quantum;
     extern ::sep::config::CudaConfig cuda;
     extern ::sep::config::APIConfig api;
 }

--- a/src/manifold/manifold_definitions.cpp
+++ b/src/manifold/manifold_definitions.cpp
@@ -3,35 +3,37 @@
 namespace sep::quantum::manifold {
 
 // Memory tier optimization parameters
-MemoryConfig memory{
-  .adaptive_threshold_rate = 0.02f,
-  .hamiltonian_coupling = 0.42f,
-  .predictive_horizon_ms = 100.0f,
-  .pattern_cache_size = 10000
+::sep::config::MemoryThresholdConfig memory{
+  .promote_stm_to_mtm = 0.7f,
+  .promote_mtm_to_ltm = 0.9f,
+  .demote_threshold = 0.3f,
+  .fragmentation_threshold = 0.3f,
+  .stm_size = 1 << 20,
+  .mtm_size = 4 << 20,
+  .ltm_size = 16 << 20,
+  .stm_to_mtm_min_gen = 5,
+  .mtm_to_ltm_min_gen = 100,
+  .use_unified_memory = true,
+  .enable_compression = true
 };
 
 // Quantum processing enhancement
-QuantumConfig quantum{
-  .manifold_dimensions = 8,
-  .coherence_modulation_factor = 0.707f,
-  .rupture_detection_sensitivity = 0.3f,
-  .qfh_hierarchy_depth = 5
+::sep::config::QuantumThresholdConfig quantum{
+  .ltm_coherence_threshold = 0.9f,
+  .mtm_coherence_threshold = 0.6f,
+  .stability_threshold = 0.8f
 };
 
 // CUDA acceleration parameters
 ::sep::config::CudaConfig cuda{
-  .warp_tile_size = 16,
-  .coherence_block_size = 256,
-  .similarity_grid_dim = 32,
-  .enable_phase_modulation = true
+  .use_gpu = true,
+  .max_memory_mb = 8192,
+  .batch_size = 1024,
+  .gpu_memory_limit = 0.9f,
+  .enable_profiling = false
 };
 
 // API coherence modulation
-::sep::config::APIConfig api{
-  .base_coherence = 0.5f,
-  .context_weight = 0.3f,
-  .state_weight = 0.7f,
-  .superposition_states = 4
-};
+::sep::config::APIConfig api{};
 
 } // namespace sep::quantum::manifold


### PR DESCRIPTION
## Summary
- update quantum manifold config header to use modern config types
- adjust manifold definition values to match new config structures

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6869fd10cc24832a9070f2979c45e281