### PR TITLE
Fix missing includes in PipeWire capture

### DIFF
--- a/src/audio/pipewire_capture.cpp
+++ b/src/audio/pipewire_capture.cpp
@@ -23,9 +23,12 @@ extern "C" {
 #include <spa/support/log.h>
 #include <spa/utils/hook.h>
 #include <spa/utils/type.h>
+#include <spa/utils/result.h>
 }
 
 // Third-party headers
+#include <vector>
+#include <functional>
 #include <spdlog/spdlog.h>
 #include <glm/gtc/constants.hpp>
 
@@ -43,11 +46,10 @@ extern "C" {
 #include <memory>
 #include <new>
 #include <thread>
+#include <chrono>
 
 namespace sep {
 namespace audio {
-
-using namespace std; // Add this to fix namespace issues
 
 
 sep::audio::PipeWireCapture::PipeWireCapture() : stream_events_{} {}


### PR DESCRIPTION
## Summary
- include `<vector>`, `<functional>`, `<chrono>` in `pipewire_capture.cpp`
- include `<spa/utils/result.h>` for `spa_strerror`
- drop stray `using namespace std` directive

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d222944b8832aa05882bd2283317d