### PR TITLE
Fix server namespace closure

### DIFF
--- a/src/api/server.cpp
+++ b/src/api/server.cpp
@@ -949,3 +949,5 @@ void SEPApiServer::setupBlenderRoutes() {
 
 } // end namespace sep::api
 #endif  // SEP_HAS_BLENDER
+}
+


### PR DESCRIPTION
## Summary
- close sep::api namespace in `src/api/server.cpp`

## Testing
- `g++ -fsyntax-only -std=c++17 -Iinclude -Isrc -Ithird_party src/api/server.cpp` *(fails: nlohmann/json.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686a900fe114832abb82b77b7b654f94