### PR TITLE
Fix server initialization order

### DIFF
--- a/src/server_main.cpp
+++ b/src/server_main.cpp
@@ -1,6 +1,7 @@
 #include "api/server.h"
 #include "core/manager.h"
 #include "core/logging.h"
+#include "api/sep_engine.h"
 #include <iostream>
 #include <memory>
 
@@ -14,6 +15,9 @@ int main(int argc, char** argv) {
     const auto& api_cfg = cfg_manager.getAPIConfig();
     logger->info("Configuration loaded. API will run on port {}.", api_cfg.port);
 
+    auto& engine = sep::api::SepEngine::getInstance();
+    engine.initialize(api_cfg);
+
     // The headless API server does not require a renderer
     sep::api::SEPApiServer server(api_cfg, nullptr);
 
@@ -25,6 +29,8 @@ int main(int argc, char** argv) {
     }
     logger->info("Server is running. Waiting for shutdown signal...");
     server.waitForShutdown();
+
+    engine.shutdown();
     logger->info("SEP Engine shutting down cleanly.");
     return 0;
 }


### PR DESCRIPTION
## Summary
- ensure SepEngine is initialized in server_main before starting the API server
- cleanly shut down engine on exit

## Testing
- `cmake .. -DSEP_BUILD_TESTS=ON -DBUILD_TESTING=ON` *(fails: could not find OpenSubdiv)*

------
https://chatgpt.com/codex/tasks/task_e_686ae069183c832a806d2a0da0581990