### PR TITLE
Fix build headers and remove blender from API

### DIFF
--- a/examples/workbench/CMakeLists.txt
+++ b/examples/workbench/CMakeLists.txt
@@ -4,6 +4,9 @@ cmake_minimum_required(VERSION 3.16)
 # Build the full-featured server/visualizer
 add_executable(sep_workbench
     main.cpp
+    config.cpp
+    demo_manager.cpp
+    demos/genesis_pattern.cpp
 )
 
 set_target_properties(sep_workbench PROPERTIES CXX_STANDARD 17)

--- a/examples/workbench/demo_manager.hpp
+++ b/examples/workbench/demo_manager.hpp
@@ -6,6 +6,7 @@
 #include <functional>
 
 #include "sep_engine_wrapper.h"
+#include "core/engine.h"
 #include <glm/glm.hpp>
 
 

--- a/examples/workbench/demos/genesis_pattern.hpp
+++ b/examples/workbench/demos/genesis_pattern.hpp
@@ -2,6 +2,8 @@
 
 #include "demo_manager.hpp"
 #include <memory>
+#include "quantum/processor.h"
+#include "memory/quantum_coherence_manager.h"
 
 namespace sep {
 namespace workbench {

--- a/include/api/server.h
+++ b/include/api/server.h
@@ -179,7 +179,9 @@ class SEPApiServer : public Server {
   /**
    * @brief Setup Blender-specific routes
    */
+#if 0
   void setupBlenderRoutes();
+#endif
 
   /**
    * @brief Setup signal handlers

--- a/include/audio/capture.h
+++ b/include/audio/capture.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include "audio/types.h"
 
 namespace sep {
 namespace audio {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,7 +20,7 @@ if(SEP_WITH_CYCLES)
 endif()
 
 add_executable(sep_engine
-    main.cpp
+    server_main.cpp
 )
 set_target_properties(sep_engine PROPERTIES CXX_STANDARD 17)
 
@@ -28,15 +28,13 @@ target_include_directories(sep_engine PRIVATE ${SEP_INCLUDE_DIRS})
 
 target_link_libraries(sep_engine PRIVATE
     sep_api
+    sep_quantum
+    sep_memory
+    sep_core
+    sep_compat
     Threads::Threads
     ${CMAKE_DL_LIBS}
 )
-if(SEP_WITH_CYCLES)
-    target_link_libraries(sep_engine PRIVATE sep_blender)
-endif()
-if(SEP_WITH_AUDIO)
-    target_link_libraries(sep_engine PRIVATE sep_audio)
-endif()
 if(TARGET CUDA::cudart)
     target_link_libraries(sep_engine PRIVATE CUDA::cudart)
 endif()

--- a/src/api/server.cpp
+++ b/src/api/server.cpp
@@ -38,10 +38,6 @@
 #include "api/server.h"
 #include "quantum/cycles.h"
 #include "compat/types.h"
-#ifdef SEP_HAS_BLENDER
-#include "blender/cycles_renderer.h"
-#include "blender/api.h"
-#endif
 
 namespace sep::api {
 
@@ -834,6 +830,8 @@ void SEPApiServer::handleSignal(int signal) {
   }
 }
 
+// Blender-specific routes are disabled in the headless API build
+#if 0
 void SEPApiServer::setupBlenderRoutes() {
 #ifdef SEP_HAS_BLENDER
     // Pattern processing endpoint
@@ -1017,10 +1015,9 @@ void SEPApiServer::setupBlenderRoutes() {
         res.code = 200;
         return res;
         
-    });
 #endif  // SEP_HAS_BLENDER
-
 }
+#endif
 
 
 } // end namespace sep::api

--- a/src/server_main.cpp
+++ b/src/server_main.cpp
@@ -1,10 +1,8 @@
 #include "api/server.h"
 #include "core/manager.h"
 #include "core/logging.h"
-#include "blender/cycles_renderer.h"
 #include <iostream>
 #include <memory>
-#include <iostream>
 
 int main(int argc, char** argv) {
     sep::logging::Manager::initialize();
@@ -18,10 +16,7 @@ int main(int argc, char** argv) {
 
     logger->info("Configuration loaded. API will run on port {}.", api_cfg.port);
 
-    auto renderer = std::make_unique<sep::blender::ccl::CyclesRenderer>();
-    renderer->initialize();
-
-    sep::api::SEPApiServer server(api_cfg, renderer.get());
+    sep::api::SEPApiServer server(api_cfg, nullptr);
     logger->info("Server object created.");
 
     if (!server.run()) {


### PR DESCRIPTION
## Summary
- fix missing includes for audio and workbench headers
- include engine header in demo manager
- add processor and coherence manager headers to Genesis demo
- disable blender routes in API server
- rename `src/main.cpp` to `src/server_main.cpp`
- adjust CMake for server and workbench targets

## Testing
- `cmake -S . -B build -DBUILD_TESTING=ON` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_686a087da374832a85c866bf4a78e414