### PR TITLE
Fix JSON config serialization and cross-language test

### DIFF
--- a/_sep/testbed/cross_language_memory_tier_test.cpp
+++ b/_sep/testbed/cross_language_memory_tier_test.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 #include "memory/memory_tier_manager.hpp"
 #include <fstream>
+#include <filesystem>
 #include <nlohmann/json.hpp>
 
 using namespace sep::memory;
@@ -11,16 +12,23 @@ TEST(CrossLanguage, MemoryTierConfigRoundTrip) {
     cfg.mtm_size = 2048;
     cfg.ltm_size = 4096;
 
+    namespace fs = std::filesystem;
+    fs::path base = fs::path(__FILE__).parent_path();
+
     nlohmann::json j = cfg;
-    std::ofstream out("_sep/testbed/config_out.json");
+    fs::path out_path = base / "config_out.json";
+    std::ofstream out(out_path);
     ASSERT_TRUE(out.is_open());
     out << j.dump();
     out.close();
 
-    int ret = std::system("node _sep/testbed/cross_language_memory.cjs _sep/testbed/config_out.json _sep/testbed/config_back.json");
+    fs::path script = base / "cross_language_memory.cjs";
+    fs::path back_path = base / "config_back.json";
+    std::string cmd = std::string("node ") + script.string() + " " + out_path.string() + " " + back_path.string();
+    int ret = std::system(cmd.c_str());
     ASSERT_EQ(ret, 0);
 
-    std::ifstream in("_sep/testbed/config_back.json");
+    std::ifstream in(back_path);
     ASSERT_TRUE(in.is_open());
     nlohmann::json j2;
     in >> j2;

--- a/_sep/testbed/memory_minimal/CMakeLists.txt
+++ b/_sep/testbed/memory_minimal/CMakeLists.txt
@@ -19,9 +19,6 @@ find_package(Threads REQUIRED)
 set(SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../src)
 
 set(MEMORY_SRC
-    ${SRC_DIR}/memory/memory_tier.cpp
-    ${SRC_DIR}/core/logging.cpp
-    ${SRC_DIR}/memory/memory_tier_manager_serialization.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/memory_tier_manager_stubs.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/allocation_metrics_stub.cpp
 )
@@ -41,6 +38,8 @@ target_link_libraries(memory_minimal_tests PRIVATE
     fmt::fmt
     spdlog::spdlog
     Threads::Threads
+    sep_memory
+    sep_core
 )
 
 target_compile_definitions(memory_minimal_tests PRIVATE SEP_MEMORY_MINIMAL)

--- a/include/core/types.h
+++ b/include/core/types.h
@@ -10,6 +10,9 @@
 #include <string>
 #include <vector>
 
+// Third-party
+#include <nlohmann/json.hpp>
+
 namespace sep {
 
 // Memory tier types that are used across multiple modules
@@ -42,6 +45,10 @@ struct MemoryThresholdConfig {
     bool use_unified_memory{true};
     bool enable_compression{true};
 };
+
+// JSON serialization helpers
+void to_json(nlohmann::json& j, const MemoryThresholdConfig& c);
+void from_json(const nlohmann::json& j, MemoryThresholdConfig& c);
 
 struct QuantumThresholdConfig {
     float ltm_coherence_threshold{0.9f};

--- a/include/memory/memory_tier_manager.hpp
+++ b/include/memory/memory_tier_manager.hpp
@@ -157,5 +157,10 @@ void to_json(nlohmann::json &j, const MemoryTierManager::Config &c);
 
 void from_json(const nlohmann::json &j, MemoryTierManager::Config &c);
 
+namespace config {
+void to_json(nlohmann::json& j, const ::sep::config::MemoryThresholdConfig& c);
+void from_json(const nlohmann::json& j, ::sep::config::MemoryThresholdConfig& c);
+} // namespace config
+
 } // namespace memory
 } // namespace sep

--- a/src/memory/memory_tier_manager_serialization.cpp
+++ b/src/memory/memory_tier_manager_serialization.cpp
@@ -35,4 +35,16 @@ void from_json(const nlohmann::json& j, MemoryTierManager::Config& c) {
 }
 
 } // namespace memory
+
+namespace config {
+
+void to_json(nlohmann::json& j, const ::sep::config::MemoryThresholdConfig& c) {
+    memory::to_json(j, reinterpret_cast<const memory::MemoryTierManager::Config&>(c));
+}
+
+void from_json(const nlohmann::json& j, ::sep::config::MemoryThresholdConfig& c) {
+    memory::from_json(j, reinterpret_cast<memory::MemoryTierManager::Config&>(c));
+}
+
+} // namespace config
 } // namespace sep


### PR DESCRIPTION
## Summary
- ensure `MemoryThresholdConfig` JSON helpers are found via ADL
- link memory_minimal tests with sep libraries and use source file paths
- update cross-language unit test to use filesystem paths

## Testing
- `make memory_minimal_tests`
- `./tests/_sep_testbed/memory_minimal/memory_minimal_tests`
- `make memory_manager_tests`
- `./tests/memory/memory_manager_tests`


------
https://chatgpt.com/codex/tasks/task_e_686d1b3f7988832aa8d5083e2fcaa3c5