### PR TITLE
Fix coherence calculation

### DIFF
--- a/include/core/types.h
+++ b/include/core/types.h
@@ -43,6 +43,17 @@ struct MemoryThresholdConfig {
     bool enable_compression{true};
 };
 
+// Minimal quantum processing thresholds used by tests. The real engine
+// defines a richer configuration, but the memory manager tests only
+// require a handful of fields. Provide a lightweight struct here so the
+// stub configuration manager can compile without pulling in the full
+// quantum stack.
+struct QuantumThresholdConfig {
+    float ltm_coherence_threshold{0.9f};
+    float mtm_coherence_threshold{0.6f};
+    float stability_threshold{0.8f};
+};
+
 // Minimal CUDA configuration used by unit tests. These fields are
 // sufficient for the parts of the engine compiled in this repository.
 struct CudaConfig {

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(sep_core STATIC
+set(SEP_CORE_SOURCES
     tracing.cpp
     allocation_metrics.cpp
     dag_graph.cpp
@@ -6,9 +6,13 @@ add_library(sep_core STATIC
     prometheus_exporter.cpp
     error_handler.cpp
     metrics_collector.cpp
-    logging.cpp
-    manager.cpp
-)
+    logging.cpp)
+
+if(NOT SEP_TESTBED_STUBS)
+    list(APPEND SEP_CORE_SOURCES manager.cpp)
+endif()
+
+add_library(sep_core STATIC ${SEP_CORE_SOURCES})
 
 # The core library does not require Redis for these tests. Explicitly
 # disable Redis support so headers guarded by SEP_NO_REDIS do not
@@ -38,9 +42,12 @@ install(DIRECTORY ${CMAKE_SOURCE_DIR}/src/core/
 
 # Enable CUDA and handle exception specs
 target_compile_definitions(sep_core PRIVATE
-    SEP_HAS_CUDA=1
     SEP_CUDACC_DISABLE_EXCEPTION_SPEC_CHECKS=1
-    SEP_NO_REDIS)
+    SEP_NO_REDIS
+    $<$<BOOL:${SEP_HAS_CUDA}>:SEP_HAS_CUDA=1>
+    $<$<NOT:$<BOOL:${SEP_HAS_CUDA}>>:SEP_HAS_CUDA=0>
+    $<$<BOOL:${SEP_BUILD_QUANTUM}>:SEP_BUILD_QUANTUM=1>
+    $<$<NOT:$<BOOL:${SEP_BUILD_QUANTUM}>>:SEP_BUILD_QUANTUM=0>)
 
 # Set library properties
 set_target_properties(sep_core PROPERTIES

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -624,42 +624,20 @@ void MemoryTierManager::calculateRelationshipCoherence() {
   std::lock_guard<std::mutex> rel_lock(relationships_mutex);
 
   for (auto &[id, pattern_ptr] : pattern_registry_) {
-    if (pattern_relationships_.count(id)) {
-      const auto &rels = pattern_relationships_.at(id);
-      if (!rels.empty()) {
-        double sum = 0.0;
-        for (const auto &r : rels) {
-          sum += r.second;
-        }
-        pattern_ptr->coherence = static_cast<float>(sum / rels.size());
-      }
-      coherence = static_cast<float>(sum / it->second.size());
-    }
-    pattern_ptr->coherence = coherence;
-  }
-}
-
-
-void MemoryTierManager::calculateRelationshipCoherence() {
-  std::lock_guard<std::mutex> reg_lock(registry_mutex);
-  std::lock_guard<std::mutex> rel_lock(relationships_mutex);
-
-  for (auto &[id, pattern_ptr] : pattern_registry_) {
     pattern_ptr->coherence = 0.0f;
     if (pattern_relationships_.count(id)) {
       const auto &rels = pattern_relationships_.at(id);
       if (!rels.empty()) {
         double sum = 0.0;
-        for (const auto &r : rels)
-          sum += r.second;
-        }
+        for (const auto &r : rels) sum += r.second;
         float avg = static_cast<float>(sum / rels.size());
         pattern_ptr->coherence = avg;
       }
     }
-    pattern_ptr->coherence = coherence;
   }
 }
+
+#endif // SEP_TESTBED_STUBS
 
 } // namespace memory
 } // namespace sep


### PR DESCRIPTION
## Summary
- fix duplicate code and incorrect assignments in `calculateRelationshipCoherence`
- provide minimal `QuantumThresholdConfig` type for stubs
- only build core manager when not using stubs
- propagate build flags for CUDA and quantum options

## Testing
- `cmake -DSEP_BUILD_QUANTUM=ON ...`
- `make memory_manager_tests`
- `./tests/memory/memory_manager_tests` *(fails: MemoryTierManagerTest.CalculateRelationshipCoherence)*

------
https://chatgpt.com/codex/tasks/task_e_686ca32942a8832aa1874816649b124d