### PR TITLE
Fix rounding artifacts in tier utilization

### DIFF
--- a/include/memory/memory_tier.hpp
+++ b/include/memory/memory_tier.hpp
@@ -27,7 +27,10 @@ using ::sep::SEPResult;
 // so that allocations of a single kilobyte in a default 1MB tier are still
 // reported as non-zero while tiny rounding artifacts after promotions or
 // defragmentation are clamped to zero.
-inline constexpr float kUtilizationEpsilon = 5e-4f;
+// A slightly larger epsilon avoids lingering non-zero utilization values
+// (e.g. 0.000244) that appear during tier promotions and internal
+// defragmentation when the used space is effectively zero.
+inline constexpr float kUtilizationEpsilon = 1e-3f;
 
 // Memory tier types
 enum class TierType {


### PR DESCRIPTION
## Summary
- bump `kUtilizationEpsilon` to suppress tiny non-zero values that appear after promotions or defragmentation

## Testing
- `./tests/memory/memory_manager_tests` *(fails: libgtest_main.so.1.15.2 not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c6420eb0c832abf673a75b9f55f16