### PR TITLE
Fix namespace qualifiers

### DIFF
--- a/include/memory/memory_tier_manager.hpp
+++ b/include/memory/memory_tier_manager.hpp
@@ -72,7 +72,7 @@ public:
 
     MemoryTierManager();
     explicit MemoryTierManager(const Config& cfg);
-    explicit MemoryTierManager(const sep::config::MemoryThresholdConfig& cfg);
+    explicit MemoryTierManager(const ::sep::config::MemoryThresholdConfig& cfg);
     ~MemoryTierManager();
 
     void init(const Config& config);
@@ -111,12 +111,12 @@ public:
 
     // Pattern management
 
-    SEPResult launch_pattern_processing(sep::pattern::PatternData* patterns,
-                                      sep::pattern::PatternData* results,
-                                      const sep::pattern::PatternConfig& config,
-                                      size_t pattern_count,
-                                      const sep::pattern::PatternData* previous_patterns,
-                                      void* stream);
+    SEPResult launch_pattern_processing(::sep::pattern::PatternData* patterns,
+                                        ::sep::pattern::PatternData* results,
+                                        const ::sep::pattern::PatternConfig& config,
+                                        size_t pattern_count,
+                                        const ::sep::pattern::PatternData* previous_patterns,
+                                        void* stream);
                                       
     void updateRelationship(std::size_t id_a, std::size_t id_b, uint8_t type);
     void removePattern(std::size_t id);

