### PR TITLE
Fix build_no_cuda compile issues

### DIFF
--- a/include/core/types.h
+++ b/include/core/types.h
@@ -43,12 +43,6 @@ struct MemoryThresholdConfig {
     bool enable_compression{true};
 };
 
-struct QuantumThresholdConfig {
-    float ltm_coherence_threshold{0.9f};
-    float mtm_coherence_threshold{0.6f};
-    float stability_threshold{0.8f};
-};
-
 // Minimal CUDA configuration used by unit tests. These fields are
 // sufficient for the parts of the engine compiled in this repository.
 struct CudaConfig {
@@ -90,13 +84,6 @@ struct LogConfig {
 // Basic analytics configuration used by quantum components
 struct AnalyticsConfig {
     bool enable{false};
-};
-
-// Coherence thresholds used by quantum components
-struct QuantumThresholdConfig {
-    float ltm_coherence_threshold{0.9f};
-    float mtm_coherence_threshold{0.6f};
-    float stability_threshold{0.8f};
 };
 
 // Aggregate system configuration stub. Only the pieces used by tests

--- a/include/memory/memory_tier_manager.hpp
+++ b/include/memory/memory_tier_manager.hpp
@@ -19,7 +19,7 @@
 #include "quantum/data.hpp"
 #ifndef SEP_NO_REDIS
 #include "memory/redis_manager.h"
-#include "persistence/pattern_data.hpp"
+#include "persistence/persistent_pattern_data.hpp"
 #endif // SEP_NO_REDIS
 
 // Standard library includes

--- a/include/memory/redis_manager.h
+++ b/include/memory/redis_manager.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "memory/types.h"
-#include "persistence/pattern_data.hpp"
+#include "persistence/persistent_pattern_data.hpp"
 
 #ifndef SEP_NO_REDIS
 #  include <hiredis/hiredis.h>
@@ -63,7 +63,12 @@ private:
         std::string getTierPatternsKey(const std::string& tier) const;
         std::string normalizeTier(const std::string& tier) const;
 
-        struct redisContext* context_;
+#if SEP_HAS_HIREDIS
+        using RedisContextPtr = ::redisContext*;
+#else
+        using RedisContextPtr = void*;
+#endif
+        RedisContextPtr context_{};
         bool connected_;
         std::mutex mutex_;
     };

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -541,8 +541,8 @@ void MemoryTierManager::removePattern(std::size_t id) {
 void MemoryTierManager::updateRelationship(std::size_t id_a, std::size_t id_b,
                                            float strength) {
   std::lock_guard<std::mutex> lock(relationships_mutex);
-  pattern_relationships_[id_a][id_b] = static_cast<float>(type);
-  pattern_relationships_[id_b][id_a] = static_cast<float>(type);
+  pattern_relationships_[id_a][id_b] = strength;
+  pattern_relationships_[id_b][id_a] = strength;
 }
 
 void MemoryTierManager::cleanupExpiredPatterns() {

--- a/src/memory/redis_manager.cpp
+++ b/src/memory/redis_manager.cpp
@@ -14,8 +14,9 @@
 #include <cuda_runtime.h>
 #include <cstdint>
 #include <cstring>
-#include <hiredis/hiredis.h>
-#define SEP_HAS_HIREDIS 1
+#if SEP_HAS_HIREDIS
+#  include <hiredis/hiredis.h>
+#endif
 // Define namespace alias to clarify that Manager is in the logging namespace
 namespace logging = sep::logging; 
 #include "memory/memory_tier_manager.hpp"

--- a/tests/memory/memory_manager_test.cpp
+++ b/tests/memory/memory_manager_test.cpp
@@ -1,6 +1,8 @@
 #include <gtest/gtest.h>
 #include "memory/memory_tier_manager.hpp"
 
+namespace mem = sep::memory;
+
 namespace {
 constexpr float EPSILON = 1e-3f;
 }

--- a/tests/memory/promotion_regression_test.cpp
+++ b/tests/memory/promotion_regression_test.cpp
@@ -2,6 +2,8 @@
 #include "memory/memory_tier_manager.hpp"
 #include "memory/memory_tier.hpp"
 
+namespace mem = sep::memory;
+
 static sep::memory::MemoryBlock* findAllocated(sep::memory::MemoryTier& tier) {
     for (const auto& b : tier.getBlocks()) {
         if (b.allocated) return const_cast<sep::memory::MemoryBlock*>(&b);


### PR DESCRIPTION
## Summary
- dedupe QuantumThresholdConfig in types.h
- fix Redis includes and context handling when built without hiredis
- fix incorrect variable in updateRelationship
- add `mem` namespace alias in unit tests

## Testing
- `./build_no_cuda.sh`

------
https://chatgpt.com/codex/tasks/task_e_686c98376fa4832abf3a655505f547f3