### PR TITLE
Fix CMake core subdirectory invocation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,8 +32,10 @@ include_directories(BEFORE
     ${SEP_SRC_DIR}
 )
 
-# Ensure core headers are available
-add_subdirectory(src/core BEFORE src/memory)
+# Ensure core headers are available. The BEFORE keyword was used incorrectly
+# here and caused CMake configuration errors. Simply add the core subdirectory
+# first so that targets are available to later modules.
+add_subdirectory(src/core)
 
 # Backwards compatibility variables
 set(SEP_ENABLE_BLENDER ${SEP_WITH_CYCLES})


### PR DESCRIPTION
## Summary
- fix CMakeLists.txt `add_subdirectory` usage to remove invalid BEFORE argument

## Testing
- `cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=g++-14 ..` *(fails: Could not find nvcc, please set CUDAToolkit_ROOT)*

------
https://chatgpt.com/codex/tasks/task_e_686c1c650f34832aaa8033ee8db3d30c