### PR TITLE
Add duplicate type scan CI

### DIFF
--- a/.github/workflows/duplicate_type_scan.yml
+++ b/.github/workflows/duplicate_type_scan.yml
@@ -1,0 +1,29 @@
+name: Duplicate Type Scan
+
+on:
+  push:
+    paths:
+      - 'src/**'
+      - 'include/**'
+      - 'examples/**'
+      - 'tests/**'
+      - '_sep/testbed/**'
+      - '.github/workflows/duplicate_type_scan.yml'
+      - 'scripts/duplicate_type_scan.py'
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'include/**'
+      - 'examples/**'
+      - 'tests/**'
+      - '_sep/testbed/**'
+      - '.github/workflows/duplicate_type_scan.yml'
+      - 'scripts/duplicate_type_scan.py'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run duplicate type scan
+        run: python3 scripts/duplicate_type_scan.py

--- a/scripts/duplicate_type_scan.py
+++ b/scripts/duplicate_type_scan.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+import os
+import re
+import sys
+
+SEARCH_ROOTS = ['src', 'examples', 'tests', '_sep/testbed']
+EXTS = {'.h', '.hpp', '.c', '.cpp', '.cc', '.cu', '.ts', '.js'}
+
+pattern = re.compile(r'\b(struct|class)\s+([A-Za-z_][A-Za-z0-9_]*)')
+
+def scan_file(path):
+    names = set()
+    try:
+        with open(path, 'r', encoding='utf-8', errors='ignore') as f:
+            for line in f:
+                m = pattern.search(line)
+                if m:
+                    names.add(m.group(2))
+    except Exception:
+        pass
+    return names
+
+def main():
+    occurrences = {}
+    duplicates = {}
+    for root in SEARCH_ROOTS:
+        if not os.path.isdir(root):
+            continue
+        for dirpath, _, files in os.walk(root):
+            for fname in files:
+                if any(fname.endswith(ext) for ext in EXTS):
+                    path = os.path.join(dirpath, fname)
+                    for name in scan_file(path):
+                        if name in occurrences:
+                            duplicates.setdefault(name, set()).update({occurrences[name], path})
+                        else:
+                            occurrences[name] = path
+    if duplicates:
+        print("Duplicate struct/class definitions found:")
+        for name, paths in sorted(duplicates.items()):
+            print(f"{name}:")
+            for p in sorted(paths):
+                print(f"  {p}")
+        sys.exit(1)
+    else:
+        print("No duplicate struct/class definitions found.")
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add a Python script for scanning duplicate struct/class definitions
- run the script in a new GitHub Actions workflow

## Testing
- `python3 scripts/duplicate_type_scan.py | head`


------
https://chatgpt.com/codex/tasks/task_e_686ca57ed6b4832a9d4891e78d9d10f9