### PR TITLE
Fix CUDA testbed library link language

### DIFF
--- a/_sep/testbed/cuda/CMakeLists.txt
+++ b/_sep/testbed/cuda/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_library(testbed_cuda_kernels STATIC increment_kernel.cu)
 set_property(TARGET testbed_cuda_kernels PROPERTY CUDA_STANDARD 17)
+set_property(TARGET testbed_cuda_kernels PROPERTY LINKER_LANGUAGE CUDA)


### PR DESCRIPTION
## Summary
- specify CUDA linker language for `testbed_cuda_kernels`

## Testing
- `./build_no_cuda.sh`

------
https://chatgpt.com/codex/tasks/task_e_686d19501778832aa455995feb82e872