### PR TITLE
Fix test CMake files for local builds

### DIFF
--- a/include/logging/manager.h
+++ b/include/logging/manager.h
@@ -1,0 +1,6 @@
+#ifndef SEP_LOGGING_MANAGER_COMPAT_H
+#define SEP_LOGGING_MANAGER_COMPAT_H
+
+#include "core/logging.h"
+
+#endif // SEP_LOGGING_MANAGER_COMPAT_H

--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -4,6 +4,13 @@ endif()
 
 find_package(GTest REQUIRED)
 
+# Skip CUDA-specific tests when CUDA support is disabled.  This prevents
+# build failures in environments without CUDA.
+if(NOT SEP_HAS_CUDA)
+    message(STATUS "Skipping CUDA tests because SEP_HAS_CUDA=OFF")
+    return()
+endif()
+
 add_executable(long_double_math_test
     long_double_math_test.cpp
 )

--- a/tests/memory/CMakeLists.txt
+++ b/tests/memory/CMakeLists.txt
@@ -4,7 +4,9 @@ endif()
 
 find_package(GTest REQUIRED)
 
-find_package(Hiredis REQUIRED CONFIG)
+# Specify minimum version to avoid HiredisConfigVersion.cmake errors when
+# PACKAGE_FIND_VERSION is empty.
+find_package(Hiredis 1.2 REQUIRED CONFIG)
 
 add_executable(memory_manager_tests
     memory_headers_test.cpp
@@ -26,9 +28,7 @@ target_link_libraries(memory_manager_tests PRIVATE
     sep_core
     GTest::GTest
     GTest::Main
-    Hiredis::Hiredis
-    CUDA::cudart
-    CUDA::cuda_driver
+    ${HIREDIS_LIBRARIES}
     Threads::Threads
 )
 if(SEP_HAS_CUDA)


### PR DESCRIPTION
## Summary
- add compatibility header so `#include "logging/manager.h"` resolves
- avoid CMake errors with hiredis by specifying version and linking with the variable
- skip CUDA unit tests entirely when CUDA is disabled

## Testing
- `./build_no_cuda.sh` *(fails: invalid new-expression of abstract class type)*

------
https://chatgpt.com/codex/tasks/task_e_686c75efbee4832aab4296c5fa227aae