### PR TITLE
Fix tier utilization under tiny allocations

### DIFF
--- a/src/memory/memory_tier.cpp
+++ b/src/memory/memory_tier.cpp
@@ -273,8 +273,8 @@ sep::SEPResult MemoryTier::defragment() {
     // The block may have been moved to another tier in a previous iteration, so
     // ensure it is still allocated before attempting to update its metrics.
     if (blk && blk->allocated) {
-      mgr.updateBlockMetrics(blk, blk->coherence, blk->stability, blk->generation,
-                             1.0f);
+      mgr.updateBlockMetrics(blk, blk->coherence, blk->stability,
+                             blk->generation, 1.0f);
     }
   }
   mgr.rebuildLookup();
@@ -323,7 +323,8 @@ float MemoryTier::calculateUtilization() const {
       used += blk.size;
   }
 
-  if (used == 0)
+  if (used == 0 ||
+      used <= static_cast<std::size_t>(config_.size * kUtilizationEpsilon))
     return 0.0f;
 
   float util = static_cast<float>(used) / static_cast<float>(config_.size);

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -187,12 +187,18 @@ float MemoryTierManager::getTierUtilization(MemoryTierEnum tier) const {
   if (t->getFreeSpace() == t->getSize())
     return 0.0f;
 
+  // When only a few bytes remain allocated, rounding can produce a
+  // non-zero utilization even though logically the tier is empty.
+  // Guard against this by explicitly comparing the used space
+  // against a scaled epsilon threshold before computing the final
+  // utilization.
+  std::size_t used = t->getSize() - t->getFreeSpace();
+  if (used == 0 ||
+      used <= static_cast<std::size_t>(t->getSize() * kUtilizationEpsilon))
+    return 0.0f;
   // Derive utilization from the tracked free space instead of walking the
   // block list.  This prevents stale metadata from influencing the result
   // after complex operations like promotion or defragmentation.
-  std::size_t used = t->getSize() - t->getFreeSpace();
-  if (used == 0)
-    return 0.0f;
 
   float util = static_cast<float>(used) / static_cast<float>(t->getSize());
 


### PR DESCRIPTION
## Summary
- handle very small allocations when measuring tier utilization
- clamp utilization to zero if used space falls under epsilon threshold

## Testing
- `apt-get install -y libcudart12 libgtest-dev` *(fails: prebuilt tests require older gtest version)*
- `../sep/tests/memory/memory_manager_tests` *(fails: missing libgtest_main.so)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_686c86397a34832abcd257866f7b9d2b