### PR TITLE
Fix relationship coherence and cleanup configs

### DIFF
--- a/include/core/types.h
+++ b/include/core/types.h
@@ -43,6 +43,12 @@ struct MemoryThresholdConfig {
     bool enable_compression{true};
 };
 
+struct QuantumThresholdConfig {
+    float ltm_coherence_threshold{0.9f};
+    float mtm_coherence_threshold{0.6f};
+    float stability_threshold{0.8f};
+};
+
 // Minimal CUDA configuration used by unit tests. These fields are
 // sufficient for the parts of the engine compiled in this repository.
 struct CudaConfig {

--- a/src/core/config_manager_stub.cpp
+++ b/src/core/config_manager_stub.cpp
@@ -5,7 +5,9 @@ namespace sep::config {
 class ConfigManager::Impl {
 public:
     MemoryThresholdConfig mem_cfg{};
+#if SEP_BUILD_QUANTUM
     QuantumThresholdConfig quantum_cfg{};
+#endif
 };
 
 ConfigManager::ConfigManager() : impl_(std::make_unique<Impl>()) {}
@@ -34,17 +36,23 @@ const LogConfig &ConfigManager::getLogConfig() const {
 const MemoryThresholdConfig &ConfigManager::getMemoryConfig() const {
     return impl_->mem_cfg;
 }
+#if SEP_BUILD_QUANTUM
 const QuantumThresholdConfig &ConfigManager::getQuantumConfig() const {
     return impl_->quantum_cfg;
 }
+#endif
 void ConfigManager::updateAPIConfig(const APIConfig &) {}
 void ConfigManager::updateCudaConfig(const CudaConfig &) {}
 void ConfigManager::updateLogConfig(const LogConfig &) {}
 void ConfigManager::updateMemoryConfig(const MemoryThresholdConfig &cfg) { impl_->mem_cfg = cfg; }
+#if SEP_BUILD_QUANTUM
 void ConfigManager::updateQuantumConfig(const QuantumThresholdConfig &cfg) { impl_->quantum_cfg = cfg; }
+#endif
 void ConfigManager::resetToDefaults() {
     impl_->mem_cfg = MemoryThresholdConfig{};
+#if SEP_BUILD_QUANTUM
     impl_->quantum_cfg = QuantumThresholdConfig{};
+#endif
 }
 
 } // namespace sep::config

--- a/src/core/manager.cpp
+++ b/src/core/manager.cpp
@@ -4,7 +4,9 @@ namespace sep::config {
 
 struct ConfigManager::Impl {
     MemoryThresholdConfig mem_cfg{};
+#if SEP_BUILD_QUANTUM
     QuantumThresholdConfig quantum_cfg{};
+#endif
 };
 
 ConfigManager::ConfigManager() : impl_(std::make_unique<Impl>()) {}
@@ -34,50 +36,27 @@ const LogConfig& ConfigManager::getLogConfig() const {
 const MemoryThresholdConfig& ConfigManager::getMemoryConfig() const {
     return impl_->mem_cfg;
 }
+#if SEP_BUILD_QUANTUM
 const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
     return impl_->quantum_cfg;
 }
-const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
-    static QuantumThresholdConfig cfg{};
-    return cfg;
-}
-const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
-    static QuantumThresholdConfig cfg{};
-    return cfg;
-}
-const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
-    static QuantumThresholdConfig cfg{};
-    return cfg;
-}
-const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
-    static QuantumThresholdConfig cfg{};
-    return cfg;
-}
-const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
-    static QuantumThresholdConfig cfg{};
-    return cfg;
-}
-const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
-    static QuantumThresholdConfig cfg{};
-    return cfg;
-}
-const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
-    static QuantumThresholdConfig cfg{};
-    return cfg;
-}
+#endif
 void ConfigManager::updateAPIConfig(const APIConfig&) {}
 void ConfigManager::updateCudaConfig(const CudaConfig&) {}
 void ConfigManager::updateLogConfig(const LogConfig&) {}
 void ConfigManager::updateMemoryConfig(const MemoryThresholdConfig& cfg) {
     impl_->mem_cfg = cfg;
 }
+#if SEP_BUILD_QUANTUM
 void ConfigManager::updateQuantumConfig(const QuantumThresholdConfig& cfg) {
     impl_->quantum_cfg = cfg;
 }
+#endif
 void ConfigManager::resetToDefaults() {
     impl_->mem_cfg = MemoryThresholdConfig{};
+#if SEP_BUILD_QUANTUM
     impl_->quantum_cfg = QuantumThresholdConfig{};
+#endif
 }
 
 } // namespace sep::config
-

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -624,42 +624,20 @@ void MemoryTierManager::calculateRelationshipCoherence() {
   std::lock_guard<std::mutex> rel_lock(relationships_mutex);
 
   for (auto &[id, pattern_ptr] : pattern_registry_) {
-    if (pattern_relationships_.count(id)) {
-      const auto &rels = pattern_relationships_.at(id);
-      if (!rels.empty()) {
-        double sum = 0.0;
-        for (const auto &r : rels) {
-          sum += r.second;
-        }
-        pattern_ptr->coherence = static_cast<float>(sum / rels.size());
-      }
-      coherence = static_cast<float>(sum / it->second.size());
-    }
-    pattern_ptr->coherence = coherence;
-  }
-}
-
-
-void MemoryTierManager::calculateRelationshipCoherence() {
-  std::lock_guard<std::mutex> reg_lock(registry_mutex);
-  std::lock_guard<std::mutex> rel_lock(relationships_mutex);
-
-  for (auto &[id, pattern_ptr] : pattern_registry_) {
     pattern_ptr->coherence = 0.0f;
     if (pattern_relationships_.count(id)) {
       const auto &rels = pattern_relationships_.at(id);
       if (!rels.empty()) {
         double sum = 0.0;
-        for (const auto &r : rels)
-          sum += r.second;
+        for (const auto &r : rels) {
+          sum += 1.0 - r.second;
         }
-        float avg = static_cast<float>(sum / rels.size());
-        pattern_ptr->coherence = avg;
+        pattern_ptr->coherence = static_cast<float>(sum / rels.size());
       }
     }
-    pattern_ptr->coherence = coherence;
   }
 }
+#endif // SEP_TESTBED_STUBS
 
 } // namespace memory
 } // namespace sep


### PR DESCRIPTION
## Summary
- clean up duplicate functions in `memory_tier_manager.cpp`
- compute relationship coherence as the average of `1 - strength`
- add missing `QuantumThresholdConfig` type and guard quantum config stubs
- simplify `ConfigManager` implementation for minimal build

## Testing
- `cmake --build cmake-nocuda --target memory_manager_tests -j$(nproc)`
- `./cmake-nocuda/tests/memory/memory_manager_tests`

------
https://chatgpt.com/codex/tasks/task_e_686ca3273528832a95d6b836dfe3aa0d