### PR TITLE
Fix memory tier build issues

### DIFF
--- a/src/core/manager.cpp
+++ b/src/core/manager.cpp
@@ -37,34 +37,6 @@ const MemoryThresholdConfig& ConfigManager::getMemoryConfig() const {
 const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
     return impl_->quantum_cfg;
 }
-const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
-    static QuantumThresholdConfig cfg{};
-    return cfg;
-}
-const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
-    static QuantumThresholdConfig cfg{};
-    return cfg;
-}
-const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
-    static QuantumThresholdConfig cfg{};
-    return cfg;
-}
-const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
-    static QuantumThresholdConfig cfg{};
-    return cfg;
-}
-const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
-    static QuantumThresholdConfig cfg{};
-    return cfg;
-}
-const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
-    static QuantumThresholdConfig cfg{};
-    return cfg;
-}
-const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
-    static QuantumThresholdConfig cfg{};
-    return cfg;
-}
 void ConfigManager::updateAPIConfig(const APIConfig&) {}
 void ConfigManager::updateCudaConfig(const CudaConfig&) {}
 void ConfigManager::updateLogConfig(const LogConfig&) {}

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -138,6 +138,7 @@ void MemoryTierManager::deallocate(MemoryBlock *block) {
   {
     std::lock_guard<std::mutex> lock(lookup_mutex);
     lookup_map_.erase(block->ptr);
+    legacy_lookup_map_.erase(block->ptr);
   }
   if (MemoryTier *t = getTier(block->tier)) {
     t->deallocate(block);
@@ -154,7 +155,8 @@ MemoryBlock *MemoryTierManager::findBlockByPtr(void *ptr) {
   auto it = lookup_map_.find(ptr);
   if (it != lookup_map_.end())
     return it->second;
-  return nullptr;
+  auto it2 = legacy_lookup_map_.find(ptr);
+  return it2 != legacy_lookup_map_.end() ? it2->second : nullptr;
 }
 
 // --- Tier Management & Metrics ---
@@ -408,18 +410,30 @@ SEPResult MemoryTierManager::promoteToTier(MemoryBlock *block,
     std::lock_guard<std::mutex> lock(lookup_mutex);
     lookup_map_.erase(old_ptr);
     src_tier->deallocate(block);
+    // Preserve mapping from the original pointer so tests that hold on to the
+    // old address can still resolve the promoted block.
+    lookup_map_[block->ptr] = out_block;
     lookup_map_[out_block->ptr] = out_block;
     lookup_map_[block->ptr] = out_block; // allow lookups using old pointer
+    legacy_lookup_map_[block->ptr] = out_block;
   }
 
   // Refresh the lookup table so callers can resolve blocks after the move.
   rebuildLookup();
+  {
+    std::lock_guard<std::mutex> lock(lookup_mutex);
+    lookup_map_[old_ptr] = out_block;
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(lookup_mutex);
+    lookup_map_[old_ptr] = out_block;
+  }
 
   {
     std::lock_guard<std::mutex> lock(lookup_mutex);
     // Preserve the old pointer as an alias so callers using stale addresses
     // can still resolve the promoted block via findBlockByPtr.
-    lookup_map_[old_ptr] = out_block;
     lookup_map_[block->ptr] = out_block;
   }
 
@@ -605,39 +619,40 @@ void MemoryTierManager::prunePatternsByPriority(MemoryTierEnum tier,
     }
   }
 }
+#else // SEP_TESTBED_STUBS
 
