### PR TITLE
Improve MemoryTierManager startup

### DIFF
--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -91,6 +91,12 @@ void MemoryTierManager::init(const Config &config) {
          stm_->calculateUtilization(), mtm_->calculateUtilization(),
          ltm_->calculateUtilization());
 
+  // Ensure the lookup table accurately reflects the fresh tiers so that unit
+  // tests querying by pointer see a consistent initial state.  This also clears
+  // any stale entries that might remain from a previous configuration when
+  // init() is called after shutdown().
+  rebuildLookup();
+
   // Redis manager is optional in this minimal build
 }
 


### PR DESCRIPTION
## Summary
- rebuild lookup map during memory manager initialization

## Testing
- `./build_no_cuda.sh`

------
https://chatgpt.com/codex/tasks/task_e_686d22f21f40832a8721efca9f9bcdba