### PR TITLE
Fix relationship update bug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ set(SEP_SRC_DIR ${CMAKE_SOURCE_DIR}/src)
 include_directories(BEFORE
     ${SEP_INCLUDE_DIR}
     ${SEP_SRC_DIR}
-    ${CMAKE_SOURCE_DIR}/third_party/glm
+    $<BUILD_INTERFACE:/usr/include>
 )
 
 # Ensure core headers are available
@@ -113,7 +113,6 @@ endif()
 include_directories(BEFORE
     ${CMAKE_SOURCE_DIR}/include
     ${CMAKE_SOURCE_DIR}/extern/crow/include
-    ${CMAKE_SOURCE_DIR}/third_party/glm
 )
 add_compile_definitions(CROW_USE_BOOST)
 
@@ -123,6 +122,7 @@ find_package(Threads REQUIRED)
 find_package(CURL REQUIRED)
 find_package(fmt REQUIRED)
 find_package(http_parser REQUIRED)
+find_package(glm REQUIRED)
 find_package(spdlog)
 if(spdlog_FOUND)
     message(STATUS "Using system spdlog")

--- a/build_no_cuda.sh
+++ b/build_no_cuda.sh
@@ -30,3 +30,4 @@ cmake -S "$REPO_ROOT" -B "$BUILD_DIR" \
   -DBUILD_TESTING=ON
 
 make memory_manager_tests -j$(nproc)
+./memory_manager_tests

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -559,8 +559,8 @@ void MemoryTierManager::removePattern(std::size_t id) {
 void MemoryTierManager::updateRelationship(std::size_t id_a, std::size_t id_b,
                                            uint8_t strength) {
   std::lock_guard<std::mutex> lock(relationships_mutex);
-  pattern_relationships_[id_a][id_b] = static_cast<float>(type);
-  pattern_relationships_[id_b][id_a] = static_cast<float>(type);
+  pattern_relationships_[id_a][id_b] = static_cast<float>(strength);
+  pattern_relationships_[id_b][id_a] = static_cast<float>(strength);
 }
 
 void MemoryTierManager::pruneWeakRelationships() {


### PR DESCRIPTION
## Summary
- fix variable name in `updateRelationship`
- run memory tests in `build_no_cuda.sh`
- switch to system GLM includes in CMake

## Testing
- `cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=g++-14 -DSEP_WITH_CYCLES=OFF -DSEP_WITH_AUDIO=OFF -DSEP_WITH_OPENSUBDIV=OFF -DSEP_WITH_OPENPGL=OFF -DSEP_WITH_OCIO=OFF -DSEP_WITH_OPENIMAGEIO=OFF -DSEP_WITH_EMBREE=OFF -DSEP_WITH_OPENVDB=OFF -DSEP_WITH_OSL=OFF -DSEP_WITH_ALEMBIC=OFF -DSEP_HAS_CUDA=0 -DBUILD_TESTING=ON ../..` *(fails: Could not find nvcc)*
- `make memory_manager_tests` *(fails to build)*


------
https://chatgpt.com/codex/tasks/task_e_686c9561fa20832abcafdcb7d2a7e97f