### PR TITLE
Fix namespace pollution in PipeWire capture

### DIFF
--- a/src/audio/pipewire_capture.cpp
+++ b/src/audio/pipewire_capture.cpp
@@ -47,7 +47,7 @@ extern "C" {
 namespace sep {
 namespace audio {
 
-using namespace std; // Add this to fix namespace issues
+
 
 
 sep::audio::PipeWireCapture::PipeWireCapture() : stream_events_{} {}


### PR DESCRIPTION
## Summary
- avoid injecting the entire standard library into the `sep::audio` namespace

## Testing
- `./build_no_cuda.sh`

------
https://chatgpt.com/codex/tasks/task_e_686d231e7aa0832aabe6b6b1748a8584