### PR TITLE
Fix zero-utilization check in tier manager

### DIFF
--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -182,12 +182,14 @@ float MemoryTierManager::getTierUtilization(MemoryTierEnum tier) const {
   if (!t)
     return 0.0f;
 
-  // Directly recompute utilization from the tier's blocks each time.  Using the
-  // cached free space value proved unreliable when blocks move between tiers,
-  // occasionally leaving a small non-zero remainder that caused equality based
-  // unit tests to fail.  calculateUtilization() iterates over the current block
-  // list ensuring an accurate value even if internal counters become
-  // temporarily inconsistent.
+  // If the tier reports all memory free, avoid redundant calculations and
+  // return zero immediately. This guards against residual rounding artifacts
+  // that sometimes appear after block moves or defragmentation.
+  if (t->getFreeSpace() == t->getSize())
+    return 0.0f;
+
+  // Recompute utilization from the current block list to prevent stale values
+  // when internal counters drift after complex promotions.
   float util = t->calculateUtilization();
 
   // Guard against rounding artifacts that may appear after a block is


### PR DESCRIPTION
## Summary
- return zero utilization immediately when a tier's free space equals its size

## Testing
- `cmake -DCMAKE_BUILD_TYPE=Debug -DSEP_HAS_CUDA=OFF -DSEP_WITH_CYCLES=OFF ..` *(fails: Could NOT find OpenSubdiv)*

------
https://chatgpt.com/codex/tasks/task_e_686c5b36f208832ab71e80d1df8ae861