### PR TITLE
Adjust utilization epsilon

### DIFF
--- a/include/memory/memory_tier.hpp
+++ b/include/memory/memory_tier.hpp
@@ -30,8 +30,8 @@ using PersistentPatternData = ::sep::persistence::PersistentPatternData;
 // 1 MiB tier while clamping rounding noise after promotions or defragmentation.
 // Increase the epsilon slightly so that tiny residual values after tier
 // defragmentation or promotion don't trip equality checks in unit tests.
-// Values below roughly 0.1% will now be clamped to zero.
-inline constexpr float kUtilizationEpsilon = 1e-3f;
+// Values below roughly 0.5% will now be clamped to zero.
+inline constexpr float kUtilizationEpsilon = 5e-3f;
 
 // Memory tier types
 enum class TierType {


### PR DESCRIPTION
## Summary
- tweak `kUtilizationEpsilon` to clamp tiny residual values more aggressively

## Testing
- `./build_no_cuda.sh`

------
https://chatgpt.com/codex/tasks/task_e_686d194c2e34832ab3955adc47dff2ca