### PR TITLE
Fix duplicate definitions to enable memory manager tests

### DIFF
--- a/include/core/types.h
+++ b/include/core/types.h
@@ -75,17 +75,6 @@ struct APIConfig {
     std::size_t max_batch_size{1024};
 };
 
-// Minimal quantum processing thresholds used by tests. The real engine
-// defines a richer configuration, but the memory manager tests only
-// require a handful of fields. Provide a lightweight struct here so the
-// stub configuration manager can compile without pulling in the full
-// quantum stack.
-struct QuantumThresholdConfig {
-    float ltm_coherence_threshold{0.9f};
-    float mtm_coherence_threshold{0.6f};
-    float stability_threshold{0.8f};
-};
-
 // Logging configuration placeholder
 struct LogConfig {
     std::string level{"info"};

--- a/src/core/manager.cpp
+++ b/src/core/manager.cpp
@@ -37,26 +37,6 @@ const MemoryThresholdConfig& ConfigManager::getMemoryConfig() const {
 const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
     return impl_->quantum_cfg;
 }
-const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
-    static QuantumThresholdConfig cfg{};
-    return cfg;
-}
-const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
-    static QuantumThresholdConfig cfg{};
-    return cfg;
-}
-const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
-    static QuantumThresholdConfig cfg{};
-    return cfg;
-}
-const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
-    static QuantumThresholdConfig cfg{};
-    return cfg;
-}
-const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
-    static QuantumThresholdConfig cfg{};
-    return cfg;
-}
 void ConfigManager::updateAPIConfig(const APIConfig&) {}
 void ConfigManager::updateCudaConfig(const CudaConfig&) {}
 void ConfigManager::updateLogConfig(const LogConfig&) {}

--- a/src/memory/CMakeLists.txt
+++ b/src/memory/CMakeLists.txt
@@ -4,13 +4,12 @@ set(SEP_MEMORY_SOURCES
     memory_tier_manager_serialization.cpp
 )
 if(NOT SEP_MEMORY_MINIMAL)
-  list(APPEND MEMORY_SRC redis_manager.cpp)
+  list(APPEND SEP_MEMORY_SOURCES redis_manager.cpp)
 endif()
 if(SEP_TESTBED_STUBS)
-  list(APPEND MEMORY_SRC ${CMAKE_SOURCE_DIR}/_sep/testbed/memory_minimal/memory_tier_manager_stubs.cpp)
+  list(APPEND SEP_MEMORY_SOURCES
+    ${CMAKE_SOURCE_DIR}/_sep/testbed/memory_minimal/memory_tier_manager_stubs.cpp)
 endif()
-
-add_library(sep_memory STATIC ${MEMORY_SRC})
 
 set(SEP_HAS_REDIS 0)
 set(HIREDIS_FOUND FALSE)

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -638,38 +638,5 @@ void MemoryTierManager::calculateRelationshipCoherence() {
   }
 }
 
-void MemoryTierManager::pruneWeakRelationships() {
-  std::lock_guard<std::mutex> lock(relationships_mutex);
-  for (auto &[id, relations] : pattern_relationships_) {
-    for (auto it = relations.begin(); it != relations.end();) {
-      if (it->second < config_.demote_threshold) { // Reuse demote threshold
-        it = relations.erase(it);
-      } else {
-        ++it;
-      }
-    }
-  }
-}
-
-void MemoryTierManager::calculateRelationshipCoherence() {
-  std::lock_guard<std::mutex> reg_lock(registry_mutex);
-  std::lock_guard<std::mutex> rel_lock(relationships_mutex);
-
-  for (auto &[id, pattern_ptr] : pattern_registry_) {
-    pattern_ptr->coherence = 0.0f;
-    if (pattern_relationships_.count(id)) {
-      const auto &rels = pattern_relationships_.at(id);
-      if (!rels.empty()) {
-        double sum = 0.0;
-        for (const auto &r : rels) {
-          sum += r.second;
-        }
-        float avg = static_cast<float>(sum / rels.size());
-        pattern_ptr->coherence = avg;
-      }
-    }
-  }
-}
-
 } // namespace memory
 } // namespace sep


### PR DESCRIPTION
## Summary
- clean up config and manager implementations
- deduplicate functions in memory tier manager
- fix build script variable names

## Testing
- `cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON -DSEP_WITH_CYCLES=OFF -DSEP_WITH_AUDIO=OFF -DSEP_WITH_OPENSUBDIV=OFF -DSEP_WITH_OPENPGL=OFF -DSEP_WITH_OCIO=OFF -DSEP_WITH_OPENIMAGEIO=OFF -DSEP_WITH_EMBREE=OFF -DSEP_WITH_OSL=OFF -DSEP_WITH_ALEMBIC=OFF -DSEP_MEMORY_MINIMAL=ON -DSEP_HAS_CUDA=0 -DSEP_TESTBED_STUBS=ON -DCMAKE_CXX_COMPILER=/usr/bin/g++-14 -DCMAKE_CXX_FLAGS="-DSEP_MEMORY_MINIMAL -DSEP_TESTBED_STUBS" ..`
- `make memory_manager_tests -j$(nproc)`
- `./tests/memory/memory_manager_tests`

------
https://chatgpt.com/codex/tasks/task_e_686c9f4d1604832a94d0878720398bf6