### PR TITLE
Fix memory module build issues

### DIFF
--- a/include/core/types.h
+++ b/include/core/types.h
@@ -14,118 +14,97 @@ namespace sep {
 
 // Memory tier types that are used across multiple modules
 enum class MemoryTierEnum {
-    // Logical memory tiers
-    STM, MTM, LTM,
-    // Physical memory locations 
-    HOST = 100,   // Host memory (CPU)
-    DEVICE = 101, // Device memory (GPU) 
-    UNIFIED = 102 // Unified memory (accessible by both CPU and GPU)
+  // Logical memory tiers
+  STM,
+  MTM,
+  LTM,
+  // Physical memory locations
+  HOST = 100,   // Host memory (CPU)
+  DEVICE = 101, // Device memory (GPU)
+  UNIFIED = 102 // Unified memory (accessible by both CPU and GPU)
 };
 
 namespace config {
 
 // Default configuration values
-constexpr const char* DEFAULT_LOG_LEVEL = "info";
-constexpr const char* DEFAULT_LOG_FILE  = "sep.log";
-constexpr const char* DEFAULT_LOG_DIR   = "logs";
+constexpr const char *DEFAULT_LOG_LEVEL = "info";
+constexpr const char *DEFAULT_LOG_FILE = "sep.log";
+constexpr const char *DEFAULT_LOG_DIR = "logs";
 
 struct MemoryThresholdConfig {
-    float promote_stm_to_mtm{0.7f};
-    float promote_mtm_to_ltm{0.9f};
-    float demote_threshold{0.3f};
-    float fragmentation_threshold{0.3f};
-    std::size_t stm_size{1 << 20};
-    std::size_t mtm_size{4 << 20};
-    std::size_t ltm_size{16 << 20};
-    uint32_t stm_to_mtm_min_gen{5};
-    uint32_t mtm_to_ltm_min_gen{100};
-    bool use_unified_memory{true};
-    bool enable_compression{true};
+  float promote_stm_to_mtm{0.7f};
+  float promote_mtm_to_ltm{0.9f};
+  float demote_threshold{0.3f};
+  float fragmentation_threshold{0.3f};
+  std::size_t stm_size{1 << 20};
+  std::size_t mtm_size{4 << 20};
+  std::size_t ltm_size{16 << 20};
+  uint32_t stm_to_mtm_min_gen{5};
+  uint32_t mtm_to_ltm_min_gen{100};
+  bool use_unified_memory{true};
+  bool enable_compression{true};
 };
 
 struct QuantumThresholdConfig {
-    float ltm_coherence_threshold{0.9f};
-    float mtm_coherence_threshold{0.6f};
-    float stability_threshold{0.8f};
+  float ltm_coherence_threshold{0.9f};
+  float mtm_coherence_threshold{0.6f};
+  float stability_threshold{0.8f};
 };
-
 
 // Minimal CUDA configuration used by unit tests. These fields are
 // sufficient for the parts of the engine compiled in this repository.
 struct CudaConfig {
-    bool use_gpu{true};
-    std::size_t max_memory_mb{8192};
-    std::size_t batch_size{1024};
-    float gpu_memory_limit{0.9f};
-    bool enable_profiling{false};
+  bool use_gpu{true};
+  std::size_t max_memory_mb{8192};
+  std::size_t batch_size{1024};
+  float gpu_memory_limit{0.9f};
+  bool enable_profiling{false};
 };
-
 
 // API server configuration. Only a subset of fields is required for
 // compiling the memory manager tests.
 struct APIConfig {
-    std::size_t max_connections{1000};
-    std::size_t timeout_ms{5000};
-    std::string host{"127.0.0.1"};
-    uint16_t port{8080};
-    std::size_t threads{4};
-    std::size_t keep_alive_timeout_ms{15000};
-    std::string log_level{"info"};
-    bool enable_metrics{true};
-    std::size_t max_batch_size{1024};
-};
-
-// Minimal quantum processing thresholds used by tests. The real engine
-// defines a richer configuration, but the memory manager tests only
-// require a handful of fields. Provide a lightweight struct here so the
-// stub configuration manager can compile without pulling in the full
-// quantum stack.
-struct QuantumThresholdConfig {
-    float ltm_coherence_threshold{0.9f};
-    float mtm_coherence_threshold{0.6f};
-    float stability_threshold{0.8f};
+  std::size_t max_connections{1000};
+  std::size_t timeout_ms{5000};
+  std::string host{"127.0.0.1"};
+  uint16_t port{8080};
+  std::size_t threads{4};
+  std::size_t keep_alive_timeout_ms{15000};
+  std::string log_level{"info"};
+  bool enable_metrics{true};
+  std::size_t max_batch_size{1024};
 };
 
 // Logging configuration placeholder
 struct LogConfig {
-    std::string level{"info"};
-    std::string file{};
-    std::string dir{"logs"};
+  std::string level{"info"};
+  std::string file{};
+  std::string dir{"logs"};
 };
 
 // Basic analytics configuration used by quantum components
 struct AnalyticsConfig {
-    bool enable{false};
+  bool enable{false};
 };
-
 
 // Aggregate system configuration stub. Only the pieces used by tests
 // are represented here.
-struct SystemConfig {
-};
+struct SystemConfig {};
 
 } // namespace config
 
 enum class PatternStateEnum {
-    UNINITIALIZED = 0,
-    INITIALIZING,
-    ACTIVE,
-    STOPPED,
-    ERROR
+  UNINITIALIZED = 0,
+  INITIALIZING,
+  ACTIVE,
+  STOPPED,
+  ERROR
 };
 
-enum class StreamFlags {
-    Default = 0,
-    NonBlocking = 1
-};
+enum class StreamFlags { Default = 0, NonBlocking = 1 };
 
 // Compression methods used across modules
-enum class CompressionMethod {
-    None,
-    LZ4,
-    ZSTD,
-    Custom
-};
+enum class CompressionMethod { None, LZ4, ZSTD, Custom };
 
 } // namespace sep
 

