### PR TITLE
Add minimal dependency install option

### DIFF
--- a/install_dependencies.py
+++ b/install_dependencies.py
@@ -30,9 +30,12 @@ def install_package(package_name):
         print(f"Error installing {package_name}: {e}")
         return False
 
-def run_script(script_path, with_cuda=False):
+def run_script(script_path, with_cuda=False, env_overrides=None):
     env = os.environ.copy()
     env["INSTALL_CUDA"] = "1" if with_cuda else "0"
+    if env_overrides:
+        if env_overrides.get("minimal"):
+            env["INSTALL_MINIMAL"] = "1"
     try:
         subprocess.check_call(["bash", script_path], env=env)
         return True
@@ -47,6 +50,7 @@ packages = ["requests", "numpy"]
 def main():
     parser = argparse.ArgumentParser(description="Install SEP Engine dependencies")
     parser.add_argument("--with-cuda", action="store_true", help="Install CUDA toolkit")
+    parser.add_argument("--minimal", action="store_true", help="Install only packages required for running unit tests")
     args = parser.parse_args()
 
     if install_pip():
@@ -54,7 +58,11 @@ def main():
             install_package(package)
 
     script = os.path.join(os.path.dirname(__file__), "scripts", "install_dependencies.sh")
-    if not run_script(script, with_cuda=args.with_cuda):
+    env = {
+        "with_cuda": args.with_cuda,
+        "minimal": args.minimal,
+    }
+    if not run_script(script, with_cuda=args.with_cuda, env_overrides=env):
         sys.exit(1)
 
     print("\nDependency installation complete. You can now try enabling the SEP Engine addon.")

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -3,51 +3,54 @@ set -e
 
 # Default to skipping CUDA unless INSTALL_CUDA is explicitly set
 : "${INSTALL_CUDA:=0}"
+# Allow a reduced package set for headless builds
+: "${INSTALL_MINIMAL:=0}"
 
 # Update package lists
 sudo apt-get update
 
-# Install system packages
-sudo apt-get install -y \
-    build-essential \
-    cmake \
-    libspdlog-dev \
-    libfmt-dev \
-    libglm-dev \
-    libboost-all-dev \
-    libasio-dev \
-    libssl-dev \
-    libcurl4-openssl-dev \
-    libhttp-parser-dev \
-    liblz4-dev \
-    libzstd-dev \
-    libgflags-dev \
-    libgoogle-glog-dev \
-    libembree-dev \
-    libpugixml-dev \
-    libopenjp2-7-dev \
-    libopenvdb-dev \
-    libimath-dev \
-    libtbb-dev \
-    libopenexr-dev \
-    libopencolorio-dev \
-    libopenimageio-dev \
-    libpipewire-0.3-dev \
-    libbenchmark-dev \
-    libgtest-dev \
-    libomp-dev \
-    libgflags-dev \
-    libgoogle-glog-dev \
-    libopenvdb-dev \
-    libopenexr-dev \
-    libopencolorio-dev \
-    libopenimageio-dev \
-    libembree-dev \
-    libpugixml-dev \
-    libopenjp2-7-dev \
-    libtbb-dev \
-    nlohmann-json3-dev \
+# Base packages required for all builds
+BASE_PACKAGES=(
+    build-essential
+    cmake
+    libspdlog-dev
+    libfmt-dev
+    libglm-dev
+    libboost-all-dev
+    libcurl4-openssl-dev
+    libhttp-parser-dev
+    liblz4-dev
+    libzstd-dev
+    libgflags-dev
+    libgoogle-glog-dev
+    libbenchmark-dev
+    libgtest-dev
+    libomp-dev
+    nlohmann-json3-dev
     pkg-config
+)
+
+# Additional libraries needed for full renderer builds
+RENDER_PACKAGES=(
+    libasio-dev
+    libssl-dev
+    libembree-dev
+    libpugixml-dev
+    libopenjp2-7-dev
+    libopenvdb-dev
+    libimath-dev
+    libtbb-dev
+    libopenexr-dev
+    libopencolorio-dev
+    libopenimageio-dev
+    libpipewire-0.3-dev
+)
+
+if [ "${INSTALL_MINIMAL}" = "1" ]; then
+    sudo apt-get install -y "${BASE_PACKAGES[@]}"
+else
+    sudo apt-get install -y "${BASE_PACKAGES[@]}" "${RENDER_PACKAGES[@]}"
+fi
 
 # Optional: CUDA toolkit for GPU builds
 if [ "${INSTALL_CUDA:-}" = "1" ]; then


### PR DESCRIPTION
## Summary
- support minimal dependency installation via `--minimal`
- respect INSTALL_MINIMAL in `install_dependencies.sh` and deduplicate package lists

## Testing
- `./build_no_cuda.sh`

------
https://chatgpt.com/codex/tasks/task_e_686d179919c0832aa9b0793a7e7f03f8