### PR TITLE
Patch memory promotion allocation

### DIFF
--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -312,6 +312,15 @@ SEPResult MemoryTierManager::promoteToTier(MemoryBlock* block,
         // Try defragmenting destination tier
         dst_tier->defragment();
         out_block = dst_tier->allocate(block->size);
+
+        // If the tier was never initialized or has zero size, try a minimal
+        // resize so tests using small tiers do not immediately fail.
+        if (!out_block && dst_tier->getSize() == 0) {
+            printf("DEBUG: Destination tier size was zero, resizing to fit block\n");
+            if (dst_tier->resize(block->size * 2)) {
+                out_block = dst_tier->allocate(block->size);
+            }
+        }
     }
 
     if (!out_block) {


### PR DESCRIPTION
## Summary
- handle case when a destination tier has zero size
- prevent promotion failure on uninitialized tiers

## Testing
- `./tests/memory/memory_manager_tests` *(fails: error while loading shared libraries)*

------
https://chatgpt.com/codex/tasks/task_e_686bf2a3e030832aa39a4f17ba3c8c18