### PR TITLE
Add minimal build options and types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,8 @@ option(SEP_WITH_OSL "Enable OpenShadingLanguage support" ON)
 option(SEP_WITH_ALEMBIC "Enable Alembic support" ON)
 option(SEP_WITH_AUDIO "Enable PipeWire audio integration" ON)
 option(SEP_WORKBENCH_DEMO "Build sep_workbench in demo mode" OFF)
+option(SEP_BUILD_ENGINE "Build the main engine component" ON)
+option(SEP_BUILD_QUANTUM "Build quantum processing components" OFF)
 
 # Configure include paths
 set(SEP_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/include)

--- a/build_no_cuda.sh
+++ b/build_no_cuda.sh
@@ -22,6 +22,8 @@ cmake -S "$REPO_ROOT" -B "$BUILD_DIR" \
   -DSEP_WITH_ALEMBIC=OFF \
   -DSEP_HAS_CUDA=0 \
   -DSEP_ENABLE_AUDIO=OFF \
-  -DSEP_WORKBENCH_DEMO=OFF
+  -DSEP_WORKBENCH_DEMO=OFF \
+  -DSEP_BUILD_ENGINE=OFF \
+  -DBUILD_TESTING=ON
 
-make -j$(nproc)
+make memory_manager_tests -j$(nproc)

--- a/include/core/types.h
+++ b/include/core/types.h
@@ -43,6 +43,47 @@ struct MemoryThresholdConfig {
     bool enable_compression{true};
 };
 
+// Minimal CUDA configuration used by unit tests. These fields are
+// sufficient for the parts of the engine compiled in this repository.
+struct CudaConfig {
+    bool use_gpu{true};
+    std::size_t max_memory_mb{8192};
+    std::size_t batch_size{1024};
+    float gpu_memory_limit{0.9f};
+    bool enable_profiling{false};
+};
+
+// API server configuration. Only a subset of fields is required for
+// compiling the memory manager tests.
+struct APIConfig {
+    std::size_t max_connections{1000};
+    std::size_t timeout_ms{5000};
+    std::string host{"127.0.0.1"};
+    uint16_t port{8080};
+    std::size_t threads{4};
+    std::size_t keep_alive_timeout_ms{15000};
+    std::string log_level{"info"};
+    bool enable_metrics{true};
+    std::size_t max_batch_size{1024};
+};
+
+// Logging configuration placeholder
+struct LogConfig {
+    std::string level{"info"};
+    std::string file{};
+    std::string dir{"logs"};
+};
+
+// Basic analytics configuration used by quantum components
+struct AnalyticsConfig {
+    bool enable{false};
+};
+
+// Aggregate system configuration stub. Only the pieces used by tests
+// are represented here.
+struct SystemConfig {
+};
+
 } // namespace config
 
 enum class PatternStateEnum {

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,17 +1,19 @@
-add_library(sep_core
-  STATIC
+add_library(sep_core STATIC
     tracing.cpp
     allocation_metrics.cpp
     dag_graph.cpp
     prometheus_exporter.cpp
     error_handler.cpp
     metrics_collector.cpp
-    engine.cpp
     logging.cpp
     error_handler.cpp
     compression.cpp
     dag_graph.cpp
 )
+
+if(SEP_BUILD_ENGINE)
+    target_sources(sep_core PRIVATE engine.cpp)
+endif()
 
 
 

--- a/src/memory/CMakeLists.txt
+++ b/src/memory/CMakeLists.txt
@@ -1,11 +1,14 @@
 add_library(sep_memory
-  STATIC 
+  STATIC
     memory_tier.cpp
     memory_tier_manager.cpp
     memory_tier_manager_serialization.cpp
     redis_manager.cpp
-    quantum_coherence_manager.cpp
 )
+
+if(SEP_BUILD_QUANTUM)
+  target_sources(sep_memory PRIVATE quantum_coherence_manager.cpp)
+endif()
 
 # Find required Redis library
 find_library(HIREDIS_LIB NAMES hiredis PATHS /usr/lib64)


### PR DESCRIPTION
## Summary
- make `build_no_cuda.sh` compile memory manager tests only
- add build-time options to disable heavy modules
- stub out basic config types used across memory tests

## Testing
- `./build_no_cuda.sh >build.log 2>&1 && tail -n 20 build.log` *(fails: invalid types in memory_tier.cpp)*

------
https://chatgpt.com/codex/tasks/task_e_686c8c872350832abc2de34382025565