### PR TITLE
Decouple Cycles renderer from server executable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,7 +141,6 @@ add_executable(sep_engine src/server_main.cpp)
 set_target_properties(sep_engine PROPERTIES CXX_STANDARD 17)
 target_include_directories(sep_engine PRIVATE
     ${CMAKE_SOURCE_DIR}/include
-    ${CMAKE_SOURCE_DIR}/extern/cycles/src
 )
 
 # Configure server_main.cpp to conditionally include Cycles code
@@ -152,9 +151,7 @@ target_compile_definitions(sep_engine PRIVATE
 )
 
 target_link_libraries(sep_engine PRIVATE
-    # High-level modules
     sep_api
-    $<$<BOOL:${SEP_WITH_CYCLES}>:sep_blender>
     $<$<BOOL:${SEP_WITH_AUDIO}>:sep_audio>
     sep_quantum
     sep_memory
@@ -167,15 +164,7 @@ target_link_libraries(sep_engine PRIVATE
 )
 
 # Only link Cycles libraries if they exist and SEP_WITH_CYCLES is enabled
-if(SEP_WITH_CYCLES AND EXISTS "${CMAKE_SOURCE_DIR}/lib/libcycles_device.a")
-    target_link_libraries(sep_engine PRIVATE
-        cycles_kernel
-        cycles_scene
-        cycles_device
-        cycles_util
-        cycles_kernel_osl
-    )
-endif()
+
 
 # Export and install targets
 include(GNUInstallDirs)

--- a/src/server_main.cpp
+++ b/src/server_main.cpp
@@ -1,9 +1,6 @@
 #include "api/server.h"
 #include "core/manager.h"
 #include "core/logging.h"
-#ifdef SEP_HAS_CYCLES
-#include "blender/cycles_renderer.h"
-#endif
 #include <iostream>
 #include <memory>
 
@@ -17,21 +14,8 @@ int main(int argc, char** argv) {
     const auto& api_cfg = cfg_manager.getAPIConfig();
     logger->info("Configuration loaded. API will run on port {}.", api_cfg.port);
 
-#ifdef SEP_HAS_CYCLES
-    // Only create the renderer when Cycles is enabled
-    std::unique_ptr<sep::blender::ccl::CyclesRenderer> renderer = nullptr;
-    renderer = std::make_unique<sep::blender::ccl::CyclesRenderer>();
-    if (renderer->initialize() != sep::SEPResult::SUCCESS) {
-        logger->critical("Failed to initialize Cycles Renderer!");
-        return 1;
-    }
-    
-    // Pass the renderer to the server when Cycles is enabled
-    sep::api::SEPApiServer server(api_cfg, renderer.get());
-#else
-    // Pass nullptr when Cycles is disabled
+    // The headless API server does not require a renderer
     sep::api::SEPApiServer server(api_cfg, nullptr);
-#endif
 
     logger->info("Server object created.");
 


### PR DESCRIPTION
## Summary
- remove renderer logic from `src/server_main.cpp`
- stop linking Cycles libraries into `sep_engine` in `CMakeLists.txt`

## Testing
- `cmake .. -DSEP_WITH_CYCLES=OFF -DSEP_WITH_AUDIO=OFF -DSEP_BUILD_TESTS=OFF` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_686adcadfa78832abf873c84752877e6