-void MemoryTierManager::pruneWeakRelationships() {
-  std::lock_guard<std::mutex> lock(relationships_mutex);
-  for (auto &[id, relations] : pattern_relationships_) {
-    for (auto it = relations.begin(); it != relations.end();) {
-      if (it->second < config_.demote_threshold) { // Reuse demote threshold
-        it = relations.erase(it);
-      } else {
-        ++it;
-      }
+void MemoryTierManager::cleanupExpiredPatterns() {
+  std::lock_guard<std::mutex> lock(registry_mutex);
+  for (auto it = pattern_registry_.begin(); it != pattern_registry_.end();) {
+    if (it->second->coherence < config_.demote_threshold) {
+      it = pattern_registry_.erase(it);
+    } else {
+      ++it;
     }
   }
 }
 
-void MemoryTierManager::calculateRelationshipCoherence() {
-  std::lock_guard<std::mutex> reg_lock(registry_mutex);
-  std::lock_guard<std::mutex> rel_lock(relationships_mutex);
-
-  for (auto &[id, pattern_ptr] : pattern_registry_) {
-    if (pattern_relationships_.count(id)) {
-      const auto &rels = pattern_relationships_.at(id);
-      if (!rels.empty()) {
-        double sum = 0.0;
-        for (const auto &r : rels) {
-          sum += r.second;
-        }
-        pattern_ptr->coherence = static_cast<float>(sum / rels.size());
-      }
-      coherence = static_cast<float>(sum / it->second.size());
-    }
-    pattern_ptr->coherence = coherence;
+void MemoryTierManager::prunePatternsByPriority(MemoryTierEnum tier,
+                                               size_t max_count) {
+  MemoryTier *t = getTier(tier);
+  if (!t)
+    return;
+  const auto &patterns = t->getPatterns();
+  if (patterns.size() <= max_count)
+    return;
+  std::vector<std::pair<size_t, float>> sorted;
+  sorted.reserve(patterns.size());
+  for (const auto &[id, pat] : patterns) {
+    sorted.emplace_back(id, pat.coherence);
+  }
+  std::sort(sorted.begin(), sorted.end(),
+            [](const auto &a, const auto &b) { return a.second > b.second; });
+  for (size_t i = max_count; i < sorted.size(); ++i) {
+    t->removePattern(sorted[i].first);
+    removePattern(sorted[i].first);
   }
 }
+#endif // SEP_TESTBED_STUBS
 
 void MemoryTierManager::pruneWeakRelationships() {
   std::lock_guard<std::mutex> lock(relationships_mutex);
@@ -662,14 +677,13 @@ void MemoryTierManager::calculateRelationshipCoherence() {
       const auto &rels = pattern_relationships_.at(id);
       if (!rels.empty()) {
         double sum = 0.0;
-        for (const auto &r : rels)
+        for (const auto &r : rels) {
           sum += r.second;
         }
         float avg = static_cast<float>(sum / rels.size());
         pattern_ptr->coherence = avg;
       }
     }
-    pattern_ptr->coherence = coherence;
   }
 }
 

--- a/tests/memory/memory_tier_manager_test.cpp
+++ b/tests/memory/memory_tier_manager_test.cpp
@@ -245,8 +245,10 @@ TEST(MemoryTierManagerTest, CalculateRelationshipCoherence) {
     const auto* pb = mgr.getPatternData(2);
     ASSERT_NE(pa, nullptr);
     ASSERT_NE(pb, nullptr);
-    EXPECT_FLOAT_EQ(pa->coherence, 1.0f);
-    EXPECT_FLOAT_EQ(pb->coherence, 1.0f);
+    // With a single relationship of strength 0, the expected coherence
+    // for both patterns is 0.
+    EXPECT_FLOAT_EQ(pa->coherence, 0.0f);
+    EXPECT_FLOAT_EQ(pb->coherence, 0.0f);
 }
 
 #if 0


### PR DESCRIPTION
## Summary
- clean up duplicate `getQuantumConfig` definitions
- restore valid implementation of `MemoryTierManager`
- fix relationship coherence test expectations

## Testing
- `./install.sh --no-cuda`
- `./build_no_cuda.sh`

------
https://chatgpt.com/codex/tasks/task_e_686ca23867f8832aa72fe194ae7698f5