### PR TITLE
Fix SEPApiServer braces for headless build

### DIFF
--- a/src/api/server.cpp
+++ b/src/api/server.cpp
@@ -945,7 +945,7 @@ void SEPApiServer::setupBlenderRoutes() {
         res.code = 200;
         return res;
     });
+#endif  // SEP_HAS_BLENDER
 }
 
 } // end namespace sep::api
-#endif  // SEP_HAS_BLENDER


### PR DESCRIPTION
## Summary
- move closing `#endif` so `setupBlenderRoutes` compiles without `SEP_HAS_BLENDER`
- close namespace outside of conditional

## Testing
- `g++ -fsyntax-only -std=c++17 src/api/server.cpp` *(fails: compat/shim.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_686a900fe114832abb82b77b7b654f94