### PR TITLE
Fix minimal test build and cross-language path

### DIFF
--- a/_sep/testbed/cross_language_memory_tier_test.cpp
+++ b/_sep/testbed/cross_language_memory_tier_test.cpp
@@ -2,6 +2,7 @@
 #include "memory/memory_tier_manager.hpp"
 #include <fstream>
 #include <nlohmann/json.hpp>
+#include <filesystem>
 
 using namespace sep::memory;
 
@@ -12,15 +13,22 @@ TEST(CrossLanguage, MemoryTierConfigRoundTrip) {
     cfg.ltm_size = 4096;
 
     nlohmann::json j = cfg;
-    std::ofstream out("../_sep/testbed/config_out.json");
+
+    std::filesystem::path base = std::filesystem::path(__FILE__).parent_path();
+    std::filesystem::path out_path = base / "config_out.json";
+    std::filesystem::path back_path = base / "config_back.json";
+    std::filesystem::path script = base / "cross_language_memory.cjs";
+
+    std::ofstream out(out_path);
     ASSERT_TRUE(out.is_open());
     out << j.dump();
     out.close();
 
-    int ret = std::system("node ../_sep/testbed/cross_language_memory.cjs ../_sep/testbed/config_out.json ../_sep/testbed/config_back.json");
+    std::string cmd = std::string("node ") + script.string() + " " + out_path.string() + " " + back_path.string();
+    int ret = std::system(cmd.c_str());
     ASSERT_EQ(ret, 0);
 
-    std::ifstream in("../_sep/testbed/config_back.json");
+    std::ifstream in(back_path);
     ASSERT_TRUE(in.is_open());
     nlohmann::json j2;
     in >> j2;

--- a/_sep/testbed/memory_minimal/CMakeLists.txt
+++ b/_sep/testbed/memory_minimal/CMakeLists.txt
@@ -14,6 +14,9 @@ add_executable(memory_minimal_tests
 find_package(GTest REQUIRED)
 find_package(fmt REQUIRED)
 find_package(spdlog)
+if(NOT spdlog_FOUND)
+    add_compile_definitions(SEP_SPDLOG_FALLBACK)
+endif()
 find_package(Threads REQUIRED)
 
 set(SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../src)
@@ -40,9 +43,11 @@ target_link_libraries(memory_minimal_tests PRIVATE
     GTest::GTest
     GTest::Main
     fmt::fmt
-    spdlog::spdlog
     Threads::Threads
 )
+if(spdlog_FOUND)
+    target_link_libraries(memory_minimal_tests PRIVATE spdlog::spdlog)
+endif()
 
 target_compile_definitions(memory_minimal_tests PRIVATE SEP_MEMORY_MINIMAL)
 


### PR DESCRIPTION
## Summary
- avoid linking spdlog in minimal testbed unless available
- resolve relative paths in cross_language_memory_tier_test using `std::filesystem`

## Testing
- `cmake .. && make -j$(nproc) memory_minimal_tests`
- `./memory_minimal_tests`

------
https://chatgpt.com/codex/tasks/task_e_686d1c01c40c832aad52a45441801ebb