### PR TITLE
Fix namespace qualification in memory tier manager

### DIFF
--- a/include/memory/memory_tier_manager.hpp
+++ b/include/memory/memory_tier_manager.hpp
@@ -72,7 +72,7 @@ public:
 
     MemoryTierManager();
     explicit MemoryTierManager(const Config& cfg);
-    explicit MemoryTierManager(const sep::config::MemoryThresholdConfig& cfg);
+    explicit MemoryTierManager(const ::sep::config::MemoryThresholdConfig& cfg);
     ~MemoryTierManager();
 
     void init(const Config& config);
@@ -111,12 +111,12 @@ public:
 
     // Pattern management
 
-    SEPResult launch_pattern_processing(sep::pattern::PatternData* patterns,
-                                      sep::pattern::PatternData* results,
-                                      const sep::pattern::PatternConfig& config,
-                                      size_t pattern_count,
-                                      const sep::pattern::PatternData* previous_patterns,
-                                      void* stream);
+    SEPResult launch_pattern_processing(::sep::pattern::PatternData* patterns,
+                                        ::sep::pattern::PatternData* results,
+                                        const ::sep::pattern::PatternConfig& config,
+                                        size_t pattern_count,
+                                        const ::sep::pattern::PatternData* previous_patterns,
+                                        void* stream);
                                       
     void updateRelationship(std::size_t id_a, std::size_t id_b, uint8_t type);
     void removePattern(std::size_t id);

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -54,7 +54,7 @@ void MemoryTierManager::resetForTesting() {
 MemoryTierManager &MemoryTierManager::getInstance() {
   std::call_once(once_flag_, []() {
     const auto &mc =
-        sep::config::ConfigManager::getInstance().getMemoryConfig();
+        ::sep::config::ConfigManager::getInstance().getMemoryConfig();
     Config cfg{};
     cfg.promote_stm_to_mtm = mc.promote_stm_to_mtm;
     cfg.promote_mtm_to_ltm = mc.promote_mtm_to_ltm;
@@ -81,7 +81,7 @@ MemoryTierManager::MemoryTierManager() {
 MemoryTierManager::MemoryTierManager(const Config &cfg) { init(cfg); }
 
 MemoryTierManager::MemoryTierManager(
-    const sep::config::MemoryThresholdConfig &mc) {
+    const ::sep::config::MemoryThresholdConfig &mc) {
   Config cfg{};
   cfg.promote_stm_to_mtm = mc.promote_stm_to_mtm;
   cfg.promote_mtm_to_ltm = mc.promote_mtm_to_ltm;
@@ -521,12 +521,12 @@ void MemoryTierManager::rebuildLookup() {
 
 // --- Pattern and Relationship Management ---
 void MemoryTierManager::registerPattern(
-    std::size_t id, const sep::pattern::PatternData &pattern) {
+    std::size_t id, const ::sep::pattern::PatternData &pattern) {
   std::lock_guard<std::mutex> lock(registry_mutex);
-  pattern_registry_[id] = std::make_unique<sep::pattern::PatternData>(pattern);
+  pattern_registry_[id] = std::make_unique<::sep::pattern::PatternData>(pattern);
 }
 
-const sep::pattern::PatternData *
+const ::sep::pattern::PatternData *
 MemoryTierManager::getPatternData(std::size_t id) const {
   std::lock_guard<std::mutex> lock(registry_mutex);
   auto it = pattern_registry_.find(id);


### PR DESCRIPTION
## Summary
- fix fully-qualified namespace usage in memory tier manager headers
- update implementation accordingly

## Testing
- `./scripts/build_no_cuda.sh` *(fails: could not find OpenSubdiv / extensive GLM errors)*

------
https://chatgpt.com/codex/tasks/task_e_686c8f1cdf5c832aa80b7e4b5663e64d