### PR TITLE
Fix engine startup segfault

### DIFF
--- a/src/api/sep_engine.cpp
+++ b/src/api/sep_engine.cpp
@@ -104,15 +104,17 @@ nlohmann::json SepEngine::initialize(const sep::config::APIConfig& /*config*/)
 {
     if (impl_->initialized) {
         json result;
-        result["success"] = false; 
+        result["success"] = false;
         result["error"] = "Engine already initialized";
         return result;
     }
-        json result;
-        result["success"] = true; 
-        result["message"] = "SEP Engine initialized successfully";
-        return result;
 
+    impl_->initialized = true;
+
+    json result;
+    result["success"] = true;
+    result["message"] = "SEP Engine initialized successfully";
+    return result;
 }
 
 nlohmann::json SepEngine::shutdown()

--- a/src/server_main.cpp
+++ b/src/server_main.cpp
@@ -1,18 +1,27 @@
 #include "api/server.h"
 #include "core/manager.h"
 #include "core/logging.h"
+#include "api/sep_engine.h"
 #include <iostream>
 #include <memory>
 
 int main(int argc, char** argv) {
+    // Initialize logging first so subsequent components can log
     sep::logging::Manager::initialize();
     auto logger = sep::logging::Manager::getInstance().getLogger("main");
     logger->info("SEP Engine starting up...");
 
+    // Load configuration before any singletons are created
     auto& cfg_manager = sep::config::ConfigManager::getInstance();
     cfg_manager.initialize(argc, argv);
     const auto& api_cfg = cfg_manager.getAPIConfig();
     logger->info("Configuration loaded. API will run on port {}.", api_cfg.port);
+
+    // Explicitly create the engine instance and initialize it with the
+    // configuration. This avoids the static initialization order issues
+    // observed when the engine is first accessed lazily.
+    auto& engine = sep::api::SepEngine::getInstance();
+    engine.initialize(api_cfg);
 
     // The headless API server does not require a renderer
     sep::api::SEPApiServer server(api_cfg, nullptr);


### PR DESCRIPTION
## Summary
- ensure SepEngine is created and initialized after loading config
- mark the engine as initialized so requests succeed

## Testing
- `cmake .. -DSEP_WITH_AUDIO=OFF -DSEP_WITH_CYCLES=OFF -DBUILD_TESTING=ON` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_686ae069183c832a806d2a0da0581990