### PR TITLE
Fix CMake paths and config duplication

### DIFF
--- a/examples/workbench/CMakeLists.txt
+++ b/examples/workbench/CMakeLists.txt
@@ -12,6 +12,7 @@ set_target_properties(sep_workbench PROPERTIES CXX_STANDARD 17)
 target_include_directories(sep_workbench PRIVATE
     ${PROJECT_SOURCE_DIR}/include
     ${PROJECT_SOURCE_DIR}/examples/workbench
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/extern/cycles/src>
 )
 
 target_link_libraries(sep_workbench PRIVATE

--- a/examples/workbench/config.hpp
+++ b/examples/workbench/config.hpp
@@ -96,16 +96,6 @@ struct NeuralDemoConfig {
     } neuron;
 };
 
-struct DigitalPhysicsConfig {
-    struct {
-        int width;
-        int height;
-    } grid;
-    struct {
-        std::string rule;
-    } rules;
-};
-
 struct FlockingConfig {
     int agent_count;
     float cohesion_weight;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,6 +34,11 @@ target_link_libraries(sep_engine PRIVATE
     sep_compat
     Threads::Threads
     ${CMAKE_DL_LIBS}
+
+    cycles_kernel
+    cycles_scene
+    cycles_device
+    cycles_util
 )
 if(SEP_WITH_CYCLES)
     target_link_libraries(sep_engine PRIVATE sep_blender)


### PR DESCRIPTION
## Summary
- link sep_engine with Cycles libraries
- expose Cycles headers to sep_workbench
- remove duplicated `DigitalPhysicsConfig` struct definition

## Testing
- `cmake -B build -S .` *(fails: could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_686a9bbdbe64832a9f4d7fc3751d0d37