### PR TITLE
Fix memory tier manager build and tests

### DIFF
--- a/include/core/manager.h
+++ b/include/core/manager.h
@@ -44,12 +44,14 @@ public:
   const CudaConfig &getCudaConfig() const;
   const LogConfig &getLogConfig() const;
   const MemoryThresholdConfig &getMemoryConfig() const;
+  const QuantumThresholdConfig &getQuantumConfig() const;
 
   // Update specific components
   void updateAPIConfig(const APIConfig &config);
   void updateCudaConfig(const CudaConfig &config);
   void updateLogConfig(const LogConfig &config);
   void updateMemoryConfig(const MemoryThresholdConfig &config);
+  void updateQuantumConfig(const QuantumThresholdConfig &config);
 
   // Reset configuration to defaults
   void resetToDefaults();

--- a/include/core/types.h
+++ b/include/core/types.h
@@ -43,11 +43,6 @@ struct MemoryThresholdConfig {
     bool enable_compression{true};
 };
 
-struct QuantumThresholdConfig {
-    float ltm_coherence_threshold{0.9f};
-    float mtm_coherence_threshold{0.6f};
-    float stability_threshold{0.8f};
-};
 
 // Minimal CUDA configuration used by unit tests. These fields are
 // sufficient for the parts of the engine compiled in this repository.
@@ -92,12 +87,6 @@ struct AnalyticsConfig {
     bool enable{false};
 };
 
-// Coherence thresholds used by quantum components
-struct QuantumThresholdConfig {
-    float ltm_coherence_threshold{0.9f};
-    float mtm_coherence_threshold{0.6f};
-    float stability_threshold{0.8f};
-};
 
 // Aggregate system configuration stub. Only the pieces used by tests
 // are represented here.

--- a/include/memory/redis_manager.h
+++ b/include/memory/redis_manager.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "memory/types.h"
-#include "persistence/pattern_data.hpp"
+#include "persistence/persistent_pattern_data.hpp"
 
 #ifndef SEP_NO_REDIS
 #  include <hiredis/hiredis.h>

--- a/src/memory/CMakeLists.txt
+++ b/src/memory/CMakeLists.txt
@@ -3,8 +3,13 @@ add_library(sep_memory
     memory_tier.cpp
     memory_tier_manager.cpp
     memory_tier_manager_serialization.cpp
-    redis_manager.cpp
 )
+
+if(SEP_HAS_REDIS)
+  target_sources(sep_memory PRIVATE redis_manager.cpp)
+else()
+  target_sources(sep_memory PRIVATE redis_manager_stub.cpp)
+endif()
 
 if(SEP_BUILD_QUANTUM)
   target_sources(sep_memory PRIVATE quantum_coherence_manager.cpp)

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -553,55 +553,6 @@ void MemoryTierManager::updateRelationship(std::size_t id_a, std::size_t id_b,
   pattern_relationships_[id_b][id_a] = static_cast<float>(strength);
 }
 
