### PR TITLE
Fix JSON serialization for memory config

### DIFF
--- a/include/memory/memory_tier_manager.hpp
+++ b/include/memory/memory_tier_manager.hpp
@@ -153,8 +153,19 @@ private:
   bool checkTierDemotion(const ::sep::pattern::PatternData &pattern) const;
 };
 
-void to_json(nlohmann::json &j, const MemoryTierManager::Config &c);
+// JSON serialization helpers.  The underlying configuration type lives in the
+// ::sep::config namespace.  Provide overloads in both the config and memory
+// namespaces so ADL works regardless of whether callers use the alias
+// MemoryTierManager::Config or the raw config::MemoryThresholdConfig type.
+} // namespace memory
 
+namespace config {
+void to_json(nlohmann::json &j, const MemoryThresholdConfig &c);
+void from_json(const nlohmann::json &j, MemoryThresholdConfig &c);
+} // namespace config
+
+namespace memory {
+void to_json(nlohmann::json &j, const MemoryTierManager::Config &c);
 void from_json(const nlohmann::json &j, MemoryTierManager::Config &c);
 
 } // namespace memory

--- a/src/memory/memory_tier_manager_serialization.cpp
+++ b/src/memory/memory_tier_manager_serialization.cpp
@@ -2,9 +2,9 @@
 #include <nlohmann/json.hpp>
 
 namespace sep {
-namespace memory {
+namespace config {
 
-void to_json(nlohmann::json& j, const MemoryTierManager::Config& c) {
+void to_json(nlohmann::json& j, const MemoryThresholdConfig& c) {
     j = nlohmann::json{
         {"stm_size", c.stm_size},
         {"mtm_size", c.mtm_size},
@@ -20,7 +20,7 @@ void to_json(nlohmann::json& j, const MemoryTierManager::Config& c) {
     };
 }
 
-void from_json(const nlohmann::json& j, MemoryTierManager::Config& c) {
+void from_json(const nlohmann::json& j, MemoryThresholdConfig& c) {
     c.stm_size = j.value("stm_size", static_cast<std::size_t>(1 << 20));
     c.mtm_size = j.value("mtm_size", static_cast<std::size_t>(4 << 20));
     c.ltm_size = j.value("ltm_size", static_cast<std::size_t>(16 << 20));
@@ -32,6 +32,18 @@ void from_json(const nlohmann::json& j, MemoryTierManager::Config& c) {
     c.enable_compression = j.value("enable_compression", true);
     c.stm_to_mtm_min_gen = j.value("stm_to_mtm_min_gen", 5u);
     c.mtm_to_ltm_min_gen = j.value("mtm_to_ltm_min_gen", 100u);
+}
+
+} // namespace config
+
+namespace memory {
+
+void to_json(nlohmann::json& j, const MemoryTierManager::Config& c) {
+    config::to_json(j, static_cast<const config::MemoryThresholdConfig&>(c));
+}
+
+void from_json(const nlohmann::json& j, MemoryTierManager::Config& c) {
+    config::from_json(j, static_cast<config::MemoryThresholdConfig&>(c));
 }
 
 } // namespace memory


### PR DESCRIPTION
## Summary
- provide serialization helpers for MemoryThresholdConfig in `sep::config`
- forward MemoryTierManager JSON helpers to these new functions
- adjust header declarations accordingly

## Testing
- `cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=g++-14 -DSEP_HAS_CUDA=OFF -DSEP_WITH_OPENSUBDIV=OFF -DSEP_WITH_OPENPGL=OFF -DSEP_WITH_OCIO=OFF -DSEP_WITH_OPENIMAGEIO=OFF -DSEP_WITH_EMBREE=OFF -DSEP_WITH_OSL=OFF -DSEP_WITH_ALEMBIC=OFF -DSEP_WITH_AUDIO=OFF -DSEP_WITH_CYCLES=OFF -B . -S ../..`
- `make memory_manager_tests -j$(nproc)`
- `./tests/memory/memory_manager_tests`

------
https://chatgpt.com/codex/tasks/task_e_686d1b3f7988832aa8d5083e2fcaa3c5