### PR TITLE
Fix tier utilization calculation

### DIFF
--- a/src/memory/memory_tier.cpp
+++ b/src/memory/memory_tier.cpp
@@ -298,10 +298,20 @@ float MemoryTier::calculateFragmentation() const {
 }
 
 float MemoryTier::calculateUtilization() const {
-  if (config_.size == 0 || used_space_ == 0)
+  if (config_.size == 0)
     return 0.0f;
-  float util =
-      static_cast<float>(used_space_) / static_cast<float>(config_.size);
+
+  // Recalculate used space on demand to avoid stale values in unit tests
+  std::size_t used = 0;
+  for (const auto &blk : blocks_) {
+    if (blk.allocated)
+      used += blk.size;
+  }
+
+  if (used == 0)
+    return 0.0f;
+
+  float util = static_cast<float>(used) / static_cast<float>(config_.size);
   return util > 1.0f ? 1.0f : util; // Cap at 100%
 }
 


### PR DESCRIPTION
## Summary
- compute tier utilization based on block list each call to avoid stale `used_space_`

## Testing
- `cmake -DBUILD_TESTING=ON ..` *(fails: could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_686c00381bb4832a9a0aeda3df4a27b6