### PR TITLE
Enable demo mode for workbench build

### DIFF
--- a/examples/workbench/CMakeLists.txt
+++ b/examples/workbench/CMakeLists.txt
@@ -9,6 +9,13 @@ add_executable(sep_workbench
 
 set_target_properties(sep_workbench PROPERTIES CXX_STANDARD 17)
 
+# Build the workbench in "demo" mode so it links against the
+# lightweight wrapper implementations defined in
+# `sep_engine_wrapper.h`.  This avoids pulling in the full engine
+# dependencies and provides stubbed renderer/engine behaviour that
+# matches the workbench examples.
+target_compile_definitions(sep_workbench PRIVATE SEP_WORKBENCH_DEMO=1)
+
 target_include_directories(sep_workbench PRIVATE
     ${PROJECT_SOURCE_DIR}/include
     ${PROJECT_SOURCE_DIR}/examples/workbench

--- a/examples/workbench/main.cpp
+++ b/examples/workbench/main.cpp
@@ -1,45 +1,68 @@
-#include "core/manager.h"
-#include "blender/cycles_renderer.h"
-#include "quantum/processor.h"
+#include "sep_engine_wrapper.h"
+#include "demo_manager.hpp"
 #include "demos/genesis_pattern.hpp"
 #include <iostream>
 #include <memory>
 #include <thread>
 #include <chrono>
-#include <iostream>
-#include <memory>
-#include <thread>
+
+using namespace sep;
+using namespace sep::workbench;
 
 int main() {
-    // 1. Initialize Core Systems
-    sep::config::ConfigManager::getInstance().initialize(0, nullptr);
-    auto& engine = sep::core::Engine::getInstance();
-    engine.init(sep::config::ConfigManager::getInstance().getAPIConfig());
+    // Create engine and renderer using the wrapper implementations.  In demo
+    // mode these classes provide lightweight stubs so we can run the
+    // workbench without the full engine stack.
+    auto engine    = std::make_unique<Engine>();
+    auto renderer  = std::make_unique<CyclesRenderer>();
 
-    // 2. Initialize the Renderer
-    sep::blender::ccl::CyclesRenderer renderer;
-    if (renderer.initialize() != sep::SEPResult::SUCCESS) {
+    if (!engine->initialize()) {
+        std::cerr << "Failed to initialize engine" << std::endl;
+        return 1;
+    }
+
+    if (!renderer->initialize()) {
         std::cerr << "FATAL: Could not initialize Cycles renderer." << std::endl;
         return 1;
     }
 
-    // 3. Initialize and run the first demo
-    auto demo = std::make_unique<sep::workbench::GenesisPatternDemo>();
-    demo->init(engine, &renderer);
+    // Register and start the Genesis demo
+    auto& demo_manager = DemoManager::getInstance();
+    demo_manager.initialize(engine.get(), renderer.get());
+    demo_manager.registerDemo("genesis", [] {
+        return std::make_unique<GenesisPatternDemo>();
+    });
+    if (!demo_manager.switchToDemo("genesis")) {
+        std::cerr << "Failed to start demo" << std::endl;
+        return 1;
+    }
 
     std::cout << "Workbench is running. Close the window to exit." << std::endl;
 
-    // 4. Main Loop
-    while (!renderer.shouldClose()) {
-        demo->update(0.016f);
-        demo->render();
-        renderer.present();
+    // Main loop using the stub event API provided by the renderer
+    const float dt = 1.0f / 60.0f;
+    while (!renderer->shouldClose()) {
+        // Forward input events to the current demo
+        if (renderer->hasKeyEvent()) {
+            unsigned char key = renderer->getLastKey();
+            demo_manager.handleKeyboard(key);
+        }
+        if (renderer->hasMouseEvent()) {
+            int x, y, button;
+            renderer->getLastMouseEvent(x, y, button);
+            demo_manager.handleMouse(x, y, button);
+        }
+
+        demo_manager.update(dt);
+        demo_manager.render();
+        renderer->present();
         std::this_thread::sleep_for(std::chrono::milliseconds(16));
     }
 
-    demo->cleanup();
-    engine.shutdown();
-    std::cout << "Workbench shut down cleanly." << std::endl;
+    demo_manager.cleanup();
+    renderer.reset();
+    engine.reset();
 
+    std::cout << "Workbench shut down cleanly." << std::endl;
     return 0;
 }


### PR DESCRIPTION
## Summary
- enable `SEP_WORKBENCH_DEMO` when building the workbench example
- rewrite the workbench's `main.cpp` to use the lightweight wrapper API

## Testing
- `npm test` *(fails: Missing script)*
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_686a9db90e30832aa6bf3014e6b4c1e0