### PR TITLE
Fix rounding issues and clamp utilization

### DIFF
--- a/src/memory/memory_tier.cpp
+++ b/src/memory/memory_tier.cpp
@@ -313,6 +313,8 @@ float MemoryTier::calculateUtilization() const {
     return 0.0f;
 
   float util = static_cast<float>(used) / static_cast<float>(config_.size);
+  if (util < 0.0f)
+    util = 0.0f;
   if (util < 1e-3f)
     return 0.0f;
   return util > 1.0f ? 1.0f : util; // Cap at 100%

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -183,8 +183,8 @@ float MemoryTierManager::getTierUtilization(MemoryTierEnum tier) const {
     return 0.0f;
 
   float util = t->calculateUtilization();
-  // Guard against rounding artifacts that may appear after a block is
-  // deallocated.  Some unit tests expect an exact zero when no memory is
+  // [2024-04-25] Guard against rounding artifacts that may appear after a
+  // block is deallocated. Unit tests expect an exact zero when no memory is
   // allocated in a tier. Integer arithmetic in MemoryTier coupled with
   // floating point division can yield values like 0.000244 instead of 0.0.
   // Treat anything close to zero as zero for stability.


### PR DESCRIPTION
## Summary
- avoid negative results in `MemoryTier::calculateUtilization`
- document rounding guard in `MemoryTierManager::getTierUtilization`

## Testing
- `./build.sh` *(fails: could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_686c06263fc0832aa582e739631edb7d