### PR TITLE
Fix tier promotion logic in MemoryTierManager

### DIFF
--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -466,17 +466,8 @@ MemoryTier *MemoryTierManager::determineTier(float coherence, float stability,
   if (coherence >= config_.promote_stm_to_mtm &&
       stability >= config_.promote_stm_to_mtm &&
       generation_count >= static_cast<int>(config_.stm_to_mtm_min_gen)) {
-    MemoryTier *mtm = getTier(MemoryTierEnum::MTM);
-    if (mtm)
-      return mtm;
+    return getTier(MemoryTierEnum::MTM);
   }
-
-    // MTM Check
-    if (coherence >= config_.promote_stm_to_mtm &&
-        stability >= config_.promote_stm_to_mtm &&
-        generation_count >= static_cast<int>(config_.stm_to_mtm_min_gen)) {
-        return getTier(MemoryTierEnum::MTM);
-    }
 
     // Default to STM or find first available
     if (MemoryTier* stm = getTier(MemoryTierEnum::STM))


### PR DESCRIPTION
## Summary
- simplify tier selection logic in `determineTier`

## Testing
- `./build_no_cuda.sh` *(fails: Could NOT find OpenVDB)*

------
https://chatgpt.com/codex/tasks/task_e_686c56cc8274832a8e9b1a22eb4c089c