### PR TITLE
Fix memory tier build issues

### DIFF
--- a/include/core/types.h
+++ b/include/core/types.h
@@ -59,13 +59,6 @@ struct CudaConfig {
     bool enable_profiling{false};
 };
 
-// Minimal quantum configuration required for memory tier tests.
-struct QuantumThresholdConfig {
-    float ltm_coherence_threshold{0.9f};
-    float mtm_coherence_threshold{0.6f};
-    float stability_threshold{0.8f};
-};
-
 // API server configuration. Only a subset of fields is required for
 // compiling the memory manager tests.
 struct APIConfig {
@@ -90,13 +83,6 @@ struct LogConfig {
 // Basic analytics configuration used by quantum components
 struct AnalyticsConfig {
     bool enable{false};
-};
-
-// Coherence thresholds used by quantum components
-struct QuantumThresholdConfig {
-    float ltm_coherence_threshold{0.9f};
-    float mtm_coherence_threshold{0.6f};
-    float stability_threshold{0.8f};
 };
 
 // Aggregate system configuration stub. Only the pieces used by tests

--- a/include/memory/redis_manager.h
+++ b/include/memory/redis_manager.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "memory/types.h"
-#include "persistence/pattern_data.hpp"
+#include "persistence/persistent_pattern_data.hpp"
 
 #ifndef SEP_NO_REDIS
 #  include <hiredis/hiredis.h>

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -553,6 +553,7 @@ void MemoryTierManager::updateRelationship(std::size_t id_a, std::size_t id_b,
   pattern_relationships_[id_b][id_a] = static_cast<float>(strength);
 }
 
+#ifndef SEP_TESTBED_STUBS
 void MemoryTierManager::cleanupExpiredPatterns() {
   std::lock_guard<std::mutex> reg_lock(registry_mutex);
   for (auto it = pattern_registry_.begin(); it != pattern_registry_.end();) {
@@ -602,6 +603,7 @@ void MemoryTierManager::prunePatternsByPriority(MemoryTierEnum tier,
     }
   }
 }
+#endif // !SEP_TESTBED_STUBS
 
 void MemoryTierManager::pruneWeakRelationships() {
   std::lock_guard<std::mutex> lock(relationships_mutex);
@@ -638,15 +640,7 @@ void MemoryTierManager::calculateRelationshipCoherence() {
 }
 #endif
 
-void MemoryTierManager::cleanupExpiredPatterns() {
-  // Stub implementation for minimal build
-}
-
-void MemoryTierManager::prunePatternsByPriority(MemoryTierEnum tier,
-                                                size_t max_count) {
-  // Stub implementation for minimal build
-}
-
+#ifdef SEP_TESTBED_STUBS
 void MemoryTierManager::cleanupExpiredPatterns() {
   std::lock_guard<std::mutex> lock(registry_mutex);
   for (auto it = pattern_registry_.begin(); it != pattern_registry_.end();) {
@@ -678,6 +672,7 @@ void MemoryTierManager::prunePatternsByPriority(MemoryTierEnum tier,
     removePattern(sorted[i].first);
   }
 }
+#endif // SEP_TESTBED_STUBS
 
 } // namespace memory
 } // namespace sep


### PR DESCRIPTION
## Summary
- fix missing include in `redis_manager.h`
- remove duplicate `QuantumThresholdConfig` struct
- guard stub functions in `MemoryTierManager`
- update stub functions for testbed minimal build

## Testing
- `cmake ..`
- `make -j$(nproc)` within `_sep/testbed/memory_minimal/build`
- `./memory_minimal_tests`


------
https://chatgpt.com/codex/tasks/task_e_686c997ef064832ab9d74514e0212f0a