### PR TITLE
Fix build for memory manager tests

### DIFF
--- a/include/persistence/pattern_data.hpp
+++ b/include/persistence/pattern_data.hpp
@@ -1,18 +1,17 @@
 #pragma once
-#include <cstdint>
+
+// Legacy wrapper that aliases the canonical PersistentPatternData definition.
+// Keeping this header ensures older includes continue to compile while
+// avoiding duplicate struct definitions across namespaces.
+
+#include "persistent_pattern_data.hpp"
 
 namespace sep {
 namespace memory { namespace persistence {
-
-struct PersistentPatternData {
-    float coherence{0.0f};
-    float stability{0.0f};
-    std::uint32_t generation_count{0};
-};
-
+using ::sep::persistence::PersistentPatternData;
 } } // namespace memory::persistence
 
 namespace persistence {
-using PersistentPatternData = ::sep::memory::persistence::PersistentPatternData;
+using PersistentPatternData = ::sep::persistence::PersistentPatternData;
 } // namespace persistence
 } // namespace sep

--- a/src/memory/CMakeLists.txt
+++ b/src/memory/CMakeLists.txt
@@ -9,10 +9,18 @@ if(SEP_BUILD_QUANTUM)
   target_sources(sep_memory PRIVATE quantum_coherence_manager.cpp)
 endif()
 
-# Find required Redis library
-set(SEP_HAS_REDIS 0)
-set(HIREDIS_FOUND FALSE)
-add_compile_definitions(SEP_NO_REDIS)
+# Find hiredis for Redis persistence support
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(HIREDIS hiredis)
+if(HIREDIS_FOUND)
+  set(SEP_HAS_REDIS 1)
+  target_sources(sep_memory PRIVATE redis_manager.cpp)
+  target_link_libraries(sep_memory PRIVATE ${HIREDIS_LIBRARIES})
+  target_include_directories(sep_memory PRIVATE ${HIREDIS_INCLUDE_DIRS})
+else()
+  set(SEP_HAS_REDIS 0)
+  add_compile_definitions(SEP_NO_REDIS)
+endif()
 
 # Add CUDA-specific compile definitions to handle exception specs
 if(SEP_HAS_CUDA)
@@ -42,6 +50,7 @@ target_link_libraries(sep_memory
     PUBLIC
         sep_core
         sep_compat
+        spdlog::spdlog
     PRIVATE
         Threads::Threads
 )

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -54,6 +54,7 @@ MemoryTierManager &MemoryTierManager::getInstance() {
   std::call_once(once_flag_, []() {
 #ifdef SEP_MEMORY_MINIMAL
     Config cfg{};
+    instance_ = std::make_unique<MemoryTierManager>(cfg);
 #else
     const auto &mc =
         ::sep::config::ConfigManager::getInstance().getMemoryConfig();
@@ -69,10 +70,7 @@ MemoryTierManager &MemoryTierManager::getInstance() {
     cfg.ltm_size = mc.ltm_size;
     cfg.use_unified_memory = mc.use_unified_memory;
     cfg.enable_compression = mc.enable_compression;
-#endif
     instance_ = std::make_unique<MemoryTierManager>(cfg);
-#else
-    instance_ = std::make_unique<MemoryTierManager>();
 #endif
   });
   return *instance_;
@@ -557,10 +555,10 @@ void MemoryTierManager::removePattern(std::size_t id) {
 }
 
 void MemoryTierManager::updateRelationship(std::size_t id_a, std::size_t id_b,
-                                           uint8_t strength) {
+                                           float strength) {
   std::lock_guard<std::mutex> lock(relationships_mutex);
-  pattern_relationships_[id_a][id_b] = static_cast<float>(type);
-  pattern_relationships_[id_b][id_a] = static_cast<float>(type);
+  pattern_relationships_[id_a][id_b] = strength;
+  pattern_relationships_[id_b][id_a] = strength;
 }
 
 void MemoryTierManager::pruneWeakRelationships() {
@@ -573,6 +571,40 @@ void MemoryTierManager::pruneWeakRelationships() {
         ++it;
       }
     }
+  }
+}
+
+void MemoryTierManager::cleanupExpiredPatterns() {
+  std::lock_guard<std::mutex> reg_lock(registry_mutex);
+  for (auto it = pattern_registry_.begin(); it != pattern_registry_.end();) {
+    if (it->second->coherence < config_.demote_threshold) {
+      std::size_t id = it->first;
+      it = pattern_registry_.erase(it);
+      removePattern(id);
+    } else {
+      ++it;
+    }
+  }
+}
+
+void MemoryTierManager::prunePatternsByPriority(MemoryTierEnum tier,
+                                                size_t max_count) {
+  MemoryTier* t = getTier(tier);
+  if (!t)
+    return;
+  auto& patterns = t->getPatterns();
+  if (patterns.size() <= max_count)
+    return;
+
+  std::vector<std::pair<size_t, float>> entries;
+  entries.reserve(patterns.size());
+  for (const auto& p : patterns) {
+    entries.emplace_back(p.first, p.second.coherence);
+  }
+  std::sort(entries.begin(), entries.end(),
+            [](auto& a, auto& b) { return a.second > b.second; });
+  for (size_t i = max_count; i < entries.size(); ++i) {
+    t->removePattern(entries[i].first);
   }
 }
 


### PR DESCRIPTION
## Summary
- resolve header conflict with PersistentPatternData alias
- link sep_memory with spdlog and hiredis
- add missing MemoryTierManager helpers

## Testing
- `cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=g++-14 -DCMAKE_CXX_FLAGS="-DSEP_MEMORY_MINIMAL" -DSEP_HAS_CUDA=0 -DSEP_WITH_OPENSUBDIV=OFF -DSEP_WITH_OPENPGL=OFF -DSEP_WITH_OCIO=OFF -DSEP_WITH_OPENIMAGEIO=OFF -DSEP_WITH_EMBREE=OFF -DSEP_WITH_OPENVDB=OFF -DSEP_WITH_OSL=OFF -DSEP_WITH_ALEMBIC=OFF -DSEP_WITH_CYCLES=OFF -DBUILD_TESTING=ON -B build -S .`
- `make memory_manager_tests -C build -j$(nproc)`
- `./tests/memory/memory_manager_tests` *(fails: MemoryManager.BasicSTMAllocation)*


------
https://chatgpt.com/codex/tasks/task_e_686c9561fa20832abcafdcb7d2a7e97f