### PR TITLE
Fix build for workbench and engine

### DIFF
--- a/examples/workbench/CMakeLists.txt
+++ b/examples/workbench/CMakeLists.txt
@@ -12,6 +12,7 @@ set_target_properties(sep_workbench PROPERTIES CXX_STANDARD 17)
 target_include_directories(sep_workbench PRIVATE
     ${PROJECT_SOURCE_DIR}/include
     ${PROJECT_SOURCE_DIR}/examples/workbench
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/extern/cycles/src>
 )
 
 target_link_libraries(sep_workbench PRIVATE

--- a/examples/workbench/config.hpp
+++ b/examples/workbench/config.hpp
@@ -96,16 +96,6 @@ struct NeuralDemoConfig {
     } neuron;
 };
 
-struct DigitalPhysicsConfig {
-    struct {
-        int width;
-        int height;
-    } grid;
-    struct {
-        std::string rule;
-    } rules;
-};
-
 struct FlockingConfig {
     int agent_count;
     float cohesion_weight;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,7 +36,13 @@ target_link_libraries(sep_engine PRIVATE
     ${CMAKE_DL_LIBS}
 )
 if(SEP_WITH_CYCLES)
-    target_link_libraries(sep_engine PRIVATE sep_blender)
+    target_link_libraries(sep_engine PRIVATE
+        sep_blender
+        cycles_kernel
+        cycles_scene
+        cycles_device
+        cycles_util
+    )
 endif()
 if(TARGET CUDA::cudart)
     target_link_libraries(sep_engine PRIVATE CUDA::cudart)


### PR DESCRIPTION
## Summary
- add cycles source headers to workbench build
- link sep_engine with cycles libraries when cycles are enabled
- remove duplicate DigitalPhysicsConfig structure

## Testing
- `cmake ..` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_686a9bbdbe64832a9f4d7fc3751d0d37