### PR TITLE
Lower utilization clamp threshold

### DIFF
--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -187,14 +187,13 @@ float MemoryTierManager::getTierUtilization(MemoryTierEnum tier) const {
   // deallocated. Several unit tests expect an exact zero value when no memory
   // is allocated in a tier. Because used_space_ is tracked using integer
   // arithmetic, floating point division can produce values like
-  // 0.000244140625 instead of exactly 0.  Clamp anything smaller than the
-  // epsilon used in the tests so those comparisons remain stable.
-  // Clamp values extremely close to zero.  Some unit tests check for
-  // an exact zero when no memory is allocated in a tier.  Integer
-  // accounting in MemoryTier coupled with floating point division can
-  // yield results like 0.000244 instead of 0.0 after a deallocation.
-  // Anything below 1e-3 is considered zero for test stability.
-  if (util < 1e-3f)
+  // 0.000244140625 instead of exactly 0.  Values of this magnitude are
+  // valid when tiers are large (e.g. allocating a few kilobytes in a
+  // multi‑megabyte pool).  A too‑large clamp obscures these small but
+  // meaningful allocations, causing promotion tests to observe zero
+  // utilization.  Use a much smaller threshold so we still zero out
+  // rounding errors while preserving tiny legitimate values.
+  if (util < 1e-6f)
     return 0.0f;
 
   // Utilization should never be negative, but guard against underflow just in


### PR DESCRIPTION
## Summary
- allow reporting tiny but nonzero utilization values

## Testing
- `./tests/memory/memory_manager_tests` *(fails: cannot open shared object libcuda)*

------
https://chatgpt.com/codex/tasks/task_e_686c03926d1c832aba299d5fd9158a98