### PR TITLE
Fix missing endif in memory_tier_manager.hpp

### DIFF
--- a/include/memory/memory_tier_manager.hpp
+++ b/include/memory/memory_tier_manager.hpp
@@ -20,6 +20,7 @@
 #ifndef SEP_NO_REDIS
 #include "memory/redis_manager.h"
 #include "persistence/pattern_data.hpp"
+#endif // SEP_NO_REDIS
 
 // Standard library includes
 #include <cstddef>


### PR DESCRIPTION
## Summary
- close `SEP_NO_REDIS` guard in `memory_tier_manager.hpp`

## Testing
- `cmake -DBUILD_TESTING=ON -DCMAKE_CXX_COMPILER=g++-14 ..` *(fails: target `GTest::GTest` not found)*
- `make` *(fails to compile due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686c8fbb4188832a8da1582759e29973