### PR TITLE
Add CUDA-disabled build helper

### DIFF
--- a/build_no_cuda.sh
+++ b/build_no_cuda.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+
+# Simple build script that disables CUDA to aid debugging.
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+BUILD_DIR="${REPO_ROOT}/cmake-nocuda"
+
+mkdir -p "$BUILD_DIR"
+cd "$BUILD_DIR"
+
+cmake -S "$REPO_ROOT" -B "$BUILD_DIR" \
+  -DCMAKE_C_COMPILER=/usr/bin/gcc \
+  -DCMAKE_CXX_COMPILER=/usr/bin/g++ \
+  -DSEP_WITH_CYCLES=OFF \
+  -DSEP_WITH_AUDIO=OFF \
+  -DSEP_HAS_CUDA=0 \
+  -DSEP_ENABLE_AUDIO=OFF \
+  -DSEP_WORKBENCH_DEMO=OFF
+
+make -j$(nproc)


### PR DESCRIPTION
## Summary
- document failing memory tests in TODO log
- add new script to configure a no-CUDA build

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c09825de0832a8123c9c4c68136aa