### PR TITLE
Fix build scripts and config for memory tiers

### DIFF
--- a/build_no_cuda.sh
+++ b/build_no_cuda.sh
@@ -24,8 +24,10 @@ cmake -S "$REPO_ROOT" -B "$BUILD_DIR" \
   -DSEP_WITH_OSL=OFF \
   -DSEP_WITH_ALEMBIC=OFF \
   -DSEP_HAS_CUDA=0 \
+  -DSEP_NO_REDIS=ON \
   -DSEP_ENABLE_AUDIO=OFF \
   -DSEP_WORKBENCH_DEMO=OFF \
   -DBUILD_TESTING=ON
 
 make memory_manager_tests -j$(nproc)
+ctest --output-on-failure

--- a/include/core/types.h
+++ b/include/core/types.h
@@ -79,6 +79,13 @@ struct AnalyticsConfig {
     bool enable{false};
 };
 
+// Coherence thresholds used by quantum components
+struct QuantumThresholdConfig {
+    float ltm_coherence_threshold{0.9f};
+    float mtm_coherence_threshold{0.6f};
+    float stability_threshold{0.8f};
+};
+
 // Aggregate system configuration stub. Only the pieces used by tests
 // are represented here.
 struct SystemConfig {

--- a/include/memory/memory_tier.hpp
+++ b/include/memory/memory_tier.hpp
@@ -84,9 +84,6 @@ struct MemoryBlock {
         : ptr(p), size(s), offset(off), original_size(s), tier(t) {}
 };
 
-#include "persistence/persistent_pattern_data.hpp"
-
-using PersistentPatternData = ::sep::persistence::PersistentPatternData;
 
 class MemoryTier {
 public:
@@ -129,12 +126,12 @@ public:
     }
 
     // Pattern management methods
-    bool canAcceptPattern(const PersistentPatternData& pattern) const;
-    void addPattern(size_t id, PersistentPatternData pattern);
+    bool canAcceptPattern(const ::sep::persistence::PersistentPatternData& pattern) const;
+    void addPattern(size_t id, ::sep::persistence::PersistentPatternData pattern);
     void removePattern(size_t id);
-    const PersistentPatternData* getPattern(size_t id) const;
-    PersistentPatternData* getPattern(size_t id);
-    const std::unordered_map<size_t, PersistentPatternData>& getPatterns() const {
+    const ::sep::persistence::PersistentPatternData* getPattern(size_t id) const;
+    ::sep::persistence::PersistentPatternData* getPattern(size_t id);
+    const std::unordered_map<size_t, ::sep::persistence::PersistentPatternData>& getPatterns() const {
         return m_patterns;
     }
 
@@ -152,7 +149,7 @@ private:
     size_t m_max_patterns{0};
     float m_coherence_threshold{0.0f};
     int m_min_generations{0};
-    std::unordered_map<size_t, PersistentPatternData> m_patterns;
+    std::unordered_map<size_t, ::sep::persistence::PersistentPatternData> m_patterns;
 };
 
 }  // namespace memory

--- a/include/memory/redis_manager.h
+++ b/include/memory/redis_manager.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "memory/types.h"
-#include "persistence/persistent_pattern_data.hpp"
+#include "persistence/pattern_data.hpp"
 
 #ifndef SEP_NO_REDIS
 #  include <hiredis/hiredis.h>

--- a/src/memory/memory_tier.cpp
+++ b/src/memory/memory_tier.cpp
@@ -567,7 +567,7 @@ bool MemoryTier::resize(std::size_t new_size) {
 }
 
 bool MemoryTier::canAcceptPattern(
-    const ::sep::memory::persistence::PersistentPatternData &pattern) const {
+    const ::sep::persistence::PersistentPatternData &pattern) const {
   if (m_patterns.size() >= m_max_patterns)
     return false;
   if (pattern.coherence < m_coherence_threshold)
@@ -581,7 +581,7 @@ bool MemoryTier::canAcceptPattern(
 }
 
 void MemoryTier::addPattern(size_t id,
-                            ::sep::memory::persistence::PersistentPatternData pattern) {
+                            ::sep::persistence::PersistentPatternData pattern) {
   if (!canAcceptPattern(pattern))
     return;
   // PatternData doesn't have id or memory_tier fields
@@ -591,13 +591,13 @@ void MemoryTier::addPattern(size_t id,
 
 void MemoryTier::removePattern(size_t id) { m_patterns.erase(id); }
 
-const ::sep::memory::persistence::PersistentPatternData *
+const ::sep::persistence::PersistentPatternData *
 MemoryTier::getPattern(size_t id) const {
   auto it = m_patterns.find(id);
   return it == m_patterns.end() ? nullptr : &it->second;
 }
 
-::sep::memory::persistence::PersistentPatternData *MemoryTier::getPattern(size_t id) {
+::sep::persistence::PersistentPatternData *MemoryTier::getPattern(size_t id) {
   auto it = m_patterns.find(id);
   return it == m_patterns.end() ? nullptr : &it->second;
 }

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -75,9 +75,6 @@ MemoryTierManager &MemoryTierManager::getInstance() {
     cfg.enable_compression = mc.enable_compression;
 #endif
     instance_ = std::make_unique<MemoryTierManager>(cfg);
-#else
-    instance_ = std::make_unique<MemoryTierManager>();
-#endif
   });
   return *instance_;
 }

--- a/tests/memory/CMakeLists.txt
+++ b/tests/memory/CMakeLists.txt
@@ -23,8 +23,11 @@ add_executable(memory_manager_tests
     promotion_regression_test.cpp
     pattern_init_test.cpp
     pattern_promotion_test.cpp
-    redis_manager_test.cpp
 )
+
+if(SEP_HAS_REDIS)
+    target_sources(memory_manager_tests PRIVATE redis_manager_test.cpp)
+endif()
 
 target_link_libraries(memory_manager_tests PRIVATE
     sep_memory


### PR DESCRIPTION
## Summary
- define `QuantumThresholdConfig`
- clean up memory tier manager singleton initialization
- adjust persistent pattern data handling
- fix Redis test build in CMake
- disable Redis in no-CUDA build script

## Testing
- `./build_no_cuda.sh` *(fails: fmt missing and other link errors)*

------
https://chatgpt.com/codex/tasks/task_e_686c92dcb5e0832a90718fac194dd219