### PR TITLE
Add JS memory tier constants

### DIFF
--- a/memory_tiers.js
+++ b/memory_tiers.js
@@ -1,0 +1,15 @@
+export const STM = 0;
+export const MTM = 1;
+export const LTM = 2;
+export const HOST = 100;
+export const DEVICE = 101;
+export const UNIFIED = 102;
+
+export default {
+  STM,
+  MTM,
+  LTM,
+  HOST,
+  DEVICE,
+  UNIFIED,
+};

--- a/sep_client.js
+++ b/sep_client.js
@@ -1,4 +1,5 @@
 import fetch from 'node-fetch';
+import { STM, MTM, LTM, HOST, DEVICE, UNIFIED } from './memory_tiers.js';
 
 export default class SepClient {
   constructor(config = {}) {
@@ -32,7 +33,7 @@ export default class SepClient {
     return this.retryRequest(() => fetch(url, options));
   }
 
-  async getMemoryState(tier) {
+  async getMemoryState(tier = STM) {
     const url = `${this.baseUrl}/api/memory/${tier}`;
     return this.retryRequest(() => fetch(url));
   }

--- a/tests/js/memory_tiers.test.js
+++ b/tests/js/memory_tiers.test.js
@@ -1,0 +1,12 @@
+import assert from 'assert';
+import { STM, MTM, LTM, HOST, DEVICE, UNIFIED } from '../../memory_tiers.js';
+
+// These constants must match the values defined in include/core/types.h
+assert.strictEqual(STM, 0, 'STM should equal 0');
+assert.strictEqual(MTM, 1, 'MTM should equal 1');
+assert.strictEqual(LTM, 2, 'LTM should equal 2');
+assert.strictEqual(HOST, 100, 'HOST should equal 100');
+assert.strictEqual(DEVICE, 101, 'DEVICE should equal 101');
+assert.strictEqual(UNIFIED, 102, 'UNIFIED should equal 102');
+
+console.log('memory_tiers constants match C++ definitions');


### PR DESCRIPTION
## Summary
- expose memory tier constants in a new `memory_tiers.js`
- use the constants in `sep_client.js`
- add a small unit test checking the JS values match C++

## Testing
- `node tests/js/memory_tiers.test.js`

------
https://chatgpt.com/codex/tasks/task_e_686ca41b9798832a855f0629d33bb096