### PR TITLE
Update build_no_cuda script to run test from build dir

### DIFF
--- a/build_no_cuda.sh
+++ b/build_no_cuda.sh
@@ -32,4 +32,4 @@ cmake -S "$REPO_ROOT" -B "$BUILD_DIR" \
   -DBUILD_TESTING=ON
 
 make memory_manager_tests -j$(nproc)
-./tests/memory/memory_manager_tests
+./memory_manager_tests


### PR DESCRIPTION
## Summary
- run `memory_manager_tests` directly from the build directory in `build_no_cuda.sh`

## Testing
- `shellcheck build_no_cuda.sh`


------
https://chatgpt.com/codex/tasks/task_e_686ca31f3924832a9df0ebcd12af4bc3