### PR TITLE
Fix build_no_cuda and memory tier tests

### DIFF
--- a/include/core/types.h
+++ b/include/core/types.h
@@ -59,12 +59,6 @@ struct CudaConfig {
     bool enable_profiling{false};
 };
 
-// Minimal quantum configuration required for memory tier tests.
-struct QuantumThresholdConfig {
-    float ltm_coherence_threshold{0.9f};
-    float mtm_coherence_threshold{0.6f};
-    float stability_threshold{0.8f};
-};
 
 // API server configuration. Only a subset of fields is required for
 // compiling the memory manager tests.
@@ -92,12 +86,6 @@ struct AnalyticsConfig {
     bool enable{false};
 };
 
-// Coherence thresholds used by quantum components
-struct QuantumThresholdConfig {
-    float ltm_coherence_threshold{0.9f};
-    float mtm_coherence_threshold{0.6f};
-    float stability_threshold{0.8f};
-};
 
 // Aggregate system configuration stub. Only the pieces used by tests
 // are represented here.

--- a/include/memory/redis_manager.h
+++ b/include/memory/redis_manager.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "memory/types.h"
-#include "persistence/pattern_data.hpp"
+#include "persistence/persistent_pattern_data.hpp"
 
 #ifndef SEP_NO_REDIS
 #  include <hiredis/hiredis.h>

--- a/src/core/manager.cpp
+++ b/src/core/manager.cpp
@@ -32,15 +32,10 @@ const MemoryThresholdConfig& ConfigManager::getMemoryConfig() const {
     static MemoryThresholdConfig cfg{};
     return cfg;
 }
-const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
-    static QuantumThresholdConfig cfg{};
-    return cfg;
-}
 void ConfigManager::updateAPIConfig(const APIConfig&) {}
 void ConfigManager::updateCudaConfig(const CudaConfig&) {}
 void ConfigManager::updateLogConfig(const LogConfig&) {}
 void ConfigManager::updateMemoryConfig(const MemoryThresholdConfig&) {}
-void ConfigManager::updateQuantumConfig(const QuantumThresholdConfig&) {}
 void ConfigManager::resetToDefaults() {}
 
 } // namespace sep::config

--- a/src/memory/CMakeLists.txt
+++ b/src/memory/CMakeLists.txt
@@ -1,10 +1,13 @@
-add_library(sep_memory
-  STATIC
+add_library(sep_memory STATIC
     memory_tier.cpp
     memory_tier_manager.cpp
-    memory_tier_manager_serialization.cpp
-    redis_manager.cpp
-)
+    memory_tier_manager_serialization.cpp)
+
+if(SEP_HAS_REDIS)
+  target_sources(sep_memory PRIVATE redis_manager.cpp)
+else()
+  target_sources(sep_memory PRIVATE redis_manager_stub.cpp)
+endif()
 
 if(SEP_BUILD_QUANTUM)
   target_sources(sep_memory PRIVATE quantum_coherence_manager.cpp)

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -638,46 +638,5 @@ void MemoryTierManager::calculateRelationshipCoherence() {
 }
 #endif
 
-void MemoryTierManager::cleanupExpiredPatterns() {
-  // Stub implementation for minimal build
-}
-
-void MemoryTierManager::prunePatternsByPriority(MemoryTierEnum tier,
-                                                size_t max_count) {
-  // Stub implementation for minimal build
-}
-
-void MemoryTierManager::cleanupExpiredPatterns() {
-  std::lock_guard<std::mutex> lock(registry_mutex);
-  for (auto it = pattern_registry_.begin(); it != pattern_registry_.end();) {
-    if (it->second->coherence < config_.demote_threshold) {
-      it = pattern_registry_.erase(it);
-    } else {
-      ++it;
-    }
-  }
-}
-
-void MemoryTierManager::prunePatternsByPriority(MemoryTierEnum tier,
-                                               size_t max_count) {
-  MemoryTier *t = getTier(tier);
-  if (!t)
-    return;
-  const auto &patterns = t->getPatterns();
-  if (patterns.size() <= max_count)
-    return;
-  std::vector<std::pair<size_t, float>> sorted;
-  sorted.reserve(patterns.size());
-  for (const auto &[id, pat] : patterns) {
-    sorted.emplace_back(id, pat.coherence);
-  }
-  std::sort(sorted.begin(), sorted.end(),
-            [](const auto &a, const auto &b) { return a.second > b.second; });
-  for (size_t i = max_count; i < sorted.size(); ++i) {
-    t->removePattern(sorted[i].first);
-    removePattern(sorted[i].first);
-  }
-}
-
 } // namespace memory
 } // namespace sep

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,8 @@
 # Common test configuration
 # Configure test output directory
+include(CTest)
+enable_testing()
+
 set(TEST_OUTPUT_DIR ${CMAKE_BINARY_DIR}/tests)
 file(MAKE_DIRECTORY ${TEST_OUTPUT_DIR})
 
@@ -36,8 +39,6 @@ add_subdirectory(workbench)
 # Testbed directory temporarily disabled
 
 # Configure test discovery
-include(CTest)
-enable_testing()
 
 add_custom_target(run_all_tests
     COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure

--- a/tests/memory/CMakeLists.txt
+++ b/tests/memory/CMakeLists.txt
@@ -32,6 +32,8 @@ set(TEST_SOURCES
     pattern_promotion_test.cpp
 )
 
+add_executable(memory_manager_tests ${TEST_SOURCES})
+
 if(SEP_HAS_REDIS)
     target_sources(memory_manager_tests PRIVATE redis_manager_test.cpp)
 endif()

--- a/tests/memory/memory_manager_test.cpp
+++ b/tests/memory/memory_manager_test.cpp
@@ -5,6 +5,8 @@ namespace {
 constexpr float EPSILON = 1e-3f;
 }
 
+namespace mem = sep::memory;
+
 
 TEST(MemoryManager, BasicSTMAllocation) {
     sep::memory::MemoryTierManager mgr;

--- a/tests/memory/promotion_regression_test.cpp
+++ b/tests/memory/promotion_regression_test.cpp
@@ -2,6 +2,8 @@
 #include "memory/memory_tier_manager.hpp"
 #include "memory/memory_tier.hpp"
 
+namespace mem = sep::memory;
+
 static sep::memory::MemoryBlock* findAllocated(sep::memory::MemoryTier& tier) {
     for (const auto& b : tier.getBlocks()) {
         if (b.allocated) return const_cast<sep::memory::MemoryBlock*>(&b);


### PR DESCRIPTION
## Summary
- fix duplicate structs in `core/types.h`
- include correct header for Redis manager
- drop unused quantum config methods
- only compile Redis sources when redis enabled
- clean up duplicate functions in memory tier manager
- enable CTest earlier so tests register
- add namespace aliases in tests

## Testing
- `./build_no_cuda.sh`
- `./cmake-nocuda/tests/memory/memory_manager_tests`

------
https://chatgpt.com/codex/tasks/task_e_686c98d0e628832ab1db3e9fae82a26c