### PR TITLE
Fix memory manager build and tests

### DIFF
--- a/include/core/types.h
+++ b/include/core/types.h
@@ -43,6 +43,14 @@ struct MemoryThresholdConfig {
     bool enable_compression{true};
 };
 
+// Configuration controlling when patterns move between tiers based on coherence
+// and stability. Only a subset of fields is required for the unit tests.
+struct QuantumThresholdConfig {
+    float ltm_coherence_threshold{0.9f};
+    float mtm_coherence_threshold{0.6f};
+    float stability_threshold{0.8f};
+};
+
 
 // Minimal CUDA configuration used by unit tests. These fields are
 // sufficient for the parts of the engine compiled in this repository.

--- a/src/core/config_manager_stub.cpp
+++ b/src/core/config_manager_stub.cpp
@@ -5,6 +5,7 @@ namespace sep::config {
 class ConfigManager::Impl {
 public:
     MemoryThresholdConfig mem_cfg{};
+    QuantumThresholdConfig quant_cfg{};
 };
 
 ConfigManager::ConfigManager() : impl_(std::make_unique<Impl>()) {}
@@ -33,10 +34,17 @@ const LogConfig &ConfigManager::getLogConfig() const {
 const MemoryThresholdConfig &ConfigManager::getMemoryConfig() const {
     return impl_->mem_cfg;
 }
+const QuantumThresholdConfig &ConfigManager::getQuantumConfig() const {
+    return impl_->quant_cfg;
+}
 void ConfigManager::updateAPIConfig(const APIConfig &) {}
 void ConfigManager::updateCudaConfig(const CudaConfig &) {}
 void ConfigManager::updateLogConfig(const LogConfig &) {}
 void ConfigManager::updateMemoryConfig(const MemoryThresholdConfig &cfg) { impl_->mem_cfg = cfg; }
-void ConfigManager::resetToDefaults() { impl_->mem_cfg = MemoryThresholdConfig{}; }
+void ConfigManager::updateQuantumConfig(const QuantumThresholdConfig &cfg) { impl_->quant_cfg = cfg; }
+void ConfigManager::resetToDefaults() {
+    impl_->mem_cfg = MemoryThresholdConfig{};
+    impl_->quant_cfg = QuantumThresholdConfig{};
+}
 
 } // namespace sep::config

--- a/src/core/manager.cpp
+++ b/src/core/manager.cpp
@@ -32,10 +32,15 @@ const MemoryThresholdConfig& ConfigManager::getMemoryConfig() const {
     static MemoryThresholdConfig cfg{};
     return cfg;
 }
+const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
+    static QuantumThresholdConfig cfg{};
+    return cfg;
+}
 void ConfigManager::updateAPIConfig(const APIConfig&) {}
 void ConfigManager::updateCudaConfig(const CudaConfig&) {}
 void ConfigManager::updateLogConfig(const LogConfig&) {}
 void ConfigManager::updateMemoryConfig(const MemoryThresholdConfig&) {}
+void ConfigManager::updateQuantumConfig(const QuantumThresholdConfig&) {}
 void ConfigManager::resetToDefaults() {}
 
 } // namespace sep::config

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -639,7 +639,7 @@ void MemoryTierManager::calculateRelationshipCoherence() {
   std::lock_guard<std::mutex> rel_lock(relationships_mutex);
 
   for (auto &[id, pattern_ptr] : pattern_registry_) {
-    pattern_ptr->coherence = 1.0f;
+    pattern_ptr->coherence = 0.0f;
     if (pattern_relationships_.count(id)) {
       const auto &rels = pattern_relationships_.at(id);
       if (!rels.empty()) {
@@ -648,47 +648,10 @@ void MemoryTierManager::calculateRelationshipCoherence() {
           sum += r.second;
         }
         float avg = static_cast<float>(sum / rels.size());
-        pattern_ptr->coherence = 1.0f - avg;
+        pattern_ptr->coherence = avg;
       }
     }
   }
 }
-#endif
-
-
-
-void MemoryTierManager::cleanupExpiredPatterns() {
-  std::lock_guard<std::mutex> lock(registry_mutex);
-  for (auto it = pattern_registry_.begin(); it != pattern_registry_.end();) {
-    if (it->second->coherence < config_.demote_threshold) {
-      it = pattern_registry_.erase(it);
-    } else {
-      ++it;
-    }
-  }
-}
-
-void MemoryTierManager::prunePatternsByPriority(MemoryTierEnum tier,
-                                               size_t max_count) {
-  MemoryTier *t = getTier(tier);
-  if (!t)
-    return;
-  const auto &patterns = t->getPatterns();
-  if (patterns.size() <= max_count)
-    return;
-  std::vector<std::pair<size_t, float>> sorted;
-  sorted.reserve(patterns.size());
-  for (const auto &[id, pat] : patterns) {
-    sorted.emplace_back(id, pat.coherence);
-  }
-  std::sort(sorted.begin(), sorted.end(),
-            [](const auto &a, const auto &b) { return a.second > b.second; });
-  for (size_t i = max_count; i < sorted.size(); ++i) {
-    t->removePattern(sorted[i].first);
-    removePattern(sorted[i].first);
-  }
-}
-#endif // SEP_TESTBED_STUBS
-
 } // namespace memory
 } // namespace sep


### PR DESCRIPTION
## Summary
- add `QuantumThresholdConfig` struct and integrate with config manager
- remove duplicate stubs in `MemoryTierManager`
- fix coherence calculation logic
- provide stub implementations for new config accessors

## Testing
- `./build_no_cuda.sh`

------
https://chatgpt.com/codex/tasks/task_e_686c9c6813ec832a9f28f98d557d0016