### PR TITLE
Fix memory tier tests

### DIFF
--- a/include/core/types.h
+++ b/include/core/types.h
@@ -43,6 +43,14 @@ struct MemoryThresholdConfig {
     bool enable_compression{true};
 };
 
+// Quantum pattern processing thresholds used by unit tests.  Only the
+// minimal fields required for compilation are defined here.
+struct QuantumThresholdConfig {
+    float ltm_coherence_threshold{0.9f};
+    float mtm_coherence_threshold{0.6f};
+    float stability_threshold{0.8f};
+};
+
 
 // Minimal CUDA configuration used by unit tests. These fields are
 // sufficient for the parts of the engine compiled in this repository.

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -619,43 +619,7 @@ void MemoryTierManager::prunePatternsByPriority(MemoryTierEnum tier,
     }
   }
 }
-#endif // !SEP_TESTBED_STUBS
-
-void MemoryTierManager::pruneWeakRelationships() {
-  std::lock_guard<std::mutex> lock(relationships_mutex);
-  for (auto &[id, relations] : pattern_relationships_) {
-    for (auto it = relations.begin(); it != relations.end();) {
-      if (it->second < config_.demote_threshold) { // Reuse demote threshold
-        it = relations.erase(it);
-      } else {
-        ++it;
-      }
-    }
-  }
-}
-
-void MemoryTierManager::calculateRelationshipCoherence() {
-  std::lock_guard<std::mutex> reg_lock(registry_mutex);
-  std::lock_guard<std::mutex> rel_lock(relationships_mutex);
-
-  for (auto &[id, pattern_ptr] : pattern_registry_) {
-    pattern_ptr->coherence = 1.0f;
-    if (pattern_relationships_.count(id)) {
-      const auto &rels = pattern_relationships_.at(id);
-      if (!rels.empty()) {
-        double sum = 0.0;
-        for (const auto &r : rels) {
-          sum += r.second;
-        }
-        float avg = static_cast<float>(sum / rels.size());
-        pattern_ptr->coherence = 1.0f - avg;
-      }
-    }
-  }
-}
-#endif
-
-
+#else // SEP_TESTBED_STUBS
 
 void MemoryTierManager::cleanupExpiredPatterns() {
   std::lock_guard<std::mutex> lock(registry_mutex);
@@ -689,6 +653,39 @@ void MemoryTierManager::prunePatternsByPriority(MemoryTierEnum tier,
   }
 }
 #endif // SEP_TESTBED_STUBS
+
+void MemoryTierManager::pruneWeakRelationships() {
+  std::lock_guard<std::mutex> lock(relationships_mutex);
+  for (auto &[id, relations] : pattern_relationships_) {
+    for (auto it = relations.begin(); it != relations.end();) {
+      if (it->second < config_.demote_threshold) { // Reuse demote threshold
+        it = relations.erase(it);
+      } else {
+        ++it;
+      }
+    }
+  }
+}
+
+void MemoryTierManager::calculateRelationshipCoherence() {
+  std::lock_guard<std::mutex> reg_lock(registry_mutex);
+  std::lock_guard<std::mutex> rel_lock(relationships_mutex);
+
+  for (auto &[id, pattern_ptr] : pattern_registry_) {
+    pattern_ptr->coherence = 0.0f;
+    if (pattern_relationships_.count(id)) {
+      const auto &rels = pattern_relationships_.at(id);
+      if (!rels.empty()) {
+        double sum = 0.0;
+        for (const auto &r : rels) {
+          sum += r.second;
+        }
+        float avg = static_cast<float>(sum / rels.size());
+        pattern_ptr->coherence = avg;
+      }
+    }
+  }
+}
 
 } // namespace memory
 } // namespace sep


### PR DESCRIPTION
## Summary
- add missing `QuantumThresholdConfig` definition
- fix `calculateRelationshipCoherence` logic
- clean up testbed stub macros in `MemoryTierManager`

## Testing
- `./build_no_cuda.sh`

------
https://chatgpt.com/codex/tasks/task_e_686c9c99085c832aa36142126600db36