### PR TITLE
Add glog and gflags packages

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -37,6 +37,7 @@ PACKAGES=(
   libcurl4-openssl-dev libhttp-parser-dev libopenvdb-dev
   libfmt-dev pkg-config
   libspdlog-dev libgtest-dev libgmock-dev libhiredis-dev libglm-dev nlohmann-json3-dev
+  libgflags-dev libgoogle-glog-dev
   liblz4-dev libzstd-dev
   libpipewire-0.3-dev libfftw3-dev libopenexr-dev
   valgrind


### PR DESCRIPTION
## Summary
- include libgflags-dev and libgoogle-glog-dev in installer
- run dependency installation and confirm with build script

## Testing
- `bash install.sh --no-cuda`
- `bash build.sh` *(fails: `CUDAToolkit_ROOT` not found after dependency checks)*
- `bash build_no_cuda.sh` *(fails: compilation errors in config_manager files)*

------
https://chatgpt.com/codex/tasks/task_e_686ca328a58c832aa0b2a1ea2c5ffd7a