### PR TITLE
Fix lookup refresh after block promotion

### DIFF
--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -390,6 +390,12 @@ SEPResult MemoryTierManager::promoteToTier(MemoryBlock *block,
     lookup_map_[out_block->ptr] = out_block;
   }
 
+  // Rebuild the lookup table to keep any stale pointers from previous
+  // defragmentation or resize operations in sync with the new block
+  // locations.  Unit tests rely on findBlockByPtr returning the latest
+  // address so we refresh the map after every successful move.
+  rebuildLookup();
+
   return SEPResult::SUCCESS;
 }
 


### PR DESCRIPTION
## Summary
- ensure lookup map stays current when moving blocks across tiers

## Testing
- `./tests/memory/memory_manager_tests --gtest_filter=MemoryTierManagerTest.PromotionAndDemotion` *(fails: error while loading shared libraries)*

------
https://chatgpt.com/codex/tasks/task_e_686c5b36f208832ab71e80d1df8ae861