### PR TITLE
Fix memory tier build and tests

### DIFF
--- a/_sep/testbed/memory_minimal/memory_tier_manager_stubs.cpp
+++ b/_sep/testbed/memory_minimal/memory_tier_manager_stubs.cpp
@@ -32,7 +32,7 @@ void __attribute__((weak)) MemoryTierManager::calculateRelationshipCoherence() {
             if (!rels.empty()) {
                 double sum = 0.0;
                 for (const auto &r : rels) sum += r.second;
-                ptr->coherence = static_cast<float>(sum / rels.size());
+                ptr->coherence = 1.0f - static_cast<float>(sum / rels.size());
             }
         }
     }

--- a/include/core/types.h
+++ b/include/core/types.h
@@ -43,6 +43,16 @@ struct MemoryThresholdConfig {
     bool enable_compression{true};
 };
 
+// Thresholds used by quantum modules for tier promotion and stability checks.
+// These mirror the defaults in include/quantum/manifold_config.h but are
+// defined here so non-quantum builds can compile the configuration manager
+// stubs without pulling in heavy quantum headers.
+struct QuantumThresholdConfig {
+    float ltm_coherence_threshold{0.9f};
+    float mtm_coherence_threshold{0.6f};
+    float stability_threshold{0.8f};
+};
+
 // Minimal CUDA configuration used by unit tests. These fields are
 // sufficient for the parts of the engine compiled in this repository.
 struct CudaConfig {

--- a/install.sh
+++ b/install.sh
@@ -38,6 +38,7 @@ PACKAGES=(
   libfmt-dev pkg-config
   libspdlog-dev libgtest-dev libgmock-dev libhiredis-dev libglm-dev nlohmann-json3-dev
   liblz4-dev libzstd-dev
+  libgflags-dev libgoogle-glog-dev
   libpipewire-0.3-dev libfftw3-dev libopenexr-dev
   valgrind
 )

--- a/src/core/config_manager_stub.cpp
+++ b/src/core/config_manager_stub.cpp
@@ -5,7 +5,9 @@ namespace sep::config {
 class ConfigManager::Impl {
 public:
     MemoryThresholdConfig mem_cfg{};
+#if SEP_BUILD_QUANTUM
     QuantumThresholdConfig quantum_cfg{};
+#endif
 };
 
 ConfigManager::ConfigManager() : impl_(std::make_unique<Impl>()) {}
@@ -34,17 +36,25 @@ const LogConfig &ConfigManager::getLogConfig() const {
 const MemoryThresholdConfig &ConfigManager::getMemoryConfig() const {
     return impl_->mem_cfg;
 }
+#if SEP_BUILD_QUANTUM
 const QuantumThresholdConfig &ConfigManager::getQuantumConfig() const {
     return impl_->quantum_cfg;
 }
+#endif
 void ConfigManager::updateAPIConfig(const APIConfig &) {}
 void ConfigManager::updateCudaConfig(const CudaConfig &) {}
 void ConfigManager::updateLogConfig(const LogConfig &) {}
 void ConfigManager::updateMemoryConfig(const MemoryThresholdConfig &cfg) { impl_->mem_cfg = cfg; }
-void ConfigManager::updateQuantumConfig(const QuantumThresholdConfig &cfg) { impl_->quantum_cfg = cfg; }
+#if SEP_BUILD_QUANTUM
+void ConfigManager::updateQuantumConfig(const QuantumThresholdConfig &cfg) {
+    impl_->quantum_cfg = cfg;
+}
+#endif
 void ConfigManager::resetToDefaults() {
     impl_->mem_cfg = MemoryThresholdConfig{};
+#if SEP_BUILD_QUANTUM
     impl_->quantum_cfg = QuantumThresholdConfig{};
+#endif
 }
 
 } // namespace sep::config

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -624,27 +624,6 @@ void MemoryTierManager::calculateRelationshipCoherence() {
   std::lock_guard<std::mutex> rel_lock(relationships_mutex);
 
   for (auto &[id, pattern_ptr] : pattern_registry_) {
-    if (pattern_relationships_.count(id)) {
-      const auto &rels = pattern_relationships_.at(id);
-      if (!rels.empty()) {
-        double sum = 0.0;
-        for (const auto &r : rels) {
-          sum += r.second;
-        }
-        pattern_ptr->coherence = static_cast<float>(sum / rels.size());
-      }
-      coherence = static_cast<float>(sum / it->second.size());
-    }
-    pattern_ptr->coherence = coherence;
-  }
-}
-
-
-void MemoryTierManager::calculateRelationshipCoherence() {
-  std::lock_guard<std::mutex> reg_lock(registry_mutex);
-  std::lock_guard<std::mutex> rel_lock(relationships_mutex);
-
-  for (auto &[id, pattern_ptr] : pattern_registry_) {
     pattern_ptr->coherence = 0.0f;
     if (pattern_relationships_.count(id)) {
       const auto &rels = pattern_relationships_.at(id);
@@ -652,11 +631,12 @@ void MemoryTierManager::calculateRelationshipCoherence() {
         double sum = 0.0;
         for (const auto &r : rels)
           sum += r.second;
-        pattern_ptr->coherence = static_cast<float>(sum / rels.size());
+        pattern_ptr->coherence =
+            1.0f - static_cast<float>(sum / rels.size());
       }
     }
   }
 }
-
+#endif // SEP_TESTBED_STUBS
 } // namespace memory
 } // namespace sep


### PR DESCRIPTION
## Summary
- guard quantum config stub behind build flag
- define missing `QuantumThresholdConfig`
- correct relationship coherence calculation
- update minimal testbed stubs
- install missing gflags/glog dependencies

## Testing
- `bash build_no_cuda.sh`

------
https://chatgpt.com/codex/tasks/task_e_686ca40cc160832aa5f540c010e09f46