### PR TITLE
Fix missing include

### DIFF
--- a/examples/workbench/main.cpp
+++ b/examples/workbench/main.cpp
@@ -2,6 +2,7 @@
 #include <stdexcept>
 
 #include "demo_manager.hpp"
+#include "config.hpp"
 #include "demos/genesis_pattern.hpp"
 #include "demos/audio_visualizer.hpp"
 #include "demos/memory_garden.hpp"


### PR DESCRIPTION
## Summary
- include workbench config header so `Config::getInstance` is found

## Testing
- `cmake ..` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_686aabb61094832a97d9643a62234833