### PR TITLE
Fix API server namespace closure

### DIFF
--- a/src/api/server.cpp
+++ b/src/api/server.cpp
@@ -945,7 +945,7 @@ void SEPApiServer::setupBlenderRoutes() {
         res.code = 200;
         return res;
     });
+#endif  // SEP_HAS_BLENDER
 }
 
 } // end namespace sep::api
-#endif  // SEP_HAS_BLENDER


### PR DESCRIPTION
## Summary
- close `sep::api` namespace correctly in `server.cpp`

## Testing
- `cmake ..` (fails: `Could not find nvcc, please set CUDAToolkit_ROOT`)


------
https://chatgpt.com/codex/tasks/task_e_686a900fe114832abb82b77b7b654f94