### PR TITLE
Fix memory tier promotions for tests

### DIFF
--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -241,6 +241,39 @@ void MemoryTierManager::optimizeTiers() {
   if (ltm_) ltm_->defragment();
 }
 
+// Convenience helpers used in tests
+SEPResult MemoryTierManager::promoteBlock(MemoryBlock *block,
+                                          MemoryBlock *&out_block) {
+  if (!block || !block->allocated)
+    return SEPResult::INVALID_ARGUMENT;
+
+  MemoryTierEnum target = block->tier;
+  if (block->tier == MemoryTierEnum::STM)
+    target = MemoryTierEnum::MTM;
+  else if (block->tier == MemoryTierEnum::MTM)
+    target = MemoryTierEnum::LTM;
+  else
+    return SEPResult::INVALID_ARGUMENT;
+
+  return promoteToTier(block, target, out_block);
+}
+
+SEPResult MemoryTierManager::demoteBlock(MemoryBlock *block,
+                                         MemoryBlock *&out_block) {
+  if (!block || !block->allocated)
+    return SEPResult::INVALID_ARGUMENT;
+
+  MemoryTierEnum target;
+  if (block->tier == MemoryTierEnum::LTM)
+    target = MemoryTierEnum::MTM;
+  else if (block->tier == MemoryTierEnum::MTM)
+    target = MemoryTierEnum::STM;
+  else
+    return SEPResult::INVALID_ARGUMENT;
+
+  return promoteToTier(block, target, out_block);
+}
+
 // --- Promotion and Demotion Logic ---
 SEPResult MemoryTierManager::promoteToTier(MemoryBlock* block,
                                           MemoryTierEnum target_tier,
@@ -346,8 +379,8 @@ MemoryBlock *MemoryTierManager::updateBlockMetrics(MemoryBlock *block,
   if (result == SEPResult::SUCCESS)
     return new_block;
 
-  // If migration failed, return the original block.
-  return block;
+  // Explicit failure path for callers expecting nullptr on failure
+  return nullptr;
 
 }
 


### PR DESCRIPTION
## Summary
- add promoteBlock and demoteBlock implementations
- return `nullptr` from `updateBlockMetrics` when promotion fails

## Testing
- `./tests/memory/memory_manager_tests` *(fails: error while loading shared libraries: libcudart.so.12)*

------
https://chatgpt.com/codex/tasks/task_e_686beb64a324832a802a97187531de71