### PR TITLE
Fix JSON serialization namespace and test paths

### DIFF
--- a/_sep/testbed/cross_language_memory_tier_test.cpp
+++ b/_sep/testbed/cross_language_memory_tier_test.cpp
@@ -12,15 +12,15 @@ TEST(CrossLanguage, MemoryTierConfigRoundTrip) {
     cfg.ltm_size = 4096;
 
     nlohmann::json j = cfg;
-    std::ofstream out("_sep/testbed/config_out.json");
+    std::ofstream out("../_sep/testbed/config_out.json");
     ASSERT_TRUE(out.is_open());
     out << j.dump();
     out.close();
 
-    int ret = std::system("node _sep/testbed/cross_language_memory.cjs _sep/testbed/config_out.json _sep/testbed/config_back.json");
+    int ret = std::system("node ../_sep/testbed/cross_language_memory.cjs ../_sep/testbed/config_out.json ../_sep/testbed/config_back.json");
     ASSERT_EQ(ret, 0);
 
-    std::ifstream in("_sep/testbed/config_back.json");
+    std::ifstream in("../_sep/testbed/config_back.json");
     ASSERT_TRUE(in.is_open());
     nlohmann::json j2;
     in >> j2;

--- a/_sep/testbed/memory_minimal/CMakeLists.txt
+++ b/_sep/testbed/memory_minimal/CMakeLists.txt
@@ -20,6 +20,7 @@ set(SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../src)
 
 set(MEMORY_SRC
     ${SRC_DIR}/memory/memory_tier.cpp
+    ${SRC_DIR}/memory/memory_tier_manager.cpp
     ${SRC_DIR}/core/logging.cpp
     ${SRC_DIR}/memory/memory_tier_manager_serialization.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/memory_tier_manager_stubs.cpp

--- a/include/memory/memory_tier_manager.hpp
+++ b/include/memory/memory_tier_manager.hpp
@@ -153,9 +153,11 @@ private:
   bool checkTierDemotion(const ::sep::pattern::PatternData &pattern) const;
 };
 
-void to_json(nlohmann::json &j, const MemoryTierManager::Config &c);
-
-void from_json(const nlohmann::json &j, MemoryTierManager::Config &c);
-
 } // namespace memory
+
+namespace config {
+void to_json(nlohmann::json &j, const MemoryThresholdConfig &c);
+void from_json(const nlohmann::json &j, MemoryThresholdConfig &c);
+} // namespace config
+
 } // namespace sep

--- a/src/memory/memory_tier_manager_serialization.cpp
+++ b/src/memory/memory_tier_manager_serialization.cpp
@@ -2,9 +2,9 @@
 #include <nlohmann/json.hpp>
 
 namespace sep {
-namespace memory {
+namespace config {
 
-void to_json(nlohmann::json& j, const MemoryTierManager::Config& c) {
+void to_json(nlohmann::json& j, const MemoryThresholdConfig& c) {
     j = nlohmann::json{
         {"stm_size", c.stm_size},
         {"mtm_size", c.mtm_size},
@@ -20,7 +20,7 @@ void to_json(nlohmann::json& j, const MemoryTierManager::Config& c) {
     };
 }
 
-void from_json(const nlohmann::json& j, MemoryTierManager::Config& c) {
+void from_json(const nlohmann::json& j, MemoryThresholdConfig& c) {
     c.stm_size = j.value("stm_size", static_cast<std::size_t>(1 << 20));
     c.mtm_size = j.value("mtm_size", static_cast<std::size_t>(4 << 20));
     c.ltm_size = j.value("ltm_size", static_cast<std::size_t>(16 << 20));
@@ -34,5 +34,5 @@ void from_json(const nlohmann::json& j, MemoryTierManager::Config& c) {
     c.mtm_to_ltm_min_gen = j.value("mtm_to_ltm_min_gen", 100u);
 }
 
-} // namespace memory
+} // namespace config
 } // namespace sep


### PR DESCRIPTION
## Summary
- move JSON serialization functions for MemoryThresholdConfig to `sep::config`
- include `memory_tier_manager.cpp` in memory_minimal tests
- adjust cross-language test file paths

## Testing
- `cmake ../_sep/testbed/memory_minimal`
- `make -j4`
- `./memory_minimal_tests`

------
https://chatgpt.com/codex/tasks/task_e_686d194c2e34832ab3955adc47dff2ca