### PR TITLE
Fix MemoryTierManager tests state

### DIFF
--- a/include/memory/memory_tier_manager.hpp
+++ b/include/memory/memory_tier_manager.hpp
@@ -127,6 +127,9 @@ public:
     void cleanupExpiredPatterns();
     void prunePatternsByPriority(MemoryTierEnum tier, size_t max_count);
 
+    // Test helpers
+    void resetForTesting(const Config& cfg = Config());
+
     dag::DagGraph& getDagGraph() {
         return dag_graph_;
     }

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -117,6 +117,11 @@ void MemoryTierManager::shutdown() {
   pattern_relationships_.clear();
 }
 
+void MemoryTierManager::resetForTesting(const Config& cfg) {
+  shutdown();
+  init(cfg);
+}
+
 // --- Core Memory Operations ---
 MemoryBlock* MemoryTierManager::allocate(std::size_t size, MemoryTierEnum tier) {
   MemoryTier* t = getTier(tier);

--- a/tests/memory/memory_tier_manager_test.cpp
+++ b/tests/memory/memory_tier_manager_test.cpp
@@ -30,6 +30,7 @@ TEST(MemoryTierManagerTest, AllocationAndDeallocation) {
 TEST(MemoryTierManagerTest, PromotionAndDemotion) {
     const float EPSILON = 0.001f;
     MemoryTierManager mgr;
+    mgr.resetForTesting();
     
     // Initial allocation in MTM
     MemoryBlock* block = mgr.allocate(1024, MemoryTierEnum::MTM);
@@ -67,6 +68,7 @@ TEST(MemoryTierManagerTest, PromotionAndDemotion) {
 TEST(MemoryTierManagerTest, DefragmentationTriggersPromotionDemotion) {
     const float EPSILON = 0.001f;
     MemoryTierManager mgr;
+    mgr.resetForTesting();
     
     // Initial allocation in MTM
     MemoryBlock* block = mgr.allocate(1024, MemoryTierEnum::MTM);
@@ -106,6 +108,7 @@ TEST(MemoryTierManagerTest, DefragmentationTriggersPromotionDemotion) {
 TEST(MemoryTierManagerTest, OptimizeBlocksPromotionDemotion) {
     const float EPSILON = 0.001f;
     MemoryTierManager mgr;
+    mgr.resetForTesting();
     MemoryBlock* block = mgr.allocate(1024, MemoryTierEnum::STM);
     ASSERT_NE(block, nullptr);
 


### PR DESCRIPTION
## Summary
- add `resetForTesting` helper to `MemoryTierManager`
- use the helper in tier manager tests to ensure clean state before each

## Testing
- `cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=g++ -B . -S ../..` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_686be87728f0832ab56b9bee8491c0bb