### PR TITLE
Fix memory tier manager tests

### DIFF
--- a/_sep/testbed/memory_minimal/CMakeLists.txt
+++ b/_sep/testbed/memory_minimal/CMakeLists.txt
@@ -28,6 +28,7 @@ set(MEMORY_SRC
 target_sources(memory_minimal_tests PRIVATE ${MEMORY_SRC})
 target_compile_definitions(memory_minimal_tests PRIVATE SEP_MINIMAL=1)
 target_compile_definitions(memory_minimal_tests PRIVATE SEP_TESTBED_STUBS)
+target_compile_definitions(memory_minimal_tests PRIVATE SEP_NO_REDIS)
 
 target_include_directories(memory_minimal_tests PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../include

--- a/include/core/types.h
+++ b/include/core/types.h
@@ -43,11 +43,6 @@ struct MemoryThresholdConfig {
     bool enable_compression{true};
 };
 
-struct QuantumThresholdConfig {
-    float ltm_coherence_threshold{0.9f};
-    float mtm_coherence_threshold{0.6f};
-    float stability_threshold{0.8f};
-};
 
 // Minimal CUDA configuration used by unit tests. These fields are
 // sufficient for the parts of the engine compiled in this repository.
@@ -59,12 +54,6 @@ struct CudaConfig {
     bool enable_profiling{false};
 };
 
-// Minimal quantum configuration required for memory tier tests.
-struct QuantumThresholdConfig {
-    float ltm_coherence_threshold{0.9f};
-    float mtm_coherence_threshold{0.6f};
-    float stability_threshold{0.8f};
-};
 
 // API server configuration. Only a subset of fields is required for
 // compiling the memory manager tests.

--- a/include/memory/memory_tier_manager.hpp
+++ b/include/memory/memory_tier_manager.hpp
@@ -147,6 +147,11 @@ private:
   std::unique_ptr<MemoryTier> mtm_;
   std::unique_ptr<MemoryTier> ltm_;
   std::unordered_map<void *, MemoryBlock *> lookup_map_;
+  // Legacy pointer lookup table used during tier transitions. When blocks
+  // move between tiers the old pointer remains valid for a short period so
+  // tests can resolve both the new and previous addresses. This map stores
+  // those temporary associations until the next rebuild.
+  std::unordered_map<void *, MemoryBlock *> legacy_lookup_map_;
 
 private:
   dag::DagGraph dag_graph_;

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -622,7 +622,6 @@ void MemoryTierManager::pruneWeakRelationships() {
   }
 }
 
-#ifndef SEP_TESTBED_STUBS
 void MemoryTierManager::calculateRelationshipCoherence() {
   std::lock_guard<std::mutex> reg_lock(registry_mutex);
   std::lock_guard<std::mutex> rel_lock(relationships_mutex);
@@ -640,48 +639,6 @@ void MemoryTierManager::calculateRelationshipCoherence() {
         pattern_ptr->coherence = 1.0f - avg;
       }
     }
-  }
-}
-#endif
-
-void MemoryTierManager::cleanupExpiredPatterns() {
-  // Stub implementation for minimal build
-}
-
-void MemoryTierManager::prunePatternsByPriority(MemoryTierEnum tier,
-                                                size_t max_count) {
-  // Stub implementation for minimal build
-}
-
-void MemoryTierManager::cleanupExpiredPatterns() {
-  std::lock_guard<std::mutex> lock(registry_mutex);
-  for (auto it = pattern_registry_.begin(); it != pattern_registry_.end();) {
-    if (it->second->coherence < config_.demote_threshold) {
-      it = pattern_registry_.erase(it);
-    } else {
-      ++it;
-    }
-  }
-}
-
-void MemoryTierManager::prunePatternsByPriority(MemoryTierEnum tier,
-                                               size_t max_count) {
-  MemoryTier *t = getTier(tier);
-  if (!t)
-    return;
-  const auto &patterns = t->getPatterns();
-  if (patterns.size() <= max_count)
-    return;
-  std::vector<std::pair<size_t, float>> sorted;
-  sorted.reserve(patterns.size());
-  for (const auto &[id, pat] : patterns) {
-    sorted.emplace_back(id, pat.coherence);
-  }
-  std::sort(sorted.begin(), sorted.end(),
-            [](const auto &a, const auto &b) { return a.second > b.second; });
-  for (size_t i = max_count; i < sorted.size(); ++i) {
-    t->removePattern(sorted[i].first);
-    removePattern(sorted[i].first);
   }
 }
 


### PR DESCRIPTION
## Summary
- add missing legacy lookup table to MemoryTierManager
- remove duplicate functions in memory tier manager implementation
- clean up extra struct definitions in core types
- add SEP_NO_REDIS for memory minimal testbed

## Testing
- `cd _sep/testbed/memory_minimal/build && make -j$(nproc) && ./memory_minimal_tests >/tmp/test.log && tail -n 5 /tmp/test.log`

------
https://chatgpt.com/codex/tasks/task_e_686c997ef064832ab9d74514e0212f0a