### PR TITLE
Fix memory manager build

### DIFF
--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -78,9 +78,6 @@ MemoryTierManager &MemoryTierManager::getInstance() {
     cfg.enable_compression = mc.enable_compression;
 #endif
     instance_ = std::make_unique<MemoryTierManager>(cfg);
-#else
-    instance_ = std::make_unique<MemoryTierManager>();
-#endif
   });
   return *instance_;
 }
@@ -564,7 +561,7 @@ void MemoryTierManager::removePattern(std::size_t id) {
 }
 
 void MemoryTierManager::updateRelationship(std::size_t id_a, std::size_t id_b,
-                                           uint8_t strength) {
+                                           float strength) {
   std::lock_guard<std::mutex> lock(relationships_mutex);
   pattern_relationships_[id_a][id_b] = strength;
   pattern_relationships_[id_b][id_a] = strength;


### PR DESCRIPTION
## Summary
- fix bad `#else` clause in `MemoryTierManager::getInstance`
- correct argument type for `updateRelationship`

## Testing
- `./build_no_cuda.sh`
- `ctest --output-on-failure -j4` *(fails: No tests were found)*
- `../tests/memory/memory_manager_tests` *(fails: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_686c94494510832aad140b9285e1001e