### PR TITLE
Improve memory test dependencies

### DIFF
--- a/include/core/logging.h
+++ b/include/core/logging.h
@@ -2,6 +2,7 @@
 #define SEP_LOGGING_MANAGER_H
 
 #include "memory/types.h"
+#include "core/logging_types.h"
 #include "core/tracing.h"
 #include <spdlog/spdlog.h>
 #include <memory>

--- a/include/core/logging_types.h
+++ b/include/core/logging_types.h
@@ -1,0 +1,30 @@
+#pragma once
+#include <string>
+#include <cstddef>
+
+namespace sep::logging {
+
+enum class Level {
+  TRACE,
+  DEBUG,
+  INFO,
+  WARN,
+  ERROR,
+  CRITICAL
+};
+
+struct LoggerConfig {
+  std::string name;
+  Level level{Level::INFO};
+  struct ConsoleConfig {
+    bool enabled{true};
+  } console;
+  struct FileConfig {
+    std::string path;
+    std::size_t max_size{1048576};
+    std::size_t max_files{3};
+  } file;
+  std::string pattern;
+};
+
+} // namespace sep::logging

--- a/include/logging/manager.h
+++ b/include/logging/manager.h
@@ -1,0 +1,2 @@
+#pragma once
+#include "core/logging.h"

--- a/install.sh
+++ b/install.sh
@@ -32,6 +32,7 @@ PACKAGES=(
   libembree-dev libpugixml-dev libopenjp2-7-dev
   libcurl4-openssl-dev libhttp-parser-dev libopenvdb-dev
   libfmt-dev
+  libspdlog-dev libgtest-dev libhiredis-dev
 )
 
 echo "Updating package lists..."

--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -2,6 +2,10 @@ if(NOT BUILD_TESTING)
     return()
 endif()
 
+if(NOT SEP_HAS_CUDA)
+    return()
+endif()
+
 find_package(GTest REQUIRED)
 
 add_executable(long_double_math_test

--- a/tests/memory/CMakeLists.txt
+++ b/tests/memory/CMakeLists.txt
@@ -4,7 +4,7 @@ endif()
 
 find_package(GTest REQUIRED)
 
-find_package(Hiredis REQUIRED CONFIG)
+find_package(Hiredis 1.0 REQUIRED CONFIG)
 
 add_executable(memory_manager_tests
     memory_headers_test.cpp
@@ -26,9 +26,7 @@ target_link_libraries(memory_manager_tests PRIVATE
     sep_core
     GTest::GTest
     GTest::Main
-    Hiredis::Hiredis
-    CUDA::cudart
-    CUDA::cuda_driver
+    ${HIREDIS_LIBRARIES}
     Threads::Threads
 )
 if(SEP_HAS_CUDA)
@@ -49,6 +47,7 @@ target_include_directories(memory_manager_tests PRIVATE
     ${CMAKE_SOURCE_DIR}/include/memory
     ${CMAKE_SOURCE_DIR}/include/core
     ${CMAKE_SOURCE_DIR}/include/compat
+    ${HIREDIS_INCLUDE_DIRS}
 )
 
 target_compile_definitions(memory_manager_tests PRIVATE


### PR DESCRIPTION
## Summary
- install extra deps for memory tests
- fix Hiredis config usage
- avoid building CUDA tests when CUDA is off
- add stub logging types and header alias for compatibility

## Testing
- `./build_no_cuda.sh` *(fails: invalid new-expression of abstract class, missing persistence types)*

------
https://chatgpt.com/codex/tasks/task_e_686c75efbee4832aab4296c5fa227aae