### PR TITLE
Add fallback host allocation for tier manager

### DIFF
--- a/src/memory/memory_tier.cpp
+++ b/src/memory/memory_tier.cpp
@@ -51,6 +51,11 @@ MemoryTier::MemoryTier(const Config &config)
       auto logger = sep::logging::Manager::getInstance().getLogger("memory");
       if (logger) {
         logger->error("Failed to allocate managed memory: {}", err);
+        logger->info("Falling back to host allocation");
+      }
+      memory_pool_ = std::malloc(config.size);
+      if (!memory_pool_ && logger) {
+        logger->error("Host allocation fallback failed");
       }
     }
 #else


### PR DESCRIPTION
## Summary
- ensure CUDA allocation failures fall back to malloc in `MemoryTier`

## Testing
- `cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=g++ ..` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_686bf05f343c832ab670418f518b01e9