### PR TITLE
Fix core cmake and cleanup headers

### DIFF
--- a/_sep/testbed/memory_minimal/CMakeLists.txt
+++ b/_sep/testbed/memory_minimal/CMakeLists.txt
@@ -21,6 +21,7 @@ set(SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../src)
 set(MEMORY_SRC
     ${SRC_DIR}/memory/memory_tier.cpp
     ${SRC_DIR}/core/logging.cpp
+    ${SRC_DIR}/memory/memory_tier_manager_serialization.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/memory_tier_manager_stubs.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/allocation_metrics_stub.cpp
 )

--- a/include/core/types.h
+++ b/include/core/types.h
@@ -52,30 +52,6 @@ struct QuantumThresholdConfig {
     float stability_threshold{0.8f};
 };
 
-// Quantum processing thresholds used by experimental components
-struct QuantumThresholdConfig {
-    float ltm_coherence_threshold{0.9f};
-    float mtm_coherence_threshold{0.6f};
-    float stability_threshold{0.8f};
-};
-
-// Minimal quantum processing thresholds used by tests. The real engine
-// defines a richer configuration, but the memory manager tests only
-// require a handful of fields. Provide a lightweight struct here so the
-// stub configuration manager can compile without pulling in the full
-// quantum stack.
-struct QuantumThresholdConfig {
-    float ltm_coherence_threshold{0.9f};
-    float mtm_coherence_threshold{0.6f};
-    float stability_threshold{0.8f};
-};
-
-struct QuantumThresholdConfig {
-    float ltm_coherence_threshold{0.9f};
-    float mtm_coherence_threshold{0.6f};
-    float stability_threshold{0.8f};
-};
-
 // Minimal CUDA configuration used by unit tests. These fields are
 // sufficient for the parts of the engine compiled in this repository.
 struct CudaConfig {
@@ -108,13 +84,6 @@ struct LogConfig {
     std::string level{"info"};
     std::string file{};
     std::string dir{"logs"};
-};
-
-// Quantum memory/coherence thresholds used by quantum processing components
-struct QuantumThresholdConfig {
-    float ltm_coherence_threshold{0.9f};
-    float mtm_coherence_threshold{0.6f};
-    float stability_threshold{0.8f};
 };
 
 // Basic analytics configuration used by quantum components

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -9,6 +9,8 @@ set(SEP_CORE_SOURCES
     logging.cpp
 )
 
+add_library(sep_core STATIC ${SEP_CORE_SOURCES})
+
 # The core library does not require Redis for these tests. Explicitly
 # disable Redis support so headers guarded by SEP_NO_REDIS do not
 # trigger missing include errors when building in minimal mode.


### PR DESCRIPTION
## Summary
- add missing `sep_core` library target
- remove duplicate `QuantumThresholdConfig` definitions
- link serialization code for memory testbed

## Testing
- `cmake .. -DSEP_ENABLE_BLENDER=OFF -DSEP_ENABLE_AUDIO=OFF -DSEP_HAS_CUDA=0 -DSEP_WITH_OPENSUBDIV=OFF -DSEP_WITH_OPENPGL=OFF -DSEP_WITH_OCIO=OFF -DSEP_WITH_OPENIMAGEIO=OFF -DSEP_WITH_EMBREE=OFF -DSEP_WITH_OSL=OFF -DSEP_WITH_ALEMBIC=OFF -DSEP_MINIMAL=ON`
- `make -j$(nproc)` *(fails: conversion from `MemoryTierManager::Config` to JSON)*

------
https://chatgpt.com/codex/tasks/task_e_686cae980c80832a9d5f53f2693fa564