### PR TITLE
Fix spdlog linking in minimal testbed

### DIFF
--- a/_sep/testbed/memory_minimal/CMakeLists.txt
+++ b/_sep/testbed/memory_minimal/CMakeLists.txt
@@ -51,9 +51,13 @@ target_link_libraries(memory_minimal_tests PRIVATE
     sep_memory
     sep_core
 )
-if(spdlog_FOUND)
-    target_link_libraries(memory_minimal_tests PRIVATE spdlog::spdlog)
-endif()
+
+# When spdlog is available we use the header-only interface to avoid
+# linking against the compiled library. Linking against spdlog::spdlog
+# pulls in additional compile definitions like SPDLOG_COMPILED_LIB which
+# conflict with SPDLOG_HEADER_ONLY and lead to missing symbol errors when
+# building the minimal testbed. The header-only target provides all
+# required functionality for these tests without external dependencies.
 
 target_compile_definitions(memory_minimal_tests PRIVATE
     SEP_MEMORY_MINIMAL


### PR DESCRIPTION
## Summary
- keep minimal testbed using header-only spdlog
- avoid linking against compiled spdlog library to prevent missing symbols

## Testing
- `cmake -B build_tmp -S . -DCMAKE_BUILD_TYPE=Debug -DSEP_MINIMAL=ON -DSEP_WITH_OPENSUBDIV=OFF -DSEP_WITH_OPENPGL=OFF -DSEP_WITH_OCIO=OFF -DSEP_WITH_OPENIMAGEIO=OFF -DSEP_WITH_EMBREE=OFF -DSEP_WITH_OSL=OFF -DSEP_WITH_ALEMBIC=OFF -DSEP_WITH_AUDIO=OFF -DSEP_HAS_CUDA=OFF`
- `cmake --build build_tmp --target memory_minimal_tests`
- `./build_tmp/tests/_sep_testbed/memory_minimal/memory_minimal_tests`


------
https://chatgpt.com/codex/tasks/task_e_686d22f21f40832a8721efca9f9bcdba