### PR TITLE
Fix hiredis optional in memory tests

### DIFF
--- a/tests/memory/CMakeLists.txt
+++ b/tests/memory/CMakeLists.txt
@@ -4,7 +4,11 @@ endif()
 
 find_package(GTest REQUIRED)
 
-find_package(Hiredis CONFIG)
+# Redis is optional for the unit tests.  Some environments may not
+# provide a complete CMake configuration for hiredis which would
+# otherwise cause configuration to fail.  Search for the package but
+# continue silently if it is not available.
+find_package(Hiredis 1.0 CONFIG QUIET)
 
 add_executable(memory_manager_tests
     memory_headers_test.cpp
@@ -28,7 +32,7 @@ target_link_libraries(memory_manager_tests PRIVATE
     GTest::Main
     Threads::Threads
 )
-if(HIREDIS_FOUND)
+if(TARGET Hiredis::Hiredis)
     target_link_libraries(memory_manager_tests PRIVATE Hiredis::Hiredis)
 endif()
 if(SEP_HAS_CUDA)


### PR DESCRIPTION
## Summary
- make hiredis optional when building memory tests so configuration doesn't fail

## Testing
- `cmake .. -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON -DSEP_HAS_CUDA=OFF -DSEP_WITH_CYCLES=OFF -DSEP_WITH_OPENSUBDIV=OFF -DSEP_WITH_OPENPGL=OFF -DSEP_WITH_OCIO=OFF -DSEP_WITH_OPENIMAGEIO=OFF -DSEP_WITH_EMBREE=OFF -DSEP_WITH_OSL=OFF -DSEP_WITH_ALEMBIC=OFF -DSEP_WITH_AUDIO=OFF`
- `make memory_manager_tests -j$(nproc)` *(fails: invalid new-expression of abstract class type)*

------
https://chatgpt.com/codex/tasks/task_e_686c883df824832a9566c29f91c754d1