### PR TITLE
Add persistent pattern data struct

### DIFF
--- a/include/memory/memory_tier.hpp
+++ b/include/memory/memory_tier.hpp
@@ -15,6 +15,7 @@
 #include "../core/common.h"
 #include "../core/types.h"
 #include "types.h"
+#include "persistence/pattern_data.hpp"
 
 namespace sep {
 namespace memory {

--- a/include/memory/memory_tier_manager.hpp
+++ b/include/memory/memory_tier_manager.hpp
@@ -17,6 +17,7 @@
 #include "quantum/types.h"
 #include "quantum/data.hpp"
 #include "memory/redis_manager.h"
+#include "persistence/pattern_data.hpp"
 
 // Standard library includes
 #include <cstddef>

--- a/include/memory/redis_manager.h
+++ b/include/memory/redis_manager.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "memory/types.h"
+#include "persistence/pattern_data.hpp"
 
 #ifndef SEP_NO_REDIS
 #  include <hiredis/hiredis.h>

--- a/include/persistence/pattern_data.hpp
+++ b/include/persistence/pattern_data.hpp
@@ -1,0 +1,18 @@
+#pragma once
+#include <cstdint>
+
+namespace sep {
+namespace memory { namespace persistence {
+
+struct PersistentPatternData {
+    float coherence{0.0f};
+    float stability{0.0f};
+    std::uint32_t generation_count{0};
+};
+
+} } // namespace memory::persistence
+
+namespace persistence {
+using PersistentPatternData = ::sep::memory::persistence::PersistentPatternData;
+} // namespace persistence
+} // namespace sep


### PR DESCRIPTION
## Summary
- introduce `PersistentPatternData` struct for persistence
- include the new header in Redis and memory tier managers
- wire memory tier header to use persistent pattern data

## Testing
- `cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=g++-14 -DBUILD_TESTING=ON -DSEP_HAS_CUDA=0 -DSEP_WITH_CYCLES=OFF -DSEP_WITH_OPENSUBDIV=OFF -DSEP_WITH_OPENPGL=OFF -DSEP_WITH_OPENIMAGEIO=OFF -DSEP_WITH_EMBREE=OFF -DSEP_WITH_OSL=OFF -DSEP_WITH_AUDIO=OFF -DSEP_WITH_ALEMBIC=OFF ..`
- `make -j$(nproc) memory_manager_tests` *(fails: invalid new-expression of abstract class type `DefaultCompressor`)*

------
https://chatgpt.com/codex/tasks/task_e_686c8c548af4832a9e4f5a7216253c43