### PR TITLE
Implement utilization clamp constant

### DIFF
--- a/include/memory/memory_tier.hpp
+++ b/include/memory/memory_tier.hpp
@@ -23,6 +23,8 @@ using ::sep::CompressionMethod;
 using ::sep::MemoryTierEnum;
 using ::sep::SEPResult;
 
+inline constexpr float UTILIZATION_EPSILON = 1e-3f;
+
 // Memory tier types
 enum class TierType {
     HOST = 0,   // Host memory (CPU)

--- a/src/memory/memory_tier.cpp
+++ b/src/memory/memory_tier.cpp
@@ -313,7 +313,7 @@ float MemoryTier::calculateUtilization() const {
     return 0.0f;
 
   float util = static_cast<float>(used) / static_cast<float>(config_.size);
-  if (util < 1e-3f)
+  if (util < UTILIZATION_EPSILON)
     return 0.0f;
   return util > 1.0f ? 1.0f : util; // Cap at 100%
 }

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -188,7 +188,7 @@ float MemoryTierManager::getTierUtilization(MemoryTierEnum tier) const {
   // allocated in a tier. Integer arithmetic in MemoryTier coupled with
   // floating point division can yield values like 0.000244 instead of 0.0.
   // Treat anything close to zero as zero for stability.
-  if (std::fabs(util) < 1e-3f)
+  if (std::fabs(util) < UTILIZATION_EPSILON)
     return 0.0f;
 
   // Utilization should never be negative, but guard against underflow just in

--- a/tests/memory/memory_tier_manager_test.cpp
+++ b/tests/memory/memory_tier_manager_test.cpp
@@ -22,13 +22,13 @@ TEST(MemoryTierManagerTest, AllocationAndDeallocation) {
     ASSERT_NE(block, nullptr);
     EXPECT_GT(mgr.getTierUtilization(MemoryTierEnum::STM), 0.0f);
     mgr.deallocate(block);
-    const float EPSILON = 0.001f;
+    const float EPSILON = UTILIZATION_EPSILON;
     EXPECT_LT(mgr.getTierUtilization(MemoryTierEnum::STM), EPSILON)
         << "Expected STM utilization near 0, got: " << mgr.getTierUtilization(MemoryTierEnum::STM);
 }
 
 TEST(MemoryTierManagerTest, PromotionAndDemotion) {
-    const float EPSILON = 0.001f;
+    const float EPSILON = UTILIZATION_EPSILON;
     MemoryTierManager mgr;
     mgr.resetForTesting();
     
@@ -66,7 +66,7 @@ TEST(MemoryTierManagerTest, PromotionAndDemotion) {
 }
 
 TEST(MemoryTierManagerTest, DefragmentationTriggersPromotionDemotion) {
-    const float EPSILON = 0.001f;
+    const float EPSILON = UTILIZATION_EPSILON;
     MemoryTierManager mgr;
     mgr.resetForTesting();
     
@@ -106,7 +106,7 @@ TEST(MemoryTierManagerTest, DefragmentationTriggersPromotionDemotion) {
 
 
 TEST(MemoryTierManagerTest, OptimizeBlocksPromotionDemotion) {
-    const float EPSILON = 0.001f;
+    const float EPSILON = UTILIZATION_EPSILON;
     MemoryTierManager mgr;
     mgr.resetForTesting();
     MemoryBlock* block = mgr.allocate(1024, MemoryTierEnum::STM);


### PR DESCRIPTION
## Summary
- centralize EPSILON as `UTILIZATION_EPSILON`
- use the constant in memory tier logic and tests to avoid float noise

## Testing
- `ctest --output-on-failure ./tests/memory/memory_tier_manager_test.cpp` *(fails: No tests were found)*
- `npm test` *(fails: missing script)*


------
https://chatgpt.com/codex/tasks/task_e_686c06263fc0832aa582e739631edb7d