### PR TITLE
Fix build for minimal Redis config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,10 @@ else()
     add_compile_definitions(SEP_HAS_BLENDER=0)
 endif()
 
+# Redis is disabled in the minimal build
+add_compile_definitions(SEP_NO_REDIS)
+add_compile_definitions(SEP_HAS_REDIS=0)
+
 # Ensure our custom Crow wrappers take precedence over the third-party headers
 include_directories(BEFORE
     ${CMAKE_SOURCE_DIR}/include

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -32,7 +32,8 @@ install(DIRECTORY ${CMAKE_SOURCE_DIR}/src/core/
 # Enable CUDA and handle exception specs
 target_compile_definitions(sep_core PRIVATE
     SEP_HAS_CUDA=1
-    SEP_CUDACC_DISABLE_EXCEPTION_SPEC_CHECKS=1)
+    SEP_CUDACC_DISABLE_EXCEPTION_SPEC_CHECKS=1
+    SEP_NO_REDIS)
 
 # Set library properties
 set_target_properties(sep_core PROPERTIES

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -71,9 +71,6 @@ MemoryTierManager &MemoryTierManager::getInstance() {
     cfg.enable_compression = mc.enable_compression;
 #endif
     instance_ = std::make_unique<MemoryTierManager>(cfg);
-#else
-    instance_ = std::make_unique<MemoryTierManager>();
-#endif
   });
   return *instance_;
 }
@@ -557,10 +554,10 @@ void MemoryTierManager::removePattern(std::size_t id) {
 }
 
 void MemoryTierManager::updateRelationship(std::size_t id_a, std::size_t id_b,
-                                           uint8_t strength) {
+                                           float strength) {
   std::lock_guard<std::mutex> lock(relationships_mutex);
-  pattern_relationships_[id_a][id_b] = static_cast<float>(type);
-  pattern_relationships_[id_b][id_a] = static_cast<float>(type);
+  pattern_relationships_[id_a][id_b] = strength;
+  pattern_relationships_[id_b][id_a] = strength;
 }
 
 void MemoryTierManager::pruneWeakRelationships() {

--- a/tests/memory/memory_manager_test.cpp
+++ b/tests/memory/memory_manager_test.cpp
@@ -10,7 +10,7 @@ TEST(MemoryManager, BasicSTMAllocation) {
     sep::memory::MemoryTierManager mgr;
     sep::memory::MemoryBlock* blk = mgr.allocate(128, sep::memory::MemoryTierEnum::STM);
     ASSERT_NE(blk, nullptr);
-    EXPECT_GT(mgr.getTierUtilization(sep::memory::MemoryTierEnum::STM), 0.0f);
+    EXPECT_GT(mgr.getTierUtilization(sep::memory::MemoryTierEnum::STM), EPSILON);
     mgr.deallocate(blk);
     EXPECT_NEAR(mgr.getTierUtilization(sep::memory::MemoryTierEnum::STM), 0.0f, EPSILON);
 }
@@ -19,7 +19,7 @@ TEST(MemoryManager, BasicMTMAllocation) {
     sep::memory::MemoryTierManager mgr;
     sep::memory::MemoryBlock* blk = mgr.allocate(256, sep::memory::MemoryTierEnum::MTM);
     ASSERT_NE(blk, nullptr);
-    EXPECT_GT(mgr.getTierUtilization(sep::memory::MemoryTierEnum::MTM), 0.0f);
+    EXPECT_GT(mgr.getTierUtilization(sep::memory::MemoryTierEnum::MTM), EPSILON);
     mgr.deallocate(blk);
     EXPECT_NEAR(mgr.getTierUtilization(sep::memory::MemoryTierEnum::MTM), 0.0f, EPSILON);
 }
@@ -28,7 +28,7 @@ TEST(MemoryManager, BasicLTMAllocation) {
     sep::memory::MemoryTierManager mgr;
     sep::memory::MemoryBlock* blk = mgr.allocate(512, sep::memory::MemoryTierEnum::LTM);
     ASSERT_NE(blk, nullptr);
-    EXPECT_GT(mgr.getTierUtilization(sep::memory::MemoryTierEnum::LTM), 0.0f);
+    EXPECT_GT(mgr.getTierUtilization(sep::memory::MemoryTierEnum::LTM), EPSILON);
     mgr.deallocate(blk);
     EXPECT_NEAR(mgr.getTierUtilization(sep::memory::MemoryTierEnum::LTM), 0.0f, EPSILON);
 }
@@ -41,9 +41,9 @@ TEST(MemoryManager, MultipleAllocations) {
     ASSERT_NE(s, nullptr);
     ASSERT_NE(m, nullptr);
     ASSERT_NE(l, nullptr);
-    EXPECT_GT(mgr.getTierUtilization(sep::memory::MemoryTierEnum::STM), 0.0f);
-    EXPECT_GT(mgr.getTierUtilization(sep::memory::MemoryTierEnum::MTM), 0.0f);
-    EXPECT_GT(mgr.getTierUtilization(sep::memory::MemoryTierEnum::LTM), 0.0f);
+    EXPECT_GT(mgr.getTierUtilization(sep::memory::MemoryTierEnum::STM), EPSILON);
+    EXPECT_GT(mgr.getTierUtilization(sep::memory::MemoryTierEnum::MTM), EPSILON);
+    EXPECT_GT(mgr.getTierUtilization(sep::memory::MemoryTierEnum::LTM), EPSILON);
     mgr.deallocate(s);
     mgr.deallocate(m);
     mgr.deallocate(l);


### PR DESCRIPTION
## Summary
- disable Redis globally and fix build for sep_core
- clean up memory tier manager implementation
- tweak memory tests to tolerate small allocations

## Testing
- `cmake --build cmake-nocuda --target memory_manager_tests`
- `./cmake-nocuda/tests/memory/memory_manager_tests` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_686c95fa1378832a93aa3eedb4f50eb5