### PR TITLE
Fix lookup map updates during memory block promotion

### DIFF
--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -398,7 +398,6 @@ SEPResult MemoryTierManager::promoteToTier(MemoryBlock *block,
     lookup_map_.erase(old_ptr);
     src_tier->deallocate(block);
     lookup_map_[out_block->ptr] = out_block;
-    lookup_map_[block->ptr] = out_block; // allow lookups using old pointer
   }
 
   // Refresh the lookup table so callers can resolve blocks after the move.


### PR DESCRIPTION
## Summary
- handle lookup map updates consistently when moving blocks between tiers
- preserve old pointers only after rebuilding the lookup table

## Testing
- `bash build_no_cuda.sh`

------
https://chatgpt.com/codex/tasks/task_e_686d19f75c64832aab311bee490fe2cf