### PR TITLE
Fix audio capture header includes

### DIFF
--- a/include/audio/capture.h
+++ b/include/audio/capture.h
@@ -1,6 +1,10 @@
 #pragma once
 
 #include <memory>
+#ifdef SEP_HAS_AUDIO
+#include <functional>
+#include "audio/export.h"
+#endif
 #include "audio/types.h"
 
 namespace sep {
@@ -16,9 +20,6 @@ protected:
   AudioCapture() = default;
 };
 #else
-#include <functional>
-
-#include "audio/export.h"
 
 class SEP_AUDIO_API AudioCapture {
 public:


### PR DESCRIPTION
## Summary
- move `<functional>` include outside the `sep::audio` namespace

## Testing
- `g++-14 -I../../.. -I../../../../include -I../../../include -c /tmp/test.cpp -o /tmp/test.o`

------
https://chatgpt.com/codex/tasks/task_e_686d232e46d4832aa4bcf40ca3f5ec8d