### PR TITLE
Separate server binary from workbench

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ project(sep_engine VERSION 1.0.0 LANGUAGES C CXX)
 # without the heavyweight integrations.
 option(SEP_WITH_CYCLES "Enable Blender Cycles integration" OFF)
 option(SEP_WITH_AUDIO "Enable PipeWire audio integration" ON)
+option(SEP_WORKBENCH_DEMO "Build sep_workbench in demo mode" OFF)
 
 # Add include paths after project declaration
 include_directories(BEFORE ${CMAKE_SOURCE_DIR}/include)
@@ -141,20 +142,18 @@ add_executable(sep_engine src/server_main.cpp)
 set_target_properties(sep_engine PROPERTIES CXX_STANDARD 17)
 target_include_directories(sep_engine PRIVATE
     ${CMAKE_SOURCE_DIR}/include
-    ${CMAKE_SOURCE_DIR}/extern/cycles/src
 )
 
 # Configure server_main.cpp to conditionally include Cycles code
 target_compile_definitions(sep_engine PRIVATE
-    SEP_HAS_CYCLES=${SEP_HAS_CYCLES}
-    SEP_HAS_BLENDER=${SEP_HAS_BLENDER}
+    SEP_HAS_CYCLES=0
+    SEP_HAS_BLENDER=0
     SEP_HAS_AUDIO=${SEP_HAS_AUDIO}
 )
 
 target_link_libraries(sep_engine PRIVATE
     # High-level modules
     sep_api
-    $<$<BOOL:${SEP_WITH_CYCLES}>:sep_blender>
     $<$<BOOL:${SEP_WITH_AUDIO}>:sep_audio>
     sep_quantum
     sep_memory
@@ -167,15 +166,6 @@ target_link_libraries(sep_engine PRIVATE
 )
 
 # Only link Cycles libraries if they exist and SEP_WITH_CYCLES is enabled
-if(SEP_WITH_CYCLES AND EXISTS "${CMAKE_SOURCE_DIR}/lib/libcycles_device.a")
-    target_link_libraries(sep_engine PRIVATE
-        cycles_kernel
-        cycles_scene
-        cycles_device
-        cycles_util
-        cycles_kernel_osl
-    )
-endif()
 
 # Export and install targets
 include(GNUInstallDirs)

--- a/examples/workbench/CMakeLists.txt
+++ b/examples/workbench/CMakeLists.txt
@@ -18,7 +18,11 @@ set_target_properties(sep_workbench PROPERTIES CXX_STANDARD 17)
 # `sep_engine_wrapper.h`.  This avoids pulling in the full engine
 # dependencies and provides stubbed renderer/engine behaviour that
 # matches the workbench examples.
-target_compile_definitions(sep_workbench PRIVATE SEP_WORKBENCH_DEMO=1)
+if(SEP_WORKBENCH_DEMO)
+    target_compile_definitions(sep_workbench PRIVATE SEP_WORKBENCH_DEMO=1)
+else()
+    target_compile_definitions(sep_workbench PRIVATE SEP_WORKBENCH_DEMO=0)
+endif()
 
 target_include_directories(sep_workbench PRIVATE
     ${PROJECT_SOURCE_DIR}/examples/workbench
@@ -26,7 +30,6 @@ target_include_directories(sep_workbench PRIVATE
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/extern/cycles/src>
 )
 
-target_compile_definitions(sep_workbench PRIVATE SEP_WORKBENCH_DEMO)
 
 target_link_libraries(sep_workbench PRIVATE
     sep_api

--- a/src/server_main.cpp
+++ b/src/server_main.cpp
@@ -1,9 +1,6 @@
 #include "api/server.h"
 #include "core/manager.h"
 #include "core/logging.h"
-#ifdef SEP_HAS_CYCLES
-#include "blender/cycles_renderer.h"
-#endif
 #include <iostream>
 #include <memory>
 
@@ -17,21 +14,7 @@ int main(int argc, char** argv) {
     const auto& api_cfg = cfg_manager.getAPIConfig();
     logger->info("Configuration loaded. API will run on port {}.", api_cfg.port);
 
-#ifdef SEP_HAS_CYCLES
-    // Only create the renderer when Cycles is enabled
-    std::unique_ptr<sep::blender::ccl::CyclesRenderer> renderer = nullptr;
-    renderer = std::make_unique<sep::blender::ccl::CyclesRenderer>();
-    if (renderer->initialize() != sep::SEPResult::SUCCESS) {
-        logger->critical("Failed to initialize Cycles Renderer!");
-        return 1;
-    }
-    
-    // Pass the renderer to the server when Cycles is enabled
-    sep::api::SEPApiServer server(api_cfg, renderer.get());
-#else
-    // Pass nullptr when Cycles is disabled
     sep::api::SEPApiServer server(api_cfg, nullptr);
-#endif
 
     logger->info("Server object created.");
 


### PR DESCRIPTION
## Summary
- remove Cycles usage from `server_main.cpp`
- make `sep_engine` compile without Blender
- allow `sep_workbench` to optionally build in demo mode

## Testing
- `cmake .. -DBUILD_TESTING=ON -DSEP_WITH_CYCLES=OFF -DSEP_WITH_AUDIO=OFF -DSEP_WORKBENCH_DEMO=ON` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_686adcadfa78832abf873c84752877e6