### PR TITLE
Add minimal dependency option

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,20 @@ distributions). These are now installed automatically by `install.sh`.
 ./install.sh
 ```
 
-Add `--no-cuda` if you do not need CUDA support. Use `--minimal` to install only the packages required for unit tests (skipping heavy rendering dependencies). Once installed, compile and execute the memory manager tests to validate the setup:
+Add `--no-cuda` if you do not need CUDA support. Use `--minimal` to install only the packages required for unit tests (skipping heavy rendering dependencies). For example:
+
+```bash
+./install.sh --no-cuda --minimal
+```
+
+The Python helper `install_dependencies.py` offers the same functionality on systems
+without `sudo` access:
+
+```bash
+python3 install_dependencies.py --no-cuda --minimal
+```
+
+Once installed, compile and execute the memory manager tests to validate the setup:
 
 ```bash
 cd sep_build/build

--- a/install.sh
+++ b/install.sh
@@ -11,10 +11,15 @@ sudo apt-get update
 
 # Optional argument parsing
 USE_CUDA=1
+MINIMAL=0
 for arg in "$@"; do
   case "$arg" in
     --no-cuda)
       USE_CUDA=0
+      shift
+      ;;
+    --minimal)
+      MINIMAL=1
       shift
       ;;
   esac
@@ -32,20 +37,29 @@ LOG_DIR="$WS_DIR/logs"
 BUILD_DIR="$WS_DIR/build/deps"
 mkdir -p "$LOG_DIR" "$BUILD_DIR"
 
-PACKAGES=(
+BASE_PACKAGES=(
   build-essential cmake git
   libglu1-mesa-dev libpcre3-dev libtbb-dev libxrandr-dev libglfw3-dev
-  libboost-all-dev libopencolorio-dev libopenimageio-dev
-  libembree-dev libpugixml-dev libopenjp2-7-dev
-  libcurl4-openssl-dev libhttp-parser-dev libopenvdb-dev
+  libboost-all-dev
+  libpugixml-dev libopenjp2-7-dev
+  libcurl4-openssl-dev libhttp-parser-dev
   libfmt-dev pkg-config
   libspdlog-dev libgtest-dev libgmock-dev libhiredis-dev libglm-dev nlohmann-json3-dev
   libgflags-dev libgoogle-glog-dev
   liblz4-dev libzstd-dev
   libpipewire-0.3-dev libfftw3-dev libopenexr-dev
-  libgflags-dev libgoogle-glog-dev
   valgrind
 )
+EXTRA_PACKAGES=(
+  libopencolorio-dev libopenimageio-dev
+  libembree-dev libopenvdb-dev
+)
+
+if [ "$MINIMAL" -eq 1 ]; then
+  PACKAGES=("${BASE_PACKAGES[@]}")
+else
+  PACKAGES=("${BASE_PACKAGES[@]}" "${EXTRA_PACKAGES[@]}")
+fi
 
 echo "Updating package lists..."
 sudo apt-get update -y

--- a/install_dependencies.py
+++ b/install_dependencies.py
@@ -30,9 +30,10 @@ def install_package(package_name):
         print(f"Error installing {package_name}: {e}")
         return False
 
-def run_script(script_path, install_cuda=False):
+def run_script(script_path, install_cuda=False, minimal=False):
     env = os.environ.copy()
     env["INSTALL_CUDA"] = "1" if install_cuda else "0"
+    env["INSTALL_MINIMAL"] = "1" if minimal else "0"
     try:
         subprocess.check_call(["bash", script_path], env=env)
         return True
@@ -49,6 +50,7 @@ def main():
     group = parser.add_mutually_exclusive_group()
     group.add_argument("--with-cuda", action="store_true", help="Install CUDA toolkit")
     group.add_argument("--no-cuda", action="store_true", help="Skip CUDA installation (default)")
+    parser.add_argument("--minimal", action="store_true", help="Install only core dependencies")
     args = parser.parse_args()
 
     if install_pip():
@@ -57,7 +59,7 @@ def main():
 
     script = os.path.join(os.path.dirname(__file__), "scripts", "install_dependencies.sh")
     install_cuda = args.with_cuda and not args.no_cuda
-    if not run_script(script, install_cuda=install_cuda):
+    if not run_script(script, install_cuda=install_cuda, minimal=args.minimal):
         sys.exit(1)
 
     print("\nDependency installation complete. You can now try enabling the SEP Engine addon.")

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -17,33 +17,47 @@ if command -v apt-get >/dev/null 2>&1; then
     PM="apt-get"
     UPDATE_CMD="$SUDO apt-get update -y"
     INSTALL_CMD="$SUDO apt-get install -y"
-    PKGS=(
+    BASE_PKGS=(
         build-essential cmake git
         libspdlog-dev libfmt-dev libglm-dev libboost-all-dev
         libasio-dev libssl-dev libcurl4-openssl-dev libhttp-parser-dev
         liblz4-dev libzstd-dev libgflags-dev libgoogle-glog-dev
-        libembree-dev libpugixml-dev libopenjp2-7-dev libopenvdb-dev
-        libimath-dev libtbb-dev libopenexr-dev libopencolorio-dev
-        libopenimageio-dev libpipewire-0.3-dev libbenchmark-dev
+        libpugixml-dev libopenjp2-7-dev
+        libimath-dev libtbb-dev libopenexr-dev
+        libpipewire-0.3-dev libbenchmark-dev
         libgtest-dev libomp-dev nlohmann-json3-dev pkg-config
+    )
+    EXTRA_PKGS=(
+        libembree-dev libopenvdb-dev
+        libopencolorio-dev libopenimageio-dev
     )
 elif command -v dnf >/dev/null 2>&1; then
     PM="dnf"
     UPDATE_CMD="$SUDO dnf -y update"
     INSTALL_CMD="$SUDO dnf -y install"
-    PKGS=(
+    BASE_PKGS=(
         gcc gcc-c++ make cmake git
         spdlog-devel fmt-devel glm-devel boost-devel
         asio-devel openssl-devel libcurl-devel http-parser-devel
         lz4-devel zstd-devel gflags-devel glog-devel
-        embree-devel pugixml-devel openjpeg2-devel openvdb-devel
-        imath-devel tbb-devel openexr-devel OpenColorIO-devel
-        OpenImageIO-devel pipewire-devel benchmark-devel
+        pugixml-devel openjpeg2-devel
+        imath-devel tbb-devel openexr-devel
+        pipewire-devel benchmark-devel
         gtest-devel libomp-devel nlohmann-json-devel pkgconfig
+    )
+    EXTRA_PKGS=(
+        embree-devel openvdb-devel
+        OpenColorIO-devel OpenImageIO-devel
     )
 else
     echo "Error: supported package manager not found (apt-get or dnf)" >&2
     exit 1
+fi
+
+if [ "$INSTALL_MINIMAL" = "1" ]; then
+    PKGS=("${BASE_PKGS[@]}")
+else
+    PKGS=("${BASE_PKGS[@]}" "${EXTRA_PKGS[@]}")
 fi
 
 # Update package lists


### PR DESCRIPTION
## Summary
- support `--minimal` in dependency installers
- show minimal install usage in the README

## Testing
- `make memory_manager_tests`
- `./tests/memory/memory_manager_tests`

------
https://chatgpt.com/codex/tasks/task_e_686d18f97e5c832a9be13a5cfb665b84