--- a/src/core/manager.cpp
+++ b/src/core/manager.cpp
@@ -3,80 +3,52 @@
 namespace sep::config {
 
 struct ConfigManager::Impl {
-    MemoryThresholdConfig mem_cfg{};
-    QuantumThresholdConfig quantum_cfg{};
+  MemoryThresholdConfig mem_cfg{};
+  QuantumThresholdConfig quantum_cfg{};
 };
 
 ConfigManager::ConfigManager() = default;
 ConfigManager::~ConfigManager() = default;
 
-void ConfigManager::initialize(int, char**) {}
-const SystemConfig& ConfigManager::getConfig() const {
-    static SystemConfig cfg{};
-    return cfg;
+void ConfigManager::initialize(int, char **) {}
+const SystemConfig &ConfigManager::getConfig() const {
+  static SystemConfig cfg{};
+  return cfg;
 }
-void ConfigManager::setConfig(const SystemConfig&) {}
-bool ConfigManager::loadFromFile(const sep::shim::string&) { return false; }
+void ConfigManager::setConfig(const SystemConfig &) {}
+bool ConfigManager::loadFromFile(const sep::shim::string &) { return false; }
 bool ConfigManager::loadFromEnvironment() { return false; }
-bool ConfigManager::loadFromCommandLine(int, char**) { return false; }
-const APIConfig& ConfigManager::getAPIConfig() const {
-    static APIConfig cfg{};
-    return cfg;
+bool ConfigManager::loadFromCommandLine(int, char **) { return false; }
+const APIConfig &ConfigManager::getAPIConfig() const {
+  static APIConfig cfg{};
+  return cfg;
 }
-const CudaConfig& ConfigManager::getCudaConfig() const {
-    static CudaConfig cfg{};
-    return cfg;
+const CudaConfig &ConfigManager::getCudaConfig() const {
+  static CudaConfig cfg{};
+  return cfg;
 }
-const LogConfig& ConfigManager::getLogConfig() const {
-    static LogConfig cfg{};
-    return cfg;
+const LogConfig &ConfigManager::getLogConfig() const {
+  static LogConfig cfg{};
+  return cfg;
 }
-const MemoryThresholdConfig& ConfigManager::getMemoryConfig() const {
-    return impl_->mem_cfg;
+const MemoryThresholdConfig &ConfigManager::getMemoryConfig() const {
+  return impl_->mem_cfg;
 }
-const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
-    return impl_->quantum_cfg;
+const QuantumThresholdConfig &ConfigManager::getQuantumConfig() const {
+  return impl_->quantum_cfg;
 }
-const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
-    static QuantumThresholdConfig cfg{};
-    return cfg;
+void ConfigManager::updateAPIConfig(const APIConfig &) {}
+void ConfigManager::updateCudaConfig(const CudaConfig &) {}
+void ConfigManager::updateLogConfig(const LogConfig &) {}
+void ConfigManager::updateMemoryConfig(const MemoryThresholdConfig &cfg) {
+  impl_->mem_cfg = cfg;
 }
-const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
-    static QuantumThresholdConfig cfg{};
-    return cfg;
-}
-const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
-    static QuantumThresholdConfig cfg{};
-    return cfg;
-}
-const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
-    static QuantumThresholdConfig cfg{};
-    return cfg;
-}
-const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
-    static QuantumThresholdConfig cfg{};
-    return cfg;
-}
-const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
-    static QuantumThresholdConfig cfg{};
-    return cfg;
-}
-const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
-    static QuantumThresholdConfig cfg{};
-    return cfg;
-}
-void ConfigManager::updateAPIConfig(const APIConfig&) {}
-void ConfigManager::updateCudaConfig(const CudaConfig&) {}
-void ConfigManager::updateLogConfig(const LogConfig&) {}
-void ConfigManager::updateMemoryConfig(const MemoryThresholdConfig& cfg) {
-    impl_->mem_cfg = cfg;
-}
-void ConfigManager::updateQuantumConfig(const QuantumThresholdConfig& cfg) {
-    impl_->quantum_cfg = cfg;
+void ConfigManager::updateQuantumConfig(const QuantumThresholdConfig &cfg) {
+  impl_->quantum_cfg = cfg;
 }
 void ConfigManager::resetToDefaults() {
-    impl_->mem_cfg = MemoryThresholdConfig{};
-    impl_->quantum_cfg = QuantumThresholdConfig{};
+  impl_->mem_cfg = MemoryThresholdConfig{};
+  impl_->quantum_cfg = QuantumThresholdConfig{};
 }
 
 } // namespace sep::config

