### PR TITLE
Fix CUDA detection for testbed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,7 @@ configure_sep()
 # CUDA is optional for many unit tests. Allow disabling via SEP_HAS_CUDA
 option(SEP_HAS_CUDA "Enable CUDA support" ON)
 if(SEP_HAS_CUDA)
+    enable_language(CUDA)
     find_package(CUDAToolkit REQUIRED)
     add_compile_definitions(SEP_HAS_CUDA=1)
 else()


### PR DESCRIPTION
## Summary
- ensure CMake knows about CUDA when SEP_HAS_CUDA is ON

## Testing
- `./build_no_cuda.sh`

------
https://chatgpt.com/codex/tasks/task_e_686d19ec1e50832aa6926bcf99fd5627