### PR TITLE
Implement clamping fix for total utilization

### DIFF
--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -232,7 +232,8 @@ float MemoryTierManager::getTotalUtilization() const {
   }
   if (total_size == 0)
     return 0.0f;
-  return static_cast<float>(used) / static_cast<float>(total_size);
+  float util = static_cast<float>(used) / static_cast<float>(total_size);
+  return std::fabs(util) < 1e-3f ? 0.0f : util;
 }
 
 float MemoryTierManager::getTotalFragmentation() const {


### PR DESCRIPTION
## Summary
- ensure `getTotalUtilization` returns 0 for near-zero usage
- maintain stability by avoiding floating-point noise after deallocations

## Testing
- `N/A`

------
https://chatgpt.com/codex/tasks/task_e_686c06263fc0832aa582e739631edb7d