### PR TITLE
Make CUDA optional and fix CMake ordering

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,12 @@ include_directories(BEFORE
 )
 
 # Ensure core headers are available
-add_subdirectory(src/core BEFORE src/memory)
+# Build the core subsystem first so that memory and other components can
+# link against it. The previous invocation attempted to use the unsupported
+# `BEFORE` argument to `add_subdirectory`, which caused configuration errors
+# with newer versions of CMake. We simply add the directories in the
+# required order instead.
+add_subdirectory(src/core)
 
 # Backwards compatibility variables
 set(SEP_ENABLE_BLENDER ${SEP_WITH_CYCLES})
@@ -78,10 +83,14 @@ link_directories(${CMAKE_SOURCE_DIR}/lib)
 include(SEPConfig)
 configure_sep()
 
-# CUDA is a hard requirement for the project
-find_package(CUDAToolkit REQUIRED)
-set(SEP_HAS_CUDA 1)
-add_compile_definitions(SEP_HAS_CUDA=1)
+# CUDA is optional for many unit tests. Allow disabling via SEP_HAS_CUDA
+option(SEP_HAS_CUDA "Enable CUDA support" ON)
+if(SEP_HAS_CUDA)
+    find_package(CUDAToolkit REQUIRED)
+    add_compile_definitions(SEP_HAS_CUDA=1)
+else()
+    add_compile_definitions(SEP_HAS_CUDA=0)
+endif()
 
 if(SEP_WITH_CYCLES)
     add_compile_definitions(SEP_HAS_CYCLES=1)


### PR DESCRIPTION
## Summary
- initialize core subdirectory without deprecated BEFORE argument
- allow building without CUDA by making CUDA optional

## Testing
- `sudo apt-get install -y libfmt-dev libhttp-parser-dev libspdlog-dev libtbb-dev libopenvdb-dev libembree-dev libopenimageio-dev libboost-all-dev`
- `cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=g++-14 -DSEP_HAS_CUDA=OFF ..` *(fails: Could NOT find OpenSubdiv)*


------
https://chatgpt.com/codex/tasks/task_e_686c1c650f34832aaa8033ee8db3d30c