### PR TITLE
Fix memory_minimal test build

### DIFF
--- a/_sep/testbed/memory_minimal/CMakeLists.txt
+++ b/_sep/testbed/memory_minimal/CMakeLists.txt
@@ -44,13 +44,10 @@ target_link_libraries(memory_minimal_tests PRIVATE
     fmt::fmt
     spdlog::spdlog
     Threads::Threads
-    sep_memory
-    sep_core
 )
 
 target_compile_definitions(memory_minimal_tests PRIVATE
     SEP_MEMORY_MINIMAL
-    SPDLOG_HEADER_ONLY
 )
 
 add_test(NAME memory_minimal_tests COMMAND memory_minimal_tests)


### PR DESCRIPTION
## Summary
- remove unnecessary dependencies from memory_minimal testbed
- rely on built-in sources and avoid SPDLOG_HEADER_ONLY

## Testing
- `cmake ..`
- `make -j$(nproc) memory_minimal_tests`
- `./memory_minimal_tests`

------
https://chatgpt.com/codex/tasks/task_e_686d222944b8832aa05882bd2283317d