### PR TITLE
Fix memory tier build issues

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -53,6 +53,7 @@ target_link_libraries(sep_core
     PUBLIC
         Threads::Threads
         sep_compat
+        fmt::fmt
 )
 
 # Install headers from include directory

--- a/src/memory/CMakeLists.txt
+++ b/src/memory/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(sep_memory
     memory_tier.cpp
     memory_tier_manager.cpp
     memory_tier_manager_serialization.cpp
+    redis_manager.cpp
 )
 
 if(SEP_BUILD_QUANTUM)
@@ -43,6 +44,7 @@ target_link_libraries(sep_memory
         sep_core
         sep_compat
     PRIVATE
+        fmt::fmt
         Threads::Threads
 )
 if(HIREDIS_FOUND)

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -78,9 +78,6 @@ MemoryTierManager &MemoryTierManager::getInstance() {
     cfg.enable_compression = mc.enable_compression;
 #endif
     instance_ = std::make_unique<MemoryTierManager>(cfg);
-#else
-    instance_ = std::make_unique<MemoryTierManager>();
-#endif
   });
   return *instance_;
 }
@@ -564,7 +561,7 @@ void MemoryTierManager::removePattern(std::size_t id) {
 }
 
 void MemoryTierManager::updateRelationship(std::size_t id_a, std::size_t id_b,
-                                           uint8_t strength) {
+                                           float strength) {
   std::lock_guard<std::mutex> lock(relationships_mutex);
   pattern_relationships_[id_a][id_b] = strength;
   pattern_relationships_[id_b][id_a] = strength;


### PR DESCRIPTION
## Summary
- fix preprocessor mismatch in `memory_tier_manager.cpp`
- make `updateRelationship` take a float parameter
- link fmt in `sep_core` and `sep_memory`
- compile redis persistence code by default

## Testing
- `./build_no_cuda.sh >build_no_cuda_full.log 2>&1` *(fails: undefined reference to cleanupExpiredPatterns)*

------
https://chatgpt.com/codex/tasks/task_e_686c94494510832aad140b9285e1001e