### PR TITLE
Fix memory tier cleanup

### DIFF
--- a/src/memory/memory_tier.cpp
+++ b/src/memory/memory_tier.cpp
@@ -184,7 +184,10 @@ void MemoryTier::deallocate(MemoryBlock *block) {
   // Update block state
   block->allocated = false;
   block->utilization = 0.0f;
-  used_space_ -= block->size;
+  if (used_space_ >= block->size)
+    used_space_ -= block->size;
+  else
+    used_space_ = 0;
 
   // Preserve properties for potential promotion/demotion
   block->coherence = coherence;

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -132,6 +132,7 @@ void MemoryTierManager::shutdown() {
 void MemoryTierManager::resetForTesting(const Config& cfg) {
   shutdown();
   init(cfg);
+  rebuildLookup();
 }
 
 // --- Core Memory Operations ---


### PR DESCRIPTION
## Summary
- avoid underflow when deallocating blocks
- rebuild lookup data when resetting MemoryTierManager

## Testing
- `tests/memory/memory_manager_tests` *(fails: libgtest_main.so.1.15.2: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_686c5138b190832ab292c0c5daa66b0c