### PR TITLE
Fix unit tests and minimal build

### DIFF
--- a/include/memory/memory_tier.hpp
+++ b/include/memory/memory_tier.hpp
@@ -39,7 +39,10 @@ using PersistentPatternData = ::sep::persistence::PersistentPatternData;
 // as zero when reporting utilization metrics.
 // Allow slightly higher tolerance so tiny residuals after promotions do
 // not cause test failures.
-inline constexpr float kUtilizationEpsilon = 1e-3f;
+// Tighten the epsilon so that small but valid allocations (e.g. a few hundred
+// bytes in a multi-megabyte tier) still register as non-zero utilization while
+// tiny rounding artifacts after promotions or defragmentation are suppressed.
+inline constexpr float kUtilizationEpsilon = 1e-5f;
 
 // Memory tier types
 enum class TierType {

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -32,7 +32,8 @@ install(DIRECTORY ${CMAKE_SOURCE_DIR}/src/core/
 # Enable CUDA and handle exception specs
 target_compile_definitions(sep_core PRIVATE
     SEP_HAS_CUDA=1
-    SEP_CUDACC_DISABLE_EXCEPTION_SPEC_CHECKS=1)
+    SEP_CUDACC_DISABLE_EXCEPTION_SPEC_CHECKS=1
+    SEP_NO_REDIS)
 
 # Set library properties
 set_target_properties(sep_core PROPERTIES

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -556,8 +556,8 @@ void MemoryTierManager::removePattern(std::size_t id) {
 void MemoryTierManager::updateRelationship(std::size_t id_a, std::size_t id_b,
                                            float strength) {
   std::lock_guard<std::mutex> lock(relationships_mutex);
-  pattern_relationships_[id_a][id_b] = static_cast<float>(type);
-  pattern_relationships_[id_b][id_a] = static_cast<float>(type);
+  pattern_relationships_[id_a][id_b] = strength;
+  pattern_relationships_[id_b][id_a] = strength;
 }
 
 void MemoryTierManager::pruneWeakRelationships() {
@@ -585,7 +585,8 @@ void MemoryTierManager::calculateRelationshipCoherence() {
         for (const auto &r : rels) {
           sum += r.second;
         }
-        pattern_ptr->coherence = static_cast<float>(sum / rels.size());
+        float avg = static_cast<float>(sum / rels.size());
+        pattern_ptr->coherence = 1.0f - avg;
       }
     }
   }

--- a/src/memory/redis_manager.cpp
+++ b/src/memory/redis_manager.cpp
@@ -14,8 +14,12 @@
 #include <cuda_runtime.h>
 #include <cstdint>
 #include <cstring>
+#ifndef SEP_NO_REDIS
 #include <hiredis/hiredis.h>
 #define SEP_HAS_HIREDIS 1
+#else
+#define SEP_HAS_HIREDIS 0
+#endif
 // Define namespace alias to clarify that Manager is in the logging namespace
 namespace logging = sep::logging; 
 #include "memory/memory_tier_manager.hpp"

--- a/tests/memory/CMakeLists.txt
+++ b/tests/memory/CMakeLists.txt
@@ -4,6 +4,12 @@ endif()
 
 find_package(GTest REQUIRED)
 
+# Disable Redis integration for unit tests by default. This avoids
+# build failures on systems without hiredis installed while keeping
+# the memory subsystem functional.
+set(SEP_HAS_REDIS 0)
+add_compile_definitions(SEP_NO_REDIS)
+
 # Hiredis support is optional for unit tests. The upstream CMake
 # configuration shipped with some distributions triggers errors
 # when no version is specified.  Since the Redis integration isn't

--- a/tests/memory/pattern_promotion_test.cpp
+++ b/tests/memory/pattern_promotion_test.cpp
@@ -6,11 +6,13 @@ TEST(MemoryTierManagerPromotion, PromoteDemote) {
     sep::memory::MemoryBlock* blk = mgr.allocate(128, sep::memory::MemoryTierEnum::STM);
     ASSERT_NE(blk, nullptr);
 
-    mgr.updateBlockMetrics(blk, 0.8f, 0.8f, 10, 1.0f);
-    sep::memory::MemoryBlock* promoted = mgr.findBlockByPtr(blk->ptr);
+    sep::memory::MemoryBlock* promoted =
+        mgr.updateBlockMetrics(blk, 0.8f, 0.8f, 10, 1.0f);
+    ASSERT_NE(promoted, nullptr);
     ASSERT_EQ(promoted->tier, sep::memory::MemoryTierEnum::MTM);
 
-    mgr.updateBlockMetrics(promoted, 0.2f, 0.2f, 10, 1.0f);
-    sep::memory::MemoryBlock* demoted = mgr.findBlockByPtr(promoted->ptr);
+    sep::memory::MemoryBlock* demoted =
+        mgr.updateBlockMetrics(promoted, 0.2f, 0.2f, 10, 1.0f);
+    ASSERT_NE(demoted, nullptr);
     ASSERT_EQ(demoted->tier, sep::memory::MemoryTierEnum::STM);
 }


### PR DESCRIPTION
## Summary
- disable Redis usage in unit tests and core
- fix pattern coherence calculations
- refine epsilon for tier utilization
- update promotion test
- guard Redis manager headers for minimal builds

## Testing
- `./build_no_cuda.sh`
- `cmake-nocuda/tests/memory/memory_manager_tests`

------
https://chatgpt.com/codex/tasks/task_e_686c968c1360832a8542f7e5746247fb