### PR TITLE
Fix memory tier tests and build

### DIFF
--- a/include/core/types.h
+++ b/include/core/types.h
@@ -43,6 +43,13 @@ struct MemoryThresholdConfig {
     bool enable_compression{true};
 };
 
+// Minimal quantum threshold settings used by tests
+struct QuantumThresholdConfig {
+    float ltm_coherence_threshold{0.9f};
+    float mtm_coherence_threshold{0.6f};
+    float stability_threshold{0.8f};
+};
+
 
 // Minimal CUDA configuration used by unit tests. These fields are
 // sufficient for the parts of the engine compiled in this repository.

--- a/src/memory/CMakeLists.txt
+++ b/src/memory/CMakeLists.txt
@@ -4,13 +4,11 @@ set(SEP_MEMORY_SOURCES
     memory_tier_manager_serialization.cpp
 )
 if(NOT SEP_MEMORY_MINIMAL)
-  list(APPEND MEMORY_SRC redis_manager.cpp)
+  list(APPEND SEP_MEMORY_SOURCES redis_manager.cpp)
 endif()
 if(SEP_TESTBED_STUBS)
-  list(APPEND MEMORY_SRC ${CMAKE_SOURCE_DIR}/_sep/testbed/memory_minimal/memory_tier_manager_stubs.cpp)
+  list(APPEND SEP_MEMORY_SOURCES ${CMAKE_SOURCE_DIR}/_sep/testbed/memory_minimal/memory_tier_manager_stubs.cpp)
 endif()
-
-add_library(sep_memory STATIC ${MEMORY_SRC})
 
 set(SEP_HAS_REDIS 0)
 set(HIREDIS_FOUND FALSE)

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -619,44 +619,7 @@ void MemoryTierManager::prunePatternsByPriority(MemoryTierEnum tier,
     }
   }
 }
-#endif // !SEP_TESTBED_STUBS
-
-void MemoryTierManager::pruneWeakRelationships() {
-  std::lock_guard<std::mutex> lock(relationships_mutex);
-  for (auto &[id, relations] : pattern_relationships_) {
-    for (auto it = relations.begin(); it != relations.end();) {
-      if (it->second < config_.demote_threshold) { // Reuse demote threshold
-        it = relations.erase(it);
-      } else {
-        ++it;
-      }
-    }
-  }
-}
-
-void MemoryTierManager::calculateRelationshipCoherence() {
-  std::lock_guard<std::mutex> reg_lock(registry_mutex);
-  std::lock_guard<std::mutex> rel_lock(relationships_mutex);
-
-  for (auto &[id, pattern_ptr] : pattern_registry_) {
-    pattern_ptr->coherence = 1.0f;
-    if (pattern_relationships_.count(id)) {
-      const auto &rels = pattern_relationships_.at(id);
-      if (!rels.empty()) {
-        double sum = 0.0;
-        for (const auto &r : rels) {
-          sum += r.second;
-        }
-        float avg = static_cast<float>(sum / rels.size());
-        pattern_ptr->coherence = 1.0f - avg;
-      }
-    }
-  }
-}
-#endif
-
-
-
+#else
 void MemoryTierManager::cleanupExpiredPatterns() {
   std::lock_guard<std::mutex> lock(registry_mutex);
   for (auto it = pattern_registry_.begin(); it != pattern_registry_.end();) {
@@ -689,6 +652,38 @@ void MemoryTierManager::prunePatternsByPriority(MemoryTierEnum tier,
   }
 }
 #endif // SEP_TESTBED_STUBS
+
+void MemoryTierManager::pruneWeakRelationships() {
+  std::lock_guard<std::mutex> lock(relationships_mutex);
+  for (auto &[id, relations] : pattern_relationships_) {
+    for (auto it = relations.begin(); it != relations.end();) {
+      if (it->second < config_.demote_threshold) { // Reuse demote threshold
+        it = relations.erase(it);
+      } else {
+        ++it;
+      }
+    }
+  }
+}
+
+void MemoryTierManager::calculateRelationshipCoherence() {
+  std::lock_guard<std::mutex> reg_lock(registry_mutex);
+  std::lock_guard<std::mutex> rel_lock(relationships_mutex);
+
+  for (auto &[id, pattern_ptr] : pattern_registry_) {
+    pattern_ptr->coherence = 0.0f;
+    if (pattern_relationships_.count(id)) {
+      const auto &rels = pattern_relationships_.at(id);
+      if (!rels.empty()) {
+        double sum = 0.0;
+        for (const auto &r : rels) {
+          sum += r.second;
+        }
+        pattern_ptr->coherence = static_cast<float>(sum / rels.size());
+      }
+    }
+  }
+}
 
 } // namespace memory
 } // namespace sep


### PR DESCRIPTION
## Summary
- clean up duplicate library definitions in `src/memory/CMakeLists.txt`
- add stub `QuantumThresholdConfig` used by tests
- restructure memory tier manager testbed stubs and correct coherence calculation

## Testing
- `cmake --build build_nocuda --target memory_manager_tests -j$(nproc)`
- `./build_nocuda/tests/memory/memory_manager_tests`


------
https://chatgpt.com/codex/tasks/task_e_686c9d537300832a8fbc9345cda95412