### PR TITLE
Fix blender routes compile error

### DIFF
--- a/include/api/server.h
+++ b/include/api/server.h
@@ -177,9 +177,9 @@ class SEPApiServer : public Server {
   void setup_routes();
 
   /**
-   * @brief Setup Blender-specific routes (disabled)
+   * @brief Setup Blender-specific routes (enabled if SEP_HAS_BLENDER)
    */
-#if 0
+#ifdef SEP_HAS_BLENDER
   void setupBlenderRoutes();
 #endif
 


### PR DESCRIPTION
## Summary
- expose `setupBlenderRoutes` in `SEPApiServer`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686a0d798aa4832ab7e8e54e9f8ca4d9