### PR TITLE
Fix memory tier manager namespaces

### DIFF
--- a/_sep/testbed/memory_minimal/CMakeLists.txt
+++ b/_sep/testbed/memory_minimal/CMakeLists.txt
@@ -10,14 +10,16 @@ set(MEMORY_SRC
 )
 
 target_sources(memory_minimal_tests PRIVATE ${MEMORY_SRC})
+target_compile_definitions(memory_minimal_tests PRIVATE SEP_MINIMAL=1)
 
 target_include_directories(memory_minimal_tests PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../include
 )
 
 target_link_libraries(memory_minimal_tests PRIVATE
-    GTest::GTest
-    GTest::Main
+    gtest
+    gtest_main
+    pthread
 )
 
 add_test(NAME memory_minimal_tests COMMAND memory_minimal_tests)

--- a/include/memory/memory_tier_manager.hpp
+++ b/include/memory/memory_tier_manager.hpp
@@ -72,7 +72,7 @@ public:
 
     MemoryTierManager();
     explicit MemoryTierManager(const Config& cfg);
-    explicit MemoryTierManager(const sep::config::MemoryThresholdConfig& cfg);
+    explicit MemoryTierManager(const ::sep::config::MemoryThresholdConfig& cfg);
     ~MemoryTierManager();
 
     void init(const Config& config);
@@ -111,14 +111,14 @@ public:
 
     // Pattern management
 
