### PR TITLE
Fix memory tier utilization bookkeeping

### DIFF
--- a/src/memory/memory_tier.cpp
+++ b/src/memory/memory_tier.cpp
@@ -194,6 +194,15 @@ void MemoryTier::deallocate(MemoryBlock *block) {
   block->wait = wait;
 
   mergeAdjacentBlocks();
+
+  // Recompute used space after merging to avoid tiny residual values that can
+  // accumulate when tiers are resized or defragmented.  Unit tests rely on
+  // exact zero utilization when all blocks have been freed.
+  used_space_ = 0;
+  for (const auto &blk : blocks_) {
+    if (blk.allocated)
+      used_space_ += blk.size;
+  }
 }
 
 ::sep::SEPResult MemoryTier::defragment() {


### PR DESCRIPTION
## Summary
- recompute `used_space_` after merging blocks on deallocation to avoid leftover utilization

## Testing
- `make memory_minimal_tests`
- `./memory_minimal_tests`

------
https://chatgpt.com/codex/tasks/task_e_686d1c01c40c832aad52a45441801ebb