### PR TITLE
Fix std namespace pollution in capture header

### DIFF
--- a/include/audio/capture.h
+++ b/include/audio/capture.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include <memory>
+#ifdef SEP_HAS_AUDIO
+#include <functional>
+#endif
 #include "audio/types.h"
 
 namespace sep {
@@ -16,8 +19,6 @@ protected:
   AudioCapture() = default;
 };
 #else
-#include <functional>
-
 #include "audio/export.h"
 
 class SEP_AUDIO_API AudioCapture {


### PR DESCRIPTION
## Summary
- include `<functional>` outside of the `sep::audio` namespace in `capture.h`
- this prevents accidental nesting of the `std` namespace

## Testing
- `./build_no_cuda.sh`

------
https://chatgpt.com/codex/tasks/task_e_686d231e7aa0832aabe6b6b1748a8584