### PR TITLE
Fix lookup alias handling

### DIFF
--- a/include/memory/memory_tier_manager.hpp
+++ b/include/memory/memory_tier_manager.hpp
@@ -130,7 +130,9 @@ private:
   // Legacy pointer lookup table used during tier transitions. When blocks
   // move between tiers the old pointer remains valid for a short period so
   // tests can resolve both the new and previous addresses. This map stores
-  // those temporary associations until the next rebuild.
+  // those temporary associations until the next rebuild. The entries are
+  // cleared whenever rebuildLookup() is invoked to keep stale pointers from
+  // accumulating across multiple promotions or defragmentation cycles.
   std::unordered_map<void *, MemoryBlock *> legacy_lookup_map_;
 
 private:

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -143,6 +143,9 @@ MemoryBlock *MemoryTierManager::findBlockByPtr(void *ptr) {
   auto it = lookup_map_.find(ptr);
   if (it != lookup_map_.end())
     return it->second;
+  auto lit = legacy_lookup_map_.find(ptr);
+  if (lit != legacy_lookup_map_.end())
+    return lit->second;
   return nullptr;
 }
 
@@ -398,19 +401,12 @@ SEPResult MemoryTierManager::promoteToTier(MemoryBlock *block,
     lookup_map_.erase(old_ptr);
     src_tier->deallocate(block);
     lookup_map_[out_block->ptr] = out_block;
-    lookup_map_[block->ptr] = out_block; // allow lookups using old pointer
+    legacy_lookup_map_[old_ptr] = out_block;
   }
 
   // Refresh the lookup table so callers can resolve blocks after the move.
   rebuildLookup();
 
-  {
-    std::lock_guard<std::mutex> lock(lookup_mutex);
-    // Preserve the old pointer as an alias so callers using stale addresses
-    // can still resolve the promoted block via findBlockByPtr.
-    lookup_map_[old_ptr] = out_block;
-    lookup_map_[block->ptr] = out_block;
-  }
 
   return SEPResult::SUCCESS;
 }
@@ -496,6 +492,7 @@ MemoryTier *MemoryTierManager::determineTier(float coherence, float stability,
 void MemoryTierManager::rebuildLookup() {
   std::lock_guard<std::mutex> lock(lookup_mutex);
   lookup_map_.clear();
+  legacy_lookup_map_.clear();
   auto add_blocks = [this](MemoryTier *tier) {
     if (!tier)
       return;


### PR DESCRIPTION
## Summary
- keep a separate alias table for legacy block addresses
- clear alias table during lookup rebuild
- check alias table in findBlockByPtr

## Testing
- `ctest -R memory_manager_tests --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_686d1975f4a0832aa0a53d41378c4ddf