### PR TITLE
Fix missing quantum config type

### DIFF
--- a/include/core/types.h
+++ b/include/core/types.h
@@ -43,6 +43,12 @@ struct MemoryThresholdConfig {
     bool enable_compression{true};
 };
 
+struct QuantumThresholdConfig {
+    float ltm_coherence_threshold{0.9f};
+    float mtm_coherence_threshold{0.6f};
+    float stability_threshold{0.8f};
+};
+
 
 // Minimal CUDA configuration used by unit tests. These fields are
 // sufficient for the parts of the engine compiled in this repository.

--- a/include/memory/memory_tier_manager.hpp
+++ b/include/memory/memory_tier_manager.hpp
@@ -147,6 +147,7 @@ private:
   std::unique_ptr<MemoryTier> mtm_;
   std::unique_ptr<MemoryTier> ltm_;
   std::unordered_map<void *, MemoryBlock *> lookup_map_;
+  std::unordered_map<void *, MemoryBlock *> legacy_lookup_map_;
 
 private:
   dag::DagGraph dag_graph_;

--- a/src/core/config_manager_stub.cpp
+++ b/src/core/config_manager_stub.cpp
@@ -5,6 +5,7 @@ namespace sep::config {
 class ConfigManager::Impl {
 public:
     MemoryThresholdConfig mem_cfg{};
+    QuantumThresholdConfig quantum_cfg{};
 };
 
 ConfigManager::ConfigManager() : impl_(std::make_unique<Impl>()) {}
@@ -33,10 +34,17 @@ const LogConfig &ConfigManager::getLogConfig() const {
 const MemoryThresholdConfig &ConfigManager::getMemoryConfig() const {
     return impl_->mem_cfg;
 }
+const QuantumThresholdConfig &ConfigManager::getQuantumConfig() const {
+    return impl_->quantum_cfg;
+}
 void ConfigManager::updateAPIConfig(const APIConfig &) {}
 void ConfigManager::updateCudaConfig(const CudaConfig &) {}
 void ConfigManager::updateLogConfig(const LogConfig &) {}
 void ConfigManager::updateMemoryConfig(const MemoryThresholdConfig &cfg) { impl_->mem_cfg = cfg; }
-void ConfigManager::resetToDefaults() { impl_->mem_cfg = MemoryThresholdConfig{}; }
+void ConfigManager::updateQuantumConfig(const QuantumThresholdConfig &cfg) { impl_->quantum_cfg = cfg; }
+void ConfigManager::resetToDefaults() {
+    impl_->mem_cfg = MemoryThresholdConfig{};
+    impl_->quantum_cfg = QuantumThresholdConfig{};
+}
 
 } // namespace sep::config

--- a/src/core/manager.cpp
+++ b/src/core/manager.cpp
@@ -2,7 +2,10 @@
 
 namespace sep::config {
 
-struct ConfigManager::Impl {};
+struct ConfigManager::Impl {
+    MemoryThresholdConfig mem_cfg{};
+    QuantumThresholdConfig quantum_cfg{};
+};
 
 ConfigManager::ConfigManager() = default;
 ConfigManager::~ConfigManager() = default;
@@ -29,13 +32,23 @@ const LogConfig& ConfigManager::getLogConfig() const {
     return cfg;
 }
 const MemoryThresholdConfig& ConfigManager::getMemoryConfig() const {
-    static MemoryThresholdConfig cfg{};
-    return cfg;
+    return impl_->mem_cfg;
+}
+const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
+    return impl_->quantum_cfg;
 }
 void ConfigManager::updateAPIConfig(const APIConfig&) {}
 void ConfigManager::updateCudaConfig(const CudaConfig&) {}
 void ConfigManager::updateLogConfig(const LogConfig&) {}
-void ConfigManager::updateMemoryConfig(const MemoryThresholdConfig&) {}
-void ConfigManager::resetToDefaults() {}
+void ConfigManager::updateMemoryConfig(const MemoryThresholdConfig& cfg) {
+    impl_->mem_cfg = cfg;
+}
+void ConfigManager::updateQuantumConfig(const QuantumThresholdConfig& cfg) {
+    impl_->quantum_cfg = cfg;
+}
+void ConfigManager::resetToDefaults() {
+    impl_->mem_cfg = MemoryThresholdConfig{};
+    impl_->quantum_cfg = QuantumThresholdConfig{};
+}
 
 } // namespace sep::config

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -656,37 +656,6 @@ void MemoryTierManager::calculateRelationshipCoherence() {
 
 
 
-void MemoryTierManager::cleanupExpiredPatterns() {
-  std::lock_guard<std::mutex> lock(registry_mutex);
-  for (auto it = pattern_registry_.begin(); it != pattern_registry_.end();) {
-    if (it->second->coherence < config_.demote_threshold) {
-      it = pattern_registry_.erase(it);
-    } else {
-      ++it;
-    }
-  }
-}
-
-void MemoryTierManager::prunePatternsByPriority(MemoryTierEnum tier,
-                                               size_t max_count) {
-  MemoryTier *t = getTier(tier);
-  if (!t)
-    return;
-  const auto &patterns = t->getPatterns();
-  if (patterns.size() <= max_count)
-    return;
-  std::vector<std::pair<size_t, float>> sorted;
-  sorted.reserve(patterns.size());
-  for (const auto &[id, pat] : patterns) {
-    sorted.emplace_back(id, pat.coherence);
-  }
-  std::sort(sorted.begin(), sorted.end(),
-            [](const auto &a, const auto &b) { return a.second > b.second; });
-  for (size_t i = max_count; i < sorted.size(); ++i) {
-    t->removePattern(sorted[i].first);
-    removePattern(sorted[i].first);
-  }
-}
 
 } // namespace memory
 } // namespace sep


### PR DESCRIPTION
## Summary
- add `QuantumThresholdConfig` struct
- expose quantum config through `ConfigManager` stubs
- maintain backwards compat for `MemoryTierManager`
- remove duplicate definitions in `MemoryTierManager`

## Testing
- `./build_no_cuda.sh`
- `ctest --output-on-failure` *(fails: quantum_optimizer_tests, memory_manager_tests, api_tests, workbench_demo_tests)*

------
https://chatgpt.com/codex/tasks/task_e_686c9bfcfe3c832a9d70743cd62b09c7