### PR TITLE
Fix memory tests for minimal build

### DIFF
--- a/include/memory/memory_tier.hpp
+++ b/include/memory/memory_tier.hpp
@@ -39,7 +39,7 @@ using PersistentPatternData = ::sep::persistence::PersistentPatternData;
 // as zero when reporting utilization metrics.
 // Allow slightly higher tolerance so tiny residuals after promotions do
 // not cause test failures.
-inline constexpr float kUtilizationEpsilon = 1e-3f;
+inline constexpr float kUtilizationEpsilon = 1e-5f;
 
 // Memory tier types
 enum class TierType {

--- a/include/memory/memory_tier_manager.hpp
+++ b/include/memory/memory_tier_manager.hpp
@@ -19,7 +19,6 @@
 #include "quantum/data.hpp"
 #ifndef SEP_NO_REDIS
 #include "memory/redis_manager.h"
-#include "persistence/pattern_data.hpp"
 #endif // SEP_NO_REDIS
 
 // Standard library includes

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -423,11 +423,16 @@ SEPResult MemoryTierManager::promoteToTier(MemoryBlock *block,
     lookup_map_[out_block->ptr] = out_block;
   }
 
-  // Rebuild the lookup table to keep any stale pointers from previous
-  // defragmentation or resize operations in sync with the new block
-  // locations.  Unit tests rely on findBlockByPtr returning the latest
-  // address so we refresh the map after every successful move.
+  // Rebuild lookup first so all active blocks are registered with their
+  // current addresses.
   rebuildLookup();
+
+  {
+    std::lock_guard<std::mutex> lock(lookup_mutex);
+    // Preserve the old pointer as an alias so callers using stale addresses
+    // can still resolve the promoted block via findBlockByPtr.
+    lookup_map_[block->ptr] = out_block;
+  }
 
   return SEPResult::SUCCESS;
 }
@@ -556,8 +561,9 @@ void MemoryTierManager::removePattern(std::size_t id) {
 void MemoryTierManager::updateRelationship(std::size_t id_a, std::size_t id_b,
                                            float strength) {
   std::lock_guard<std::mutex> lock(relationships_mutex);
-  pattern_relationships_[id_a][id_b] = static_cast<float>(type);
-  pattern_relationships_[id_b][id_a] = static_cast<float>(type);
+  float s = strength <= 0.0f ? 1.0f : strength;
+  pattern_relationships_[id_a][id_b] = s;
+  pattern_relationships_[id_b][id_a] = s;
 }
 
 void MemoryTierManager::pruneWeakRelationships() {

--- a/src/memory/redis_manager.cpp
+++ b/src/memory/redis_manager.cpp
@@ -14,8 +14,12 @@
 #include <cuda_runtime.h>
 #include <cstdint>
 #include <cstring>
-#include <hiredis/hiredis.h>
-#define SEP_HAS_HIREDIS 1
+#ifndef SEP_NO_REDIS
+#  include <hiredis/hiredis.h>
+#  define SEP_HAS_HIREDIS 1
+#else
+#  define SEP_HAS_HIREDIS 0
+#endif
 // Define namespace alias to clarify that Manager is in the logging namespace
 namespace logging = sep::logging; 
 #include "memory/memory_tier_manager.hpp"


### PR DESCRIPTION
## Summary
- remove missing include from memory_tier_manager
- guard redis manager header when redis is disabled
- fix pointer handling in promoteToTier
- clamp relationship strength default
- tighten utilization epsilon so small allocations show

## Testing
- `./build_no_cuda.sh`
- `./cmake-nocuda/tests/memory/memory_manager_tests`

------
https://chatgpt.com/codex/tasks/task_e_686c968c1360832a8542f7e5746247fb