### PR TITLE
Fix build_no_cuda memory tests

### DIFF
--- a/include/core/types.h
+++ b/include/core/types.h
@@ -59,13 +59,6 @@ struct CudaConfig {
     bool enable_profiling{false};
 };
 
-// Minimal quantum configuration required for memory tier tests.
-struct QuantumThresholdConfig {
-    float ltm_coherence_threshold{0.9f};
-    float mtm_coherence_threshold{0.6f};
-    float stability_threshold{0.8f};
-};
-
 // API server configuration. Only a subset of fields is required for
 // compiling the memory manager tests.
 struct APIConfig {
@@ -90,13 +83,6 @@ struct LogConfig {
 // Basic analytics configuration used by quantum components
 struct AnalyticsConfig {
     bool enable{false};
-};
-
-// Coherence thresholds used by quantum components
-struct QuantumThresholdConfig {
-    float ltm_coherence_threshold{0.9f};
-    float mtm_coherence_threshold{0.6f};
-    float stability_threshold{0.8f};
 };
 
 // Aggregate system configuration stub. Only the pieces used by tests

--- a/include/memory/memory_tier_manager.hpp
+++ b/include/memory/memory_tier_manager.hpp
@@ -19,7 +19,7 @@
 #include "quantum/data.hpp"
 #ifndef SEP_NO_REDIS
 #include "memory/redis_manager.h"
-#include "persistence/pattern_data.hpp"
+#include "persistence/persistent_pattern_data.hpp"
 #endif // SEP_NO_REDIS
 
 // Standard library includes

--- a/include/memory/redis_manager.h
+++ b/include/memory/redis_manager.h
@@ -1,13 +1,15 @@
 #pragma once
 
 #include "memory/types.h"
-#include "persistence/pattern_data.hpp"
+#include "persistence/persistent_pattern_data.hpp"
 
 #ifndef SEP_NO_REDIS
 #  include <hiredis/hiredis.h>
 #  define SEP_HAS_HIREDIS 1
 #else
 #  define SEP_HAS_HIREDIS 0
+   struct redisContext;
+   struct redisReply;
 #endif
 
 #include <memory>
@@ -63,7 +65,7 @@ private:
         std::string getTierPatternsKey(const std::string& tier) const;
         std::string normalizeTier(const std::string& tier) const;
 
-        struct redisContext* context_;
+        struct ::redisContext* context_;
         bool connected_;
         std::mutex mutex_;
     };

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -541,8 +541,8 @@ void MemoryTierManager::removePattern(std::size_t id) {
 void MemoryTierManager::updateRelationship(std::size_t id_a, std::size_t id_b,
                                            float strength) {
   std::lock_guard<std::mutex> lock(relationships_mutex);
-  pattern_relationships_[id_a][id_b] = static_cast<float>(type);
-  pattern_relationships_[id_b][id_a] = static_cast<float>(type);
+  pattern_relationships_[id_a][id_b] = strength;
+  pattern_relationships_[id_b][id_a] = strength;
 }
 
 void MemoryTierManager::cleanupExpiredPatterns() {

--- a/src/memory/redis_manager.cpp
+++ b/src/memory/redis_manager.cpp
@@ -14,8 +14,12 @@
 #include <cuda_runtime.h>
 #include <cstdint>
 #include <cstring>
+#ifndef SEP_NO_REDIS
 #include <hiredis/hiredis.h>
 #define SEP_HAS_HIREDIS 1
+#else
+#define SEP_HAS_HIREDIS 0
+#endif
 // Define namespace alias to clarify that Manager is in the logging namespace
 namespace logging = sep::logging; 
 #include "memory/memory_tier_manager.hpp"

--- a/tests/memory/memory_manager_test.cpp
+++ b/tests/memory/memory_manager_test.cpp
@@ -10,27 +10,27 @@ TEST(MemoryManager, BasicSTMAllocation) {
     sep::memory::MemoryTierManager mgr;
     sep::memory::MemoryBlock* blk = mgr.allocate(128, sep::memory::MemoryTierEnum::STM);
     ASSERT_NE(blk, nullptr);
-    EXPECT_GT(mgr.getTierUtilization(mem::MemoryTierEnum::STM), 0.0f);
+    EXPECT_GT(mgr.getTierUtilization(sep::memory::MemoryTierEnum::STM), 0.0f);
     mgr.deallocate(blk);
-    EXPECT_NEAR(mgr.getTierUtilization(mem::MemoryTierEnum::STM), 0.0f, EPSILON);
+    EXPECT_NEAR(mgr.getTierUtilization(sep::memory::MemoryTierEnum::STM), 0.0f, EPSILON);
 }
 
 TEST(MemoryManager, BasicMTMAllocation) {
     sep::memory::MemoryTierManager mgr;
     sep::memory::MemoryBlock* blk = mgr.allocate(256, sep::memory::MemoryTierEnum::MTM);
     ASSERT_NE(blk, nullptr);
-    EXPECT_GT(mgr.getTierUtilization(mem::MemoryTierEnum::MTM), 0.0f);
+    EXPECT_GT(mgr.getTierUtilization(sep::memory::MemoryTierEnum::MTM), 0.0f);
     mgr.deallocate(blk);
-    EXPECT_NEAR(mgr.getTierUtilization(mem::MemoryTierEnum::MTM), 0.0f, EPSILON);
+    EXPECT_NEAR(mgr.getTierUtilization(sep::memory::MemoryTierEnum::MTM), 0.0f, EPSILON);
 }
 
 TEST(MemoryManager, BasicLTMAllocation) {
     sep::memory::MemoryTierManager mgr;
     sep::memory::MemoryBlock* blk = mgr.allocate(512, sep::memory::MemoryTierEnum::LTM);
     ASSERT_NE(blk, nullptr);
-    EXPECT_GT(mgr.getTierUtilization(mem::MemoryTierEnum::LTM), 0.0f);
+    EXPECT_GT(mgr.getTierUtilization(sep::memory::MemoryTierEnum::LTM), 0.0f);
     mgr.deallocate(blk);
-    EXPECT_NEAR(mgr.getTierUtilization(mem::MemoryTierEnum::LTM), 0.0f, EPSILON);
+    EXPECT_NEAR(mgr.getTierUtilization(sep::memory::MemoryTierEnum::LTM), 0.0f, EPSILON);
 }
 
 TEST(MemoryManager, MultipleAllocations) {
@@ -41,15 +41,15 @@ TEST(MemoryManager, MultipleAllocations) {
     ASSERT_NE(s, nullptr);
     ASSERT_NE(m, nullptr);
     ASSERT_NE(l, nullptr);
-    EXPECT_GT(mgr.getTierUtilization(mem::MemoryTierEnum::STM), 0.0f);
-    EXPECT_GT(mgr.getTierUtilization(mem::MemoryTierEnum::MTM), 0.0f);
-    EXPECT_GT(mgr.getTierUtilization(mem::MemoryTierEnum::LTM), 0.0f);
+    EXPECT_GT(mgr.getTierUtilization(sep::memory::MemoryTierEnum::STM), 0.0f);
+    EXPECT_GT(mgr.getTierUtilization(sep::memory::MemoryTierEnum::MTM), 0.0f);
+    EXPECT_GT(mgr.getTierUtilization(sep::memory::MemoryTierEnum::LTM), 0.0f);
     mgr.deallocate(s);
     mgr.deallocate(m);
     mgr.deallocate(l);
-    EXPECT_NEAR(mgr.getTierUtilization(mem::MemoryTierEnum::STM), 0.0f, EPSILON);
-    EXPECT_NEAR(mgr.getTierUtilization(mem::MemoryTierEnum::MTM), 0.0f, EPSILON);
-    EXPECT_NEAR(mgr.getTierUtilization(mem::MemoryTierEnum::LTM), 0.0f, EPSILON);
+    EXPECT_NEAR(mgr.getTierUtilization(sep::memory::MemoryTierEnum::STM), 0.0f, EPSILON);
+    EXPECT_NEAR(mgr.getTierUtilization(sep::memory::MemoryTierEnum::MTM), 0.0f, EPSILON);
+    EXPECT_NEAR(mgr.getTierUtilization(sep::memory::MemoryTierEnum::LTM), 0.0f, EPSILON);
 }
 
 TEST(MemoryManager, TotalAllocatedMemory) {

--- a/tests/memory/promotion_regression_test.cpp
+++ b/tests/memory/promotion_regression_test.cpp
@@ -2,6 +2,8 @@
 #include "memory/memory_tier_manager.hpp"
 #include "memory/memory_tier.hpp"
 
+namespace mem = sep::memory;
+
 static sep::memory::MemoryBlock* findAllocated(sep::memory::MemoryTier& tier) {
     for (const auto& b : tier.getBlocks()) {
         if (b.allocated) return const_cast<sep::memory::MemoryBlock*>(&b);


### PR DESCRIPTION
## Summary
- dedupe `QuantumThresholdConfig` definitions
- fix path and forward declarations for redis headers
- guard hiredis integration with `SEP_NO_REDIS`
- repair updateRelationship logic
- fix test namespace references

## Testing
- `./build_no_cuda.sh`

------
https://chatgpt.com/codex/tasks/task_e_686c98376fa4832abf3a655505f547f3