### PR TITLE
Fix memory test build issues

### DIFF
--- a/include/core/types.h
+++ b/include/core/types.h
@@ -43,6 +43,13 @@ struct MemoryThresholdConfig {
     bool enable_compression{true};
 };
 
+// Quantum coherence thresholds used by the pattern processor.
+struct QuantumThresholdConfig {
+    float ltm_coherence_threshold{0.9f};
+    float mtm_coherence_threshold{0.6f};
+    float stability_threshold{0.8f};
+};
+
 
 // Minimal CUDA configuration used by unit tests. These fields are
 // sufficient for the parts of the engine compiled in this repository.

--- a/include/memory/memory_tier_manager.hpp
+++ b/include/memory/memory_tier_manager.hpp
@@ -147,6 +147,7 @@ private:
   std::unique_ptr<MemoryTier> mtm_;
   std::unique_ptr<MemoryTier> ltm_;
   std::unordered_map<void *, MemoryBlock *> lookup_map_;
+  std::unordered_map<void *, MemoryBlock *> legacy_lookup_map_;
 
 private:
   dag::DagGraph dag_graph_;

--- a/src/core/config_manager_stub.cpp
+++ b/src/core/config_manager_stub.cpp
@@ -5,6 +5,7 @@ namespace sep::config {
 class ConfigManager::Impl {
 public:
     MemoryThresholdConfig mem_cfg{};
+    QuantumThresholdConfig quantum_cfg{};
 };
 
 ConfigManager::ConfigManager() : impl_(std::make_unique<Impl>()) {}
@@ -33,10 +34,17 @@ const LogConfig &ConfigManager::getLogConfig() const {
 const MemoryThresholdConfig &ConfigManager::getMemoryConfig() const {
     return impl_->mem_cfg;
 }
+const QuantumThresholdConfig &ConfigManager::getQuantumConfig() const {
+    return impl_->quantum_cfg;
+}
 void ConfigManager::updateAPIConfig(const APIConfig &) {}
 void ConfigManager::updateCudaConfig(const CudaConfig &) {}
 void ConfigManager::updateLogConfig(const LogConfig &) {}
 void ConfigManager::updateMemoryConfig(const MemoryThresholdConfig &cfg) { impl_->mem_cfg = cfg; }
-void ConfigManager::resetToDefaults() { impl_->mem_cfg = MemoryThresholdConfig{}; }
+void ConfigManager::updateQuantumConfig(const QuantumThresholdConfig &cfg) { impl_->quantum_cfg = cfg; }
+void ConfigManager::resetToDefaults() {
+    impl_->mem_cfg = MemoryThresholdConfig{};
+    impl_->quantum_cfg = QuantumThresholdConfig{};
+}
 
 } // namespace sep::config

--- a/src/core/manager.cpp
+++ b/src/core/manager.cpp
@@ -32,10 +32,15 @@ const MemoryThresholdConfig& ConfigManager::getMemoryConfig() const {
     static MemoryThresholdConfig cfg{};
     return cfg;
 }
+const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
+    static QuantumThresholdConfig cfg{};
+    return cfg;
+}
 void ConfigManager::updateAPIConfig(const APIConfig&) {}
 void ConfigManager::updateCudaConfig(const CudaConfig&) {}
 void ConfigManager::updateLogConfig(const LogConfig&) {}
 void ConfigManager::updateMemoryConfig(const MemoryThresholdConfig&) {}
+void ConfigManager::updateQuantumConfig(const QuantumThresholdConfig&) {}
 void ConfigManager::resetToDefaults() {}
 
 } // namespace sep::config

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -569,6 +569,7 @@ void MemoryTierManager::updateRelationship(std::size_t id_a, std::size_t id_b,
   pattern_relationships_[id_b][id_a] = static_cast<float>(strength);
 }
 
+#if !defined(SEP_MEMORY_MINIMAL)
 void MemoryTierManager::cleanupExpiredPatterns() {
   std::lock_guard<std::mutex> reg_lock(registry_mutex);
   for (auto it = pattern_registry_.begin(); it != pattern_registry_.end();) {
@@ -618,6 +619,7 @@ void MemoryTierManager::prunePatternsByPriority(MemoryTierEnum tier,
     }
   }
 }
+#endif
 
 void MemoryTierManager::pruneWeakRelationships() {
   std::lock_guard<std::mutex> lock(relationships_mutex);


### PR DESCRIPTION
## Summary
- add `QuantumThresholdConfig` to core types
- store and access quantum config in `ConfigManager` stubs
- track legacy pointer map in MemoryTierManager
- disable complex clean-up logic when `SEP_MEMORY_MINIMAL` is set

## Testing
- `./build_no_cuda.sh` *(fails: MemoryTierManagerTest.CalculateRelationshipCoherence)*

------
https://chatgpt.com/codex/tasks/task_e_686c9bfcfe3c832a9d70743cd62b09c7