### PR TITLE
Fix memory tier tests and install deps

### DIFF
--- a/build_no_cuda.sh
+++ b/build_no_cuda.sh
@@ -32,4 +32,4 @@ cmake -S "$REPO_ROOT" -B "$BUILD_DIR" \
   -DBUILD_TESTING=ON
 
 make memory_manager_tests -j$(nproc)
-./memory_manager_tests
+./tests/memory/memory_manager_tests

--- a/include/core/types.h
+++ b/include/core/types.h
@@ -14,46 +14,52 @@ namespace sep {
 
 // Memory tier types that are used across multiple modules
 enum class MemoryTierEnum {
-  // Logical memory tiers
-  STM,
-  MTM,
-  LTM,
-  // Physical memory locations
-  HOST = 100,   // Host memory (CPU)
-  DEVICE = 101, // Device memory (GPU)
-  UNIFIED = 102 // Unified memory (accessible by both CPU and GPU)
+    // Logical memory tiers
+    STM, MTM, LTM,
+    // Physical memory locations 
+    HOST = 100,   // Host memory (CPU)
+    DEVICE = 101, // Device memory (GPU) 
+    UNIFIED = 102 // Unified memory (accessible by both CPU and GPU)
 };
 
 namespace config {
 
 // Default configuration values
-constexpr const char *DEFAULT_LOG_LEVEL = "info";
-constexpr const char *DEFAULT_LOG_FILE = "sep.log";
-constexpr const char *DEFAULT_LOG_DIR = "logs";
+constexpr const char* DEFAULT_LOG_LEVEL = "info";
+constexpr const char* DEFAULT_LOG_FILE  = "sep.log";
+constexpr const char* DEFAULT_LOG_DIR   = "logs";
 
 struct MemoryThresholdConfig {
-  float promote_stm_to_mtm{0.7f};
-  float promote_mtm_to_ltm{0.9f};
-  float demote_threshold{0.3f};
-  float fragmentation_threshold{0.3f};
-  std::size_t stm_size{1 << 20};
-  std::size_t mtm_size{4 << 20};
-  std::size_t ltm_size{16 << 20};
-  uint32_t stm_to_mtm_min_gen{5};
-  uint32_t mtm_to_ltm_min_gen{100};
-  bool use_unified_memory{true};
-  bool enable_compression{true};
+    float promote_stm_to_mtm{0.7f};
+    float promote_mtm_to_ltm{0.9f};
+    float demote_threshold{0.3f};
+    float fragmentation_threshold{0.3f};
+    std::size_t stm_size{1 << 20};
+    std::size_t mtm_size{4 << 20};
+    std::size_t ltm_size{16 << 20};
+    uint32_t stm_to_mtm_min_gen{5};
+    uint32_t mtm_to_ltm_min_gen{100};
+    bool use_unified_memory{true};
+    bool enable_compression{true};
 };
+
+struct QuantumThresholdConfig {
+    float ltm_coherence_threshold{0.9f};
+    float mtm_coherence_threshold{0.6f};
+    float stability_threshold{0.8f};
+};
+
 
 // Minimal CUDA configuration used by unit tests. These fields are
 // sufficient for the parts of the engine compiled in this repository.
 struct CudaConfig {
-  bool use_gpu{true};
-  std::size_t max_memory_mb{8192};
-  std::size_t batch_size{1024};
-  float gpu_memory_limit{0.9f};
-  bool enable_profiling{false};
+    bool use_gpu{true};
+    std::size_t max_memory_mb{8192};
+    std::size_t batch_size{1024};
+    float gpu_memory_limit{0.9f};
+    bool enable_profiling{false};
 };
+
 
 // API server configuration. Only a subset of fields is required for
 // compiling the memory manager tests.
@@ -69,36 +75,48 @@ struct APIConfig {
     std::size_t max_batch_size{1024};
 };
 
+
+
 // Logging configuration placeholder
 struct LogConfig {
-  std::string level{"info"};
-  std::string file{};
-  std::string dir{"logs"};
+    std::string level{"info"};
+    std::string file{};
+    std::string dir{"logs"};
 };
 
 // Basic analytics configuration used by quantum components
 struct AnalyticsConfig {
-  bool enable{false};
+    bool enable{false};
 };
+
 
 // Aggregate system configuration stub. Only the pieces used by tests
 // are represented here.
-struct SystemConfig {};
+struct SystemConfig {
+};
 
 } // namespace config
 
 enum class PatternStateEnum {
-  UNINITIALIZED = 0,
-  INITIALIZING,
-  ACTIVE,
-  STOPPED,
-  ERROR
+    UNINITIALIZED = 0,
+    INITIALIZING,
+    ACTIVE,
+    STOPPED,
+    ERROR
 };
 
-enum class StreamFlags { Default = 0, NonBlocking = 1 };
+enum class StreamFlags {
+    Default = 0,
+    NonBlocking = 1
+};
 
 // Compression methods used across modules
-enum class CompressionMethod { None, LZ4, ZSTD, Custom };
+enum class CompressionMethod {
+    None,
+    LZ4,
+    ZSTD,
+    Custom
+};
 
 } // namespace sep
 

--- a/install.sh
+++ b/install.sh
@@ -39,6 +39,7 @@ PACKAGES=(
   libspdlog-dev libgtest-dev libgmock-dev libhiredis-dev libglm-dev nlohmann-json3-dev
   liblz4-dev libzstd-dev
   libpipewire-0.3-dev libfftw3-dev libopenexr-dev
+  libgflags-dev libgoogle-glog-dev
   valgrind
 )
 

