### PR TITLE
Improve dependency installer

### DIFF
--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -15,12 +15,25 @@ sudo apt-get install -y \
     libasio-dev \
     libssl-dev \
     libcurl4-openssl-dev \
+    libhttp-parser-dev \
     liblz4-dev \
     libzstd-dev \
     libpipewire-0.3-dev \
     libbenchmark-dev \
     libgtest-dev \
-    libomp-dev
+    libomp-dev \
+    libgflags-dev \
+    libgoogle-glog-dev \
+    libopenvdb-dev \
+    libopenexr-dev \
+    libopencolorio-dev \
+    libopenimageio-dev \
+    libembree-dev \
+    libpugixml-dev \
+    libopenjp2-7-dev \
+    libtbb-dev \
+    nlohmann-json3-dev \
+    pkg-config
 
 # Optional: CUDA toolkit for GPU builds
 if [ "${INSTALL_CUDA:-}" = "1" ]; then


### PR DESCRIPTION
## Summary
- expand `install_dependencies.sh` to include all required packages

## Testing
- `bash -n scripts/install_dependencies.sh`
- `./build_no_cuda.sh` *(fails: `sep_core` target missing)*
- `cmake` configuring testbed *(fails: multiple struct redefinition errors)*

------
https://chatgpt.com/codex/tasks/task_e_686d12e77ab4832a953d1f70879d1451