### PR TITLE
Improve build path checks

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -64,7 +64,7 @@ check_package() {
     
     # Check for libraries in multiple locations (suppress permission errors)
     if ldconfig -p 2>/dev/null | grep -q -i "$lib_base" ||
-       find /usr/lib* -name "${lib_base}*.so*" 2>/dev/null | grep -q . ||
+       find /usr/lib* /usr/lib/x86_64-linux-gnu -name "${lib_base}*.so*" 2>/dev/null | grep -q . ||
        find /usr/local/lib* -name "${lib_base}*.so*" 2>/dev/null | grep -q .; then
       echo "✓ $pkg_name found"
       return 0
@@ -307,18 +307,26 @@ fi
 # Create build directory
 mkdir -p "${BUILD_DIR}"
 
-# Create symbolic link for Cycles if it exists in the primary location
-if [ ! -L "${CYCLES_ROOT_DIR}" ] && [ -d "${SRC_DIR}/cycles" ]; then
-  echo "Found Cycles at ${SRC_DIR}/cycles, creating symlink..."
-  mkdir -p "$(dirname "${CYCLES_ROOT_DIR}")"
-  ln -sf "${SRC_DIR}/cycles" "${CYCLES_ROOT_DIR}"
-fi
+# Optionally disable Cycles integration
+if [ "${SKIP_CYCLES:-0}" != "1" ]; then
+  # Create symbolic link for Cycles if it exists in the primary location
+  if [ ! -L "${CYCLES_ROOT_DIR}" ] && [ -d "${SRC_DIR}/cycles" ]; then
+    echo "Found Cycles at ${SRC_DIR}/cycles, creating symlink..."
+    mkdir -p "$(dirname "${CYCLES_ROOT_DIR}")"
+    ln -sf "${SRC_DIR}/cycles" "${CYCLES_ROOT_DIR}"
+  fi
 
-if [ ! -d "${CYCLES_ROOT_DIR}" ]; then
-  echo "Error: Cycles directory not found at ${SRC_DIR}/cycles or ${CYCLES_ROOT_DIR}."
-  exit 1
+  if [ ! -d "${CYCLES_ROOT_DIR}" ]; then
+    echo "Warning: Cycles directory not found. Building without Cycles support."
+    export CMAKE_ARGS="${CMAKE_ARGS} -DSEP_WITH_CYCLES=OFF"
+    SKIP_CYCLES=1
+  else
+    echo "Using Cycles root: ${CYCLES_ROOT_DIR}"
+  fi
+else
+  echo "Skipping Cycles checks by request"
+  export CMAKE_ARGS="${CMAKE_ARGS} -DSEP_WITH_CYCLES=OFF"
 fi
-echo "Using Cycles root: ${CYCLES_ROOT_DIR}"
 
 # --- Dependency Detection ---
 # Check for PipeWire using pkg-config (most reliable method)

--- a/install_dependencies.py
+++ b/install_dependencies.py
@@ -30,9 +30,10 @@ def install_package(package_name):
         print(f"Error installing {package_name}: {e}")
         return False
 
-def run_script(script_path, install_cuda=False):
+def run_script(script_path, install_cuda=False, install_cycles=False):
     env = os.environ.copy()
     env["INSTALL_CUDA"] = "1" if install_cuda else "0"
+    env["SKIP_CYCLES"] = "0" if install_cycles else "1"
     try:
         subprocess.check_call(["bash", script_path], env=env)
         return True
@@ -46,9 +47,13 @@ packages = ["requests", "numpy"]
 # Install pip if needed
 def main():
     parser = argparse.ArgumentParser(description="Install SEP Engine dependencies")
-    group = parser.add_mutually_exclusive_group()
-    group.add_argument("--with-cuda", action="store_true", help="Install CUDA toolkit")
-    group.add_argument("--no-cuda", action="store_true", help="Skip CUDA installation (default)")
+    cuda_group = parser.add_mutually_exclusive_group()
+    cuda_group.add_argument("--with-cuda", action="store_true", help="Install CUDA toolkit")
+    cuda_group.add_argument("--no-cuda", action="store_true", help="Skip CUDA installation (default)")
+
+    cycles_group = parser.add_mutually_exclusive_group()
+    cycles_group.add_argument("--with-cycles", action="store_true", help="Install Cycles renderer")
+    cycles_group.add_argument("--no-cycles", action="store_true", help="Skip Cycles setup (default)")
     args = parser.parse_args()
 
     if install_pip():
@@ -57,7 +62,8 @@ def main():
 
     script = os.path.join(os.path.dirname(__file__), "scripts", "install_dependencies.sh")
     install_cuda = args.with_cuda and not args.no_cuda
-    if not run_script(script, install_cuda=install_cuda):
+    install_cycles = args.with_cycles and not args.no_cycles
+    if not run_script(script, install_cuda=install_cuda, install_cycles=install_cycles):
         sys.exit(1)
 
     print("\nDependency installation complete. You can now try enabling the SEP Engine addon.")


### PR DESCRIPTION
## Summary
- fix library lookup paths in `build.sh`
- allow skipping Cycles checks
- add `--with-cycles/--no-cycles` to dependency installer

## Testing
- `./build_no_cuda.sh`


------
https://chatgpt.com/codex/tasks/task_e_686d18f97e5c832a9be13a5cfb665b84