### PR TITLE
Fix spdlog linkage for testbed

### DIFF
--- a/_sep/testbed/memory_minimal/CMakeLists.txt
+++ b/_sep/testbed/memory_minimal/CMakeLists.txt
@@ -14,6 +14,10 @@ add_executable(memory_minimal_tests
 find_package(GTest REQUIRED)
 find_package(fmt REQUIRED)
 find_package(spdlog)
+if(spdlog_FOUND)
+    message(STATUS "Using header-only spdlog for testbed")
+    add_compile_definitions(SPDLOG_HEADER_ONLY)
+endif()
 find_package(Threads REQUIRED)
 
 set(SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../src)
@@ -40,7 +44,7 @@ target_link_libraries(memory_minimal_tests PRIVATE
     GTest::GTest
     GTest::Main
     fmt::fmt
-    spdlog::spdlog
+    spdlog::spdlog_header_only
     Threads::Threads
 )
 


### PR DESCRIPTION
## Summary
- use header-only spdlog for `_sep/testbed/memory_minimal`

## Testing
- `cmake ../_sep/testbed/memory_minimal`
- `make -j$(nproc)`
- `./memory_minimal_tests`

------
https://chatgpt.com/codex/tasks/task_e_686d1c910ba4832aab77a01c4325f994