### PR TITLE
Fix missing Blender route declaration

### DIFF
--- a/include/api/server.h
+++ b/include/api/server.h
@@ -177,9 +177,9 @@ class SEPApiServer : public Server {
   void setup_routes();
 
   /**
-   * @brief Setup Blender-specific routes (disabled)
+   * @brief Setup Blender-specific routes
    */
-#if 0
+#ifdef SEP_HAS_BLENDER
   void setupBlenderRoutes();
 #endif
 


### PR DESCRIPTION
## Summary
- add missing `setupBlenderRoutes` declaration when Blender is enabled

## Testing
- `cmake -S . -B build` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_686a0d798aa4832ab7e8e54e9f8ca4d9