### PR TITLE
Remove duplicate getQuantumConfig implementation

### DIFF
--- a/include/core/types.h
+++ b/include/core/types.h
@@ -43,6 +43,13 @@ struct MemoryThresholdConfig {
     bool enable_compression{true};
 };
 
+// Quantum processing thresholds used by experimental components
+struct QuantumThresholdConfig {
+    float ltm_coherence_threshold{0.9f};
+    float mtm_coherence_threshold{0.6f};
+    float stability_threshold{0.8f};
+};
+
 // Minimal CUDA configuration used by unit tests. These fields are
 // sufficient for the parts of the engine compiled in this repository.
 struct CudaConfig {

--- a/src/core/config_manager_stub.cpp
+++ b/src/core/config_manager_stub.cpp
@@ -5,7 +5,9 @@ namespace sep::config {
 class ConfigManager::Impl {
 public:
     MemoryThresholdConfig mem_cfg{};
+#if SEP_BUILD_QUANTUM
     QuantumThresholdConfig quantum_cfg{};
+#endif
 };
 
 ConfigManager::ConfigManager() : impl_(std::make_unique<Impl>()) {}
@@ -34,17 +36,23 @@ const LogConfig &ConfigManager::getLogConfig() const {
 const MemoryThresholdConfig &ConfigManager::getMemoryConfig() const {
     return impl_->mem_cfg;
 }
+#if SEP_BUILD_QUANTUM
 const QuantumThresholdConfig &ConfigManager::getQuantumConfig() const {
     return impl_->quantum_cfg;
 }
+#endif
 void ConfigManager::updateAPIConfig(const APIConfig &) {}
 void ConfigManager::updateCudaConfig(const CudaConfig &) {}
 void ConfigManager::updateLogConfig(const LogConfig &) {}
 void ConfigManager::updateMemoryConfig(const MemoryThresholdConfig &cfg) { impl_->mem_cfg = cfg; }
+#if SEP_BUILD_QUANTUM
 void ConfigManager::updateQuantumConfig(const QuantumThresholdConfig &cfg) { impl_->quantum_cfg = cfg; }
+#endif
 void ConfigManager::resetToDefaults() {
     impl_->mem_cfg = MemoryThresholdConfig{};
+#if SEP_BUILD_QUANTUM
     impl_->quantum_cfg = QuantumThresholdConfig{};
+#endif
 }
 
 } // namespace sep::config

--- a/src/core/manager.cpp
+++ b/src/core/manager.cpp
@@ -4,7 +4,9 @@ namespace sep::config {
 
 struct ConfigManager::Impl {
     MemoryThresholdConfig mem_cfg{};
+#if SEP_BUILD_QUANTUM
     QuantumThresholdConfig quantum_cfg{};
+#endif
 };
 
 ConfigManager::ConfigManager() : impl_(std::make_unique<Impl>()) {}
@@ -34,49 +36,27 @@ const LogConfig& ConfigManager::getLogConfig() const {
 const MemoryThresholdConfig& ConfigManager::getMemoryConfig() const {
     return impl_->mem_cfg;
 }
+#if SEP_BUILD_QUANTUM
 const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
     return impl_->quantum_cfg;
 }
-const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
-    static QuantumThresholdConfig cfg{};
-    return cfg;
-}
-const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
-    static QuantumThresholdConfig cfg{};
-    return cfg;
-}
-const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
-    static QuantumThresholdConfig cfg{};
-    return cfg;
-}
-const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
-    static QuantumThresholdConfig cfg{};
-    return cfg;
-}
-const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
-    static QuantumThresholdConfig cfg{};
-    return cfg;
-}
-const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
-    static QuantumThresholdConfig cfg{};
-    return cfg;
-}
-const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
-    static QuantumThresholdConfig cfg{};
-    return cfg;
-}
+#endif
 void ConfigManager::updateAPIConfig(const APIConfig&) {}
 void ConfigManager::updateCudaConfig(const CudaConfig&) {}
 void ConfigManager::updateLogConfig(const LogConfig&) {}
 void ConfigManager::updateMemoryConfig(const MemoryThresholdConfig& cfg) {
     impl_->mem_cfg = cfg;
 }
+#if SEP_BUILD_QUANTUM
 void ConfigManager::updateQuantumConfig(const QuantumThresholdConfig& cfg) {
     impl_->quantum_cfg = cfg;
 }
+#endif
 void ConfigManager::resetToDefaults() {
     impl_->mem_cfg = MemoryThresholdConfig{};
+#if SEP_BUILD_QUANTUM
     impl_->quantum_cfg = QuantumThresholdConfig{};
+#endif
 }
 
 } // namespace sep::config

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -661,5 +661,7 @@ void MemoryTierManager::calculateRelationshipCoherence() {
   }
 }
 
+#endif // SEP_TESTBED_STUBS
+
 } // namespace memory
 } // namespace sep


### PR DESCRIPTION
## Summary
- deduplicate `ConfigManager::getQuantumConfig()` implementation
- add missing `QuantumThresholdConfig` struct for minimal builds
- guard quantum-specific code with `SEP_BUILD_QUANTUM`
- close preprocessor block in `memory_tier_manager.cpp`

## Testing
- `./build_no_cuda.sh`

------
https://chatgpt.com/codex/tasks/task_e_686ca3261b6c832aba04fb3cbba0e527