### PR TITLE
Fix workbench config usage and provide profiler stub

### DIFF
--- a/examples/workbench/main.cpp
+++ b/examples/workbench/main.cpp
@@ -38,7 +38,7 @@ int main() {
 }
 
 void initializeEngine() {
-    const auto& config = Config::getInstance();
+    const auto& config = workbench::Config::getInstance();
     const auto& engine_config = config.engine();
 
     g_engine = std::make_unique<Engine>();
@@ -53,7 +53,7 @@ void initializeEngine() {
 
 void initializeRenderer() {
     // Load configuration
-    auto& config = Config::getInstance();
+    auto& config = workbench::Config::getInstance();
     if (!config.load("config.json")) {
         throw std::runtime_error("Failed to load configuration");
     }

--- a/src/blender/CMakeLists.txt
+++ b/src/blender/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(sep_blender STATIC
     compression.cpp
     compression_utils.cpp
     cycles_renderer.cpp
+    profiler_stub.cpp
     factory.cpp
     gpu_context.cpp
     mesh_handler.cpp

--- a/src/blender/profiler_stub.cpp
+++ b/src/blender/profiler_stub.cpp
@@ -1,0 +1,16 @@
+namespace ccl {
+class Profiler {
+public:
+    Profiler() = default;
+    ~Profiler() = default;
+    void reset(int, int) {}
+    void start() {}
+    void stop() {}
+    void add_state(void*) {}
+    void remove_state(void*) {}
+    unsigned long long get_event(int) { return 0; }
+    bool get_shader(int, unsigned long long&, unsigned long long&) { return false; }
+    bool get_object(int, unsigned long long&, unsigned long long&) { return false; }
+    bool active() const { return false; }
+};
+}


### PR DESCRIPTION
## Summary
- fix Config namespace usage in workbench example
- add minimal stub implementation of ccl::Profiler
- include stub in blender build

## Testing
- `./scripts/code_analysis_suite.sh` *(prints help)*

------
https://chatgpt.com/codex/tasks/task_e_686aabb61094832a97d9643a62234833