### PR TITLE
Enable non-CUDA builds and optional test run

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,6 @@ include_directories(BEFORE
 # `BEFORE` argument to `add_subdirectory`, which caused configuration errors
 # with newer versions of CMake. We simply add the directories in the
 # required order instead.
-add_subdirectory(src/core)
 
 # Backwards compatibility variables
 set(SEP_ENABLE_BLENDER ${SEP_WITH_CYCLES})
@@ -115,15 +114,21 @@ find_package(fmt REQUIRED)
 find_package(http_parser REQUIRED)
 find_package(spdlog REQUIRED)
 find_package(OpenVDB REQUIRED)
-find_package(OpenSubdiv REQUIRED)
-find_package(OpenPGL REQUIRED)
+if(SEP_WITH_CYCLES)
+    find_package(OpenSubdiv REQUIRED)
+    find_package(OpenPGL REQUIRED)
+endif()
 find_package(OpenColorIO REQUIRED)
 find_package(Imath REQUIRED)
 find_package(TBB REQUIRED)
 find_package(OpenImageIO REQUIRED)
 find_package(embree REQUIRED)
-find_package(OSL REQUIRED)
-find_package(Alembic REQUIRED)
+if(SEP_WITH_CYCLES)
+    find_package(OSL REQUIRED)
+endif()
+if(SEP_WITH_CYCLES)
+    find_package(Alembic REQUIRED)
+endif()
 
 # Add subdirectories
 add_subdirectory(src/core)
@@ -140,15 +145,17 @@ endif()
 if(SEP_WITH_CYCLES)
     add_subdirectory(src/blender)
 endif()
-add_subdirectory(extern/cycles/third_party/cuew)
-add_subdirectory(extern/cycles/third_party/hipew)
-add_subdirectory(extern/cycles/third_party/sky)
+if(SEP_WITH_CYCLES)
+    add_subdirectory(extern/cycles/third_party/cuew)
+    add_subdirectory(extern/cycles/third_party/hipew)
+    add_subdirectory(extern/cycles/third_party/sky)
+endif()
 
 # Add tests directory
 add_subdirectory(tests)
 
 # Build Cycles from source when prebuilt libraries are not available
-if(NOT EXISTS "${CMAKE_SOURCE_DIR}/lib/libcycles_device.a")
+if(SEP_WITH_CYCLES AND NOT EXISTS "${CMAKE_SOURCE_DIR}/lib/libcycles_device.a")
   message(STATUS "Prebuilt Cycles libraries not found; building from source")
   set(WITH_CYCLES_DEVICE_HIP OFF CACHE BOOL "Disable HIP" FORCE)
   set(WITH_CYCLES_DEVICE_HIPRT OFF CACHE BOOL "Disable HIPRT" FORCE)
@@ -184,8 +191,7 @@ target_link_libraries(sep_engine PRIVATE
     ${CURL_LIBRARIES}
     ${CMAKE_DL_LIBS}
     $<$<TARGET_EXISTS:CUDA::cudart>:CUDA::cudart>
-    CUDA::cudart
-    CUDA::cuda_driver
+    $<$<TARGET_EXISTS:CUDA::cuda_driver>:CUDA::cuda_driver>
 )
 
 # Only link Cycles libraries if they exist and SEP_WITH_CYCLES is enabled

--- a/install.sh
+++ b/install.sh
@@ -13,6 +13,7 @@ PACKAGES=(
   libboost-all-dev libopencolorio-dev libopenimageio-dev
   libembree-dev libpugixml-dev libopenjp2-7-dev
   libcurl4-openssl-dev libhttp-parser-dev libopenvdb-dev
+  libfmt-dev libspdlog-dev
 )
 
 echo "Updating package lists..."
@@ -67,4 +68,14 @@ if ! dpkg -s libusd-dev >/dev/null 2>&1; then
 fi
 
 echo "All dependencies installed. See $LOG_DIR for logs."
-  
+
+# Optional build and test step when invoked with --run-tests
+if [[ "${1:-}" == "--run-tests" ]]; then
+  echo "Building project without CUDA for validation..."
+  if ./build_no_cuda.sh > "$LOG_DIR/build.log" 2>&1; then
+    echo "Running memory manager tests..."
+    (cd cmake-nocuda && ctest --output-on-failure -R memory_manager_tests >> "$LOG_DIR/test.log" 2>&1)
+  else
+    echo "Build failed. Check $LOG_DIR/build.log for details." >&2
+  fi
+fi

--- a/src/compat/CMakeLists.txt
+++ b/src/compat/CMakeLists.txt
@@ -68,15 +68,21 @@ set_target_properties(sep_compat PROPERTIES
     CUDA_ARCHITECTURES "75;70;61;60"
 )
 
-target_link_libraries(sep_compat
-    PUBLIC
-        CUDA::cudart
-        CUDA::cuda_driver
-)
+if(SEP_HAS_CUDA)
+    target_link_libraries(sep_compat
+        PUBLIC
+            CUDA::cudart
+            CUDA::cuda_driver
+    )
+endif()
 
 set_property(TARGET sep_compat PROPERTY CUDA_STANDARD 17)
 
-target_compile_definitions(sep_compat PUBLIC SEP_USE_CUDA=1)
+if(SEP_HAS_CUDA)
+    target_compile_definitions(sep_compat PUBLIC SEP_USE_CUDA=1)
+else()
+    target_compile_definitions(sep_compat PUBLIC SEP_USE_CUDA=0)
+endif()
 
 # Include directories
 target_include_directories(sep_compat
@@ -93,6 +99,7 @@ target_include_directories(sep_compat
 target_link_libraries(sep_compat
     PUBLIC
         sep_core
-        CUDA::cudart
-        CUDA::cuda_driver
 )
+if(SEP_HAS_CUDA)
+    target_link_libraries(sep_compat PUBLIC CUDA::cudart CUDA::cuda_driver)
+endif()

--- a/src/memory/CMakeLists.txt
+++ b/src/memory/CMakeLists.txt
@@ -12,23 +12,38 @@ find_library(HIREDIS_LIB NAMES hiredis PATHS /usr/lib64 REQUIRED)
 find_path(HIREDIS_INCLUDE_DIR NAMES hiredis.h PATHS /usr/include/hiredis REQUIRED)
 
 # Add CUDA-specific compile definitions to handle exception specs
-target_compile_definitions(sep_memory PRIVATE
-    SEP_HAS_CUDA=1
-    SEP_CUDACC_DISABLE_EXCEPTION_SPEC_CHECKS=1)
+if(SEP_HAS_CUDA)
+    target_compile_definitions(sep_memory PRIVATE
+        SEP_HAS_CUDA=1
+        SEP_CUDACC_DISABLE_EXCEPTION_SPEC_CHECKS=1)
+else()
+    target_compile_definitions(sep_memory PRIVATE
+        SEP_HAS_CUDA=0)
+endif()
 
 # Configure dependencies
-find_package(CUDA REQUIRED)
+if(SEP_HAS_CUDA)
+    find_package(CUDAToolkit REQUIRED)
+endif()
 find_package(Threads REQUIRED)
 
 # Set CUDA properties
-set_target_properties(sep_memory PROPERTIES
-    CUDA_SEPARABLE_COMPILATION ON
-    CUDA_RESOLVE_DEVICE_SYMBOLS ON
-    POSITION_INDEPENDENT_CODE ON
-    CUDA_ARCHITECTURES "75;70;61;60"
-    CXX_VISIBILITY_PRESET default
-    VISIBILITY_INLINES_HIDDEN OFF
-)
+if(SEP_HAS_CUDA)
+    set_target_properties(sep_memory PROPERTIES
+        CUDA_SEPARABLE_COMPILATION ON
+        CUDA_RESOLVE_DEVICE_SYMBOLS ON
+        POSITION_INDEPENDENT_CODE ON
+        CUDA_ARCHITECTURES "75;70;61;60"
+        CXX_VISIBILITY_PRESET default
+        VISIBILITY_INLINES_HIDDEN OFF
+    )
+else()
+    set_target_properties(sep_memory PROPERTIES
+        POSITION_INDEPENDENT_CODE ON
+        CXX_VISIBILITY_PRESET default
+        VISIBILITY_INLINES_HIDDEN OFF
+    )
+endif()
 
 # Link dependencies
 target_link_libraries(sep_memory
@@ -51,13 +66,22 @@ target_include_directories(sep_memory
 )
 
 # Add compile definitions
-target_compile_definitions(sep_memory
-    PUBLIC
-        SEP_HAS_CUDA=1
-    PRIVATE
-        SEP_USE_CUDA=1
-        SEP_HAS_REDIS=1
-)
+if(SEP_HAS_CUDA)
+    target_compile_definitions(sep_memory
+        PUBLIC
+            SEP_HAS_CUDA=1
+        PRIVATE
+            SEP_USE_CUDA=1
+            SEP_HAS_REDIS=1
+    )
+else()
+    target_compile_definitions(sep_memory
+        PUBLIC
+            SEP_HAS_CUDA=0
+        PRIVATE
+            SEP_HAS_REDIS=1
+    )
+endif()
 
 message(STATUS "Found hiredis: ${HIREDIS_LIB}")
 message(STATUS "Found hiredis headers: ${HIREDIS_INCLUDE_DIR}")

--- a/tests/memory/CMakeLists.txt
+++ b/tests/memory/CMakeLists.txt
@@ -27,17 +27,25 @@ target_link_libraries(memory_manager_tests PRIVATE
     GTest::GTest
     GTest::Main
     hiredis
-    CUDA::cudart
-    CUDA::cuda_driver
     Threads::Threads
 )
+if(SEP_HAS_CUDA)
+    target_link_libraries(memory_manager_tests PRIVATE CUDA::cudart CUDA::cuda_driver)
+endif()
 
-target_compile_definitions(memory_manager_tests PRIVATE
-    SEP_HAS_CUDA=1
-    SEP_USE_CUDA=1
-    SEP_HAS_REDIS=1
-    SEP_CUDACC_DISABLE_EXCEPTION_SPEC_CHECKS=1
-)
+if(SEP_HAS_CUDA)
+    target_compile_definitions(memory_manager_tests PRIVATE
+        SEP_HAS_CUDA=1
+        SEP_USE_CUDA=1
+        SEP_HAS_REDIS=1
+        SEP_CUDACC_DISABLE_EXCEPTION_SPEC_CHECKS=1
+    )
+else()
+    target_compile_definitions(memory_manager_tests PRIVATE
+        SEP_HAS_CUDA=0
+        SEP_HAS_REDIS=1
+    )
+endif()
 
 # Include directories are inherited from linked targets
 target_include_directories(memory_manager_tests PRIVATE
@@ -48,10 +56,17 @@ target_include_directories(memory_manager_tests PRIVATE
     ${CMAKE_SOURCE_DIR}/include/compat
 )
 
-target_compile_definitions(memory_manager_tests PRIVATE
-    SEP_HAS_CUDA=1
-    SEP_USE_CUDA=1
-    SEP_HAS_REDIS=1
-)
+if(SEP_HAS_CUDA)
+    target_compile_definitions(memory_manager_tests PRIVATE
+        SEP_HAS_CUDA=1
+        SEP_USE_CUDA=1
+        SEP_HAS_REDIS=1
+    )
+else()
+    target_compile_definitions(memory_manager_tests PRIVATE
+        SEP_HAS_CUDA=0
+        SEP_HAS_REDIS=1
+    )
+endif()
 
 add_test(NAME memory_manager_tests COMMAND memory_manager_tests)


### PR DESCRIPTION
## Summary
- add fmt/spdlog packages in `install.sh`
- allow `install.sh --run-tests` to build without CUDA and run memory tests
- guard Cycles dependencies in `CMakeLists.txt`
- make `sep_memory` and `sep_compat` respect `SEP_HAS_CUDA`
- update memory tests to compile when CUDA is disabled

## Testing
- `cmake -S . -B build_nocuda_test -DCMAKE_C_COMPILER=/usr/bin/gcc -DCMAKE_CXX_COMPILER=/usr/bin/g++ -DSEP_WITH_CYCLES=OFF -DSEP_WITH_AUDIO=OFF -DSEP_HAS_CUDA=0 -DSEP_ENABLE_AUDIO=OFF -DSEP_WORKBENCH_DEMO=OFF`


------
https://chatgpt.com/codex/tasks/task_e_686c70fa0e5c832a871353e5c1ab86c1