### PR TITLE
Update dependency scripts with minimal option

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ distributions). These are now installed automatically by `install.sh`.
 ./install.sh
 ```
 
-Add `--no-cuda` if you do not need CUDA support. Once installed, compile and execute the memory manager tests to validate the setup:
+Add `--no-cuda` if you do not need CUDA support. Use `--minimal` to install only the packages required for unit tests (skipping heavy rendering dependencies). Once installed, compile and execute the memory manager tests to validate the setup:
 
 ```bash
 cd sep_build/build

--- a/install_dependencies.py
+++ b/install_dependencies.py
@@ -30,9 +30,10 @@ def install_package(package_name):
         print(f"Error installing {package_name}: {e}")
         return False
 
-def run_script(script_path, with_cuda=False):
+def run_script(script_path, with_cuda=False, minimal=False):
     env = os.environ.copy()
     env["INSTALL_CUDA"] = "1" if with_cuda else "0"
+    env["INSTALL_MINIMAL"] = "1" if minimal else "0"
     try:
         subprocess.check_call(["bash", script_path], env=env)
         return True
@@ -47,6 +48,7 @@ packages = ["requests", "numpy"]
 def main():
     parser = argparse.ArgumentParser(description="Install SEP Engine dependencies")
     parser.add_argument("--with-cuda", action="store_true", help="Install CUDA toolkit")
+    parser.add_argument("--minimal", action="store_true", help="Install only core dependencies")
     args = parser.parse_args()
 
     if install_pip():
@@ -54,7 +56,7 @@ def main():
             install_package(package)
 
     script = os.path.join(os.path.dirname(__file__), "scripts", "install_dependencies.sh")
-    if not run_script(script, with_cuda=args.with_cuda):
+    if not run_script(script, with_cuda=args.with_cuda, minimal=args.minimal):
         sys.exit(1)
 
     print("\nDependency installation complete. You can now try enabling the SEP Engine addon.")

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -1,53 +1,40 @@
 #!/usr/bin/env bash
 set -e
 
-# Default to skipping CUDA unless INSTALL_CUDA is explicitly set
+# Unless overridden, install the full dependency set.
+: "${INSTALL_MINIMAL:=0}"
 : "${INSTALL_CUDA:=0}"
 
-# Update package lists
-sudo apt-get update
+# Base packages required for building and running unit tests
+BASE_PACKAGES=(
+    build-essential cmake git
+    libspdlog-dev libfmt-dev libglm-dev
+    libboost-all-dev libasio-dev libssl-dev
+    libcurl4-openssl-dev libhttp-parser-dev
+    liblz4-dev libzstd-dev
+    libgflags-dev libgoogle-glog-dev
+    libpugixml-dev libopenjp2-7-dev
+    libimath-dev libtbb-dev libopenexr-dev
+    libpipewire-0.3-dev libbenchmark-dev
+    libgtest-dev libomp-dev
+    nlohmann-json3-dev pkg-config
+)
 
-# Install system packages
-sudo apt-get install -y \
-    build-essential \
-    cmake \
-    libspdlog-dev \
-    libfmt-dev \
-    libglm-dev \
-    libboost-all-dev \
-    libasio-dev \
-    libssl-dev \
-    libcurl4-openssl-dev \
-    libhttp-parser-dev \
-    liblz4-dev \
-    libzstd-dev \
-    libgflags-dev \
-    libgoogle-glog-dev \
-    libembree-dev \
-    libpugixml-dev \
-    libopenjp2-7-dev \
-    libopenvdb-dev \
-    libimath-dev \
-    libtbb-dev \
-    libopenexr-dev \
-    libopencolorio-dev \
-    libopenimageio-dev \
-    libpipewire-0.3-dev \
-    libbenchmark-dev \
-    libgtest-dev \
-    libomp-dev \
-    libgflags-dev \
-    libgoogle-glog-dev \
-    libopenvdb-dev \
-    libopenexr-dev \
-    libopencolorio-dev \
-    libopenimageio-dev \
-    libembree-dev \
-    libpugixml-dev \
-    libopenjp2-7-dev \
-    libtbb-dev \
-    nlohmann-json3-dev \
-    pkg-config
+# Additional heavy libraries used by rendering integrations
+FULL_PACKAGES=(
+    libembree-dev libopenvdb-dev
+    libopencolorio-dev libopenimageio-dev
+)
+
+# Choose package list based on INSTALL_MINIMAL flag
+if [ "${INSTALL_MINIMAL}" = "1" ]; then
+    PACKAGES=("${BASE_PACKAGES[@]}")
+else
+    PACKAGES=("${BASE_PACKAGES[@]}" "${FULL_PACKAGES[@]}")
+fi
+
+sudo apt-get update
+sudo apt-get install -y "${PACKAGES[@]}"
 
 # Optional: CUDA toolkit for GPU builds
 if [ "${INSTALL_CUDA:-}" = "1" ]; then


### PR DESCRIPTION
## Summary
- extend the Python installer to accept a `--minimal` flag
- add `INSTALL_MINIMAL` mode in `install_dependencies.sh`
- update README to document the flag

## Testing
- `./build_no_cuda.sh`

------
https://chatgpt.com/codex/tasks/task_e_686d15fbdc8c832aa1bd6f626dfdab96