### PR TITLE
Add MemoryTierManager testing reset

### DIFF
--- a/include/memory/memory_tier_manager.hpp
+++ b/include/memory/memory_tier_manager.hpp
@@ -65,6 +65,8 @@ public:
 
     // Singleton access
     static MemoryTierManager& getInstance();
+    /** Reset the singleton instance for tests */
+    static void resetForTesting();
 
     MemoryTierManager();
     explicit MemoryTierManager(const Config& cfg);

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -35,6 +35,15 @@ std::mutex relationships_mutex;
 std::unique_ptr<MemoryTierManager> MemoryTierManager::instance_;
 std::once_flag MemoryTierManager::once_flag_;
 
+void MemoryTierManager::resetForTesting() {
+    if (instance_) {
+        instance_->shutdown();
+        instance_.reset();
+    }
+    once_flag_ = std::once_flag{};
+}
+
+
 // --- Singleton Implementation ---
 
 MemoryTierManager &MemoryTierManager::getInstance() {


### PR DESCRIPTION
## Summary
- add a `resetForTesting` static helper to `MemoryTierManager`

## Testing
- `./tests/memory/memory_manager_tests` *(fails: error while loading shared libraries: libcudart.so.12)*

------
https://chatgpt.com/codex/tasks/task_e_686be87728f0832ab56b9bee8491c0bb