### PR TITLE
Fix build configuration and remove obsolete driver

### DIFF
--- a/include/quantum/manifold_config.h
+++ b/include/quantum/manifold_config.h
@@ -3,48 +3,14 @@
 #include "core/types.h"
 
 namespace sep::quantum::manifold {
-// Default configuration values used across the engine. These are defined as
-// inline variables so the header can be included in multiple translation
-// units without causing linker conflicts.
 
-inline ::sep::config::MemoryThresholdConfig memory{
-    .promote_stm_to_mtm = 0.7f,
-    .promote_mtm_to_ltm = 0.9f,
-    .demote_threshold = 0.3f,
-    .fragmentation_threshold = 0.3f,
-    .stm_size = 1 << 20,
-    .mtm_size = 4 << 20,
-    .ltm_size = 16 << 20,
-    .stm_to_mtm_min_gen = 5,
-    .mtm_to_ltm_min_gen = 100,
-    .use_unified_memory = true,
-    .enable_compression = true
-};
+// Default configuration values used across the engine.
+// They are declared here and defined in a single translation unit
+// to avoid duplicate symbol errors during linking.
 
-inline ::sep::config::QuantumThresholdConfig quantum{
-    .ltm_coherence_threshold = 0.9f,
-    .mtm_coherence_threshold = 0.6f,
-    .stability_threshold = 0.8f
-};
+extern ::sep::config::MemoryThresholdConfig memory;
+extern ::sep::config::QuantumThresholdConfig quantum;
+extern ::sep::config::CudaConfig cuda;
+extern ::sep::config::APIConfig api;
 
-inline ::sep::config::CudaConfig cuda{
-    .use_gpu = true,
-    .max_memory_mb = 8192,
-    .batch_size = 1024,
-    .gpu_memory_limit = 0.9f,
-    .enable_profiling = false
-};
-
-inline ::sep::config::APIConfig api{
-    .max_connections = 1000,
-    .timeout_ms = 5000,
-    .host = "127.0.0.1",
-    .port = 8080,
-    .threads = 4,
-    .keep_alive_timeout_ms = 15000,
-    .log_level = "info",
-    .enable_metrics = true,
-    .max_batch_size = 1024
-};
-}
-
+} // namespace sep::quantum::manifold

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,34 +5,24 @@ set(SEP_INCLUDE_DIRS
     ${PIPEWIRE_INCLUDE_DIRS}
 )
 
-# Add component subdirectories
-add_subdirectory(api)
-if(SEP_WITH_AUDIO)
-    add_subdirectory(audio)
-endif()
-if(SEP_WITH_CYCLES)
-    add_subdirectory(blender)
-endif()
-add_subdirectory(compat)
+# Component subdirectories
 add_subdirectory(core)
 add_subdirectory(compat)
-add_subdirectory(manifold)
+add_subdirectory(embeddings)
 add_subdirectory(memory)
 add_subdirectory(quantum)
-add_subdirectory(embeddings)
 add_subdirectory(api)
-if(SEP_WITH_CYCLES)
-    add_subdirectory(blender)
-endif()
 if(SEP_WITH_AUDIO)
     add_subdirectory(audio)
 endif()
+if(SEP_WITH_CYCLES)
+    add_subdirectory(blender)
+endif()
 
-# --- CORRECTED EXECUTABLE TARGET ---
+# Main executable used for development testing
 add_executable(sep_engine
     main.cpp
 )
-
 set_target_properties(sep_engine PROPERTIES CXX_STANDARD 17)
 
 target_include_directories(sep_engine PRIVATE ${SEP_INCLUDE_DIRS})
