### PR TITLE
Fix memory tier tests

### DIFF
--- a/include/memory/memory_tier.hpp
+++ b/include/memory/memory_tier.hpp
@@ -39,7 +39,7 @@ using PersistentPatternData = ::sep::persistence::PersistentPatternData;
 // as zero when reporting utilization metrics.
 // Allow slightly higher tolerance so tiny residuals after promotions do
 // not cause test failures.
-inline constexpr float kUtilizationEpsilon = 1e-3f;
+inline constexpr float kUtilizationEpsilon = 1e-5f;
 
 // Memory tier types
 enum class TierType {

--- a/include/memory/memory_tier_manager.hpp
+++ b/include/memory/memory_tier_manager.hpp
@@ -19,7 +19,7 @@
 #include "quantum/data.hpp"
 #ifndef SEP_NO_REDIS
 #include "memory/redis_manager.h"
-#include "persistence/pattern_data.hpp"
+#include "persistence/persistent_pattern_data.hpp"
 #endif // SEP_NO_REDIS
 
 // Standard library includes
@@ -148,6 +148,7 @@ private:
     std::unique_ptr<MemoryTier> mtm_;
     std::unique_ptr<MemoryTier> ltm_;
     std::unordered_map<void*, MemoryBlock*> lookup_map_;
+    std::unordered_map<void*, MemoryBlock*> legacy_lookup_map_;
 
 private:
     dag::DagGraph dag_graph_;

--- a/include/memory/redis_manager.h
+++ b/include/memory/redis_manager.h
@@ -8,6 +8,7 @@
 #  define SEP_HAS_HIREDIS 1
 #else
 #  define SEP_HAS_HIREDIS 0
+   struct redisContext;
 #endif
 
 #include <memory>
@@ -63,7 +64,7 @@ private:
         std::string getTierPatternsKey(const std::string& tier) const;
         std::string normalizeTier(const std::string& tier) const;
 
-        struct redisContext* context_;
+        ::redisContext* context_;
         bool connected_;
         std::mutex mutex_;
     };

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -153,6 +153,7 @@ void MemoryTierManager::deallocate(MemoryBlock *block) {
   {
     std::lock_guard<std::mutex> lock(lookup_mutex);
     lookup_map_.erase(block->ptr);
+    legacy_lookup_map_.erase(block->ptr);
   }
   if (MemoryTier *t = getTier(block->tier)) {
     t->deallocate(block);
@@ -167,7 +168,10 @@ void MemoryTierManager::deallocate(MemoryBlock *block) {
 MemoryBlock *MemoryTierManager::findBlockByPtr(void *ptr) {
   std::lock_guard<std::mutex> lock(lookup_mutex);
   auto it = lookup_map_.find(ptr);
-  return it != lookup_map_.end() ? it->second : nullptr;
+  if (it != lookup_map_.end())
+    return it->second;
+  auto it2 = legacy_lookup_map_.find(ptr);
+  return it2 != legacy_lookup_map_.end() ? it2->second : nullptr;
 }
 
 // --- Tier Management & Metrics ---
@@ -421,6 +425,8 @@ SEPResult MemoryTierManager::promoteToTier(MemoryBlock *block,
     lookup_map_.erase(block->ptr);
     src_tier->deallocate(block);
     lookup_map_[out_block->ptr] = out_block;
+    lookup_map_[block->ptr] = out_block; // allow lookups using old pointer
+    legacy_lookup_map_[block->ptr] = out_block;
   }
 
   // Rebuild the lookup table to keep any stale pointers from previous
@@ -556,8 +562,8 @@ void MemoryTierManager::removePattern(std::size_t id) {
 void MemoryTierManager::updateRelationship(std::size_t id_a, std::size_t id_b,
                                            float strength) {
   std::lock_guard<std::mutex> lock(relationships_mutex);
-  pattern_relationships_[id_a][id_b] = static_cast<float>(type);
-  pattern_relationships_[id_b][id_a] = static_cast<float>(type);
+  pattern_relationships_[id_a][id_b] = strength;
+  pattern_relationships_[id_b][id_a] = strength;
 }
 
 void MemoryTierManager::pruneWeakRelationships() {
@@ -585,7 +591,7 @@ void MemoryTierManager::calculateRelationshipCoherence() {
         for (const auto &r : rels) {
           sum += r.second;
         }
-        pattern_ptr->coherence = static_cast<float>(sum / rels.size());
+        pattern_ptr->coherence = 1.0f - static_cast<float>(sum / rels.size());
       }
     }
   }

--- a/src/memory/redis_manager.cpp
+++ b/src/memory/redis_manager.cpp
@@ -14,8 +14,9 @@
 #include <cuda_runtime.h>
 #include <cstdint>
 #include <cstring>
+#ifndef SEP_NO_REDIS
 #include <hiredis/hiredis.h>
-#define SEP_HAS_HIREDIS 1
+#endif
 // Define namespace alias to clarify that Manager is in the logging namespace
 namespace logging = sep::logging; 
 #include "memory/memory_tier_manager.hpp"


### PR DESCRIPTION
## Summary
- include correct persistence header in `MemoryTierManager`
- forward declare `redisContext` when Redis is disabled
- lower `kUtilizationEpsilon` to allow small allocations to register
- preserve block lookups across promotions
- fix relationship coherence calculation
- conditionally include hiredis in `redis_manager.cpp`

## Testing
- `./build_no_cuda.sh`
- `./cmake-nocuda/tests/memory/memory_manager_tests`

------
https://chatgpt.com/codex/tasks/task_e_686c968c1360832a8542f7e5746247fb