### PR TITLE
Initialize renderer in entry point

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,7 +137,7 @@ add_subdirectory(examples/workbench)
 
 # Main executable
 # Minimal CLI to test the core engine logic
-add_executable(sep_engine src/api/server.cpp)
+add_executable(sep_engine src/server_main.cpp)
 set_target_properties(sep_engine PROPERTIES CXX_STANDARD 17)
 target_include_directories(sep_engine PRIVATE
     ${CMAKE_SOURCE_DIR}/include

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -27,6 +27,7 @@ target_link_libraries(sep_api
         sep_compat
         sep_embeddings
         http_parser::http_parser
+        $<$<BOOL:${SEP_WITH_CYCLES}>:sep_blender>
 )
 
 target_include_directories(sep_api

--- a/src/api/server.cpp
+++ b/src/api/server.cpp
@@ -38,6 +38,9 @@
 #include "api/server.h"
 #include "quantum/cycles.h"
 #include "compat/types.h"
+#ifdef SEP_HAS_CYCLES
+#include "blender/cycles_renderer.h"
+#endif
 
 namespace sep::api {
 

--- a/src/server_main.cpp
+++ b/src/server_main.cpp
@@ -1,6 +1,9 @@
 #include "api/server.h"
 #include "core/manager.h"
 #include "core/logging.h"
+#ifdef SEP_HAS_CYCLES
+#include "blender/cycles_renderer.h"
+#endif
 #include <iostream>
 #include <memory>
 
@@ -14,9 +17,16 @@ int main(int argc, char** argv) {
     const auto& api_cfg = cfg_manager.getAPIConfig();
     logger->info("Configuration loaded. API will run on port {}.", api_cfg.port);
 
-    logger->info("Configuration loaded. API will run on port {}.", api_cfg.port);
+    std::unique_ptr<sep::blender::ccl::CyclesRenderer> renderer = nullptr;
+#ifdef SEP_HAS_CYCLES
+    renderer = std::make_unique<sep::blender::ccl::CyclesRenderer>();
+    if (renderer->initialize() != sep::SEPResult::SUCCESS) {
+        logger->critical("Failed to initialize Cycles Renderer!");
+        return 1;
+    }
+#endif
 
-    sep::api::SEPApiServer server(api_cfg, nullptr);
+    sep::api::SEPApiServer server(api_cfg, renderer.get());
     logger->info("Server object created.");
 
     if (!server.run()) {


### PR DESCRIPTION
## Summary
- build engine executable from server_main.cpp
- link Blender renderer when SEP_WITH_CYCLES is enabled
- initialize optional Cycles renderer in `main`

## Testing
- `cmake -B build -S . -DSEP_WITH_CYCLES=OFF -DSEP_WITH_AUDIO=OFF` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_686a110ab6c8832a937e91f2aff631f0