### PR TITLE
Update dependency install scripts

### DIFF
--- a/install_dependencies.py
+++ b/install_dependencies.py
@@ -30,9 +30,9 @@ def install_package(package_name):
         print(f"Error installing {package_name}: {e}")
         return False
 
-def run_script(script_path, with_cuda=False):
+def run_script(script_path, install_cuda=False):
     env = os.environ.copy()
-    env["INSTALL_CUDA"] = "1" if with_cuda else "0"
+    env["INSTALL_CUDA"] = "1" if install_cuda else "0"
     try:
         subprocess.check_call(["bash", script_path], env=env)
         return True
@@ -46,7 +46,9 @@ packages = ["requests", "numpy"]
 # Install pip if needed
 def main():
     parser = argparse.ArgumentParser(description="Install SEP Engine dependencies")
-    parser.add_argument("--with-cuda", action="store_true", help="Install CUDA toolkit")
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--with-cuda", action="store_true", help="Install CUDA toolkit")
+    group.add_argument("--no-cuda", action="store_true", help="Skip CUDA installation (default)")
     args = parser.parse_args()
 
     if install_pip():
@@ -54,7 +56,8 @@ def main():
             install_package(package)
 
     script = os.path.join(os.path.dirname(__file__), "scripts", "install_dependencies.sh")
-    if not run_script(script, with_cuda=args.with_cuda):
+    install_cuda = args.with_cuda and not args.no_cuda
+    if not run_script(script, install_cuda=install_cuda):
         sys.exit(1)
 
     print("\nDependency installation complete. You can now try enabling the SEP Engine addon.")

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -1,60 +1,59 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 # Default to skipping CUDA unless INSTALL_CUDA is explicitly set
 : "${INSTALL_CUDA:=0}"
 
-# Update package lists
-sudo apt-get update
+# Allow running as root without sudo
+[ "$(id -u)" -eq 0 ] && SUDO="" || SUDO="sudo"
 
-# Install system packages
-sudo apt-get install -y \
-    build-essential \
-    cmake \
-    libspdlog-dev \
-    libfmt-dev \
-    libglm-dev \
-    libboost-all-dev \
-    libasio-dev \
-    libssl-dev \
-    libcurl4-openssl-dev \
-    libhttp-parser-dev \
-    liblz4-dev \
-    libzstd-dev \
-    libgflags-dev \
-    libgoogle-glog-dev \
-    libembree-dev \
-    libpugixml-dev \
-    libopenjp2-7-dev \
-    libopenvdb-dev \
-    libimath-dev \
-    libtbb-dev \
-    libopenexr-dev \
-    libopencolorio-dev \
-    libopenimageio-dev \
-    libpipewire-0.3-dev \
-    libbenchmark-dev \
-    libgtest-dev \
-    libomp-dev \
-    libgflags-dev \
-    libgoogle-glog-dev \
-    libopenvdb-dev \
-    libopenexr-dev \
-    libopencolorio-dev \
-    libopenimageio-dev \
-    libembree-dev \
-    libpugixml-dev \
-    libopenjp2-7-dev \
-    libtbb-dev \
-    nlohmann-json3-dev \
+# Basic compiler commands for later verification
+CXX=${CXX:-$(command -v g++ || echo g++)}
+
+# Update package lists
+$SUDO apt-get update -y
+
+# Install system packages (duplicates removed)
+PACKAGES=(
+    build-essential
+    cmake
+    libspdlog-dev
+    libfmt-dev
+    libglm-dev
+    libboost-all-dev
+    libasio-dev
+    libssl-dev
+    libcurl4-openssl-dev
+    libhttp-parser-dev
+    liblz4-dev
+    libzstd-dev
+    libgflags-dev
+    libgoogle-glog-dev
+    libembree-dev
+    libpugixml-dev
+    libopenjp2-7-dev
+    libopenvdb-dev
+    libimath-dev
+    libtbb-dev
+    libopenexr-dev
+    libopencolorio-dev
+    libopenimageio-dev
+    libpipewire-0.3-dev
+    libbenchmark-dev
+    libgtest-dev
+    libomp-dev
+    nlohmann-json3-dev
     pkg-config
+)
+
+$SUDO apt-get install -y "${PACKAGES[@]}"
 
 # Optional: CUDA toolkit for GPU builds
 if [ "${INSTALL_CUDA:-}" = "1" ]; then
     wget -q https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb -O /tmp/cuda-keyring.deb
-    sudo dpkg -i /tmp/cuda-keyring.deb
-    sudo apt-get update
-    sudo apt-get -y install cuda-toolkit-12-9
+    $SUDO dpkg -i /tmp/cuda-keyring.deb
+    $SUDO apt-get update -y
+    $SUDO apt-get -y install cuda-toolkit-12-9
 fi
 
 # Clone Crow (header-only web framework) if not present
@@ -68,10 +67,13 @@ if [ ! -d "third_party/glm" ]; then
 fi
 
 # Build GoogleTest libraries
-cd /usr/src/googletest
-sudo cmake . -B build
-sudo cmake --build build --target install
+if [ -d /usr/src/googletest ]; then
+    cd /usr/src/googletest
+    $SUDO cmake . -B build
+    $SUDO cmake --build build --target install
+    $SUDO ldconfig
+fi
 
 # Verify toolchain presence
+$CXX --version 2>/dev/null || true
 cmake --version
-g++ --version


### PR DESCRIPTION
## Summary
- fix dependency installation script to work without CUDA by default
- clean up package list and allow running without sudo when already root
- add mutually exclusive `--with-cuda`/`--no-cuda` flags in Python wrapper

## Testing
- `./build_no_cuda.sh`

------
https://chatgpt.com/codex/tasks/task_e_686d15fbdc8c832aa1bd6f626dfdab96