### PR TITLE
Fix duplicate coherence calculation implementation

### DIFF
--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -619,25 +619,6 @@ void MemoryTierManager::pruneWeakRelationships() {
   }
 }
 
-void MemoryTierManager::calculateRelationshipCoherence() {
-  std::lock_guard<std::mutex> reg_lock(registry_mutex);
-  std::lock_guard<std::mutex> rel_lock(relationships_mutex);
-
-  for (auto &[id, pattern_ptr] : pattern_registry_) {
-    if (pattern_relationships_.count(id)) {
-      const auto &rels = pattern_relationships_.at(id);
-      if (!rels.empty()) {
-        double sum = 0.0;
-        for (const auto &r : rels) {
-          sum += r.second;
-        }
-        pattern_ptr->coherence = static_cast<float>(sum / rels.size());
-      }
-      coherence = static_cast<float>(sum / it->second.size());
-    }
-    pattern_ptr->coherence = coherence;
-  }
-}
 
 
 void MemoryTierManager::calculateRelationshipCoherence() {


### PR DESCRIPTION
## Summary
- remove stray first definition of `calculateRelationshipCoherence`

## Testing
- `cmake --build . --target sep_memory -j$(nproc)` *(fails: QuantumThresholdConfig not found)*
- `ctest tests/memory` *(fails to run tests)*

------
https://chatgpt.com/codex/tasks/task_e_686ca31d7164832ab9c5dabff3aabf2f