--- a/src/memory/memory_tier.cpp
+++ b/src/memory/memory_tier.cpp
@@ -50,7 +50,7 @@ MemoryTier::MemoryTier(const Config &config)
 #if SEP_MEMORY_HAS_CUDA
     cudaError_t err = cudaMallocManaged(&memory_pool_, config.size);
     if (err != cudaSuccess) {
-      auto logger = sep::logging::Manager::getInstance().getLogger("memory");
+        auto logger = ::sep::logging::Manager::getInstance().getLogger("memory");
       if (logger) {
         logger->error("Failed to allocate managed memory: {}", err);
         logger->info("Falling back to host allocation");
@@ -64,7 +64,7 @@ MemoryTier::MemoryTier(const Config &config)
     memory_pool_ = std::malloc(config.size);
     cudaError_t err = memory_pool_ ? cudaSuccess : cudaErrorMemoryAllocation;
     if (err != cudaSuccess) {
-      auto logger = sep::logging::Manager::getInstance().getLogger("memory");
+        auto logger = ::sep::logging::Manager::getInstance().getLogger("memory");
       if (logger) {
         logger->error("Failed to allocate host memory: {}", err);
       }
@@ -75,10 +75,10 @@ MemoryTier::MemoryTier(const Config &config)
 #if SEP_HAS_EXCEPTIONS
     throw std::runtime_error("Failed to allocate memory pool");
 #else
-    auto logger = sep::logging::Manager::getInstance().getLogger("memory");
+    auto logger = ::sep::logging::Manager::getInstance().getLogger("memory");
     if (logger)
       LOG_CRITICAL(logger, "Failed to allocate memory pool");
-    sep::metrics::allocationFailures().value++;
+    ::sep::metrics::allocationFailures().value++;
     // leave object in uninitialized state
     return;
 #endif
@@ -128,7 +128,7 @@ MemoryBlock *MemoryTier::allocate(std::size_t size) {
     defragment();
     block = findFreeBlock(size);
     if (!block) {
-      sep::metrics::allocationFailures().value++;
+      ::sep::metrics::allocationFailures().value++;
       return nullptr; // Still no suitable block
     }
   }
@@ -196,8 +196,8 @@ void MemoryTier::deallocate(MemoryBlock *block) {
   mergeAdjacentBlocks();
 }
 
-sep::SEPResult MemoryTier::defragment() {
-  auto logger = sep::logging::Manager::getInstance().getLogger("memory");
+::sep::SEPResult MemoryTier::defragment() {
+  auto logger = ::sep::logging::Manager::getInstance().getLogger("memory");
   if (logger) {
     LOG_DEBUG(logger, "Defragmenting tier {}", static_cast<int>(config_.type));
   }
@@ -221,14 +221,14 @@ sep::SEPResult MemoryTier::defragment() {
           if (logger) {
             LOG_ERROR(logger, "Defragment memory copy failed: {}", err);
           }
-          return sep::SEPResult::CUDA_ERROR;
+          return ::sep::SEPResult::CUDA_ERROR;
         }
         err = cudaStreamSynchronize(nullptr);
         if (err != cudaSuccess) {
           if (logger) {
             LOG_ERROR(logger, "Defragment stream sync failed: {}", err);
           }
-          return sep::SEPResult::CUDA_ERROR;
+          return ::sep::SEPResult::CUDA_ERROR;
         }
 #else
         std::memmove(new_location, block.ptr, block.size);
@@ -283,7 +283,7 @@ sep::SEPResult MemoryTier::defragment() {
     LOG_INFO(logger, "Tier {} fragmentation now {:.2f}",
              static_cast<int>(config_.type), calculateFragmentation());
   }
-  return sep::SEPResult::SUCCESS;
+  return ::sep::SEPResult::SUCCESS;
 }
 
 float MemoryTier::calculateFragmentation() const {
@@ -356,7 +356,7 @@ std::size_t MemoryTier::getLargestFreeBlock() const {
 const std::deque<MemoryBlock> &MemoryTier::getBlocks() const { return blocks_; }
 
 bool MemoryTier::moveData(MemoryBlock *dst, const MemoryBlock *src) {
-  auto logger = sep::logging::Manager::getInstance().getLogger("memory");
+  auto logger = ::sep::logging::Manager::getInstance().getLogger("memory");
 
   if (!dst || !src || !dst->allocated || !src->allocated) {
     if (logger) {
@@ -383,7 +383,7 @@ bool MemoryTier::moveData(MemoryBlock *dst, const MemoryBlock *src) {
   dst->compression_ratio = src->compression_ratio;
 
 #if SEP_MEMORY_HAS_CUDA
-  cudaError_t err = sep::cuda::cudaMemcpyAsync(dst->ptr, src->ptr, size,
+  cudaError_t err = ::sep::cuda::cudaMemcpyAsync(dst->ptr, src->ptr, size,
                                                cudaMemcpyDefault, nullptr);
   if (err != cudaSuccess) {
     if (logger) {
@@ -472,18 +472,18 @@ bool MemoryTier::resize(std::size_t new_size) {
     return true;
 
   void *new_pool = nullptr;
-  auto logger = sep::logging::Manager::getInstance().getLogger("memory");
+  auto logger = ::sep::logging::Manager::getInstance().getLogger("memory");
 
   if (config_.type == MemoryTierEnum::HOST) {
     new_pool = std::malloc(new_size);
   } else {
 #if SEP_MEMORY_HAS_CUDA
-    cudaError_t err = sep::cuda::allocateManaged(&new_pool, new_size);
+    cudaError_t err = ::sep::cuda::allocateManaged(&new_pool, new_size);
     if (err != cudaSuccess) {
       if (logger) {
         LOG_ERROR(logger, "Failed to allocate managed memory: {}", err);
       }
-      sep::metrics::allocationFailures().value++;
+      ::sep::metrics::allocationFailures().value++;
       return false;
     }
 #else
@@ -493,7 +493,7 @@ bool MemoryTier::resize(std::size_t new_size) {
       if (logger) {
         LOG_ERROR(logger, "Failed to allocate host memory: {}", err);
       }
-      sep::metrics::allocationFailures().value++;
+      ::sep::metrics::allocationFailures().value++;
       return false;
     }
 #endif
@@ -502,7 +502,7 @@ bool MemoryTier::resize(std::size_t new_size) {
     if (logger) {
       LOG_ERROR(logger, "Failed to allocate memory pool of size {}", new_size);
     }
-    sep::metrics::allocationFailures().value++;
+    ::sep::metrics::allocationFailures().value++;
     return false;
   }
 
@@ -521,7 +521,7 @@ bool MemoryTier::resize(std::size_t new_size) {
         std::free(new_pool);
 #endif
       }
-      sep::metrics::allocationFailures().value++;
+      ::sep::metrics::allocationFailures().value++;
       return false;
     }
     std::memcpy(static_cast<char *>(new_pool) + offset, block.ptr, block.size);

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -54,7 +54,7 @@ void MemoryTierManager::resetForTesting() {
 MemoryTierManager &MemoryTierManager::getInstance() {
   std::call_once(once_flag_, []() {
     const auto &mc =
-        sep::config::ConfigManager::getInstance().getMemoryConfig();
+        ::sep::config::ConfigManager::getInstance().getMemoryConfig();
     Config cfg{};
     cfg.promote_stm_to_mtm = mc.promote_stm_to_mtm;
     cfg.promote_mtm_to_ltm = mc.promote_mtm_to_ltm;
@@ -81,7 +81,7 @@ MemoryTierManager::MemoryTierManager() {
 MemoryTierManager::MemoryTierManager(const Config &cfg) { init(cfg); }
 
 MemoryTierManager::MemoryTierManager(
-    const sep::config::MemoryThresholdConfig &mc) {
+    const ::sep::config::MemoryThresholdConfig &mc) {
   Config cfg{};
   cfg.promote_stm_to_mtm = mc.promote_stm_to_mtm;
   cfg.promote_mtm_to_ltm = mc.promote_mtm_to_ltm;
@@ -521,12 +521,12 @@ void MemoryTierManager::rebuildLookup() {
 
 // --- Pattern and Relationship Management ---
 void MemoryTierManager::registerPattern(
-    std::size_t id, const sep::pattern::PatternData &pattern) {
+    std::size_t id, const ::sep::pattern::PatternData &pattern) {
   std::lock_guard<std::mutex> lock(registry_mutex);
-  pattern_registry_[id] = std::make_unique<sep::pattern::PatternData>(pattern);
+  pattern_registry_[id] = std::make_unique<::sep::pattern::PatternData>(pattern);
 }
 
-const sep::pattern::PatternData *
+const ::sep::pattern::PatternData *
 MemoryTierManager::getPatternData(std::size_t id) const {
   std::lock_guard<std::mutex> lock(registry_mutex);
   auto it = pattern_registry_.find(id);


### PR DESCRIPTION
## Summary
- fix namespace qualifiers for config and pattern references in memory code

## Testing
- `./build_no_cuda.sh` *(fails: GLM compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_686c8f1cdf5c832aa80b7e4b5663e64d