-    SEPResult launch_pattern_processing(sep::pattern::PatternData* patterns,
-                                      sep::pattern::PatternData* results,
-                                      const sep::pattern::PatternConfig& config,
+    SEPResult launch_pattern_processing(::sep::pattern::PatternData* patterns,
+                                      ::sep::pattern::PatternData* results,
+                                      const ::sep::pattern::PatternConfig& config,
                                       size_t pattern_count,
-                                      const sep::pattern::PatternData* previous_patterns,
+                                      const ::sep::pattern::PatternData* previous_patterns,
                                       void* stream);
                                       
-    void updateRelationship(std::size_t id_a, std::size_t id_b, uint8_t type);
+    void updateRelationship(std::size_t id_a, std::size_t id_b, float strength);
     void removePattern(std::size_t id);
     void pruneWeakRelationships();
     void calculateRelationshipCoherence();

--- a/src/memory/memory_tier.cpp
+++ b/src/memory/memory_tier.cpp
@@ -50,7 +50,7 @@ MemoryTier::MemoryTier(const Config &config)
 #if SEP_MEMORY_HAS_CUDA
     cudaError_t err = cudaMallocManaged(&memory_pool_, config.size);
     if (err != cudaSuccess) {
-      auto logger = sep::logging::Manager::getInstance().getLogger("memory");
+      auto logger = ::sep::logging::Manager::getInstance().getLogger("memory");
       if (logger) {
         logger->error("Failed to allocate managed memory: {}", err);
         logger->info("Falling back to host allocation");
@@ -64,7 +64,7 @@ MemoryTier::MemoryTier(const Config &config)
     memory_pool_ = std::malloc(config.size);
     cudaError_t err = memory_pool_ ? cudaSuccess : cudaErrorMemoryAllocation;
     if (err != cudaSuccess) {
-      auto logger = sep::logging::Manager::getInstance().getLogger("memory");
+      auto logger = ::sep::logging::Manager::getInstance().getLogger("memory");
       if (logger) {
         logger->error("Failed to allocate host memory: {}", err);
       }
@@ -75,10 +75,10 @@ MemoryTier::MemoryTier(const Config &config)
 #if SEP_HAS_EXCEPTIONS
     throw std::runtime_error("Failed to allocate memory pool");
 #else
-    auto logger = sep::logging::Manager::getInstance().getLogger("memory");
+    auto logger = ::sep::logging::Manager::getInstance().getLogger("memory");
     if (logger)
       LOG_CRITICAL(logger, "Failed to allocate memory pool");
-    sep::metrics::allocationFailures().value++;
+    ::sep::metrics::allocationFailures().value++;
     // leave object in uninitialized state
     return;
 #endif
@@ -128,7 +128,7 @@ MemoryBlock *MemoryTier::allocate(std::size_t size) {
     defragment();
     block = findFreeBlock(size);
     if (!block) {
-      sep::metrics::allocationFailures().value++;
+      ::sep::metrics::allocationFailures().value++;
       return nullptr; // Still no suitable block
     }
   }
@@ -155,7 +155,7 @@ MemoryBlock *MemoryTier::allocate(std::size_t size) {
           ? (static_cast<float>(size) / static_cast<float>(config_.size))
           : 0.0f; // Use floating point division
   block->access_count = 0;
-  block->compression = ::blender::CompressionMethod::None;
+  block->compression = ::sep::CompressionMethod::None;
   block->original_size = size;
   block->coherence = 0.0f;
   block->last_coherence = 0.0f;
@@ -196,8 +196,8 @@ void MemoryTier::deallocate(MemoryBlock *block) {
   mergeAdjacentBlocks();
 }
 
-sep::SEPResult MemoryTier::defragment() {
-  auto logger = sep::logging::Manager::getInstance().getLogger("memory");
+::sep::SEPResult MemoryTier::defragment() {
+  auto logger = ::sep::logging::Manager::getInstance().getLogger("memory");
   if (logger) {
     LOG_DEBUG(logger, "Defragmenting tier {}", static_cast<int>(config_.type));
   }
@@ -221,14 +221,14 @@ sep::SEPResult MemoryTier::defragment() {
           if (logger) {
             LOG_ERROR(logger, "Defragment memory copy failed: {}", err);
           }
-          return sep::SEPResult::CUDA_ERROR;
+          return ::sep::SEPResult::CUDA_ERROR;
         }
         err = cudaStreamSynchronize(nullptr);
         if (err != cudaSuccess) {
           if (logger) {
             LOG_ERROR(logger, "Defragment stream sync failed: {}", err);
           }
-          return sep::SEPResult::CUDA_ERROR;
+          return ::sep::SEPResult::CUDA_ERROR;
         }
 #else
         std::memmove(new_location, block.ptr, block.size);
@@ -283,7 +283,7 @@ sep::SEPResult MemoryTier::defragment() {
     LOG_INFO(logger, "Tier {} fragmentation now {:.2f}",
              static_cast<int>(config_.type), calculateFragmentation());
   }
-  return sep::SEPResult::SUCCESS;
+  return ::sep::SEPResult::SUCCESS;
 }
 
 float MemoryTier::calculateFragmentation() const {
@@ -356,7 +356,7 @@ std::size_t MemoryTier::getLargestFreeBlock() const {
 const std::deque<MemoryBlock> &MemoryTier::getBlocks() const { return blocks_; }
 
 bool MemoryTier::moveData(MemoryBlock *dst, const MemoryBlock *src) {
-  auto logger = sep::logging::Manager::getInstance().getLogger("memory");
+  auto logger = ::sep::logging::Manager::getInstance().getLogger("memory");
 
   if (!dst || !src || !dst->allocated || !src->allocated) {
     if (logger) {
@@ -383,7 +383,7 @@ bool MemoryTier::moveData(MemoryBlock *dst, const MemoryBlock *src) {
   dst->compression_ratio = src->compression_ratio;
 
 #if SEP_MEMORY_HAS_CUDA
-  cudaError_t err = sep::cuda::cudaMemcpyAsync(dst->ptr, src->ptr, size,
+  cudaError_t err = ::sep::cuda::cudaMemcpyAsync(dst->ptr, src->ptr, size,
                                                cudaMemcpyDefault, nullptr);
   if (err != cudaSuccess) {
     if (logger) {
@@ -472,18 +472,18 @@ bool MemoryTier::resize(std::size_t new_size) {
     return true;
 
   void *new_pool = nullptr;
-  auto logger = sep::logging::Manager::getInstance().getLogger("memory");
+  auto logger = ::sep::logging::Manager::getInstance().getLogger("memory");
 
   if (config_.type == MemoryTierEnum::HOST) {
     new_pool = std::malloc(new_size);
   } else {
 #if SEP_MEMORY_HAS_CUDA
-    cudaError_t err = sep::cuda::allocateManaged(&new_pool, new_size);
+    cudaError_t err = ::sep::cuda::allocateManaged(&new_pool, new_size);
     if (err != cudaSuccess) {
       if (logger) {
         LOG_ERROR(logger, "Failed to allocate managed memory: {}", err);
       }
-      sep::metrics::allocationFailures().value++;
+      ::sep::metrics::allocationFailures().value++;
       return false;
     }
 #else
@@ -493,7 +493,7 @@ bool MemoryTier::resize(std::size_t new_size) {
       if (logger) {
         LOG_ERROR(logger, "Failed to allocate host memory: {}", err);
       }
-      sep::metrics::allocationFailures().value++;
+      ::sep::metrics::allocationFailures().value++;
       return false;
     }
 #endif
@@ -502,7 +502,7 @@ bool MemoryTier::resize(std::size_t new_size) {
     if (logger) {
       LOG_ERROR(logger, "Failed to allocate memory pool of size {}", new_size);
     }
-    sep::metrics::allocationFailures().value++;
+    ::sep::metrics::allocationFailures().value++;
     return false;
   }
 
@@ -521,7 +521,7 @@ bool MemoryTier::resize(std::size_t new_size) {
         std::free(new_pool);
 #endif
       }
-      sep::metrics::allocationFailures().value++;
+      ::sep::metrics::allocationFailures().value++;
       return false;
     }
     std::memcpy(static_cast<char *>(new_pool) + offset, block.ptr, block.size);

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -1,6 +1,9 @@
 #include "memory/memory_tier_manager.hpp"
 #include "core/common.h"
 #include "core/types.h"
+#ifndef SEP_MINIMAL
+#include "core/manager.h"
+#endif
 #include "memory/memory_tier.hpp"
 #include "memory/types.h"
 
@@ -53,8 +56,9 @@ void MemoryTierManager::resetForTesting() {
 
 MemoryTierManager &MemoryTierManager::getInstance() {
   std::call_once(once_flag_, []() {
+#ifndef SEP_MINIMAL
     const auto &mc =
-        sep::config::ConfigManager::getInstance().getMemoryConfig();
+        ::sep::config::ConfigManager::getInstance().getMemoryConfig();
     Config cfg{};
     cfg.promote_stm_to_mtm = mc.promote_stm_to_mtm;
     cfg.promote_mtm_to_ltm = mc.promote_mtm_to_ltm;
@@ -68,6 +72,9 @@ MemoryTierManager &MemoryTierManager::getInstance() {
     cfg.use_unified_memory = mc.use_unified_memory;
     cfg.enable_compression = mc.enable_compression;
     instance_ = std::make_unique<MemoryTierManager>(cfg);
+#else
+    instance_ = std::make_unique<MemoryTierManager>();
+#endif
   });
   return *instance_;
 }
@@ -81,7 +88,7 @@ MemoryTierManager::MemoryTierManager() {
 MemoryTierManager::MemoryTierManager(const Config &cfg) { init(cfg); }
 
 MemoryTierManager::MemoryTierManager(
-    const sep::config::MemoryThresholdConfig &mc) {
+    const ::sep::config::MemoryThresholdConfig &mc) {
   Config cfg{};
   cfg.promote_stm_to_mtm = mc.promote_stm_to_mtm;
   cfg.promote_mtm_to_ltm = mc.promote_mtm_to_ltm;
@@ -521,12 +528,12 @@ void MemoryTierManager::rebuildLookup() {
 
 // --- Pattern and Relationship Management ---
 void MemoryTierManager::registerPattern(
-    std::size_t id, const sep::pattern::PatternData &pattern) {
+    std::size_t id, const ::sep::pattern::PatternData &pattern) {
   std::lock_guard<std::mutex> lock(registry_mutex);
-  pattern_registry_[id] = std::make_unique<sep::pattern::PatternData>(pattern);
+  pattern_registry_[id] = std::make_unique<::sep::pattern::PatternData>(pattern);
 }
 
-const sep::pattern::PatternData *
+const ::sep::pattern::PatternData *
 MemoryTierManager::getPatternData(std::size_t id) const {
   std::lock_guard<std::mutex> lock(registry_mutex);
   auto it = pattern_registry_.find(id);

--- a/tests/memory/memory_tier_manager_test.cpp
+++ b/tests/memory/memory_tier_manager_test.cpp
@@ -6,8 +6,7 @@
 namespace sep {
 namespace memory {
 
-using namespace sep::memory;
-using sep::MemoryTierEnum;
+using ::sep::MemoryTierEnum;
 
 TEST(MemoryTierManagerTest, BasicInitialization) {
     MemoryTierManager mgr;
@@ -35,7 +34,7 @@ TEST(MemoryTierManagerTest, AllocationAndDeallocation) {
 TEST(MemoryTierManagerTest, PromotionAndDemotion) {
     const float EPSILON = 0.01f;
     MemoryTierManager mgr;
-    mgr.resetForTesting();
+    mgr.resetForTesting(MemoryTierManager::Config());
     
     // Initial allocation in MTM
     MemoryBlock* block = mgr.allocate(1024, MemoryTierEnum::MTM);
@@ -73,7 +72,7 @@ TEST(MemoryTierManagerTest, PromotionAndDemotion) {
 TEST(MemoryTierManagerTest, DefragmentationTriggersPromotionDemotion) {
     const float EPSILON = 0.01f;
     MemoryTierManager mgr;
-    mgr.resetForTesting();
+    mgr.resetForTesting(MemoryTierManager::Config());
     
     // Initial allocation in MTM
     MemoryBlock* block = mgr.allocate(1024, MemoryTierEnum::MTM);
@@ -113,7 +112,7 @@ TEST(MemoryTierManagerTest, DefragmentationTriggersPromotionDemotion) {
 TEST(MemoryTierManagerTest, OptimizeBlocksPromotionDemotion) {
     const float EPSILON = 0.01f;
     MemoryTierManager mgr;
-    mgr.resetForTesting();
+    mgr.resetForTesting(MemoryTierManager::Config());
     MemoryBlock* block = mgr.allocate(1024, MemoryTierEnum::STM);
     ASSERT_NE(block, nullptr);
 
@@ -137,7 +136,8 @@ TEST(MemoryTierManagerTest, OptimizeBlocksPromotionDemotion) {
     stm_util = mgr.getTierUtilization(MemoryTierEnum::STM);
     mtm_util = mgr.getTierUtilization(MemoryTierEnum::MTM);
     EXPECT_GT(stm_util, 0.0f) << "Expected non-zero STM utilization after demotion";
-    EXPECT_NEAR(mtm_util, 0.0f, EPSILON) << "Expected near-zero MTM utilization after demotion";
+    EXPECT_NEAR(mtm_util, 0.0f, EPSILON)
+        << "Expected near-zero MTM utilization after demotion"
         << "Expected block to be in either MTM (util=" << mtm_util
         << ") or STM (util=" << stm_util << ")";
 }
@@ -232,9 +232,9 @@ TEST(MemoryTierManagerTest, TotalMetrics) {
 
 TEST(MemoryTierManagerTest, CalculateRelationshipCoherence) {
     MemoryTierManager mgr;
-    sep::pattern::PatternData a;
+    ::sep::pattern::PatternData a;
     a.id = "1";
-    sep::pattern::PatternData b;
+    ::sep::pattern::PatternData b;
     b.id = "2";
     mgr.registerPattern(1, a);
     mgr.registerPattern(2, b);
@@ -250,10 +250,10 @@ TEST(MemoryTierManagerTest, CalculateRelationshipCoherence) {
 
 TEST(MemoryTierManagerTest, CleanupExpiredPatterns) {
     MemoryTierManager mgr;
-    sep::pattern::PatternData p1;
+    ::sep::pattern::PatternData p1;
     p1.id = "1";
     p1.coherence = 0.1f;
-    sep::pattern::PatternData p2;
+    ::sep::pattern::PatternData p2;
     p2.id = "2";
     p2.coherence = 0.8f;
     mgr.registerPattern(1, p1);
@@ -266,13 +266,13 @@ TEST(MemoryTierManagerTest, CleanupExpiredPatterns) {
 TEST(MemoryTierManagerTest, PrunePatternsByPriority) {
     MemoryTierManager mgr;
     for (size_t i = 0; i < 5; ++i) {
-        sep::persistence::PatternData pdata;
+        ::sep::persistence::PersistentPatternData pdata;
         pdata.coherence = static_cast<float>(i) / 5.0f;
         mgr.getLTM().addPattern(i, pdata);
-        sep::pattern::PatternData pat;
+        ::sep::pattern::PatternData pat;
         pat.id = std::to_string(i);
         pat.coherence = pdata.coherence;
-        pat.memory_tier = sep::memory::MemoryTierEnum::LTM;
+        pat.memory_tier = ::sep::memory::MemoryTierEnum::LTM;
         mgr.registerPattern(i, pat);
     }
     mgr.prunePatternsByPriority(MemoryTierEnum::LTM, 2);


### PR DESCRIPTION
## Summary
- fix namespace prefixes in memory tier code
- add SEP_MINIMAL compile flag
- update minimal test CMake
- tweak memory tier manager tests

## Testing
- `cmake .. && make -j$(nproc) && ctest --output-on-failure` *(fails: missing gtest libraries and unresolved symbols)*

------
https://chatgpt.com/codex/tasks/task_e_686c8f1cdf5c832aa80b7e4b5663e64d