### PR TITLE
Fix build includes and headless setup

### DIFF
--- a/examples/workbench/CMakeLists.txt
+++ b/examples/workbench/CMakeLists.txt
@@ -1,64 +1,26 @@
 cmake_minimum_required(VERSION 3.16)
 
-# Add the workbench executable with its source files
-# Build the full-featured server/visualizer
 add_executable(sep_workbench
     main.cpp
+    config.cpp
+    demo_manager.cpp
+    demos/genesis_pattern.cpp
 )
 
 set_target_properties(sep_workbench PROPERTIES CXX_STANDARD 17)
 
-# Include paths for engine headers and Cycles
 target_include_directories(sep_workbench PRIVATE
     ${PROJECT_SOURCE_DIR}/include
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_SOURCE_DIR}/extern/cycles/src
 )
 
-# Link against engine libraries and Cycles dependencies
-# This mirrors the old sep_server target
 target_link_libraries(sep_workbench PRIVATE
     sep_api
     sep_blender
     sep_audio
-    sep_embeddings
     sep_quantum
     sep_memory
     sep_compat
     sep_core
-    cycles_session
-    cycles_scene
-    cycles_device
-    cycles_kernel_osl
-    cycles_subd
-    cycles_util
-    extern_sky
-    extern_cuew
-    extern_hipew
-    OpenImageIO
-    ${OPENVDB_LIBRARIES}
-    ${OPENSUBDIV_LIBRARIES}
-    openvdb
-    bf_intern_opensubdiv
-    ${OSL_LIBRARIES}
-    ${TBB_LIBRARIES}
-    ${CURL_LIBRARIES}
-    http_parser::http_parser
-    fmt::fmt
-    spdlog::spdlog
-    hiredis
-    pipewire-0.3
-    ${EMBREE_LIBRARIES}
-    Imath
-    ${OpenPGL_LIBRARIES}
-    ${OpenColorIO_LIBRARIES}
-    ${ALEMBIC_LIBRARIES}
+    Threads::Threads
     ${CMAKE_DL_LIBS}
-    ${Threads_LIBRARIES}
-    ${CUDAToolkit_LIBRARIES}
-    pthread
-    dl
-    rt
-    m
-    z
 )

--- a/examples/workbench/demo_manager.hpp
+++ b/examples/workbench/demo_manager.hpp
@@ -6,6 +6,7 @@
 #include <functional>
 
 #include "sep_engine_wrapper.h"
+#include "core/engine.h"
 #include <glm/glm.hpp>
 
 

--- a/examples/workbench/demos/genesis_pattern.hpp
+++ b/examples/workbench/demos/genesis_pattern.hpp
@@ -2,12 +2,12 @@
 
 #include "demo_manager.hpp"
 #include <memory>
+#include "quantum/processor.h"
+#include "memory/quantum_coherence_manager.h"
 
 namespace sep {
 namespace workbench {
 
-class PatternProcessor;
-class QuantumCoherenceManager;
 
 class GenesisPatternDemo : public Demo {
 public:

--- a/include/api/server.h
+++ b/include/api/server.h
@@ -177,9 +177,11 @@ class SEPApiServer : public Server {
   void setup_routes();
 
   /**
-   * @brief Setup Blender-specific routes
+   * @brief Setup Blender-specific routes (disabled in headless build)
    */
+#if 0
   void setupBlenderRoutes();
+#endif
 
   /**
    * @brief Setup signal handlers

--- a/include/audio/capture.h
+++ b/include/audio/capture.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include "audio/types.h"
 
 namespace sep {
 namespace audio {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,7 +20,7 @@ if(SEP_WITH_CYCLES)
 endif()
 
 add_executable(sep_engine
-    main.cpp
+    server_main.cpp
 )
 set_target_properties(sep_engine PROPERTIES CXX_STANDARD 17)
 
@@ -31,12 +31,7 @@ target_link_libraries(sep_engine PRIVATE
     Threads::Threads
     ${CMAKE_DL_LIBS}
 )
-if(SEP_WITH_CYCLES)
-    target_link_libraries(sep_engine PRIVATE sep_blender)
-endif()
-if(SEP_WITH_AUDIO)
-    target_link_libraries(sep_engine PRIVATE sep_audio)
-endif()
+
 if(TARGET CUDA::cudart)
     target_link_libraries(sep_engine PRIVATE CUDA::cudart)
 endif()

--- a/src/api/server.cpp
+++ b/src/api/server.cpp
@@ -834,6 +834,8 @@ void SEPApiServer::handleSignal(int signal) {
   }
 }
 
+// Blender-specific routes are disabled in the headless build
+#if 0
 void SEPApiServer::setupBlenderRoutes() {
 #ifdef SEP_HAS_BLENDER
     // Pattern processing endpoint
@@ -1018,9 +1020,10 @@ void SEPApiServer::setupBlenderRoutes() {
         return res;
         
     });
-#endif  // SEP_HAS_BLENDER
 
+#endif  // SEP_HAS_BLENDER
 }
+#endif // 0
 
 
 } // end namespace sep::api

--- a/src/server_main.cpp
+++ b/src/server_main.cpp
@@ -1,7 +1,6 @@
 #include "api/server.h"
 #include "core/manager.h"
 #include "core/logging.h"
-#include "blender/cycles_renderer.h"
 #include <iostream>
 #include <memory>
 #include <iostream>
@@ -18,10 +17,7 @@ int main(int argc, char** argv) {
 
     logger->info("Configuration loaded. API will run on port {}.", api_cfg.port);
 
-    auto renderer = std::make_unique<sep::blender::ccl::CyclesRenderer>();
-    renderer->initialize();
-
-    sep::api::SEPApiServer server(api_cfg, renderer.get());
+    sep::api::SEPApiServer server(api_cfg, nullptr);
     logger->info("Server object created.");
 
     if (!server.run()) {


### PR DESCRIPTION
## Summary
- include audio types directly in `capture.h`
- include engine header in workbench demo manager
- include processor and coherence manager headers in Genesis Pattern demo
- disable Blender routes in the API server for headless build
- rename main executable to `server_main.cpp` and adjust `src/CMakeLists.txt`
- slim down workbench CMake

## Testing
- `cmake -S . -B build` *(fails: Could not find nvcc, please set CUDAToolkit_ROOT)*

------
https://chatgpt.com/codex/tasks/task_e_686a087da374832a85c866bf4a78e414