### PR TITLE
Fix memory_tier_manager build

### DIFF
--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -78,9 +78,6 @@ MemoryTierManager &MemoryTierManager::getInstance() {
     cfg.enable_compression = mc.enable_compression;
 #endif
     instance_ = std::make_unique<MemoryTierManager>(cfg);
-#else
-    instance_ = std::make_unique<MemoryTierManager>();
-#endif
   });
   return *instance_;
 }
@@ -564,7 +561,7 @@ void MemoryTierManager::removePattern(std::size_t id) {
 }
 
 void MemoryTierManager::updateRelationship(std::size_t id_a, std::size_t id_b,
-                                           uint8_t strength) {
+                                           float strength) {
   std::lock_guard<std::mutex> lock(relationships_mutex);
   pattern_relationships_[id_a][id_b] = strength;
   pattern_relationships_[id_b][id_a] = strength;


### PR DESCRIPTION
## Summary
- fix preprocessor guards in `MemoryTierManager::getInstance`
- fix `updateRelationship` signature

## Testing
- `./build_no_cuda.sh`
- `ctest --output-on-failure` *(no tests found)*
- `./tests/memory/memory_manager_tests --gtest_output=xml:memory_tests.xml` *(failed: missing `libcudart.so.12`)*

------
https://chatgpt.com/codex/tasks/task_e_686c94494510832aad140b9285e1001e