### PR TITLE
Fix memory tier build issues and tests

### DIFF
--- a/include/core/manager.h
+++ b/include/core/manager.h
@@ -44,14 +44,18 @@ public:
   const CudaConfig &getCudaConfig() const;
   const LogConfig &getLogConfig() const;
   const MemoryThresholdConfig &getMemoryConfig() const;
+#if SEP_BUILD_QUANTUM
   const QuantumThresholdConfig &getQuantumConfig() const;
+#endif
 
   // Update specific components
   void updateAPIConfig(const APIConfig &config);
   void updateCudaConfig(const CudaConfig &config);
   void updateLogConfig(const LogConfig &config);
   void updateMemoryConfig(const MemoryThresholdConfig &config);
+#if SEP_BUILD_QUANTUM
   void updateQuantumConfig(const QuantumThresholdConfig &config);
+#endif
 
   // Reset configuration to defaults
   void resetToDefaults();

--- a/src/memory/CMakeLists.txt
+++ b/src/memory/CMakeLists.txt
@@ -4,13 +4,17 @@ set(SEP_MEMORY_SOURCES
     memory_tier_manager_serialization.cpp
 )
 if(NOT SEP_MEMORY_MINIMAL)
-  list(APPEND MEMORY_SRC redis_manager.cpp)
+  list(APPEND SEP_MEMORY_SOURCES redis_manager.cpp)
 endif()
 if(SEP_TESTBED_STUBS)
-  list(APPEND MEMORY_SRC ${CMAKE_SOURCE_DIR}/_sep/testbed/memory_minimal/memory_tier_manager_stubs.cpp)
+  list(APPEND SEP_MEMORY_SOURCES
+       ${CMAKE_SOURCE_DIR}/_sep/testbed/memory_minimal/memory_tier_manager_stubs.cpp)
 endif()
 
-add_library(sep_memory STATIC ${MEMORY_SRC})
+add_library(sep_memory STATIC ${SEP_MEMORY_SOURCES})
+if(SEP_TESTBED_STUBS)
+  target_compile_definitions(sep_memory PRIVATE SEP_TESTBED_STUBS)
+endif()
 
 set(SEP_HAS_REDIS 0)
 set(HIREDIS_FOUND FALSE)
@@ -21,8 +25,6 @@ if(HIREDIS_FOUND)
 else()
     add_compile_definitions(SEP_NO_REDIS)
 endif()
-
-add_library(sep_memory STATIC ${SEP_MEMORY_SOURCES})
 
 if(SEP_BUILD_QUANTUM)
   target_sources(sep_memory PRIVATE quantum_coherence_manager.cpp)

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -639,7 +639,7 @@ void MemoryTierManager::calculateRelationshipCoherence() {
   std::lock_guard<std::mutex> rel_lock(relationships_mutex);
 
   for (auto &[id, pattern_ptr] : pattern_registry_) {
-    pattern_ptr->coherence = 1.0f;
+    pattern_ptr->coherence = 0.0f;
     if (pattern_relationships_.count(id)) {
       const auto &rels = pattern_relationships_.at(id);
       if (!rels.empty()) {
@@ -648,13 +648,11 @@ void MemoryTierManager::calculateRelationshipCoherence() {
           sum += r.second;
         }
         float avg = static_cast<float>(sum / rels.size());
-        pattern_ptr->coherence = 1.0f - avg;
+        pattern_ptr->coherence = avg;
       }
     }
   }
 }
-#endif
-
 
 
 void MemoryTierManager::cleanupExpiredPatterns() {
@@ -688,7 +686,6 @@ void MemoryTierManager::prunePatternsByPriority(MemoryTierEnum tier,
     removePattern(sorted[i].first);
   }
 }
-#endif // SEP_TESTBED_STUBS
 
 } // namespace memory
 } // namespace sep


### PR DESCRIPTION
## Summary
- fix compile guards for quantum config
- cleanup memory tier manager stubs and coherence calculation
- define SEP_TESTBED_STUBS build flag in memory library

## Testing
- `cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=g++-14 -DBUILD_TESTING=ON -DSEP_HAS_CUDA=OFF -DSEP_WITH_CYCLES=OFF -DSEP_WITH_AUDIO=OFF -DSEP_WITH_OPENSUBDIV=OFF -DSEP_WITH_OPENPGL=OFF -DSEP_WITH_OCIO=OFF -DSEP_WITH_OPENIMAGEIO=OFF -DSEP_WITH_EMBREE=OFF -DSEP_WITH_OSL=OFF -DSEP_WITH_ALEMBIC=OFF -DSEP_MEMORY_MINIMAL=ON -DSEP_TESTBED_STUBS=ON -DSEP_WORKBENCH_DEMO=OFF -DCMAKE_CXX_FLAGS="-DSEP_MEMORY_MINIMAL -DSEP_TESTBED_STUBS" ../..`
- `make memory_manager_tests -j$(nproc)`
- `./tests/memory/memory_manager_tests`

------
https://chatgpt.com/codex/tasks/task_e_686c9d537300832a8fbc9345cda95412