-void MemoryTierManager::cleanupExpiredPatterns() {
-  std::lock_guard<std::mutex> reg_lock(registry_mutex);
-  for (auto it = pattern_registry_.begin(); it != pattern_registry_.end();) {
-    if (it->second->coherence < config_.demote_threshold) {
-      std::size_t id = it->first;
-      it = pattern_registry_.erase(it);
-      std::lock_guard<std::mutex> rel_lock(relationships_mutex);
-      pattern_relationships_.erase(id);
-      for (auto &pair : pattern_relationships_) {
-        pair.second.erase(id);
-      }
-    } else {
-      ++it;
-    }
-  }
-}
-
-void MemoryTierManager::prunePatternsByPriority(MemoryTierEnum tier,
-                                                size_t max_count) {
-  MemoryTier *t = getTier(tier);
-  if (!t)
-    return;
-
-  auto &patterns = const_cast<std::unordered_map<size_t, PersistentPatternData> &>(
-      t->getPatterns());
-
-  if (patterns.size() <= max_count)
-    return;
-
-  std::vector<std::pair<size_t, float>> ranked;
-  ranked.reserve(patterns.size());
-  for (const auto &[id, pdata] : patterns)
-    ranked.emplace_back(id, pdata.coherence);
-
-  std::sort(ranked.begin(), ranked.end(),
-            [](const auto &a, const auto &b) { return a.second > b.second; });
-
-  for (size_t i = max_count; i < ranked.size(); ++i) {
-    size_t id = ranked[i].first;
-    t->removePattern(id);
-    std::lock_guard<std::mutex> reg_lock(registry_mutex);
-    pattern_registry_.erase(id);
-    std::lock_guard<std::mutex> rel_lock(relationships_mutex);
-    pattern_relationships_.erase(id);
-    for (auto &pair : pattern_relationships_) {
-      pair.second.erase(id);
-    }
-  }
-}
 
 void MemoryTierManager::pruneWeakRelationships() {
   std::lock_guard<std::mutex> lock(relationships_mutex);
@@ -638,14 +589,6 @@ void MemoryTierManager::calculateRelationshipCoherence() {
 }
 #endif
 
-void MemoryTierManager::cleanupExpiredPatterns() {
-  // Stub implementation for minimal build
-}
-
-void MemoryTierManager::prunePatternsByPriority(MemoryTierEnum tier,
-                                                size_t max_count) {
-  // Stub implementation for minimal build
-}
 
 void MemoryTierManager::cleanupExpiredPatterns() {
   std::lock_guard<std::mutex> lock(registry_mutex);

--- a/tests/memory/CMakeLists.txt
+++ b/tests/memory/CMakeLists.txt
@@ -32,6 +32,10 @@ set(TEST_SOURCES
     pattern_promotion_test.cpp
 )
 
+add_executable(memory_manager_tests
+    ${TEST_SOURCES}
+)
+
 if(SEP_HAS_REDIS)
     target_sources(memory_manager_tests PRIVATE redis_manager_test.cpp)
 endif()

--- a/tests/memory/memory_manager_test.cpp
+++ b/tests/memory/memory_manager_test.cpp
@@ -10,27 +10,27 @@ TEST(MemoryManager, BasicSTMAllocation) {
     sep::memory::MemoryTierManager mgr;
     sep::memory::MemoryBlock* blk = mgr.allocate(128, sep::memory::MemoryTierEnum::STM);
     ASSERT_NE(blk, nullptr);
-    EXPECT_GT(mgr.getTierUtilization(mem::MemoryTierEnum::STM), 0.0f);
+    EXPECT_GT(mgr.getTierUtilization(sep::memory::MemoryTierEnum::STM), 0.0f);
     mgr.deallocate(blk);
-    EXPECT_NEAR(mgr.getTierUtilization(mem::MemoryTierEnum::STM), 0.0f, EPSILON);
+    EXPECT_NEAR(mgr.getTierUtilization(sep::memory::MemoryTierEnum::STM), 0.0f, EPSILON);
 }
 
 TEST(MemoryManager, BasicMTMAllocation) {
     sep::memory::MemoryTierManager mgr;
     sep::memory::MemoryBlock* blk = mgr.allocate(256, sep::memory::MemoryTierEnum::MTM);
     ASSERT_NE(blk, nullptr);
-    EXPECT_GT(mgr.getTierUtilization(mem::MemoryTierEnum::MTM), 0.0f);
+    EXPECT_GT(mgr.getTierUtilization(sep::memory::MemoryTierEnum::MTM), 0.0f);
     mgr.deallocate(blk);
-    EXPECT_NEAR(mgr.getTierUtilization(mem::MemoryTierEnum::MTM), 0.0f, EPSILON);
+    EXPECT_NEAR(mgr.getTierUtilization(sep::memory::MemoryTierEnum::MTM), 0.0f, EPSILON);
 }
 
 TEST(MemoryManager, BasicLTMAllocation) {
     sep::memory::MemoryTierManager mgr;
     sep::memory::MemoryBlock* blk = mgr.allocate(512, sep::memory::MemoryTierEnum::LTM);
     ASSERT_NE(blk, nullptr);
-    EXPECT_GT(mgr.getTierUtilization(mem::MemoryTierEnum::LTM), 0.0f);
+    EXPECT_GT(mgr.getTierUtilization(sep::memory::MemoryTierEnum::LTM), 0.0f);
     mgr.deallocate(blk);
-    EXPECT_NEAR(mgr.getTierUtilization(mem::MemoryTierEnum::LTM), 0.0f, EPSILON);
+    EXPECT_NEAR(mgr.getTierUtilization(sep::memory::MemoryTierEnum::LTM), 0.0f, EPSILON);
 }
 
 TEST(MemoryManager, MultipleAllocations) {
@@ -41,15 +41,15 @@ TEST(MemoryManager, MultipleAllocations) {
     ASSERT_NE(s, nullptr);
     ASSERT_NE(m, nullptr);
     ASSERT_NE(l, nullptr);
-    EXPECT_GT(mgr.getTierUtilization(mem::MemoryTierEnum::STM), 0.0f);
-    EXPECT_GT(mgr.getTierUtilization(mem::MemoryTierEnum::MTM), 0.0f);
-    EXPECT_GT(mgr.getTierUtilization(mem::MemoryTierEnum::LTM), 0.0f);
+    EXPECT_GT(mgr.getTierUtilization(sep::memory::MemoryTierEnum::STM), 0.0f);
+    EXPECT_GT(mgr.getTierUtilization(sep::memory::MemoryTierEnum::MTM), 0.0f);
+    EXPECT_GT(mgr.getTierUtilization(sep::memory::MemoryTierEnum::LTM), 0.0f);
     mgr.deallocate(s);
     mgr.deallocate(m);
     mgr.deallocate(l);
-    EXPECT_NEAR(mgr.getTierUtilization(mem::MemoryTierEnum::STM), 0.0f, EPSILON);
-    EXPECT_NEAR(mgr.getTierUtilization(mem::MemoryTierEnum::MTM), 0.0f, EPSILON);
-    EXPECT_NEAR(mgr.getTierUtilization(mem::MemoryTierEnum::LTM), 0.0f, EPSILON);
+    EXPECT_NEAR(mgr.getTierUtilization(sep::memory::MemoryTierEnum::STM), 0.0f, EPSILON);
+    EXPECT_NEAR(mgr.getTierUtilization(sep::memory::MemoryTierEnum::MTM), 0.0f, EPSILON);
+    EXPECT_NEAR(mgr.getTierUtilization(sep::memory::MemoryTierEnum::LTM), 0.0f, EPSILON);
 }
 
 TEST(MemoryManager, TotalAllocatedMemory) {

--- a/tests/memory/promotion_regression_test.cpp
+++ b/tests/memory/promotion_regression_test.cpp
@@ -21,7 +21,7 @@ TEST(MemoryPromotionRegression, StablePromotionDemotion) {
     uint64_t wait = promoted->wait;
 
     mgr.updateBlockMetrics(promoted, 0.8f, 0.8f, 6, 1.0f); // should remain MTM
-    EXPECT_EQ(promoted->tier, mem::MemoryTierEnum::MTM);
+    EXPECT_EQ(promoted->tier, sep::memory::MemoryTierEnum::MTM);
     EXPECT_FLOAT_EQ(weight, promoted->weight);
     EXPECT_EQ(wait, promoted->wait);
 
@@ -31,7 +31,7 @@ TEST(MemoryPromotionRegression, StablePromotionDemotion) {
     weight = demoted->weight;
     wait = demoted->wait;
     mgr.updateBlockMetrics(demoted, 0.1f, 0.1f, 6, 1.0f); // remain STM
-    EXPECT_EQ(demoted->tier, mem::MemoryTierEnum::STM);
+    EXPECT_EQ(demoted->tier, sep::memory::MemoryTierEnum::STM);
     EXPECT_FLOAT_EQ(weight, demoted->weight);
     EXPECT_EQ(wait, demoted->wait);
 }


### PR DESCRIPTION
## Summary
- build memory_manager_tests from sources
- only compile redis_manager when Redis is enabled
- deduplicate QuantumThresholdConfig and expose quantum config in ConfigManager
- correct include path for Redis manager
- clean up duplicate functions in MemoryTierManager
- fix namespace in memory tests

## Testing
- `./build_no_cuda.sh`
- `./cmake-nocuda/tests/memory/memory_manager_tests`

------
https://chatgpt.com/codex/tasks/task_e_686c98d0e628832ab1db3e9fae82a26c