### PR TITLE
Fix memory manager build issues

### DIFF
--- a/include/core/manager.h
+++ b/include/core/manager.h
@@ -44,12 +44,14 @@ public:
   const CudaConfig &getCudaConfig() const;
   const LogConfig &getLogConfig() const;
   const MemoryThresholdConfig &getMemoryConfig() const;
+  const QuantumThresholdConfig &getQuantumConfig() const;
 
   // Update specific components
   void updateAPIConfig(const APIConfig &config);
   void updateCudaConfig(const CudaConfig &config);
   void updateLogConfig(const LogConfig &config);
   void updateMemoryConfig(const MemoryThresholdConfig &config);
+  void updateQuantumConfig(const QuantumThresholdConfig &config);
 
   // Reset configuration to defaults
   void resetToDefaults();

--- a/include/core/types.h
+++ b/include/core/types.h
@@ -59,12 +59,6 @@ struct CudaConfig {
     bool enable_profiling{false};
 };
 
-// Minimal quantum configuration required for memory tier tests.
-struct QuantumThresholdConfig {
-    float ltm_coherence_threshold{0.9f};
-    float mtm_coherence_threshold{0.6f};
-    float stability_threshold{0.8f};
-};
 
 // API server configuration. Only a subset of fields is required for
 // compiling the memory manager tests.
@@ -92,12 +86,6 @@ struct AnalyticsConfig {
     bool enable{false};
 };
 
-// Coherence thresholds used by quantum components
-struct QuantumThresholdConfig {
-    float ltm_coherence_threshold{0.9f};
-    float mtm_coherence_threshold{0.6f};
-    float stability_threshold{0.8f};
-};
 
 // Aggregate system configuration stub. Only the pieces used by tests
 // are represented here.

--- a/include/memory/redis_manager.h
+++ b/include/memory/redis_manager.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "memory/types.h"
-#include "persistence/pattern_data.hpp"
+#include "persistence/persistent_pattern_data.hpp"
 
 #ifndef SEP_NO_REDIS
 #  include <hiredis/hiredis.h>

--- a/src/memory/CMakeLists.txt
+++ b/src/memory/CMakeLists.txt
@@ -1,10 +1,14 @@
-add_library(sep_memory
-  STATIC
+add_library(sep_memory STATIC
     memory_tier.cpp
     memory_tier_manager.cpp
     memory_tier_manager_serialization.cpp
-    redis_manager.cpp
 )
+
+if(HIREDIS_FOUND)
+  target_sources(sep_memory PRIVATE redis_manager.cpp)
+else()
+  target_sources(sep_memory PRIVATE redis_manager_stub.cpp)
+endif()
 
 if(SEP_BUILD_QUANTUM)
   target_sources(sep_memory PRIVATE quantum_coherence_manager.cpp)

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -621,21 +621,19 @@ void MemoryTierManager::calculateRelationshipCoherence() {
         for (const auto &r : rels) {
           sum += r.second;
         }
-        pattern_ptr->coherence = static_cast<float>(sum / rels.size());
+        if (std::fabs(sum) <= std::numeric_limits<double>::epsilon()) {
+          pattern_ptr->coherence = 1.0f;
+        } else {
+          pattern_ptr->coherence = static_cast<float>(sum / rels.size());
+        }
       }
     }
   }
 }
 #endif
 
-void MemoryTierManager::cleanupExpiredPatterns() {
-  // Stub implementation for minimal build
-}
-
-void MemoryTierManager::prunePatternsByPriority(MemoryTierEnum tier,
-                                                size_t max_count) {
-  // Stub implementation for minimal build
-}
+// Stubs for minimal build are no longer required; full implementations above
+// handle cleanup and pruning even when Redis is disabled.
 
 } // namespace memory
 } // namespace sep

--- a/tests/memory/memory_manager_test.cpp
+++ b/tests/memory/memory_manager_test.cpp
@@ -5,6 +5,8 @@ namespace {
 constexpr float EPSILON = 1e-3f;
 }
 
+namespace mem = sep::memory;
+
 
 TEST(MemoryManager, BasicSTMAllocation) {
     sep::memory::MemoryTierManager mgr;

--- a/tests/memory/promotion_regression_test.cpp
+++ b/tests/memory/promotion_regression_test.cpp
@@ -2,6 +2,8 @@
 #include "memory/memory_tier_manager.hpp"
 #include "memory/memory_tier.hpp"
 
+namespace mem = sep::memory;
+
 static sep::memory::MemoryBlock* findAllocated(sep::memory::MemoryTier& tier) {
     for (const auto& b : tier.getBlocks()) {
         if (b.allocated) return const_cast<sep::memory::MemoryBlock*>(&b);


### PR DESCRIPTION
## Summary
- fix duplicate QuantumThresholdConfig declarations
- expose quantum config accessors in ConfigManager
- correct header include for Redis manager
- build Redis stub when hiredis is absent
- handle zero-strength relationships in coherence calculations
- add missing namespace aliases in tests

## Testing
- `./build_no_cuda.sh` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_686c98b8c290832a958c63e1c8287ca0