### PR TITLE
Consolidate workbench config types

### DIFF
--- a/include/memory/memory_tier_manager.hpp
+++ b/include/memory/memory_tier_manager.hpp
@@ -44,26 +44,7 @@ using ::sep::MemoryTierEnum;
 
 class MemoryTierManager {
 public:
-  struct Config {
-    std::size_t stm_size;
-    std::size_t mtm_size;
-    std::size_t ltm_size;
-    float promote_stm_to_mtm;
-    float promote_mtm_to_ltm;
-    float demote_threshold;
-    float fragmentation_threshold;
-    bool use_unified_memory;
-    bool enable_compression;
-    std::uint32_t stm_to_mtm_min_gen;
-    std::uint32_t mtm_to_ltm_min_gen;
-
-    Config()
-        : stm_size(1 << 20), mtm_size(4 << 20), ltm_size(16 << 20),
-          promote_stm_to_mtm(0.7f), promote_mtm_to_ltm(0.9f),
-          demote_threshold(0.3f), fragmentation_threshold(0.3f),
-          use_unified_memory(true), enable_compression(true),
-          stm_to_mtm_min_gen(5), mtm_to_ltm_min_gen(100) {}
-  };
+  using Config = ::sep::config::MemoryThresholdConfig;
 
   // Singleton access
   static MemoryTierManager &getInstance();

--- a/include/quantum/manifold_config.h
+++ b/include/quantum/manifold_config.h
@@ -3,48 +3,10 @@
 #include "core/types.h"
 
 namespace sep::quantum::manifold {
-// Default configuration values used across the engine. These are defined as
-// inline variables so the header can be included in multiple translation
-// units without causing linker conflicts.
-
-inline ::sep::config::MemoryThresholdConfig memory{
-    .promote_stm_to_mtm = 0.7f,
-    .promote_mtm_to_ltm = 0.9f,
-    .demote_threshold = 0.3f,
-    .fragmentation_threshold = 0.3f,
-    .stm_size = 1 << 20,
-    .mtm_size = 4 << 20,
-    .ltm_size = 16 << 20,
-    .stm_to_mtm_min_gen = 5,
-    .mtm_to_ltm_min_gen = 100,
-    .use_unified_memory = true,
-    .enable_compression = true
-};
-
-inline ::sep::config::QuantumThresholdConfig quantum{
-    .ltm_coherence_threshold = 0.9f,
-    .mtm_coherence_threshold = 0.6f,
-    .stability_threshold = 0.8f
-};
-
-inline ::sep::config::CudaConfig cuda{
-    .use_gpu = true,
-    .max_memory_mb = 8192,
-    .batch_size = 1024,
-    .gpu_memory_limit = 0.9f,
-    .enable_profiling = false
-};
-
-inline ::sep::config::APIConfig api{
-    .max_connections = 1000,
-    .timeout_ms = 5000,
-    .host = "127.0.0.1",
-    .port = 8080,
-    .threads = 4,
-    .keep_alive_timeout_ms = 15000,
-    .log_level = "info",
-    .enable_metrics = true,
-    .max_batch_size = 1024
-};
+// Default configuration values used across the engine.
+extern ::sep::config::MemoryThresholdConfig memory;
+extern ::sep::config::QuantumThresholdConfig quantum;
+extern ::sep::config::CudaConfig cuda;
+extern ::sep::config::APIConfig api;
 }
 

--- a/include/workbench/config.hpp
+++ b/include/workbench/config.hpp
@@ -73,8 +73,10 @@ struct CosmoDemoConfig {
 
 struct FlockingConfig {
     int agent_count;
+    float cohesion_weight;
+    float separation_weight;
+    float alignment_weight;
     float neighbor_radius;
-    float separation_distance;
     float max_speed;
 };
 
@@ -83,78 +85,6 @@ struct DrugDiscoveryConfig {
     float mutation_rate;
 };
 
-struct FlockingConfig {
-    int agent_count;
-    float neighbor_radius;
-    float separation_distance;
-    float max_speed;
-};
-
-struct FlockingConfig {
-    int agent_count;
-    float cohesion_weight;
-    float separation_weight;
-    float alignment_weight;
-    float neighbor_radius;
-    float max_speed;
-};
-
-struct FlockingConfig {
-    float cohesion_weight;
-    float separation_weight;
-    float alignment_weight;
-};
-
-struct FlockingConfig {
-    int agent_count;
-    float cohesion_weight;
-    float separation_weight;
-    float alignment_weight;
-    float neighbor_radius;
-    float max_speed;
-};
-
-struct FlockingConfig {
-    int agent_count;
-    float cohesion_weight;
-    float separation_weight;
-    float alignment_weight;
-    float neighbor_radius;
-    float max_speed;
-};
-
-struct FlockingConfig {
-    int agent_count;
-    float neighbor_radius;
-    float max_speed;
-};
-
-struct DigitalPhysicsConfig {
-    struct {
-        int width;
-        int height;
-    } grid;
-
-    struct {
-        std::vector<int> birth;
-        std::vector<int> survival;
-    } rules;
-};
-
-struct FlockingConfig {
-    int agent_count;
-    float neighbor_radius;
-    float max_speed;
-};
-
-struct FlockingConfig {
-    int agent_count;
-    float cohesion_weight;
-    float separation_weight;
-    float alignment_weight;
-    float neighbor_radius;
-    float max_speed;
-};
 
 struct NeuralDemoConfig {
     int neuron_count;

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -70,15 +70,7 @@ MemoryTierManager::MemoryTierManager(const Config &cfg) { init(cfg); }
 
 MemoryTierManager::MemoryTierManager(
     const ::sep::config::MemoryThresholdConfig &mc) {
-  Config cfg{};
-  cfg.promote_stm_to_mtm = mc.promote_stm_to_mtm;
-  cfg.promote_mtm_to_ltm = mc.promote_mtm_to_ltm;
-  cfg.demote_threshold = mc.demote_threshold;
-  cfg.fragmentation_threshold = mc.fragmentation_threshold;
-  cfg.stm_to_mtm_min_gen = mc.stm_to_mtm_min_gen;
-  cfg.mtm_to_ltm_min_gen = mc.mtm_to_ltm_min_gen;
-  // Note: sizes are missing from MemoryThresholdConfig, using defaults
-  init(cfg);
+  init(mc);
 }
 
 MemoryTierManager::~MemoryTierManager() { shutdown(); }

--- a/src/quantum/CMakeLists.txt
+++ b/src/quantum/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(sep_quantum STATIC
     pattern_processor_interface.cpp
     pattern_evolution.cpp
     processor.cpp
+    manifold_config.cpp
     quantum_manifold_optimizer.cpp
 )
 

--- a/src/quantum/manifold_config.cpp
+++ b/src/quantum/manifold_config.cpp
@@ -1,0 +1,45 @@
+#include "quantum/manifold_config.h"
+
+namespace sep::quantum::manifold {
+
+::sep::config::MemoryThresholdConfig memory{
+    .promote_stm_to_mtm = 0.7f,
+    .promote_mtm_to_ltm = 0.9f,
+    .demote_threshold = 0.3f,
+    .fragmentation_threshold = 0.3f,
+    .stm_size = 1 << 20,
+    .mtm_size = 4 << 20,
+    .ltm_size = 16 << 20,
+    .stm_to_mtm_min_gen = 5,
+    .mtm_to_ltm_min_gen = 100,
+    .use_unified_memory = true,
+    .enable_compression = true
+};
+
+::sep::config::QuantumThresholdConfig quantum{
+    .ltm_coherence_threshold = 0.9f,
+    .mtm_coherence_threshold = 0.6f,
+    .stability_threshold = 0.8f
+};
+
+::sep::config::CudaConfig cuda{
+    .use_gpu = true,
+    .max_memory_mb = 8192,
+    .batch_size = 1024,
+    .gpu_memory_limit = 0.9f,
+    .enable_profiling = false
+};
+
+::sep::config::APIConfig api{
+    .max_connections = 1000,
+    .timeout_ms = 5000,
+    .host = "127.0.0.1",
+    .port = 8080,
+    .threads = 4,
+    .keep_alive_timeout_ms = 15000,
+    .log_level = "info",
+    .enable_metrics = true,
+    .max_batch_size = 1024
+};
+
+} // namespace sep::quantum::manifold


### PR DESCRIPTION
## Summary
- remove many duplicate `FlockingConfig` structs in `include/workbench/config.hpp`
- keep a single `FlockingConfig` definition matching example config
- alias `MemoryTierManager::Config` to `config::MemoryThresholdConfig`
- simplify constructor and centralize default manifold config values

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686ca0be8444832aacec82a363471efa