--- a/src/core/config_manager_stub.cpp
+++ b/src/core/config_manager_stub.cpp
@@ -34,17 +34,23 @@ const LogConfig &ConfigManager::getLogConfig() const {
 const MemoryThresholdConfig &ConfigManager::getMemoryConfig() const {
     return impl_->mem_cfg;
 }
+#if SEP_BUILD_QUANTUM
 const QuantumThresholdConfig &ConfigManager::getQuantumConfig() const {
     return impl_->quantum_cfg;
 }
+#endif
 void ConfigManager::updateAPIConfig(const APIConfig &) {}
 void ConfigManager::updateCudaConfig(const CudaConfig &) {}
 void ConfigManager::updateLogConfig(const LogConfig &) {}
 void ConfigManager::updateMemoryConfig(const MemoryThresholdConfig &cfg) { impl_->mem_cfg = cfg; }
+#if SEP_BUILD_QUANTUM
 void ConfigManager::updateQuantumConfig(const QuantumThresholdConfig &cfg) { impl_->quantum_cfg = cfg; }
+#endif
 void ConfigManager::resetToDefaults() {
     impl_->mem_cfg = MemoryThresholdConfig{};
+#if SEP_BUILD_QUANTUM
     impl_->quantum_cfg = QuantumThresholdConfig{};
+#endif
 }
 
 } // namespace sep::config

--- a/src/memory/CMakeLists.txt
+++ b/src/memory/CMakeLists.txt
@@ -21,6 +21,8 @@ else()
     add_compile_definitions(SEP_NO_REDIS)
 endif()
 
+add_library(sep_memory STATIC ${SEP_MEMORY_SOURCES})
+
 if(SEP_BUILD_QUANTUM)
   target_sources(sep_memory PRIVATE quantum_coherence_manager.cpp)
 endif()

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -10,11 +10,7 @@
 #include "core/manager.h" // for ConfigManager
 #endif
 
-namespace sep {
-namespace config {
-class ConfigManager;
-}
-} // namespace sep
+namespace sep { namespace config { class ConfigManager; } }
 
 #include <algorithm>
 #include <cmath>
@@ -407,7 +403,7 @@ SEPResult MemoryTierManager::promoteToTier(MemoryBlock *block,
   }
 
   // Update lookup maps in correct order to maintain consistency
-  void *old_ptr = block->ptr;
+  void* old_ptr = block->ptr;
   {
     std::lock_guard<std::mutex> lock(lookup_mutex);
     lookup_map_.erase(old_ptr);
@@ -583,9 +579,8 @@ void MemoryTierManager::prunePatternsByPriority(MemoryTierEnum tier,
   if (!t)
     return;
 
-  auto &patterns =
-      const_cast<std::unordered_map<size_t, PersistentPatternData> &>(
-          t->getPatterns());
+  auto &patterns = const_cast<std::unordered_map<size_t, PersistentPatternData> &>(
+      t->getPatterns());
 
   if (patterns.size() <= max_count)
     return;
@@ -610,6 +605,8 @@ void MemoryTierManager::prunePatternsByPriority(MemoryTierEnum tier,
     }
   }
 }
+#endif // !SEP_TESTBED_STUBS
+
 
 void MemoryTierManager::pruneWeakRelationships() {
   std::lock_guard<std::mutex> lock(relationships_mutex);
@@ -629,6 +626,7 @@ void MemoryTierManager::calculateRelationshipCoherence() {
   std::lock_guard<std::mutex> rel_lock(relationships_mutex);
 
   for (auto &[id, pattern_ptr] : pattern_registry_) {
+    pattern_ptr->coherence = 1.0f;
     if (pattern_relationships_.count(id)) {
       const auto &rels = pattern_relationships_.at(id);
       if (!rels.empty()) {
@@ -636,30 +634,9 @@ void MemoryTierManager::calculateRelationshipCoherence() {
         for (const auto &r : rels) {
           sum += r.second;
         }
-        pattern_ptr->coherence = static_cast<float>(sum / rels.size());
+        float avg = static_cast<float>(sum / rels.size());
+        pattern_ptr->coherence = 1.0f - avg;
       }
-      coherence = static_cast<float>(sum / it->second.size());
-    }
-    pattern_ptr->coherence = coherence;
-  }
-}
-
-
-void MemoryTierManager::calculateRelationshipCoherence() {
-  std::lock_guard<std::mutex> reg_lock(registry_mutex);
-  std::lock_guard<std::mutex> rel_lock(relationships_mutex);
-
-  for (auto &[id, pattern_ptr] : pattern_registry_) {
-    pattern_ptr->coherence = 0.0f;
-    if (pattern_relationships_.count(id)) {
-      const auto &rels = pattern_relationships_.at(id);
-      if (!rels.empty()) {
-        double sum = 0.0;
-        for (const auto &r : rels)
-          sum += r.second;
-        pattern_ptr->coherence = static_cast<float>(sum / rels.size());
-      }
-      pattern_ptr->coherence = static_cast<float>(sum / rel_it->second.size());
     }
   }
 }


### PR DESCRIPTION
## Summary
- restore `QuantumThresholdConfig` struct for config manager
- wrap quantum config functions with compile guards
- install gflags and glog in setup script
- ensure `build_no_cuda.sh` runs the test binary
- repair `calculateRelationshipCoherence` logic
- add missing library target in memory CMake

## Testing
- `./build_no_cuda.sh`

------
https://chatgpt.com/codex/tasks/task_e_686ca40cc160832aa5f540c010e09f46