@@ -45,18 +35,9 @@ target_link_libraries(sep_engine PRIVATE
 if(SEP_WITH_CYCLES)
     target_link_libraries(sep_engine PRIVATE sep_blender)
 endif()
-
-if(SEP_WITH_CYCLES)
-    target_link_libraries(sep_engine PRIVATE sep_blender)
-endif()
 if(SEP_WITH_AUDIO)
     target_link_libraries(sep_engine PRIVATE sep_audio)
 endif()
-
 if(TARGET CUDA::cudart)
     target_link_libraries(sep_engine PRIVATE CUDA::cudart)
-endif()
-
-if(SEP_WITH_CYCLES)
-    target_link_libraries(sep_engine PRIVATE sep_blender)
 endif()

--- a/src/blender/CMakeLists.txt
+++ b/src/blender/CMakeLists.txt
@@ -9,7 +9,7 @@ find_package(OSL REQUIRED)
 find_package(TBB REQUIRED)
 # Add other find_package() calls here for Embree, OpenVDB etc. as needed
 
-add_library(sep_blender SHARED
+add_library(sep_blender STATIC
     api.cpp
     blender_integration.cpp
     compression.cpp
@@ -18,7 +18,6 @@ add_library(sep_blender SHARED
     factory.cpp
     gpu_context.cpp
     mesh_handler.cpp
-    oiio_output_driver.cpp
     pattern_visualization_pipeline.cpp
 )
 

--- a/src/blender/cycles_renderer.cpp
+++ b/src/blender/cycles_renderer.cpp
@@ -23,7 +23,6 @@
 
 // Project includes
 #include "blender/cycles_renderer.h"
-#include "blender/oiio_output_driver.h"
 #include "core/error_handler.h"
 #include "core/types.h"
 #include "quantum/data.hpp"

--- a/src/quantum/CMakeLists.txt
+++ b/src/quantum/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(sep_quantum STATIC
     pattern_evolution.cpp
     processor.cpp
     quantum_manifold_optimizer.cpp
+    manifold_config.cpp
 )
 
 target_include_directories(sep_quantum

--- a/src/quantum/manifold_config.cpp
+++ b/src/quantum/manifold_config.cpp
@@ -1,0 +1,45 @@
+#include "quantum/manifold_config.h"
+
+namespace sep::quantum::manifold {
+
+::sep::config::MemoryThresholdConfig memory{
+    .promote_stm_to_mtm = 0.7f,
+    .promote_mtm_to_ltm = 0.9f,
+    .demote_threshold = 0.3f,
+    .fragmentation_threshold = 0.3f,
+    .stm_size = 1 << 20,
+    .mtm_size = 4 << 20,
+    .ltm_size = 16 << 20,
+    .stm_to_mtm_min_gen = 5,
+    .mtm_to_ltm_min_gen = 100,
+    .use_unified_memory = true,
+    .enable_compression = true
+};
+
+::sep::config::QuantumThresholdConfig quantum{
+    .ltm_coherence_threshold = 0.9f,
+    .mtm_coherence_threshold = 0.6f,
+    .stability_threshold = 0.8f
+};
+
+::sep::config::CudaConfig cuda{
+    .use_gpu = true,
+    .max_memory_mb = 8192,
+    .batch_size = 1024,
+    .gpu_memory_limit = 0.9f,
+    .enable_profiling = false
+};
+
+::sep::config::APIConfig api{
+    .max_connections = 1000,
+    .timeout_ms = 5000,
+    .host = "127.0.0.1",
+    .port = 8080,
+    .threads = 4,
+    .keep_alive_timeout_ms = 15000,
+    .log_level = "info",
+    .enable_metrics = true,
+    .max_batch_size = 1024
+};
+
+} // namespace sep::quantum::manifold


### PR DESCRIPTION
## Summary
- clean up subdirectory logic in `src/CMakeLists.txt`
- switch `sep_blender` to a static library and drop obsolete driver source
- remove the unused `oiio_output_driver` include from `cycles_renderer.cpp`
- move default manifold configs into a new implementation file to avoid symbol conflicts

## Testing
- `cmake -DSEP_WITH_CYCLES=OFF -S . -B build` *(failed: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_686a056c59c8832aac376eafd9884fd4