### PR TITLE
Fix memory tier copy logic

### DIFF
--- a/src/memory/memory_tier.cpp
+++ b/src/memory/memory_tier.cpp
@@ -360,9 +360,8 @@ bool MemoryTier::moveData(MemoryBlock *dst, const MemoryBlock *src) {
   dst->compression_ratio = src->compression_ratio;
 
 #if SEP_MEMORY_HAS_CUDA
-  cudaError_t err =
-      sep::cuda::cudaMemcpyAsync(dst->ptr, src->ptr, size, cudaMemcpyDefault,
-                                 nullptr);
+  cudaError_t err = sep::cuda::cudaMemcpyAsync(
+      dst->ptr, src->ptr, size, cudaMemcpyDefault, nullptr);
   if (err != cudaSuccess) {
     if (logger) {
       LOG_ERROR(logger, "Failed to copy memory via CUDA: {}", err);
@@ -370,19 +369,7 @@ bool MemoryTier::moveData(MemoryBlock *dst, const MemoryBlock *src) {
     }
     std::memcpy(dst->ptr, src->ptr, size);
   } else {
-#if SEP_MEMORY_HAS_CUDA
-    cudaError_t err = sep::cuda::cudaMemcpyAsync(
-        dst->ptr, src->ptr, size, cudaMemcpyDefault, nullptr);
-    if (err == cudaSuccess) {
-      err = cudaStreamSynchronize(nullptr);
-    } else {
-      if (logger) {
-        LOG_ERROR(logger, "Failed to copy memory via CUDA: {}", err);
-        LOG_INFO(logger, "Falling back to CPU memcpy");
-      }
-      std::memcpy(dst->ptr, src->ptr, size);
-      err = cudaSuccess; // treat as success for subsequent checks
-    }
+    err = cudaStreamSynchronize(nullptr);
     if (err != cudaSuccess) {
       if (logger) {
         LOG_ERROR(logger, "Failed to synchronize stream: {}", err);


### PR DESCRIPTION
## Summary
- simplify CUDA copy logic in `MemoryTier::moveData`

## Testing
- `g++ -std=c++17 -Iinclude -Isrc -c src/memory/memory_tier.cpp -o /tmp/memory_tier.o` *(fails: nlohmann/json.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686c0307a474832a81647f3a798bd674