### PR TITLE
Decouple headless server build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,7 +141,6 @@ add_executable(sep_engine src/server_main.cpp)
 set_target_properties(sep_engine PROPERTIES CXX_STANDARD 17)
 target_include_directories(sep_engine PRIVATE
     ${CMAKE_SOURCE_DIR}/include
-    ${CMAKE_SOURCE_DIR}/extern/cycles/src
 )
 
 # Configure server_main.cpp to conditionally include Cycles code
@@ -154,7 +153,6 @@ target_compile_definitions(sep_engine PRIVATE
 target_link_libraries(sep_engine PRIVATE
     # High-level modules
     sep_api
-    $<$<BOOL:${SEP_WITH_CYCLES}>:sep_blender>
     $<$<BOOL:${SEP_WITH_AUDIO}>:sep_audio>
     sep_quantum
     sep_memory
@@ -165,17 +163,6 @@ target_link_libraries(sep_engine PRIVATE
     ${CMAKE_DL_LIBS}
     $<$<TARGET_EXISTS:CUDA::cudart>:CUDA::cudart>
 )
-
-# Only link Cycles libraries if they exist and SEP_WITH_CYCLES is enabled
-if(SEP_WITH_CYCLES AND EXISTS "${CMAKE_SOURCE_DIR}/lib/libcycles_device.a")
-    target_link_libraries(sep_engine PRIVATE
-        cycles_kernel
-        cycles_scene
-        cycles_device
-        cycles_util
-        cycles_kernel_osl
-    )
-endif()
 
 # Export and install targets
 include(GNUInstallDirs)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,22 +34,7 @@ target_link_libraries(sep_engine PRIVATE
     sep_compat
     Threads::Threads
     ${CMAKE_DL_LIBS}
-
-    cycles_kernel
-    cycles_scene
-    cycles_device
-    cycles_util
 )
-if(SEP_WITH_CYCLES)
-    target_link_libraries(sep_engine PRIVATE
-        sep_blender
-        cycles_kernel
-        cycles_scene
-        cycles_device
-        cycles_util
-        cycles_osl
-    )
-endif()
 if(TARGET CUDA::cudart)
     target_link_libraries(sep_engine PRIVATE CUDA::cudart)
 endif()

--- a/src/server_main.cpp
+++ b/src/server_main.cpp
@@ -2,7 +2,8 @@
 #include "core/manager.h"
 #include "core/logging.h"
 #ifdef SEP_HAS_CYCLES
-#include "blender/cycles_renderer.h"
+// Forward declaration to avoid pulling in Cycles dependencies
+namespace sep { namespace blender { namespace ccl { class CyclesRenderer; } } }
 #endif
 #include <iostream>
 #include <memory>
@@ -17,21 +18,8 @@ int main(int argc, char** argv) {
     const auto& api_cfg = cfg_manager.getAPIConfig();
     logger->info("Configuration loaded. API will run on port {}.", api_cfg.port);
 
-#ifdef SEP_HAS_CYCLES
-    // Only create the renderer when Cycles is enabled
-    std::unique_ptr<sep::blender::ccl::CyclesRenderer> renderer = nullptr;
-    renderer = std::make_unique<sep::blender::ccl::CyclesRenderer>();
-    if (renderer->initialize() != sep::SEPResult::SUCCESS) {
-        logger->critical("Failed to initialize Cycles Renderer!");
-        return 1;
-    }
-    
-    // Pass the renderer to the server when Cycles is enabled
-    sep::api::SEPApiServer server(api_cfg, renderer.get());
-#else
-    // Pass nullptr when Cycles is disabled
+    // Headless server does not instantiate a renderer
     sep::api::SEPApiServer server(api_cfg, nullptr);
-#endif
 
     logger->info("Server object created.");
 


### PR DESCRIPTION
## Summary
- avoid pulling in Cycles renderer for `sep_engine`
- stop linking Cycles libraries in the main build
- keep workbench as the visualization entrypoint

## Testing
- `cmake -S . -B build -DSEP_WITH_CYCLES=OFF` *(fails: Could not find nvcc)*
- `ctest --output-on-failure -j4 build`

------
https://chatgpt.com/codex/tasks/task_e_686adcadfa78832abf873c84752877e6