### PR TITLE
Fix include paths and add missing deps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ set(SEP_SRC_DIR ${CMAKE_SOURCE_DIR}/src)
 include_directories(BEFORE
     ${SEP_INCLUDE_DIR}
     ${SEP_SRC_DIR}
+    ${CMAKE_SOURCE_DIR}/third_party/glm
 )
 
 # Ensure core headers are available
@@ -110,6 +111,7 @@ endif()
 include_directories(BEFORE
     ${CMAKE_SOURCE_DIR}/include
     ${CMAKE_SOURCE_DIR}/extern/crow/include
+    ${CMAKE_SOURCE_DIR}/third_party/glm
 )
 add_compile_definitions(CROW_USE_BOOST)
 

--- a/install.sh
+++ b/install.sh
@@ -38,6 +38,7 @@ PACKAGES=(
   libfmt-dev
   libspdlog-dev libgtest-dev libhiredis-dev
   libpipewire-0.3-dev libfftw3-dev libopenexr-dev
+  libglm-dev nlohmann-json3-dev
   valgrind
 )
 
@@ -81,5 +82,4 @@ if apt-cache show gcc-14 >/dev/null 2>&1; then
 fi
 
 sudo ln -sf /workspace/sep /sep
-
 cd /sep

--- a/src/compat/CMakeLists.txt
+++ b/src/compat/CMakeLists.txt
@@ -92,6 +92,7 @@ target_include_directories(sep_compat
     PRIVATE
         $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src>
         $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/extern/cycles/src>
+        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/third_party/glm>
         ${CUDA_INCLUDE_DIRS}
 )
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -48,6 +48,7 @@ target_include_directories(sep_core
         $<INSTALL_INTERFACE:include>
     PRIVATE
         $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src>
+        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/third_party/glm>
 )
 
 target_link_libraries(sep_core


### PR DESCRIPTION
## Summary
- point CMake at the vendored glm headers
- install glm and nlohmann json

## Testing
- `cmake -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Debug ...`
- `cmake --build . --target memory_manager_tests` *(fails: invalid new-expression of abstract class type)*

------
https://chatgpt.com/codex/tasks/task_e_686c88eacc6c832ab5d8859a8d61b4eb