### PR TITLE
Clean up duplicate quantum config functions

### DIFF
--- a/include/core/types.h
+++ b/include/core/types.h
@@ -75,6 +75,13 @@ struct LogConfig {
     std::string dir{"logs"};
 };
 
+// Quantum memory/coherence thresholds used by quantum processing components
+struct QuantumThresholdConfig {
+    float ltm_coherence_threshold{0.9f};
+    float mtm_coherence_threshold{0.6f};
+    float stability_threshold{0.8f};
+};
+
 // Basic analytics configuration used by quantum components
 struct AnalyticsConfig {
     bool enable{false};

--- a/src/core/manager.cpp
+++ b/src/core/manager.cpp
@@ -37,34 +37,6 @@ const MemoryThresholdConfig& ConfigManager::getMemoryConfig() const {
 const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
     return impl_->quantum_cfg;
 }
-const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
-    static QuantumThresholdConfig cfg{};
-    return cfg;
-}
-const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
-    static QuantumThresholdConfig cfg{};
-    return cfg;
-}
-const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
-    static QuantumThresholdConfig cfg{};
-    return cfg;
-}
-const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
-    static QuantumThresholdConfig cfg{};
-    return cfg;
-}
-const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
-    static QuantumThresholdConfig cfg{};
-    return cfg;
-}
-const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
-    static QuantumThresholdConfig cfg{};
-    return cfg;
-}
-const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
-    static QuantumThresholdConfig cfg{};
-    return cfg;
-}
 void ConfigManager::updateAPIConfig(const APIConfig&) {}
 void ConfigManager::updateCudaConfig(const CudaConfig&) {}
 void ConfigManager::updateLogConfig(const LogConfig&) {}


### PR DESCRIPTION
## Summary
- define `QuantumThresholdConfig` in core `types.h`
- remove repeated implementations of `ConfigManager::getQuantumConfig`

## Testing
- `cmake -S ../.. -B . -DCMAKE_C_COMPILER=/usr/bin/gcc-14 -DCMAKE_CXX_COMPILER=/usr/bin/g++-14 -DSEP_HAS_CUDA=0 -DSEP_USE_CUDA=0 -DCMAKE_DISABLE_FIND_PACKAGE_CUDAToolkit=ON -DSEP_WITH_CYCLES=OFF -DSEP_WITH_AUDIO=OFF -DSEP_WITH_OPENSUBDIV=OFF -DSEP_WITH_OPENPGL=OFF -DSEP_WITH_OCIO=OFF -DSEP_WITH_OPENIMAGEIO=OFF -DSEP_WITH_EMBREE=OFF -DSEP_WITH_OPENVDB=OFF -DSEP_WITH_OSL=OFF -DSEP_WITH_ALEMBIC=OFF -DBUILD_TESTING=ON -DSEP_WORKBENCH_DEMO=OFF -DSEP_BUILD_QUANTUM=ON`
- `CXXFLAGS="-DSEP_BUILD_QUANTUM=1" make memory_manager_tests -j$(nproc)` *(fails: no declaration matches)*

------
https://chatgpt.com/codex/tasks/task_e_686ca31cd7d4832abc680c03cd8adc2e