--- a/src/memory/CMakeLists.txt
+++ b/src/memory/CMakeLists.txt
@@ -4,13 +4,14 @@ set(SEP_MEMORY_SOURCES
     memory_tier_manager_serialization.cpp
 )
 if(NOT SEP_MEMORY_MINIMAL)
-  list(APPEND MEMORY_SRC redis_manager.cpp)
+  list(APPEND SEP_MEMORY_SOURCES redis_manager.cpp)
 endif()
 if(SEP_TESTBED_STUBS)
-  list(APPEND MEMORY_SRC ${CMAKE_SOURCE_DIR}/_sep/testbed/memory_minimal/memory_tier_manager_stubs.cpp)
+  list(APPEND SEP_MEMORY_SOURCES
+      ${CMAKE_SOURCE_DIR}/_sep/testbed/memory_minimal/memory_tier_manager_stubs.cpp)
 endif()
 
-add_library(sep_memory STATIC ${MEMORY_SRC})
+add_library(sep_memory STATIC ${SEP_MEMORY_SOURCES})
 
 set(SEP_HAS_REDIS 0)
 set(HIREDIS_FOUND FALSE)
@@ -21,8 +22,6 @@ if(HIREDIS_FOUND)
 else()
     add_compile_definitions(SEP_NO_REDIS)
 endif()
-
-add_library(sep_memory STATIC ${SEP_MEMORY_SOURCES})
 
 if(SEP_BUILD_QUANTUM)
   target_sources(sep_memory PRIVATE quantum_coherence_manager.cpp)

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -10,7 +10,11 @@
 #include "core/manager.h" // for ConfigManager
 #endif
 
-namespace sep { namespace config { class ConfigManager; } }
+namespace sep {
+namespace config {
+class ConfigManager;
+}
+} // namespace sep
 
 #include <algorithm>
 #include <cmath>
