### PR TITLE
Fix install.sh to add pkg-config and gmock

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -35,10 +35,9 @@ PACKAGES=(
   libboost-all-dev libopencolorio-dev libopenimageio-dev
   libembree-dev libpugixml-dev libopenjp2-7-dev
   libcurl4-openssl-dev libhttp-parser-dev libopenvdb-dev
-  libfmt-dev
-  libspdlog-dev libgtest-dev libhiredis-dev libglm-dev nlohmann-json3-dev
+  libfmt-dev pkg-config
+  libspdlog-dev libgtest-dev libgmock-dev libhiredis-dev libglm-dev nlohmann-json3-dev
   libpipewire-0.3-dev libfftw3-dev libopenexr-dev
-  libglm-dev nlohmann-json3-dev
   valgrind
 )
 


### PR DESCRIPTION
## Summary
- add `pkg-config` and `libgmock-dev` to install script
- clean up duplicate glm/json entries

## Testing
- `sudo bash install.sh --no-cuda`
- `./build_no_cuda.sh` *(fails: compilation errors in memory subsystem)*

------
https://chatgpt.com/codex/tasks/task_e_686c914c84c0832a9c97a0694ef55f5c