### PR TITLE
Fix build for memory tier tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,4 @@ blender
 !examples/json_processor_build.cmake
 package-lock.json
 third_party/glm/
+cmake-nocuda/

--- a/include/core/types.h
+++ b/include/core/types.h
@@ -75,16 +75,6 @@ struct APIConfig {
     std::size_t max_batch_size{1024};
 };
 
-// Minimal quantum processing thresholds used by tests. The real engine
-// defines a richer configuration, but the memory manager tests only
-// require a handful of fields. Provide a lightweight struct here so the
-// stub configuration manager can compile without pulling in the full
-// quantum stack.
-struct QuantumThresholdConfig {
-    float ltm_coherence_threshold{0.9f};
-    float mtm_coherence_threshold{0.6f};
-    float stability_threshold{0.8f};
-};
 
 // Logging configuration placeholder
 struct LogConfig {

--- a/src/core/manager.cpp
+++ b/src/core/manager.cpp
@@ -37,34 +37,6 @@ const MemoryThresholdConfig& ConfigManager::getMemoryConfig() const {
 const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
     return impl_->quantum_cfg;
 }
-const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
-    static QuantumThresholdConfig cfg{};
-    return cfg;
-}
-const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
-    static QuantumThresholdConfig cfg{};
-    return cfg;
-}
-const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
-    static QuantumThresholdConfig cfg{};
-    return cfg;
-}
-const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
-    static QuantumThresholdConfig cfg{};
-    return cfg;
-}
-const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
-    static QuantumThresholdConfig cfg{};
-    return cfg;
-}
-const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
-    static QuantumThresholdConfig cfg{};
-    return cfg;
-}
-const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
-    static QuantumThresholdConfig cfg{};
-    return cfg;
-}
 void ConfigManager::updateAPIConfig(const APIConfig&) {}
 void ConfigManager::updateCudaConfig(const CudaConfig&) {}
 void ConfigManager::updateLogConfig(const LogConfig&) {}

--- a/src/memory/CMakeLists.txt
+++ b/src/memory/CMakeLists.txt
@@ -4,13 +4,11 @@ set(SEP_MEMORY_SOURCES
     memory_tier_manager_serialization.cpp
 )
 if(NOT SEP_MEMORY_MINIMAL)
-  list(APPEND MEMORY_SRC redis_manager.cpp)
+  list(APPEND SEP_MEMORY_SOURCES redis_manager.cpp)
 endif()
 if(SEP_TESTBED_STUBS)
-  list(APPEND MEMORY_SRC ${CMAKE_SOURCE_DIR}/_sep/testbed/memory_minimal/memory_tier_manager_stubs.cpp)
+  list(APPEND SEP_MEMORY_SOURCES ${CMAKE_SOURCE_DIR}/_sep/testbed/memory_minimal/memory_tier_manager_stubs.cpp)
 endif()
-
-add_library(sep_memory STATIC ${MEMORY_SRC})
 
 set(SEP_HAS_REDIS 0)
 set(HIREDIS_FOUND FALSE)

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -611,40 +611,7 @@ void MemoryTierManager::pruneWeakRelationships() {
   std::lock_guard<std::mutex> lock(relationships_mutex);
   for (auto &[id, relations] : pattern_relationships_) {
     for (auto it = relations.begin(); it != relations.end();) {
-      if (it->second < config_.demote_threshold) { // Reuse demote threshold
-        it = relations.erase(it);
-      } else {
-        ++it;
-      }
-    }
-  }
-}
-
-void MemoryTierManager::calculateRelationshipCoherence() {
-  std::lock_guard<std::mutex> reg_lock(registry_mutex);
-  std::lock_guard<std::mutex> rel_lock(relationships_mutex);
-
-  for (auto &[id, pattern_ptr] : pattern_registry_) {
-    if (pattern_relationships_.count(id)) {
-      const auto &rels = pattern_relationships_.at(id);
-      if (!rels.empty()) {
-        double sum = 0.0;
-        for (const auto &r : rels) {
-          sum += r.second;
-        }
-        pattern_ptr->coherence = static_cast<float>(sum / rels.size());
-      }
-      coherence = static_cast<float>(sum / it->second.size());
-    }
-    pattern_ptr->coherence = coherence;
-  }
-}
-
-void MemoryTierManager::pruneWeakRelationships() {
-  std::lock_guard<std::mutex> lock(relationships_mutex);
-  for (auto &[id, relations] : pattern_relationships_) {
-    for (auto it = relations.begin(); it != relations.end();) {
-      if (it->second < config_.demote_threshold) { // Reuse demote threshold
+      if (it->second < config_.demote_threshold) {
         it = relations.erase(it);
       } else {
         ++it;
@@ -659,18 +626,17 @@ void MemoryTierManager::calculateRelationshipCoherence() {
 
   for (auto &[id, pattern_ptr] : pattern_registry_) {
     pattern_ptr->coherence = 0.0f;
-    if (pattern_relationships_.count(id)) {
-      const auto &rels = pattern_relationships_.at(id);
+    auto rel_it = pattern_relationships_.find(id);
+    if (rel_it != pattern_relationships_.end()) {
+      const auto &rels = rel_it->second;
       if (!rels.empty()) {
         double sum = 0.0;
-        for (const auto &r : rels)
+        for (const auto &r : rels) {
           sum += r.second;
         }
-        float avg = static_cast<float>(sum / rels.size());
-        pattern_ptr->coherence = avg;
+        pattern_ptr->coherence = static_cast<float>(sum / rels.size());
       }
     }
-    pattern_ptr->coherence = coherence;
   }
 }
 


### PR DESCRIPTION
## Summary
- remove duplicate struct and cleanup ConfigManager
- fix memory tier CMake duplication
- tidy memory tier manager implementations
- ignore `cmake-nocuda` build dir

## Testing
- `./build_no_cuda.sh`
- `./cmake-nocuda/tests/memory/memory_manager_tests`

------
https://chatgpt.com/codex/tasks/task_e_686c9ffbe4e0832a9985285566d88923