@@ -403,7 +407,7 @@ SEPResult MemoryTierManager::promoteToTier(MemoryBlock *block,
   }
 
   // Update lookup maps in correct order to maintain consistency
-  void* old_ptr = block->ptr;
+  void *old_ptr = block->ptr;
   {
     std::lock_guard<std::mutex> lock(lookup_mutex);
     lookup_map_.erase(old_ptr);
@@ -579,8 +583,9 @@ void MemoryTierManager::prunePatternsByPriority(MemoryTierEnum tier,
   if (!t)
     return;
 
-  auto &patterns = const_cast<std::unordered_map<size_t, PersistentPatternData> &>(
-      t->getPatterns());
+  auto &patterns =
+      const_cast<std::unordered_map<size_t, PersistentPatternData> &>(
+          t->getPatterns());
 
   if (patterns.size() <= max_count)
     return;
@@ -611,40 +616,7 @@ void MemoryTierManager::pruneWeakRelationships() {
   std::lock_guard<std::mutex> lock(relationships_mutex);
   for (auto &[id, relations] : pattern_relationships_) {
     for (auto it = relations.begin(); it != relations.end();) {
-      if (it->second < config_.demote_threshold) { // Reuse demote threshold
-        it = relations.erase(it);
-      } else {
-        ++it;
-      }
-    }
-  }
-}
-
-void MemoryTierManager::calculateRelationshipCoherence() {
-  std::lock_guard<std::mutex> reg_lock(registry_mutex);
-  std::lock_guard<std::mutex> rel_lock(relationships_mutex);
-
-  for (auto &[id, pattern_ptr] : pattern_registry_) {
-    if (pattern_relationships_.count(id)) {
-      const auto &rels = pattern_relationships_.at(id);
-      if (!rels.empty()) {
-        double sum = 0.0;
-        for (const auto &r : rels) {
-          sum += r.second;
-        }
-        pattern_ptr->coherence = static_cast<float>(sum / rels.size());
-      }
-      coherence = static_cast<float>(sum / it->second.size());
-    }
-    pattern_ptr->coherence = coherence;
-  }
-}
-
-void MemoryTierManager::pruneWeakRelationships() {
-  std::lock_guard<std::mutex> lock(relationships_mutex);
-  for (auto &[id, relations] : pattern_relationships_) {
-    for (auto it = relations.begin(); it != relations.end();) {
-      if (it->second < config_.demote_threshold) { // Reuse demote threshold
+      if (it->second < config_.demote_threshold) {
         it = relations.erase(it);
       } else {
         ++it;
@@ -659,18 +631,14 @@ void MemoryTierManager::calculateRelationshipCoherence() {
 
   for (auto &[id, pattern_ptr] : pattern_registry_) {
     pattern_ptr->coherence = 0.0f;
-    if (pattern_relationships_.count(id)) {
-      const auto &rels = pattern_relationships_.at(id);
-      if (!rels.empty()) {
-        double sum = 0.0;
-        for (const auto &r : rels)
-          sum += r.second;
-        }
-        float avg = static_cast<float>(sum / rels.size());
-        pattern_ptr->coherence = avg;
+    auto rel_it = pattern_relationships_.find(id);
+    if (rel_it != pattern_relationships_.end() && !rel_it->second.empty()) {
+      double sum = 0.0;
+      for (const auto &r : rel_it->second) {
+        sum += r.second;
       }
+      pattern_ptr->coherence = static_cast<float>(sum / rel_it->second.size());
     }
-    pattern_ptr->coherence = coherence;
   }
 }
 


### PR DESCRIPTION
## Summary
- resolve duplicate library target creation in `src/memory/CMakeLists.txt`
- remove redundant struct definitions in `types.h`
- rewrite minimal `ConfigManager` implementation
- clean up memory tier manager relationship helpers

## Testing
- `cmake -DCMAKE_BUILD_TYPE=Debug -DSEP_HAS_CUDA=0 -DSEP_MEMORY_MINIMAL=ON -DSEP_TESTBED_STUBS=ON ..`
- `make memory_manager_tests` *(fails: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_686c9ffbe4e0832a9985285566d88923