### PR TITLE
Fix pointer handling in promoteToTier

### DIFF
--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -209,8 +209,12 @@ SEPResult MemoryTierManager::promoteToTier(MemoryBlock* block,
     }
     printf("DEBUG: Successfully allocated block in destination tier\n");
 
-    // Copy block properties
-    *out_block = *block;
+    // Copy block metadata but preserve the newly allocated pointer
+    void* new_ptr = out_block->ptr;      // pointer assigned by allocate()
+    std::size_t new_offset = out_block->offset;
+    *out_block = *block;                 // copy metrics and size
+    out_block->ptr = new_ptr;            // restore destination pointer
+    out_block->offset = new_offset;
     out_block->tier = target_tier;
     
     // Calculate new utilization based on destination tier size


### PR DESCRIPTION
## Summary
- handle pointer replacement correctly when promoting memory blocks

## Testing
- `cmake .. -DBUILD_TESTING=ON` *(fails: could not find OpenSubdiv)*

------
https://chatgpt.com/codex/tasks/task_e_686be1d51030832aae8d31740905400e