### PR TITLE
Fix memory tier test build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,4 @@ blender
 !examples/json_processor_build.cmake
 package-lock.json
 third_party/glm/
+cmake-nocuda/


### PR DESCRIPTION
## Summary
- ignore cmake-nocuda build directory

## Testing
- `build_no_cuda.sh` (all tests pass)

------
https://chatgpt.com/codex/tasks/task_e_686d19ec1e50832aa6926bcf99fd5627