### PR TITLE
Add minimal testbed build improvements

### DIFF
--- a/_sep/testbed/memory_minimal/CMakeLists.txt
+++ b/_sep/testbed/memory_minimal/CMakeLists.txt
@@ -1,3 +1,11 @@
+cmake_minimum_required(VERSION 3.16)
+project(memory_minimal_tests LANGUAGES CXX)
+
+find_package(GTest REQUIRED)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 add_executable(memory_minimal_tests
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../tests/memory/memory_tier_manager_test.cpp
 )
@@ -7,6 +15,11 @@ set(SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../src)
 set(MEMORY_SRC
     ${SRC_DIR}/memory/memory_tier.cpp
     ${SRC_DIR}/memory/memory_tier_manager.cpp
+    ${SRC_DIR}/core/allocation_metrics.cpp
+    ${SRC_DIR}/core/logging.cpp
+    ${SRC_DIR}/core/metrics_collector.cpp
+    ${SRC_DIR}/core/prometheus_exporter.cpp
+    ${SRC_DIR}/core/tracing.cpp
 )
 
 target_sources(memory_minimal_tests PRIVATE ${MEMORY_SRC})
@@ -16,6 +29,7 @@ target_include_directories(memory_minimal_tests PRIVATE
 )
 
 target_link_libraries(memory_minimal_tests PRIVATE
+    sep_core
     GTest::GTest
     GTest::Main
 )

--- a/build_no_cuda.sh
+++ b/build_no_cuda.sh
@@ -28,3 +28,4 @@ cmake -S "$REPO_ROOT" -B "$BUILD_DIR" \
   -DBUILD_TESTING=ON
 
 make -j$(nproc)
+ctest --output-on-failure


### PR DESCRIPTION
## Summary
- enable standalone build for memory_minimal testbed
- link core sources and gtest
- run ctest from the CUDA-free build script

## Testing
- `./build_no_cuda.sh` *(fails: error: ‘persistence’ in namespace ‘sep’ does not name a type)*

------
https://chatgpt.com/codex/tasks/task_e_686c8ebe47b4832aa6f5ff6b4fd286df