### PR TITLE
Fix memory tier manager tests and build

### DIFF
--- a/include/core/types.h
+++ b/include/core/types.h
@@ -59,12 +59,6 @@ struct CudaConfig {
     bool enable_profiling{false};
 };
 
-// Minimal quantum configuration required for memory tier tests.
-struct QuantumThresholdConfig {
-    float ltm_coherence_threshold{0.9f};
-    float mtm_coherence_threshold{0.6f};
-    float stability_threshold{0.8f};
-};
 
 // API server configuration. Only a subset of fields is required for
 // compiling the memory manager tests.
@@ -92,12 +86,6 @@ struct AnalyticsConfig {
     bool enable{false};
 };
 
-// Coherence thresholds used by quantum components
-struct QuantumThresholdConfig {
-    float ltm_coherence_threshold{0.9f};
-    float mtm_coherence_threshold{0.6f};
-    float stability_threshold{0.8f};
-};
 
 // Aggregate system configuration stub. Only the pieces used by tests
 // are represented here.

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -31,8 +31,10 @@ install(DIRECTORY ${CMAKE_SOURCE_DIR}/src/core/
 
 # Enable CUDA and handle exception specs
 target_compile_definitions(sep_core PRIVATE
-    SEP_HAS_CUDA=1
-    SEP_CUDACC_DISABLE_EXCEPTION_SPEC_CHECKS=1)
+    SEP_HAS_CUDA=$<IF:$<BOOL:${SEP_HAS_CUDA}>,1,0>
+    SEP_CUDACC_DISABLE_EXCEPTION_SPEC_CHECKS=1
+    SEP_HAS_REDIS=0
+    SEP_NO_REDIS)
 
 # Set library properties
 set_target_properties(sep_core PROPERTIES

--- a/src/memory/CMakeLists.txt
+++ b/src/memory/CMakeLists.txt
@@ -1,10 +1,14 @@
-add_library(sep_memory
-  STATIC
+set(MEMORY_SOURCES
     memory_tier.cpp
     memory_tier_manager.cpp
     memory_tier_manager_serialization.cpp
-    redis_manager.cpp
 )
+
+if(SEP_HAS_REDIS)
+    list(APPEND MEMORY_SOURCES redis_manager.cpp)
+endif()
+
+add_library(sep_memory STATIC ${MEMORY_SOURCES})
 
 if(SEP_BUILD_QUANTUM)
   target_sources(sep_memory PRIVATE quantum_coherence_manager.cpp)

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -541,8 +541,8 @@ void MemoryTierManager::removePattern(std::size_t id) {
 void MemoryTierManager::updateRelationship(std::size_t id_a, std::size_t id_b,
                                            float strength) {
   std::lock_guard<std::mutex> lock(relationships_mutex);
-  pattern_relationships_[id_a][id_b] = static_cast<float>(type);
-  pattern_relationships_[id_b][id_a] = static_cast<float>(type);
+  pattern_relationships_[id_a][id_b] = strength;
+  pattern_relationships_[id_b][id_a] = strength;
 }
 
 void MemoryTierManager::pruneWeakRelationships() {

--- a/tests/memory/CMakeLists.txt
+++ b/tests/memory/CMakeLists.txt
@@ -51,6 +51,7 @@ target_compile_definitions(memory_manager_tests PRIVATE
     SEP_HAS_CUDA=$<IF:$<BOOL:${SEP_HAS_CUDA}>,1,0>
     SEP_USE_CUDA=$<IF:$<BOOL:${SEP_HAS_CUDA}>,1,0>
     SEP_HAS_REDIS=${SEP_HAS_REDIS}
+    $<$<NOT:$<BOOL:${SEP_HAS_REDIS}>>:SEP_NO_REDIS>
     SEP_CUDACC_DISABLE_EXCEPTION_SPEC_CHECKS=1
 )
 
@@ -67,6 +68,7 @@ target_compile_definitions(memory_manager_tests PRIVATE
     SEP_HAS_CUDA=$<IF:$<BOOL:${SEP_HAS_CUDA}>,1,0>
     SEP_USE_CUDA=$<IF:$<BOOL:${SEP_HAS_CUDA}>,1,0>
     SEP_HAS_REDIS=${SEP_HAS_REDIS}
+    $<$<NOT:$<BOOL:${SEP_HAS_REDIS}>>:SEP_NO_REDIS>
 )
 
 add_test(NAME memory_manager_tests COMMAND memory_manager_tests)

--- a/tests/memory/memory_manager_smoke_test.cpp
+++ b/tests/memory/memory_manager_smoke_test.cpp
@@ -8,10 +8,10 @@ constexpr float EPSILON = 1e-3f;
 }
 
 TEST(MemoryManagerSmokeTest, AllocateAndFree) {
-    mem::MemoryTierManager manager;
-    mem::MemoryBlock* block = manager.allocate(64, mem::MemoryTierEnum::STM);
+    sep::memory::MemoryTierManager manager;
+    sep::memory::MemoryBlock* block = manager.allocate(64, sep::memory::MemoryTierEnum::STM);
     ASSERT_NE(block, nullptr);
-    EXPECT_GT(manager.getTierUtilization(mem::MemoryTierEnum::STM), 0.0f);
+    EXPECT_GT(manager.getTierUtilization(sep::memory::MemoryTierEnum::STM), 0.0f);
     manager.deallocate(block);
-    EXPECT_NEAR(manager.getTierUtilization(mem::MemoryTierEnum::STM), 0.0f, EPSILON);
+    EXPECT_NEAR(manager.getTierUtilization(sep::memory::MemoryTierEnum::STM), 0.0f, EPSILON);
 }

--- a/tests/memory/memory_manager_test.cpp
+++ b/tests/memory/memory_manager_test.cpp
@@ -10,27 +10,27 @@ TEST(MemoryManager, BasicSTMAllocation) {
     sep::memory::MemoryTierManager mgr;
     sep::memory::MemoryBlock* blk = mgr.allocate(128, sep::memory::MemoryTierEnum::STM);
     ASSERT_NE(blk, nullptr);
-    EXPECT_GT(mgr.getTierUtilization(mem::MemoryTierEnum::STM), 0.0f);
+    EXPECT_GT(mgr.getTierUtilization(sep::memory::MemoryTierEnum::STM), 0.0f);
     mgr.deallocate(blk);
-    EXPECT_NEAR(mgr.getTierUtilization(mem::MemoryTierEnum::STM), 0.0f, EPSILON);
+    EXPECT_NEAR(mgr.getTierUtilization(sep::memory::MemoryTierEnum::STM), 0.0f, EPSILON);
 }
 
 TEST(MemoryManager, BasicMTMAllocation) {
     sep::memory::MemoryTierManager mgr;
     sep::memory::MemoryBlock* blk = mgr.allocate(256, sep::memory::MemoryTierEnum::MTM);
     ASSERT_NE(blk, nullptr);
-    EXPECT_GT(mgr.getTierUtilization(mem::MemoryTierEnum::MTM), 0.0f);
+    EXPECT_GT(mgr.getTierUtilization(sep::memory::MemoryTierEnum::MTM), 0.0f);
     mgr.deallocate(blk);
-    EXPECT_NEAR(mgr.getTierUtilization(mem::MemoryTierEnum::MTM), 0.0f, EPSILON);
+    EXPECT_NEAR(mgr.getTierUtilization(sep::memory::MemoryTierEnum::MTM), 0.0f, EPSILON);
 }
 
 TEST(MemoryManager, BasicLTMAllocation) {
     sep::memory::MemoryTierManager mgr;
     sep::memory::MemoryBlock* blk = mgr.allocate(512, sep::memory::MemoryTierEnum::LTM);
     ASSERT_NE(blk, nullptr);
-    EXPECT_GT(mgr.getTierUtilization(mem::MemoryTierEnum::LTM), 0.0f);
+    EXPECT_GT(mgr.getTierUtilization(sep::memory::MemoryTierEnum::LTM), 0.0f);
     mgr.deallocate(blk);
-    EXPECT_NEAR(mgr.getTierUtilization(mem::MemoryTierEnum::LTM), 0.0f, EPSILON);
+    EXPECT_NEAR(mgr.getTierUtilization(sep::memory::MemoryTierEnum::LTM), 0.0f, EPSILON);
 }
 
 TEST(MemoryManager, MultipleAllocations) {
@@ -41,15 +41,15 @@ TEST(MemoryManager, MultipleAllocations) {
     ASSERT_NE(s, nullptr);
     ASSERT_NE(m, nullptr);
     ASSERT_NE(l, nullptr);
-    EXPECT_GT(mgr.getTierUtilization(mem::MemoryTierEnum::STM), 0.0f);
-    EXPECT_GT(mgr.getTierUtilization(mem::MemoryTierEnum::MTM), 0.0f);
-    EXPECT_GT(mgr.getTierUtilization(mem::MemoryTierEnum::LTM), 0.0f);
+    EXPECT_GT(mgr.getTierUtilization(sep::memory::MemoryTierEnum::STM), 0.0f);
+    EXPECT_GT(mgr.getTierUtilization(sep::memory::MemoryTierEnum::MTM), 0.0f);
+    EXPECT_GT(mgr.getTierUtilization(sep::memory::MemoryTierEnum::LTM), 0.0f);
     mgr.deallocate(s);
     mgr.deallocate(m);
     mgr.deallocate(l);
-    EXPECT_NEAR(mgr.getTierUtilization(mem::MemoryTierEnum::STM), 0.0f, EPSILON);
-    EXPECT_NEAR(mgr.getTierUtilization(mem::MemoryTierEnum::MTM), 0.0f, EPSILON);
-    EXPECT_NEAR(mgr.getTierUtilization(mem::MemoryTierEnum::LTM), 0.0f, EPSILON);
+    EXPECT_NEAR(mgr.getTierUtilization(sep::memory::MemoryTierEnum::STM), 0.0f, EPSILON);
+    EXPECT_NEAR(mgr.getTierUtilization(sep::memory::MemoryTierEnum::MTM), 0.0f, EPSILON);
+    EXPECT_NEAR(mgr.getTierUtilization(sep::memory::MemoryTierEnum::LTM), 0.0f, EPSILON);
 }
 
 TEST(MemoryManager, TotalAllocatedMemory) {

--- a/tests/memory/memory_tier_manager_test.cpp
+++ b/tests/memory/memory_tier_manager_test.cpp
@@ -239,7 +239,7 @@ TEST(MemoryTierManagerTest, CalculateRelationshipCoherence) {
     b.id = "2";
     mgr.registerPattern(1, a);
     mgr.registerPattern(2, b);
-    mgr.updateRelationship(1, 2, 0);
+    mgr.updateRelationship(1, 2, 1.0f);
     mgr.calculateRelationshipCoherence();
     const auto* pa = mgr.getPatternData(1);
     const auto* pb = mgr.getPatternData(2);

--- a/tests/memory/pattern_promotion_test.cpp
+++ b/tests/memory/pattern_promotion_test.cpp
@@ -6,11 +6,11 @@ TEST(MemoryTierManagerPromotion, PromoteDemote) {
     sep::memory::MemoryBlock* blk = mgr.allocate(128, sep::memory::MemoryTierEnum::STM);
     ASSERT_NE(blk, nullptr);
 
-    mgr.updateBlockMetrics(blk, 0.8f, 0.8f, 10, 1.0f);
-    sep::memory::MemoryBlock* promoted = mgr.findBlockByPtr(blk->ptr);
+    sep::memory::MemoryBlock* promoted = mgr.updateBlockMetrics(blk, 0.8f, 0.8f, 10, 1.0f);
+    ASSERT_NE(promoted, nullptr);
     ASSERT_EQ(promoted->tier, sep::memory::MemoryTierEnum::MTM);
 
-    mgr.updateBlockMetrics(promoted, 0.2f, 0.2f, 10, 1.0f);
-    sep::memory::MemoryBlock* demoted = mgr.findBlockByPtr(promoted->ptr);
+    sep::memory::MemoryBlock* demoted = mgr.updateBlockMetrics(promoted, 0.2f, 0.2f, 10, 1.0f);
+    ASSERT_NE(demoted, nullptr);
     ASSERT_EQ(demoted->tier, sep::memory::MemoryTierEnum::STM);
 }

--- a/tests/memory/promotion_regression_test.cpp
+++ b/tests/memory/promotion_regression_test.cpp
@@ -21,7 +21,7 @@ TEST(MemoryPromotionRegression, StablePromotionDemotion) {
     uint64_t wait = promoted->wait;
 
     mgr.updateBlockMetrics(promoted, 0.8f, 0.8f, 6, 1.0f); // should remain MTM
-    EXPECT_EQ(promoted->tier, mem::MemoryTierEnum::MTM);
+    EXPECT_EQ(promoted->tier, sep::memory::MemoryTierEnum::MTM);
     EXPECT_FLOAT_EQ(weight, promoted->weight);
     EXPECT_EQ(wait, promoted->wait);
 
@@ -31,7 +31,7 @@ TEST(MemoryPromotionRegression, StablePromotionDemotion) {
     weight = demoted->weight;
     wait = demoted->wait;
     mgr.updateBlockMetrics(demoted, 0.1f, 0.1f, 6, 1.0f); // remain STM
-    EXPECT_EQ(demoted->tier, mem::MemoryTierEnum::STM);
+    EXPECT_EQ(demoted->tier, sep::memory::MemoryTierEnum::STM);
     EXPECT_FLOAT_EQ(weight, demoted->weight);
     EXPECT_EQ(wait, demoted->wait);
 }


### PR DESCRIPTION
## Summary
- clean up duplicated QuantumThresholdConfig definitions
- disable Redis code when not enabled
- ensure promotion relationship strength stored correctly
- fix compile definitions in tests and libraries
- correct test logic and alias usage for memory tier enums

## Testing
- `./build_no_cuda.sh`
- `./cmake-nocuda/tests/memory/memory_manager_tests`

------
https://chatgpt.com/codex/tasks/task_e_686c97881f38832aa7239e90783f6f8c