### PR TITLE
Improve dependency installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,12 @@ distributions). These are now installed automatically by `install.sh`.
 ./install.sh
 ```
 
+Alternatively you can invoke the Python wrapper which exposes the same options:
+
+```bash
+python install_dependencies.py --minimal --no-cuda
+```
+
 Add `--no-cuda` if you do not need CUDA support. Use `--minimal` to install only the packages required for unit tests (skipping heavy rendering dependencies). Once installed, compile and execute the memory manager tests to validate the setup:
 
 ```bash

--- a/install_dependencies.py
+++ b/install_dependencies.py
@@ -30,9 +30,9 @@ def install_package(package_name):
         print(f"Error installing {package_name}: {e}")
         return False
 
-def run_script(script_path, install_cuda=False):
-    env = os.environ.copy()
-    env["INSTALL_CUDA"] = "1" if install_cuda else "0"
+def run_script(script_path, env=None):
+    if env is None:
+        env = os.environ.copy()
     try:
         subprocess.check_call(["bash", script_path], env=env)
         return True
@@ -49,6 +49,7 @@ def main():
     group = parser.add_mutually_exclusive_group()
     group.add_argument("--with-cuda", action="store_true", help="Install CUDA toolkit")
     group.add_argument("--no-cuda", action="store_true", help="Skip CUDA installation (default)")
+    parser.add_argument("--minimal", action="store_true", help="Install minimal package set")
     args = parser.parse_args()
 
     if install_pip():
@@ -57,7 +58,11 @@ def main():
 
     script = os.path.join(os.path.dirname(__file__), "scripts", "install_dependencies.sh")
     install_cuda = args.with_cuda and not args.no_cuda
-    if not run_script(script, install_cuda=install_cuda):
+    env = os.environ.copy()
+    env["INSTALL_CUDA"] = "1" if install_cuda else "0"
+    if args.minimal:
+        env["INSTALL_MINIMAL"] = "1"
+    if not run_script(script, env=env):
         sys.exit(1)
 
     print("\nDependency installation complete. You can now try enabling the SEP Engine addon.")

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -17,30 +17,52 @@ if command -v apt-get >/dev/null 2>&1; then
     PM="apt-get"
     UPDATE_CMD="$SUDO apt-get update -y"
     INSTALL_CMD="$SUDO apt-get install -y"
-    PKGS=(
-        build-essential cmake git
-        libspdlog-dev libfmt-dev libglm-dev libboost-all-dev
-        libasio-dev libssl-dev libcurl4-openssl-dev libhttp-parser-dev
-        liblz4-dev libzstd-dev libgflags-dev libgoogle-glog-dev
-        libembree-dev libpugixml-dev libopenjp2-7-dev libopenvdb-dev
-        libimath-dev libtbb-dev libopenexr-dev libopencolorio-dev
-        libopenimageio-dev libpipewire-0.3-dev libbenchmark-dev
-        libgtest-dev libomp-dev nlohmann-json3-dev pkg-config
-    )
+    if [ "$INSTALL_MINIMAL" = "1" ]; then
+        PKGS=(
+            build-essential cmake git
+            libspdlog-dev libfmt-dev libglm-dev
+            libgflags-dev libgoogle-glog-dev
+            liblz4-dev libzstd-dev
+            libtbb-dev libbenchmark-dev
+            libgtest-dev libomp-dev nlohmann-json3-dev pkg-config
+        )
+    else
+        PKGS=(
+            build-essential cmake git
+            libspdlog-dev libfmt-dev libglm-dev libboost-all-dev
+            libasio-dev libssl-dev libcurl4-openssl-dev libhttp-parser-dev
+            liblz4-dev libzstd-dev libgflags-dev libgoogle-glog-dev
+            libembree-dev libpugixml-dev libopenjp2-7-dev libopenvdb-dev
+            libimath-dev libtbb-dev libopenexr-dev libopencolorio-dev
+            libopenimageio-dev libpipewire-0.3-dev libbenchmark-dev
+            libgtest-dev libomp-dev nlohmann-json3-dev pkg-config
+        )
+    fi
 elif command -v dnf >/dev/null 2>&1; then
     PM="dnf"
     UPDATE_CMD="$SUDO dnf -y update"
     INSTALL_CMD="$SUDO dnf -y install"
-    PKGS=(
-        gcc gcc-c++ make cmake git
-        spdlog-devel fmt-devel glm-devel boost-devel
-        asio-devel openssl-devel libcurl-devel http-parser-devel
-        lz4-devel zstd-devel gflags-devel glog-devel
-        embree-devel pugixml-devel openjpeg2-devel openvdb-devel
-        imath-devel tbb-devel openexr-devel OpenColorIO-devel
-        OpenImageIO-devel pipewire-devel benchmark-devel
-        gtest-devel libomp-devel nlohmann-json-devel pkgconfig
-    )
+    if [ "$INSTALL_MINIMAL" = "1" ]; then
+        PKGS=(
+            gcc gcc-c++ make cmake git
+            spdlog-devel fmt-devel glm-devel
+            gflags-devel glog-devel
+            lz4-devel zstd-devel
+            tbb-devel benchmark-devel
+            gtest-devel libomp-devel nlohmann-json-devel pkgconfig
+        )
+    else
+        PKGS=(
+            gcc gcc-c++ make cmake git
+            spdlog-devel fmt-devel glm-devel boost-devel
+            asio-devel openssl-devel libcurl-devel http-parser-devel
+            lz4-devel zstd-devel gflags-devel glog-devel
+            embree-devel pugixml-devel openjpeg2-devel openvdb-devel
+            imath-devel tbb-devel openexr-devel OpenColorIO-devel
+            OpenImageIO-devel pipewire-devel benchmark-devel
+            gtest-devel libomp-devel nlohmann-json-devel pkgconfig
+        )
+    fi
 else
     echo "Error: supported package manager not found (apt-get or dnf)" >&2
     exit 1


### PR DESCRIPTION
## Summary
- support a minimal package set
- allow python wrapper to pass INSTALL_MINIMAL to the shell script
- document python wrapper usage

## Testing
- `python -m py_compile install_dependencies.py`
- `bash -n scripts/install_dependencies.sh`


------
https://chatgpt.com/codex/tasks/task_e_686d18f97e5c832a9be13a5cfb665b84