### PR TITLE
Fix tier utilization rounding

### DIFF
--- a/src/memory/memory_tier.cpp
+++ b/src/memory/memory_tier.cpp
@@ -313,6 +313,8 @@ float MemoryTier::calculateUtilization() const {
     return 0.0f;
 
   float util = static_cast<float>(used) / static_cast<float>(config_.size);
+  if (util < 1e-3f)
+    return 0.0f;
   return util > 1.0f ? 1.0f : util; // Cap at 100%
 }
 


### PR DESCRIPTION
## Summary
- clamp small values in `calculateUtilization`

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_686c0307a474832a81647f3a798bd674