### PR TITLE
Fix resetForTesting once_flag

### DIFF
--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -41,7 +41,9 @@ void MemoryTierManager::resetForTesting() {
         instance_->shutdown();
         instance_.reset();
     }
-    once_flag_ = std::once_flag{};
+    // std::once_flag does not support assignment, so reconstruct it
+    // in-place to reset the call-once state for subsequent tests.
+    new (&once_flag_) std::once_flag();
 }
 
 


### PR DESCRIPTION
## Summary
- reconstruct once_flag during MemoryTierManager test resets

## Testing
- `./tests/memory/memory_manager_tests` *(fails: error while loading shared libraries: libcudart.so.12)*

------
https://chatgpt.com/codex/tasks/task_e_686bf05f343c832ab670418f518b01e9