### PR TITLE
Update no-cuda build script

### DIFF
--- a/build_no_cuda.sh
+++ b/build_no_cuda.sh
@@ -9,8 +9,10 @@ mkdir -p "$BUILD_DIR"
 cd "$BUILD_DIR"
 
 cmake -S "$REPO_ROOT" -B "$BUILD_DIR" \
+  -DCMAKE_BUILD_TYPE=Debug \
+  -DBUILD_TESTING=ON \
   -DCMAKE_C_COMPILER=/usr/bin/gcc \
-  -DCMAKE_CXX_COMPILER=/usr/bin/g++ \
+  -DCMAKE_CXX_COMPILER=/usr/bin/g++-14 \
   -DSEP_WITH_CYCLES=OFF \
   -DSEP_WITH_AUDIO=OFF \
   -DSEP_WITH_OPENSUBDIV=OFF \


### PR DESCRIPTION
## Summary
- make build_no_cuda.sh enable Debug and test builds
- use g++-14 for compatibility

## Testing
- `./build_no_cuda.sh` *(fails: Logger does not name a type)*

------
https://chatgpt.com/codex/tasks/task_e_686c8c548af4832a9e4f5a7216253c43