### PR TITLE
Clamp small utilization values to zero

### DIFF
--- a/src/memory/memory_tier.cpp
+++ b/src/memory/memory_tier.cpp
@@ -13,13 +13,13 @@
 // Standard headers
 #include <algorithm>
 #include <cassert>
+#include <cmath>
 #include <cstdlib>
 #include <cstring>
 #include <deque>
 #include <limits>
 #include <stdexcept>
 #include <vector>
-#include <cmath>
 
 // CUDA support check
 #if defined(__CUDACC__)
@@ -314,10 +314,14 @@ float MemoryTier::calculateUtilization() const {
     return 0.0f;
 
   float util = static_cast<float>(used) / static_cast<float>(config_.size);
-  // Clamp tiny rounding artifacts to zero so tests comparing against
-  // exact 0.0f remain stable after deallocations.
-  if (std::fabs(util) < kUtilizationEpsilon)
+
+  // Guard against residual rounding errors that may appear when the used
+  // space is very small compared to the tier size.  Unit tests expect an
+  // exact zero value when nothing is allocated, so anything extremely close
+  // to zero should be treated as zero.
+  if (std::fabs(util) <= kUtilizationEpsilon)
     return 0.0f;
+
   return util > 1.0f ? 1.0f : util; // Cap at 100%
 }
 
