### PR TITLE
Fix Blender routes build issue and update linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,9 +144,8 @@ target_include_directories(sep_engine PRIVATE
     ${CMAKE_SOURCE_DIR}/extern/cycles/src
 )
 target_link_libraries(sep_engine PRIVATE
+    # High-level modules
     sep_api
-    Threads::Threads
-    ${CMAKE_DL_LIBS}
 )
 
 if(SEP_WITH_CYCLES)
@@ -155,6 +154,20 @@ endif()
 if(SEP_WITH_AUDIO)
     target_link_libraries(sep_engine PRIVATE sep_audio)
 endif()
+
+target_link_libraries(sep_engine PRIVATE
+    # Domain logic
+    sep_quantum
+    sep_memory
+
+    # Low-level backend & foundation
+    sep_compat
+    sep_core
+
+    Threads::Threads
+    ${CURL_LIBRARIES}
+    ${CMAKE_DL_LIBS}
+)
 
 if(TARGET CUDA::cudart)
     target_link_libraries(sep_engine PRIVATE CUDA::cudart)

--- a/include/api/server.h
+++ b/include/api/server.h
@@ -177,9 +177,9 @@ class SEPApiServer : public Server {
   void setup_routes();
 
   /**
-   * @brief Setup Blender-specific routes (disabled)
+   * @brief Setup Blender-specific routes
    */
-#if 0
+#ifdef SEP_HAS_BLENDER
   void setupBlenderRoutes();
 #endif
 


### PR DESCRIPTION
## Summary
- declare `setupBlenderRoutes()` when Blender support is enabled
- reorder static library linking for `sep_engine`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686a0d798aa4832ab7e8e54e9f8ca4d9