### PR TITLE
Fix CPU fallback in moveData

### DIFF
--- a/src/memory/memory_tier.cpp
+++ b/src/memory/memory_tier.cpp
@@ -343,26 +343,17 @@ bool MemoryTier::moveData(MemoryBlock *dst, const MemoryBlock *src) {
   dst->last_coherence = src->last_coherence;
   dst->compression_ratio = src->compression_ratio;
 
-  if (config_.type == MemoryTierEnum::HOST) {
+#if SEP_MEMORY_HAS_CUDA
+  cudaError_t err =
+      sep::cuda::cudaMemcpyAsync(dst->ptr, src->ptr, size, cudaMemcpyDefault,
+                                 nullptr);
+  if (err != cudaSuccess) {
+    if (logger) {
+      LOG_ERROR(logger, "Failed to copy memory via CUDA: {}", err);
+      LOG_INFO(logger, "Falling back to CPU memcpy");
+    }
     std::memcpy(dst->ptr, src->ptr, size);
   } else {
-#if SEP_MEMORY_HAS_CUDA
-        cudaError_t err =
-            sep::cuda::cudaMemcpyAsync(dst->ptr, src->ptr, size, cudaMemcpyDefault, nullptr);
-        if (err == cudaSuccess) {
-            err = cudaStreamSynchronize(nullptr);
-        }
-        if (err != cudaSuccess) {
-            if (logger) {
-                LOG_ERROR(logger, "Failed to copy memory via CUDA: {}", err);
-                LOG_INFO(logger, "Falling back to CPU memcpy");
-            }
-            std::memcpy(dst->ptr, src->ptr, size);
-        }
-#else
-        std::memcpy(dst->ptr, src->ptr, size);
-#endif
-    }
     err = cudaStreamSynchronize(nullptr);
     if (err != cudaSuccess) {
       if (logger) {
@@ -370,10 +361,11 @@ bool MemoryTier::moveData(MemoryBlock *dst, const MemoryBlock *src) {
       }
       return false;
     }
-#else
-    std::memcpy(dst->ptr, src->ptr, size);
-#endif
   }
+#else
+  std::memcpy(dst->ptr, src->ptr, size);
+#endif
+  (void)logger; // suppress unused variable warning when CUDA is disabled
 
   // No need to update used_space_ here since it's already tracked in
   // allocate/deallocate


### PR DESCRIPTION
## Summary
- simplify fallback logic for copying memory when CUDA is unavailable

## Testing
- `tests/memory/memory_manager_tests --gtest_filter=MemoryTierManagerTest.PromotionAndDemotion -V` *(fails: cannot open shared object file libcuda rt)*

------
https://chatgpt.com/codex/tasks/task_e_686bedd7e850832aac1db82e657da3cb