### PR TITLE
Fix spdlog linkage for memory_minimal tests

### DIFF
--- a/_sep/testbed/memory_minimal/CMakeLists.txt
+++ b/_sep/testbed/memory_minimal/CMakeLists.txt
@@ -44,6 +44,9 @@ target_link_libraries(memory_minimal_tests PRIVATE
     Threads::Threads
 )
 
-target_compile_definitions(memory_minimal_tests PRIVATE SEP_MEMORY_MINIMAL)
+target_compile_definitions(memory_minimal_tests PRIVATE
+    SEP_MEMORY_MINIMAL
+    SPDLOG_HEADER_ONLY
+)
 
 add_test(NAME memory_minimal_tests COMMAND memory_minimal_tests)


### PR DESCRIPTION
## Summary
- enable header-only spdlog in the memory_minimal testbed

## Testing
- `bash build_no_cuda.sh`
- `./memory_minimal_tests`

------
https://chatgpt.com/codex/tasks/task_e_686d1c910ba4832aab77a01c4325f994