### PR TITLE
Add glog and gflags deps

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -37,6 +37,7 @@ PACKAGES=(
   libcurl4-openssl-dev libhttp-parser-dev libopenvdb-dev
   libfmt-dev pkg-config
   libspdlog-dev libgtest-dev libgmock-dev libhiredis-dev libglm-dev nlohmann-json3-dev
+  libgflags-dev libgoogle-glog-dev
   liblz4-dev libzstd-dev
   libpipewire-0.3-dev libfftw3-dev libopenexr-dev
   valgrind


### PR DESCRIPTION
## Summary
- extend `install.sh` PACKAGES list with `libgflags-dev` and `libgoogle-glog-dev`
- run the installer to confirm these packages install correctly

## Testing
- `bash install.sh --no-cuda`

------
https://chatgpt.com/codex/tasks/task_e_686ca31e7c4c832abac58e7f3f3ece51