### PR TITLE
Remove blender routes from API server

### DIFF
--- a/src/api/server.cpp
+++ b/src/api/server.cpp
@@ -35,9 +35,6 @@
 #include "quantum/types.h"
 #include "api/server.h"
 #include "compat/types.h"
-#ifdef SEP_HAS_CYCLES
-#include "blender/cycles_renderer.h"
-#endif
 
 namespace sep::api {
 
@@ -826,126 +823,6 @@ void SEPApiServer::handleSignal(int signal) {
   }
 }
 
-// Blender-specific routes are disabled in the headless API build
-void SEPApiServer::setupBlenderRoutes() {
-#ifdef SEP_HAS_BLENDER
-    // Pattern processing endpoint
-    app_->route_dynamic("/api/v1/patterns/process")
-    .methods(::crow::HTTPMethod::POST)([this](const ::crow::request& req) {
-        try {
-            auto json = nlohmann::json::parse(std::string(req.body));
-            if (!json.is_object()) {
-                ::crow::response res;
-                res.code = HTTP_BAD_REQUEST;
-                res.write("Invalid JSON format");
-                return res;
-            }
+// Blender-specific routes removed from SEPApiServer
 
-            // Extract mesh data
-            auto mesh = json["mesh"];
-            auto config = json["config"];
-            
-            // Configure processing
-            sep::quantum::ProcessingConfig proc_config;
-            proc_config.max_patterns = config.value("max_patterns", 10000);
-            proc_config.mutation_rate = config.value("mutation_rate", 0.01f);
-            proc_config.ltm_coherence_threshold = config.value("ltm_threshold", 0.9f);
-            proc_config.mtm_coherence_threshold = config.value("mtm_threshold", 0.6f);
-            proc_config.stability_threshold = config.value("stability", 0.8f);
-            proc_config.enable_cuda = config.value("enable_cuda", false);
-            
-            // Use persistent pattern processor
-            auto* processor = pattern_processor_.get();
-            if (!processor) {
-                ::crow::response res;
-                res.body = "Pattern processor unavailable";
-                res.code = 500;
-                return res;
-            }
-
-            // Process vertices through quantum manifold
-            std::vector<sep::pattern::PatternData> patterns;
-            for (const auto& v : mesh["vertices"]) {
-                sep::pattern::PatternData pattern;
-                pattern.position = glm::vec4(
-                    v[0].get<float>(),
-                    v[1].get<float>(),
-                    v[2].get<float>(),
-                    1.0f
-                );
-                pattern.attributes = glm::vec4(0.0f);
-                patterns.push_back(pattern);
-            }
-
-            // Add patterns to processor
-            for (const auto& pattern : patterns) {
-                if (processor->addPattern(pattern) != sep::SEPResult::SUCCESS) {
-                    ::crow::response res;
-                    res.body = "Failed to add pattern to processor";
-                    res.code = 500;
-                    return res;
-                }
-            }
-
-            // Process patterns
-            const auto& results = processor->process();
-
-            // Prepare response JSON
-            nlohmann::json response;
-            response["success"] = true;
-
-            // Processed patterns
-            nlohmann::json processed_patterns = nlohmann::json::array();
-            for (const auto& pattern : results) {
-                nlohmann::json processed;
-                nlohmann::json attr_array = nlohmann::json::array();
-                attr_array.push_back(pattern.attributes.x);
-                attr_array.push_back(pattern.attributes.y);
-                attr_array.push_back(pattern.attributes.z);
-                attr_array.push_back(pattern.attributes.w);
-                processed["attributes"] = attr_array;
-                processed["metrics"] = {
-                    {"coherence", pattern.coherence},
-                    {"stability", pattern.stability},
-                    {"entropy", pattern.entropy}
-                };
-                processed_patterns.push_back(processed);
-            }
-            response["processed_patterns"] = processed_patterns;
-
-            // Return success response
-            ::crow::response res;
-            res.body = response.dump();
-            res.code = 200;
-            return res;
-
-        } catch (const std::exception& e) {
-            ::crow::response res;
-            res.body = std::string("Error processing request: ") + e.what();
-            res.code = 500;
-            return res;
-        }
-    });
-
-    
-    // Health check endpoint
-    app_->route_dynamic("/health")
-    .methods(::crow::HTTPMethod::GET)
-    ([](const ::crow::request&) {
-        nlohmann::json response = {
-            {"status", "running"},
-            {"engine_initialized", sep::api::SepEngine::getInstance().getHealthStatus()["initialized"]},
-            {"quantum_processor_ready", true},
-            {"cycles_available", true}, // Cycles support determined at build time
-            {"timestamp", std::time(nullptr)}
-        };
-        
-        ::crow::response res;
-        res.body = response.dump();
-        res.code = 200;
-        return res;
-    });
-}
-
-} // end namespace sep::api
-#endif  // SEP_HAS_BLENDER
+} // namespace sep::api

--- a/src/server_main.cpp
+++ b/src/server_main.cpp
@@ -6,9 +6,6 @@
 #endif
 #include <iostream>
 #include <memory>
-#ifdef SEP_HAS_CYCLES
-#include "blender/cycles_renderer.h"
-#endif
 
 int main(int argc, char** argv) {
     sep::logging::Manager::initialize();


### PR DESCRIPTION
## Summary
- remove unused Blender routes
- tidy server_main includes

## Testing
- `cmake -S . -B build -DSEP_WITH_CYCLES=OFF` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_686a19b74a3c832a9e767f1a82425707