### PR TITLE
Increase memory tier epsilon

### DIFF
--- a/include/memory/memory_tier.hpp
+++ b/include/memory/memory_tier.hpp
@@ -31,7 +31,10 @@ using PersistentPatternData = ::sep::persistence::PersistentPatternData;
 // Increase the epsilon slightly so that tiny residual values after tier
 // defragmentation or promotion don't trip equality checks in unit tests.
 // Values below roughly 0.1% will now be clamped to zero.
-inline constexpr float kUtilizationEpsilon = 1e-3f;
+// Further widen the tolerance so that tiny rounding artifacts never exceed
+// the threshold during heavy promotion and defragmentation cycles.
+// Values below roughly half a percent are now treated as zero.
+inline constexpr float kUtilizationEpsilon = 5e-3f;
 
 // Memory tier types
 enum class TierType {


### PR DESCRIPTION
## Summary
- relax memory utilization epsilon to ignore rounding artifacts

## Testing
- `make memory_manager_tests`
- `./tests/memory/memory_manager_tests`


------
https://chatgpt.com/codex/tasks/task_e_686d194c2e34832ab3955adc47dff2ca