### PR TITLE
Fix MemoryThresholdConfig JSON serialization

### DIFF
--- a/include/memory/memory_tier_manager.hpp
+++ b/include/memory/memory_tier_manager.hpp
@@ -153,9 +153,22 @@ private:
   bool checkTierDemotion(const ::sep::pattern::PatternData &pattern) const;
 };
 
+
 void to_json(nlohmann::json &j, const MemoryTierManager::Config &c);
 
 void from_json(const nlohmann::json &j, MemoryTierManager::Config &c);
 
 } // namespace memory
+} // namespace sep
+
+namespace sep {
+namespace config {
+
+// Serialization helpers for MemoryThresholdConfig. These wrappers
+// enable ADL-based conversion when using the alias
+// MemoryTierManager::Config.
+void to_json(nlohmann::json &j, const MemoryThresholdConfig &c);
+void from_json(const nlohmann::json &j, MemoryThresholdConfig &c);
+
+} // namespace config
 } // namespace sep

--- a/src/memory/memory_tier_manager_serialization.cpp
+++ b/src/memory/memory_tier_manager_serialization.cpp
@@ -2,9 +2,9 @@
 #include <nlohmann/json.hpp>
 
 namespace sep {
-namespace memory {
+namespace config {
 
-void to_json(nlohmann::json& j, const MemoryTierManager::Config& c) {
+void to_json(nlohmann::json& j, const MemoryThresholdConfig& c) {
     j = nlohmann::json{
         {"stm_size", c.stm_size},
         {"mtm_size", c.mtm_size},
@@ -20,7 +20,7 @@ void to_json(nlohmann::json& j, const MemoryTierManager::Config& c) {
     };
 }
 
-void from_json(const nlohmann::json& j, MemoryTierManager::Config& c) {
+void from_json(const nlohmann::json& j, MemoryThresholdConfig& c) {
     c.stm_size = j.value("stm_size", static_cast<std::size_t>(1 << 20));
     c.mtm_size = j.value("mtm_size", static_cast<std::size_t>(4 << 20));
     c.ltm_size = j.value("ltm_size", static_cast<std::size_t>(16 << 20));
@@ -34,5 +34,5 @@ void from_json(const nlohmann::json& j, MemoryTierManager::Config& c) {
     c.mtm_to_ltm_min_gen = j.value("mtm_to_ltm_min_gen", 100u);
 }
 
-} // namespace memory
+} // namespace config
 } // namespace sep


### PR DESCRIPTION
## Summary
- expose MemoryThresholdConfig JSON helpers in the correct namespace
- update serialization implementation accordingly

## Testing
- `./build_no_cuda.sh`

------
https://chatgpt.com/codex/tasks/task_e_686d1b3f7988832aa8d5083e2fcaa3c5