### PR TITLE
Pin Python version in installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,9 @@
 # SEP Engine dependency installer
 set -euo pipefail
 
+# Pinned Python version used for all installs
+PYTHON_VERSION="3.13.*"
+
 wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb
 sudo dpkg -i cuda-keyring_1.1-1_all.deb
 sudo apt-get update
@@ -71,7 +74,9 @@ if ! command -v python3.13 >/dev/null; then
   echo "Installing Python 3.13..."
   sudo add-apt-repository ppa:deadsnakes/ppa -y
   sudo apt-get update -y
-  sudo apt-get install -y python3.13 python3.13-dev | tee -a "$LOG_DIR/apt.log"
+  # Explicitly install the pinned version
+  sudo apt-get install -y "python3.13=${PYTHON_VERSION}" \
+    "python3.13-dev=${PYTHON_VERSION}" | tee -a "$LOG_DIR/apt.log"
 fi
 
 # Install GCC 14 if available


### PR DESCRIPTION
## Summary
- pin Python 3.13 version in `install.sh`
- ensure apt install respects the pinned version

## Testing
- `shellcheck install.sh`
- `ctest -V`

------
https://chatgpt.com/codex/tasks/task_e_686ca32fa1e4832aba4cdfd4e0688749