### PR TITLE
Fix missing closing brace in server.cpp

### DIFF
--- a/src/api/server.cpp
+++ b/src/api/server.cpp
@@ -949,3 +949,6 @@ void SEPApiServer::setupBlenderRoutes() {
 
 } // end namespace sep::api
 #endif  // SEP_HAS_BLENDER
+
+}
+


### PR DESCRIPTION
## Summary
- add missing closing bracket at end of `src/api/server.cpp`

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_686a900fe114832abb82b77b7b654f94