### PR TITLE
Add duplicate type scan and cross-language roundtrip test

### DIFF
--- a/.github/workflows/duplicate_type_check.yml
+++ b/.github/workflows/duplicate_type_check.yml
@@ -1,0 +1,29 @@
+name: Duplicate Type Check
+
+on:
+  push:
+    paths:
+      - 'include/**'
+      - 'src/**'
+      - 'examples/**'
+      - 'tests/**'
+      - '_sep/testbed/**'
+      - 'scripts/check_duplicate_types.py'
+      - '.github/workflows/duplicate_type_check.yml'
+  pull_request:
+    paths:
+      - 'include/**'
+      - 'src/**'
+      - 'examples/**'
+      - 'tests/**'
+      - '_sep/testbed/**'
+      - 'scripts/check_duplicate_types.py'
+      - '.github/workflows/duplicate_type_check.yml'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run duplicate type check
+        run: python3 scripts/check_duplicate_types.py

--- a/_sep/testbed/CMakeLists.txt
+++ b/_sep/testbed/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(testbed_tests STATIC
     audio_factory_test.cpp
     api_makejsonresponse_test.cpp
     neuro_spike_test.cpp
+    node_roundtrip_test.cpp
 )
 add_subdirectory(embeddings)
 

--- a/_sep/testbed/memory_config.json
+++ b/_sep/testbed/memory_config.json
@@ -1,0 +1,13 @@
+{
+  "stm_size": 1048576,
+  "mtm_size": 4194304,
+  "ltm_size": 16777216,
+  "promote_stm_to_mtm": 0.7,
+  "promote_mtm_to_ltm": 0.9,
+  "demote_threshold": 0.3,
+  "fragmentation_threshold": 0.3,
+  "use_unified_memory": true,
+  "enable_compression": true,
+  "stm_to_mtm_min_gen": 5,
+  "mtm_to_ltm_min_gen": 100
+}

--- a/_sep/testbed/memory_config_roundtrip.cjs
+++ b/_sep/testbed/memory_config_roundtrip.cjs
@@ -1,0 +1,15 @@
+const fs = require('fs');
+
+function testRoundtrip(jsonPath) {
+  const data = JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
+  if (typeof data.stm_size !== 'number') throw new Error('stm_size missing');
+  const out = JSON.stringify(data);
+  const parsed = JSON.parse(out);
+  return parsed.stm_size === data.stm_size;
+}
+
+if (require.main === module) {
+  const ok = testRoundtrip(process.argv[2]);
+  console.log(ok ? 'roundtrip ok' : 'roundtrip failed');
+  process.exit(ok ? 0 : 1);
+}

--- a/_sep/testbed/node_roundtrip_test.cpp
+++ b/_sep/testbed/node_roundtrip_test.cpp
@@ -1,0 +1,7 @@
+#include <gtest/gtest.h>
+#include <cstdlib>
+
+TEST(NodeRoundTrip, MemoryConfig) {
+    int ret = std::system("node _sep/testbed/memory_config_roundtrip.cjs _sep/testbed/memory_config.json > /dev/null");
+    ASSERT_EQ(ret, 0);
+}

--- a/scripts/check_duplicate_types.py
+++ b/scripts/check_duplicate_types.py
@@ -1,0 +1,42 @@
+import os
+import re
+import sys
+from collections import defaultdict
+
+def gather_files(root_dirs):
+    for root_dir in root_dirs:
+        for dirpath, _, files in os.walk(root_dir):
+            for fname in files:
+                if fname.endswith(('.h', '.hpp', '.c', '.cpp', '.cc', '.cu')):
+                    yield os.path.join(dirpath, fname)
+
+def extract_definitions(path):
+    pattern = re.compile(r'^(?:template<[^>]+>\s*)?(struct|class)\s+(\w+)\s*(?:\{|$)')
+    results = []
+    with open(path, 'r', encoding='utf-8', errors='ignore') as f:
+        for line in f:
+            m = pattern.match(line.strip())
+            if m and '{' in line:
+                results.append(m.group(2))
+    return results
+
+def main():
+    roots = sys.argv[1:] if len(sys.argv) > 1 else ['include', 'src', 'examples', 'tests', '_sep/testbed']
+    defs = defaultdict(list)
+    for file in gather_files(roots):
+        for name in extract_definitions(file):
+            defs[name].append(file)
+
+    duplicates = {n: paths for n, paths in defs.items() if len(paths) > 1}
+    if duplicates:
+        print('Duplicate struct/class definitions found:')
+        for name, paths in duplicates.items():
+            print(f'{name}:')
+            for p in paths:
+                print(f'  - {p}')
+        sys.exit(1)
+    else:
+        print('No duplicate struct/class definitions found.')
+
+if __name__ == '__main__':
+    main()

--- a/src/memoryTier.ts
+++ b/src/memoryTier.ts
@@ -1,0 +1,13 @@
+export enum MemoryTierEnum {
+  STM = 0,
+  MTM = 1,
+  LTM = 2,
+  HOST = 100,
+  DEVICE = 101,
+  UNIFIED = 102
+}
+
+export interface MemoryTierConfig {
+  type: MemoryTierEnum;
+  size: number;
+}


### PR DESCRIPTION
## Summary
- add enumeration for memory tiers for Node.js
- add script to detect duplicate struct/class definitions across codebase
- run duplicate type check in CI
- add simple Node roundtrip test under testbed

## Testing
- `node _sep/testbed/memory_config_roundtrip.cjs _sep/testbed/memory_config.json`
- `cmake .. -DBUILD_TESTING=ON` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_686ca57ed6b4832a9d4891e78d9d10f9