### PR TITLE
Add build toggles for Blender and Audio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,11 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 project(sep_engine VERSION 1.0.0 LANGUAGES C CXX)
 
+# Optional modules can be toggled at configure time. Disable them to build a
+# minimal engine when dependencies are missing.
+option(SEP_ENABLE_BLENDER "Enable Blender/Cycles Integration" ON)
+option(SEP_ENABLE_AUDIO "Enable PipeWire Audio Integration" ON)
+
 # Add include paths after project declaration
 include_directories(BEFORE ${CMAKE_SOURCE_DIR}/include)
 
@@ -57,9 +62,7 @@ find_package(CUDAToolkit REQUIRED)
 set(SEP_HAS_CUDA 1)
 add_compile_definitions(SEP_HAS_CUDA=1)
 
-# Blender integration is always built
-# Blender integration is disabled for the console workbench
-set(SEP_HAS_BLENDER 0)
+# Blender integration can be toggled at configure time
 
 # Ensure our custom Crow wrappers take precedence over the third-party headers
 include_directories(BEFORE
@@ -87,7 +90,6 @@ find_package(OSL REQUIRED)
 find_package(Alembic REQUIRED)
 
 # Audio support can be disabled
-option(SEP_ENABLE_AUDIO "Enable audio support" ON)
 # Invoke cmake with `-DSEP_ENABLE_AUDIO=OFF` to build without audio capture
 
 # Add subdirectories
@@ -102,7 +104,9 @@ if(SEP_ENABLE_AUDIO)
     add_subdirectory(src/audio)
     add_compile_definitions(SEP_HAS_AUDIO=1)
 endif()
-add_subdirectory(src/blender)
+if(SEP_ENABLE_BLENDER)
+    add_subdirectory(src/blender)
+endif()
 add_subdirectory(extern/cycles/third_party/cuew)
 add_subdirectory(extern/cycles/third_party/hipew)
 add_subdirectory(extern/cycles/third_party/sky)

--- a/docs/README.md
+++ b/docs/README.md
@@ -79,9 +79,10 @@ SEP can optionally render through Blender's Cycles engine. Building it requires
 a number of external packages such as OpenVDB, OpenImageIO, OpenEXR/Imath,
 OpenSubdiv and OpenImageDenoise. The helper script
 `scripts/setup_cycles_env.sh` exports all required environment variables, builds
-OpenVDB and then configures Cycles with CMake. Run this script after installing
-the dependencies and whenever you start a new shell that doesn't have those
-variables set.
+OpenVDB and then configures Cycles with CMake. **Run this script in every new
+terminal session** before configuring the project so CMake can locate the Cycles
+headers and libraries. Failing to source it will lead to missing header errors
+during compilation.
 
 The script defines variables including `OPENVDB_INCLUDE_DIR`,
 `OPENVDB_LIBRARY`, `OPENIMAGEIO_INCLUDE_DIR`, `OPENIMAGEIO_LIBRARY`,


### PR DESCRIPTION
## Summary
- allow Blender and PipeWire modules to be disabled at configure time
- document the requirement to source the Cycles environment script before building

## Testing
- `cmake .. -DSEP_ENABLE_BLENDER=OFF -DSEP_ENABLE_AUDIO=OFF` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6869ffbd789c832aad0a18b3f23a99fb