### PR TITLE
Fix install dependencies

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -36,7 +36,7 @@ PACKAGES=(
   libembree-dev libpugixml-dev libopenjp2-7-dev
   libcurl4-openssl-dev libhttp-parser-dev libopenvdb-dev
   libfmt-dev
-  libspdlog-dev libgtest-dev libhiredis-dev
+  libspdlog-dev libgtest-dev libhiredis-dev libglm-dev nlohmann-json3-dev
   libpipewire-0.3-dev libfftw3-dev libopenexr-dev
   valgrind
 )


### PR DESCRIPTION
## Summary
- add missing GLM and nlohmann-json packages

## Testing
- `ctest --output-on-failure -R memory_manager_tests` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_686c88eacc6c832ab5d8859a8d61b4eb