### PR TITLE
Relax epsilon for memory tier metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,4 @@ blender
 !sep_engine/
 !examples/json_processor_build.cmake
 package-lock.json
+third_party/glm/

--- a/include/memory/memory_tier.hpp
+++ b/include/memory/memory_tier.hpp
@@ -31,7 +31,10 @@ using ::sep::SEPResult;
 // when tiers temporarily hold extremely small allocations during promotion
 // or defragmentation.  Values below this threshold are effectively treated
 // as zero utilization in tests.
-inline constexpr float kUtilizationEpsilon = 1e-3f;
+// Relax the epsilon to further suppress tiny residuals that appear after
+// promotions or tier defragmentation.  Values below this threshold are treated
+// as zero when reporting utilization metrics.
+inline constexpr float kUtilizationEpsilon = 1e-2f;
 
 // Memory tier types
 enum class TierType {


### PR DESCRIPTION
## Summary
- ignore third_party/glm
- broaden allowed epsilon when measuring tier utilization to better handle tiny rounding artifacts

## Testing
- `cmake -DCMAKE_BUILD_TYPE=Debug -DSEP_HAS_CUDA=0 -DBUILD_TESTING=ON -DCMAKE_DISABLE_FIND_PACKAGE_Hiredis=TRUE ..` *(failed: could not compile due to missing dependencies)*
- `make memory_manager_tests` *(failed: missing headers like nlohmann/json.hpp)*

------
https://chatgpt.com/codex/tasks/task_e_686c883df824832a9566c29f91c754d1