### PR TITLE
Fix memory tier JSON serialization and test paths

### DIFF
--- a/_sep/testbed/cross_language_memory_tier_test.cpp
+++ b/_sep/testbed/cross_language_memory_tier_test.cpp
@@ -12,15 +12,17 @@ TEST(CrossLanguage, MemoryTierConfigRoundTrip) {
     cfg.ltm_size = 4096;
 
     nlohmann::json j = cfg;
-    std::ofstream out("_sep/testbed/config_out.json");
+    std::string base = SEP_SOURCE_DIR;
+    std::ofstream out(base + "/_sep/testbed/config_out.json");
     ASSERT_TRUE(out.is_open());
     out << j.dump();
     out.close();
 
-    int ret = std::system("node _sep/testbed/cross_language_memory.cjs _sep/testbed/config_out.json _sep/testbed/config_back.json");
+    std::string cmd = "node " + base + "/_sep/testbed/cross_language_memory.cjs " + base + "/_sep/testbed/config_out.json " + base + "/_sep/testbed/config_back.json";
+    int ret = std::system(cmd.c_str());
     ASSERT_EQ(ret, 0);
 
-    std::ifstream in("_sep/testbed/config_back.json");
+    std::ifstream in(base + "/_sep/testbed/config_back.json");
     ASSERT_TRUE(in.is_open());
     nlohmann::json j2;
     in >> j2;

--- a/_sep/testbed/memory_minimal/CMakeLists.txt
+++ b/_sep/testbed/memory_minimal/CMakeLists.txt
@@ -20,6 +20,7 @@ set(SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../src)
 
 set(MEMORY_SRC
     ${SRC_DIR}/memory/memory_tier.cpp
+    ${SRC_DIR}/memory/memory_tier_manager.cpp
     ${SRC_DIR}/core/logging.cpp
     ${SRC_DIR}/memory/memory_tier_manager_serialization.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/memory_tier_manager_stubs.cpp
@@ -30,6 +31,7 @@ target_sources(memory_minimal_tests PRIVATE ${MEMORY_SRC})
 target_compile_definitions(memory_minimal_tests PRIVATE SEP_MINIMAL=1)
 target_compile_definitions(memory_minimal_tests PRIVATE SEP_TESTBED_STUBS)
 target_compile_definitions(memory_minimal_tests PRIVATE SEP_NO_REDIS)
+target_compile_definitions(memory_minimal_tests PRIVATE SEP_SOURCE_DIR="${CMAKE_SOURCE_DIR}")
 
 target_include_directories(memory_minimal_tests PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../include

--- a/include/memory/memory_tier_manager.hpp
+++ b/include/memory/memory_tier_manager.hpp
@@ -158,4 +158,12 @@ void to_json(nlohmann::json &j, const MemoryTierManager::Config &c);
 void from_json(const nlohmann::json &j, MemoryTierManager::Config &c);
 
 } // namespace memory
+
+namespace config {
+
+void to_json(nlohmann::json &j, const MemoryThresholdConfig &c);
+
+void from_json(const nlohmann::json &j, MemoryThresholdConfig &c);
+
+} // namespace config
 } // namespace sep

--- a/src/memory/memory_tier_manager_serialization.cpp
+++ b/src/memory/memory_tier_manager_serialization.cpp
@@ -35,4 +35,16 @@ void from_json(const nlohmann::json& j, MemoryTierManager::Config& c) {
 }
 
 } // namespace memory
+
+namespace config {
+
+void to_json(nlohmann::json& j, const MemoryThresholdConfig& c) {
+    memory::to_json(j, c);
+}
+
+void from_json(const nlohmann::json& j, MemoryThresholdConfig& c) {
+    memory::from_json(j, c);
+}
+
+} // namespace config
 } // namespace sep


### PR DESCRIPTION
## Summary
- expose JSON converters for `MemoryThresholdConfig`
- bridge config serialization in `memory_tier_manager_serialization.cpp`
- ensure `memory_minimal_tests` builds `memory_tier_manager.cpp`
- allow tests to locate source directory
- update cross-language test to use absolute paths

## Testing
- `./tests/memory/memory_manager_tests`
- `./tests/_sep_testbed/memory_minimal/memory_minimal_tests`


------
https://chatgpt.com/codex/tasks/task_e_686d1b3f7988832aa8d5083e2fcaa3c5