@@ -365,8 +369,8 @@ bool MemoryTier::moveData(MemoryBlock *dst, const MemoryBlock *src) {
   dst->compression_ratio = src->compression_ratio;
 
 #if SEP_MEMORY_HAS_CUDA
-  cudaError_t err = sep::cuda::cudaMemcpyAsync(
-      dst->ptr, src->ptr, size, cudaMemcpyDefault, nullptr);
+  cudaError_t err = sep::cuda::cudaMemcpyAsync(dst->ptr, src->ptr, size,
+                                               cudaMemcpyDefault, nullptr);
   if (err != cudaSuccess) {
     if (logger) {
       LOG_ERROR(logger, "Failed to copy memory via CUDA: {}", err);

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -1,16 +1,16 @@
 #include "memory/memory_tier_manager.hpp"
+#include "core/common.h"
+#include "core/types.h"
 #include "memory/memory_tier.hpp"
 #include "memory/types.h"
-#include "core/types.h"
-#include "core/common.h"
 
 #include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
 #include <memory>
 #include <mutex>
 #include <string>
-#include <cstring>
-#include <cmath>
-#include <cstdio>
 
 namespace sep {
 namespace memory {
@@ -21,8 +21,8 @@ struct MemoryBlock;
 
 // Using declarations
 using Config = MemoryTierManager::Config;
-using ::sep::core::SEPResult;
 using ::sep::MemoryTierEnum;
+using ::sep::core::SEPResult;
 using ::sep::pattern::PatternData;
 using ::sep::persistence::PersistentPatternData;
 using ::sep::quantum::Pattern;
@@ -39,13 +39,12 @@ std::unique_ptr<MemoryTierManager> MemoryTierManager::instance_;
 std::once_flag MemoryTierManager::once_flag_;
 
 void MemoryTierManager::resetForTesting() {
-    if (instance_) {
-        instance_->shutdown();
-        instance_.reset();
-    }
-    once_flag_ = std::once_flag{};
+  if (instance_) {
+    instance_->shutdown();
+    instance_.reset();
+  }
+  once_flag_ = std::once_flag{};
 }
-
 
 // --- Singleton Implementation ---
 
@@ -76,48 +75,43 @@ MemoryTierManager::MemoryTierManager() {
   init(cfg);
 }
 
-MemoryTierManager::MemoryTierManager(const Config &cfg) {
-  init(cfg);
-}
+MemoryTierManager::MemoryTierManager(const Config &cfg) { init(cfg); }
 
 MemoryTierManager::MemoryTierManager(
     const sep::config::MemoryThresholdConfig &mc) {
   Config cfg{};
   cfg.promote_stm_to_mtm = mc.promote_stm_to_mtm;
-    cfg.promote_mtm_to_ltm = mc.promote_mtm_to_ltm;
-    cfg.demote_threshold = mc.demote_threshold;
-    cfg.fragmentation_threshold = mc.fragmentation_threshold;
-    cfg.stm_to_mtm_min_gen = mc.stm_to_mtm_min_gen;
-    cfg.mtm_to_ltm_min_gen = mc.mtm_to_ltm_min_gen;
-    // Note: sizes are missing from MemoryThresholdConfig, using defaults
-    init(cfg);
+  cfg.promote_mtm_to_ltm = mc.promote_mtm_to_ltm;
+  cfg.demote_threshold = mc.demote_threshold;
+  cfg.fragmentation_threshold = mc.fragmentation_threshold;
+  cfg.stm_to_mtm_min_gen = mc.stm_to_mtm_min_gen;
+  cfg.mtm_to_ltm_min_gen = mc.mtm_to_ltm_min_gen;
+  // Note: sizes are missing from MemoryThresholdConfig, using defaults
+  init(cfg);
 }
 
-MemoryTierManager::~MemoryTierManager() {
-  shutdown();
-}
+MemoryTierManager::~MemoryTierManager() { shutdown(); }
 
-void MemoryTierManager::init(const Config& config) {
-    printf("DEBUG: Initializing MemoryTierManager\n");
-    config_ = config;
-    
-    MemoryTier::Config scfg{MemoryTierEnum::STM, config_.stm_size};
-    MemoryTier::Config mcfg{MemoryTierEnum::MTM, config_.mtm_size};
-    MemoryTier::Config lcfg{MemoryTierEnum::LTM, config_.ltm_size};
-    
-    printf("DEBUG: Creating tiers - STM: %zu, MTM: %zu, LTM: %zu\n",
-           config_.stm_size, config_.mtm_size, config_.ltm_size);
-           
-    stm_ = std::make_unique<MemoryTier>(scfg);
-    mtm_ = std::make_unique<MemoryTier>(mcfg);
-    ltm_ = std::make_unique<MemoryTier>(lcfg);
+void MemoryTierManager::init(const Config &config) {
+  printf("DEBUG: Initializing MemoryTierManager\n");
+  config_ = config;
 
-    printf("DEBUG: Initial utilization - STM: %f, MTM: %f, LTM: %f\n",
-           stm_->calculateUtilization(),
-           mtm_->calculateUtilization(),
-           ltm_->calculateUtilization());
+  MemoryTier::Config scfg{MemoryTierEnum::STM, config_.stm_size};
+  MemoryTier::Config mcfg{MemoryTierEnum::MTM, config_.mtm_size};
+  MemoryTier::Config lcfg{MemoryTierEnum::LTM, config_.ltm_size};
 
-    // Redis manager is optional in this minimal build
+  printf("DEBUG: Creating tiers - STM: %zu, MTM: %zu, LTM: %zu\n",
+         config_.stm_size, config_.mtm_size, config_.ltm_size);
+
+  stm_ = std::make_unique<MemoryTier>(scfg);
+  mtm_ = std::make_unique<MemoryTier>(mcfg);
+  ltm_ = std::make_unique<MemoryTier>(lcfg);
+
+  printf("DEBUG: Initial utilization - STM: %f, MTM: %f, LTM: %f\n",
+         stm_->calculateUtilization(), mtm_->calculateUtilization(),
+         ltm_->calculateUtilization());
+
+  // Redis manager is optional in this minimal build
 }
 
 void MemoryTierManager::shutdown() {
@@ -129,56 +123,62 @@ void MemoryTierManager::shutdown() {
   pattern_relationships_.clear();
 }
 
-void MemoryTierManager::resetForTesting(const Config& cfg) {
+void MemoryTierManager::resetForTesting(const Config &cfg) {
   shutdown();
   init(cfg);
 }
 
 // --- Core Memory Operations ---
-MemoryBlock* MemoryTierManager::allocate(std::size_t size, MemoryTierEnum tier) {
-  MemoryTier* t = getTier(tier);
+MemoryBlock *MemoryTierManager::allocate(std::size_t size,
+                                         MemoryTierEnum tier) {
+  MemoryTier *t = getTier(tier);
   if (!t)
     return nullptr;
-  MemoryBlock* blk = t->allocate(size);
+  MemoryBlock *blk = t->allocate(size);
   if (blk) {
     std::lock_guard<std::mutex> lock(lookup_mutex);
     lookup_map_[blk->ptr] = blk;
   }
-    return blk;
+  return blk;
 }
-void MemoryTierManager::deallocate(MemoryBlock* block) {
-  if (!block) return;
+void MemoryTierManager::deallocate(MemoryBlock *block) {
+  if (!block)
+    return;
   {
     std::lock_guard<std::mutex> lock(lookup_mutex);
     lookup_map_.erase(block->ptr);
   }
-    if (MemoryTier* t = getTier(block->tier)) {
-      t->deallocate(block);
-    }
+  if (MemoryTier *t = getTier(block->tier)) {
+    t->deallocate(block);
+  }
 }
 
-MemoryBlock* MemoryTierManager::findBlockByPtr(void* ptr) {
+MemoryBlock *MemoryTierManager::findBlockByPtr(void *ptr) {
   std::lock_guard<std::mutex> lock(lookup_mutex);
   auto it = lookup_map_.find(ptr);
   return it != lookup_map_.end() ? it->second : nullptr;
 }
 
 // --- Tier Management & Metrics ---
-MemoryTier* MemoryTierManager::getTier(MemoryTierEnum tier) {
+MemoryTier *MemoryTierManager::getTier(MemoryTierEnum tier) {
   switch (tier) {
-    case MemoryTierEnum::STM: return stm_.get();
-    case MemoryTierEnum::MTM: return mtm_.get();
-    case MemoryTierEnum::LTM: return ltm_.get();
-    default: return nullptr;
+  case MemoryTierEnum::STM:
+    return stm_.get();
+  case MemoryTierEnum::MTM:
+    return mtm_.get();
+  case MemoryTierEnum::LTM:
+    return ltm_.get();
+  default:
+    return nullptr;
   }
 }
 
-MemoryTier& MemoryTierManager::getSTM() { return *stm_; }
-MemoryTier& MemoryTierManager::getMTM() { return *mtm_; }
-MemoryTier& MemoryTierManager::getLTM() { return *ltm_; }
+MemoryTier &MemoryTierManager::getSTM() { return *stm_; }
+MemoryTier &MemoryTierManager::getMTM() { return *mtm_; }
+MemoryTier &MemoryTierManager::getLTM() { return *ltm_; }
 
 float MemoryTierManager::getTierUtilization(MemoryTierEnum tier) const {
-  const MemoryTier* t = const_cast<MemoryTierManager*>(this)->getTier(tier);
+  const MemoryTier *t = const_cast<MemoryTierManager *>(this)->getTier(tier);
   if (!t)
     return 0.0f;
 
@@ -188,7 +188,7 @@ float MemoryTierManager::getTierUtilization(MemoryTierEnum tier) const {
   // allocated in a tier. Integer arithmetic in MemoryTier coupled with
   // floating point division can yield values like 0.000244 instead of 0.0.
   // Treat anything close to zero as zero for stability.
-  if (std::fabs(util) < kUtilizationEpsilon)
+  if (std::fabs(util) <= kUtilizationEpsilon)
     return 0.0f;
 
   // Utilization should never be negative, but guard against underflow just in
@@ -200,7 +200,7 @@ float MemoryTierManager::getTierUtilization(MemoryTierEnum tier) const {
 }
 
 float MemoryTierManager::getTierFragmentation(MemoryTierEnum tier) const {
-  const MemoryTier* t = const_cast<MemoryTierManager*>(this)->getTier(tier);
+  const MemoryTier *t = const_cast<MemoryTierManager *>(this)->getTier(tier);
   return t ? t->calculateFragmentation() : 0.0f;
 }
 
@@ -233,7 +233,7 @@ float MemoryTierManager::getTotalUtilization() const {
   if (total_size == 0)
     return 0.0f;
   float util = static_cast<float>(used) / static_cast<float>(total_size);
-  return std::fabs(util) < kUtilizationEpsilon ? 0.0f : util;
+  return std::fabs(util) <= kUtilizationEpsilon ? 0.0f : util;
 }
 
 float MemoryTierManager::getTotalFragmentation() const {
@@ -257,9 +257,12 @@ float MemoryTierManager::getTotalFragmentation() const {
 }
 
 void MemoryTierManager::optimizeTiers() {
-  if (stm_) stm_->defragment();
-  if (mtm_) mtm_->defragment();
-  if (ltm_) ltm_->defragment();
+  if (stm_)
+    stm_->defragment();
+  if (mtm_)
+    mtm_->defragment();
+  if (ltm_)
+    ltm_->defragment();
 }
 
 // Convenience helpers used in tests
@@ -296,96 +299,98 @@ SEPResult MemoryTierManager::demoteBlock(MemoryBlock *block,
 }
 
 // --- Promotion and Demotion Logic ---
-SEPResult MemoryTierManager::promoteToTier(MemoryBlock* block,
-                                          MemoryTierEnum target_tier,
-                                          MemoryBlock*& out_block) {
-    out_block = nullptr;
-    printf("DEBUG: Attempting promotion from tier %d to tier %d\n",
-           static_cast<int>(block->tier), static_cast<int>(target_tier));
-    if (!block || !block->allocated) {
-        return SEPResult::INVALID_ARGUMENT;
-    }
+SEPResult MemoryTierManager::promoteToTier(MemoryBlock *block,
+                                           MemoryTierEnum target_tier,
+                                           MemoryBlock *&out_block) {
+  out_block = nullptr;
+  printf("DEBUG: Attempting promotion from tier %d to tier %d\n",
+         static_cast<int>(block->tier), static_cast<int>(target_tier));
+  if (!block || !block->allocated) {
+    return SEPResult::INVALID_ARGUMENT;
+  }
 
-    // Get source and destination tiers
-    MemoryTier* src_tier = getTier(block->tier);
-    MemoryTier* dst_tier = getTier(target_tier);
-    if (!src_tier || !dst_tier) {
-        return SEPResult::INVALID_ARGUMENT;
-    }
+  // Get source and destination tiers
+  MemoryTier *src_tier = getTier(block->tier);
+  MemoryTier *dst_tier = getTier(target_tier);
+  if (!src_tier || !dst_tier) {
+    return SEPResult::INVALID_ARGUMENT;
+  }
 
-    // Try to allocate in destination tier
+  // Try to allocate in destination tier
+  out_block = dst_tier->allocate(block->size);
+  if (!out_block) {
+    printf("DEBUG: Initial allocation failed, attempting defragmentation\n");
+    dst_tier->defragment();
     out_block = dst_tier->allocate(block->size);
-    if (!out_block) {
-        printf("DEBUG: Initial allocation failed, attempting defragmentation\n");
-        dst_tier->defragment();
+
+    // Ensure tier has at least space for the block
+    if (!out_block && dst_tier->getSize() < block->size * 2) {
+      std::size_t target = std::max(block->size * 2, dst_tier->getSize() * 2);
+      if (dst_tier->resize(target))
         out_block = dst_tier->allocate(block->size);
-
-        // Ensure tier has at least space for the block
-        if (!out_block && dst_tier->getSize() < block->size * 2) {
-            std::size_t target = std::max(block->size * 2, dst_tier->getSize() * 2);
-            if (dst_tier->resize(target))
-                out_block = dst_tier->allocate(block->size);
-        }
     }
+  }
 
+  if (!out_block) {
+    printf("DEBUG: Allocation failed even after defragmentation; attempting "
+           "resize\n");
+    std::size_t new_size = dst_tier->getSize();
+    // Avoid infinite loops when the tier size is initially zero
+    if (new_size == 0)
+      new_size = block->size * 2;
+    while (new_size < block->size) {
+      new_size = new_size == 0 ? block->size : new_size * 2;
+    }
+    if (dst_tier->resize(new_size)) {
+      out_block = dst_tier->allocate(block->size);
+    }
     if (!out_block) {
-        printf("DEBUG: Allocation failed even after defragmentation; attempting resize\n");
-        std::size_t new_size = dst_tier->getSize();
-        // Avoid infinite loops when the tier size is initially zero
-        if (new_size == 0)
-            new_size = block->size * 2;
-        while (new_size < block->size) {
-            new_size = new_size == 0 ? block->size : new_size * 2;
-        }
-        if (dst_tier->resize(new_size)) {
-            out_block = dst_tier->allocate(block->size);
-        }
-        if (!out_block) {
-            // As a final attempt, grow the destination tier to fit the block
-            std::size_t new_size = dst_tier->getSize() + block->size;
-            if (dst_tier->resize(std::max(new_size, dst_tier->getSize() * 2))) {
-                out_block = dst_tier->allocate(block->size);
-            }
-        }
-        if (!out_block) {
-            printf("DEBUG: Allocation failed even after resizing\n");
-            return SEPResult::ALLOCATION_FAILED;
-        }
+      // As a final attempt, grow the destination tier to fit the block
+      std::size_t new_size = dst_tier->getSize() + block->size;
+      if (dst_tier->resize(std::max(new_size, dst_tier->getSize() * 2))) {
+        out_block = dst_tier->allocate(block->size);
+      }
     }
-    printf("DEBUG: Successfully allocated block in destination tier\n");
-
-    // Copy block metadata but preserve the newly allocated pointer
-    void* new_ptr = out_block->ptr;      // pointer assigned by allocate()
-    std::size_t new_offset = out_block->offset;
-    *out_block = *block;                 // copy metrics and size
-    out_block->ptr = new_ptr;            // restore destination pointer
-    out_block->offset = new_offset;
-    out_block->tier = target_tier;
-    
-    // Calculate new utilization based on destination tier size
-    size_t total_size = dst_tier->getSize();
-    out_block->utilization = total_size > 0 ?
-        static_cast<float>(block->size) / static_cast<float>(total_size) : 0.0f;
-
-    // Move data between tiers
-    printf("DEBUG: Attempting to move data between tiers\n");
-    if (!dst_tier->moveData(out_block, block)) {
-        printf("DEBUG: Data move failed, falling back to host memcpy\n");
-        std::memcpy(out_block->ptr, block->ptr,
-                    std::min(out_block->size, block->size));
-    } else {
-        printf("DEBUG: Data move successful\n");
+    if (!out_block) {
+      printf("DEBUG: Allocation failed even after resizing\n");
+      return SEPResult::ALLOCATION_FAILED;
     }
+  }
+  printf("DEBUG: Successfully allocated block in destination tier\n");
 
-    // Update lookup maps in correct order to maintain consistency
-    {
-        std::lock_guard<std::mutex> lock(lookup_mutex);
-        lookup_map_.erase(block->ptr);
-        src_tier->deallocate(block);
-        lookup_map_[out_block->ptr] = out_block;
-    }
+  // Copy block metadata but preserve the newly allocated pointer
+  void *new_ptr = out_block->ptr; // pointer assigned by allocate()
+  std::size_t new_offset = out_block->offset;
+  *out_block = *block;      // copy metrics and size
+  out_block->ptr = new_ptr; // restore destination pointer
+  out_block->offset = new_offset;
+  out_block->tier = target_tier;
 
-    return SEPResult::SUCCESS;
+  // Calculate new utilization based on destination tier size
+  size_t total_size = dst_tier->getSize();
+  out_block->utilization = total_size > 0 ? static_cast<float>(block->size) /
+                                                static_cast<float>(total_size)
+                                          : 0.0f;
+
+  // Move data between tiers
+  printf("DEBUG: Attempting to move data between tiers\n");
+  if (!dst_tier->moveData(out_block, block)) {
+    printf("DEBUG: Data move failed, falling back to host memcpy\n");
+    std::memcpy(out_block->ptr, block->ptr,
+                std::min(out_block->size, block->size));
+  } else {
+    printf("DEBUG: Data move successful\n");
+  }
+
+  // Update lookup maps in correct order to maintain consistency
+  {
+    std::lock_guard<std::mutex> lock(lookup_mutex);
+    lookup_map_.erase(block->ptr);
+    src_tier->deallocate(block);
+    lookup_map_[out_block->ptr] = out_block;
+  }
+
+  return SEPResult::SUCCESS;
 }
 
 MemoryBlock *MemoryTierManager::updateBlockMetrics(MemoryBlock *block,
@@ -423,7 +428,8 @@ MemoryBlock *MemoryTierManager::updateBlockMetrics(MemoryBlock *block,
     return block; // No move needed
 
   MemoryBlock *new_block = nullptr;
-  SEPResult result = promoteToTier(block, target_tier_ptr->getType(), new_block);
+  SEPResult result =
+      promoteToTier(block, target_tier_ptr->getType(), new_block);
 
   if (result == SEPResult::SUCCESS) {
     // Some implementations may mistakenly return SUCCESS but leave the
@@ -437,60 +443,62 @@ MemoryBlock *MemoryTierManager::updateBlockMetrics(MemoryBlock *block,
   // input on failure rather than a nullptr which could lead to unexpected
   // crashes in tests.
   return block;
-
 }
 
 MemoryTier *MemoryTierManager::determineTier(float coherence, float stability,
                                              int generation_count) {
-    // LTM Check. If thresholds indicate promotion to LTM we return the tier
-    // directly. The allocation step will handle defragmentation or resizing
-    // if necessary, so we no longer gate promotion on free space.
-    if (coherence >= config_.promote_mtm_to_ltm &&
-        stability >= config_.promote_mtm_to_ltm && // stability heuristic
-        generation_count >= static_cast<int>(config_.mtm_to_ltm_min_gen)) {
-        MemoryTier* ltm = getTier(MemoryTierEnum::LTM);
-        if (ltm)
-            return ltm;
-    }
+  // LTM Check. If thresholds indicate promotion to LTM we return the tier
+  // directly. The allocation step will handle defragmentation or resizing
+  // if necessary, so we no longer gate promotion on free space.
+  if (coherence >= config_.promote_mtm_to_ltm &&
+      stability >= config_.promote_mtm_to_ltm && // stability heuristic
+      generation_count >= static_cast<int>(config_.mtm_to_ltm_min_gen)) {
+    MemoryTier *ltm = getTier(MemoryTierEnum::LTM);
+    if (ltm)
+      return ltm;
+  }
 
+  // MTM Check
+  if (coherence >= config_.promote_stm_to_mtm &&
+      stability >= config_.promote_stm_to_mtm &&
+      generation_count >= static_cast<int>(config_.stm_to_mtm_min_gen)) {
+    MemoryTier *mtm = getTier(MemoryTierEnum::MTM);
+    if (mtm)
+      return mtm;
+  }
 
-    // MTM Check
-    if (coherence >= config_.promote_stm_to_mtm &&
-        stability >= config_.promote_stm_to_mtm &&
-        generation_count >= static_cast<int>(config_.stm_to_mtm_min_gen)) {
-        MemoryTier* mtm = getTier(MemoryTierEnum::MTM);
-        if (mtm)
-            return mtm;
-    }
+  // Default to STM or find first available
+  MemoryTier *stm = getTier(MemoryTierEnum::STM);
+  if (stm && stm->getFreeSpace() > 0)
+    return stm;
 
-    // Default to STM or find first available
-    MemoryTier* stm = getTier(MemoryTierEnum::STM);
-    if (stm && stm->getFreeSpace() > 0) return stm;
+  // Fallback if target tier is full
+  MemoryTier *mtm = getTier(MemoryTierEnum::MTM);
+  if (mtm && mtm->getFreeSpace() > 0)
+    return mtm;
 
-    // Fallback if target tier is full
-    MemoryTier* mtm = getTier(MemoryTierEnum::MTM);
-    if (mtm && mtm->getFreeSpace() > 0) return mtm;
+  MemoryTier *ltm = getTier(MemoryTierEnum::LTM);
+  if (ltm && ltm->getFreeSpace() > 0)
+    return ltm;
 
-    MemoryTier* ltm = getTier(MemoryTierEnum::LTM);
-    if (ltm && ltm->getFreeSpace() > 0) return ltm;
-
-    return nullptr; // No space available
+  return nullptr; // No space available
 }
 
 void MemoryTierManager::rebuildLookup() {
-    std::lock_guard<std::mutex> lock(lookup_mutex);
-    lookup_map_.clear();
-    auto add_blocks = [this](MemoryTier* tier) {
-        if (!tier) return;
-        const auto& blocks = tier->getBlocks();
-        for (const auto& blk : blocks) {
-            if (blk.allocated)
-                lookup_map_[blk.ptr] = const_cast<MemoryBlock*>(&blk);
-        }
-    };
-    add_blocks(stm_.get());
-    add_blocks(mtm_.get());
-    add_blocks(ltm_.get());
+  std::lock_guard<std::mutex> lock(lookup_mutex);
+  lookup_map_.clear();
+  auto add_blocks = [this](MemoryTier *tier) {
+    if (!tier)
+      return;
+    const auto &blocks = tier->getBlocks();
+    for (const auto &blk : blocks) {
+      if (blk.allocated)
+        lookup_map_[blk.ptr] = const_cast<MemoryBlock *>(&blk);
+    }
+  };
+  add_blocks(stm_.get());
+  add_blocks(mtm_.get());
+  add_blocks(ltm_.get());
 }
 
 // --- Pattern and Relationship Management ---
@@ -500,7 +508,8 @@ void MemoryTierManager::registerPattern(
   pattern_registry_[id] = std::make_unique<sep::pattern::PatternData>(pattern);
 }
 
-const sep::pattern::PatternData* MemoryTierManager::getPatternData(std::size_t id) const {
+const sep::pattern::PatternData *
+MemoryTierManager::getPatternData(std::size_t id) const {
   std::lock_guard<std::mutex> lock(registry_mutex);
   auto it = pattern_registry_.find(id);
   return it == pattern_registry_.end() ? nullptr : it->second.get();
@@ -510,14 +519,12 @@ void MemoryTierManager::removePattern(std::size_t id) {
   std::lock_guard<std::mutex> lock(registry_mutex);
   pattern_registry_.erase(id);
 
-
   // Also remove relationships associated with this pattern
   std::lock_guard<std::mutex> rel_lock(relationships_mutex);
   pattern_relationships_.erase(id);
-  for (auto& pair : pattern_relationships_) {
+  for (auto &pair : pattern_relationships_) {
     pair.second.erase(id);
-    }
-
+  }
 }
 
 void MemoryTierManager::updateRelationship(std::size_t id_a, std::size_t id_b,
@@ -529,8 +536,8 @@ void MemoryTierManager::updateRelationship(std::size_t id_a, std::size_t id_b,
 
 void MemoryTierManager::pruneWeakRelationships() {
   std::lock_guard<std::mutex> lock(relationships_mutex);
-  for (auto& [id, relations] : pattern_relationships_) {
-    for (auto it = relations.begin(); it != relations.end(); ) {
+  for (auto &[id, relations] : pattern_relationships_) {
+    for (auto it = relations.begin(); it != relations.end();) {
       if (it->second < config_.demote_threshold) { // Reuse demote threshold
         it = relations.erase(it);
       } else {
@@ -546,17 +553,17 @@ void MemoryTierManager::calculateRelationshipCoherence() {
 
   for (auto &[id, pattern_ptr] : pattern_registry_) {
     if (pattern_relationships_.count(id)) {
-      const auto& rels = pattern_relationships_.at(id);
+      const auto &rels = pattern_relationships_.at(id);
       if (!rels.empty()) {
         double sum = 0.0;
         for (const auto &r : rels) {
           sum += r.second;
-          }
-          pattern_ptr->coherence = static_cast<float>(sum / rels.size());
+        }
+        pattern_ptr->coherence = static_cast<float>(sum / rels.size());
       }
     }
   }
 }
 
-} // namespace sep::memory
+} // namespace memory
 } // namespace sep


### PR DESCRIPTION
## Summary
- guard against tiny rounding errors when computing tier utilization
- adjust MemoryTierManager zero check logic

## Testing
- `cmake -S .. -B cmake-no-cuda -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DSEP_HAS_CUDA=0 -DSEP_USE_CUDA=0 -DCMAKE_DISABLE_FIND_PACKAGE_CUDAToolkit=ON -DSEP_WITH_CYCLES=OFF -DSEP_WITH_AUDIO=OFF` *(fails: Could not find fmt)*

------
https://chatgpt.com/codex/tasks/task_e_686c5138b190832ab292c0c5daa66b0c