### PR TITLE
Fix missing #endif in header

### DIFF
--- a/include/memory/memory_tier_manager.hpp
+++ b/include/memory/memory_tier_manager.hpp
@@ -20,6 +20,7 @@
 #ifndef SEP_NO_REDIS
 #include "memory/redis_manager.h"
 #include "persistence/pattern_data.hpp"
+#endif // SEP_NO_REDIS
 
 // Standard library includes
 #include <cstddef>


### PR DESCRIPTION
## Summary
- close conditional include in memory tier manager header to fix build

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c8fbb4188832a8da1582759e29973