### PR TITLE
Fix duplicate quantum config accessor

### DIFF
--- a/src/core/manager.cpp
+++ b/src/core/manager.cpp
@@ -36,10 +36,6 @@ const LogConfig& ConfigManager::getLogConfig() const {
 const MemoryThresholdConfig& ConfigManager::getMemoryConfig() const {
     return impl_->mem_cfg;
 }
-#if SEP_BUILD_QUANTUM
-const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
-    return impl_->quantum_cfg;
-}
 void ConfigManager::updateAPIConfig(const APIConfig&) {}
 void ConfigManager::updateCudaConfig(const CudaConfig&) {}
 void ConfigManager::updateLogConfig(const LogConfig&) {}


### PR DESCRIPTION
## Summary
- remove redundant implementation of `getQuantumConfig` in `manager.cpp`

## Testing
- `cmake ..` *(fails: Could not find nvcc)*
- `cmake .. -DSEP_HAS_CUDA=0` *(fails: Could NOT find OpenSubdiv)*

------
https://chatgpt.com/codex/tasks/task_e_686ca90d96d8832a8cfc37de199e6265