### PR TITLE
Fix segfault by initializing engine in server main

### DIFF
--- a/src/server_main.cpp
+++ b/src/server_main.cpp
@@ -1,6 +1,7 @@
 #include "api/server.h"
 #include "core/manager.h"
 #include "core/logging.h"
+#include "api/sep_engine.h"
 #include <iostream>
 #include <memory>
 
@@ -14,6 +15,14 @@ int main(int argc, char** argv) {
     const auto& api_cfg = cfg_manager.getAPIConfig();
     logger->info("Configuration loaded. API will run on port {}.", api_cfg.port);
 
+    // Initialize core engine before starting server
+    auto& engine = sep::api::SepEngine::getInstance();
+    auto init_result = engine.initialize(api_cfg);
+    if (!init_result.value("success", true)) {
+        logger->critical("Engine initialization failed: {}", init_result.dump());
+        return 1;
+    }
+
     // The headless API server does not require a renderer
     sep::api::SEPApiServer server(api_cfg, nullptr);
 
@@ -25,6 +34,11 @@ int main(int argc, char** argv) {
     }
     logger->info("Server is running. Waiting for shutdown signal...");
     server.waitForShutdown();
+
+    auto shutdown_result = engine.shutdown();
+    if (!shutdown_result.value("success", true)) {
+        logger->error("Engine shutdown reported issues: {}", shutdown_result.dump());
+    }
     logger->info("SEP Engine shutting down cleanly.");
     return 0;
 }


### PR DESCRIPTION
## Summary
- init SepEngine before starting the API server
- shut down engine after server exits

## Testing
- `cmake -S . -B build` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_686ae069183c832a806d2a0da0581990