### PR TITLE
Fix std namespace pollution

### DIFF
--- a/include/audio/capture.h
+++ b/include/audio/capture.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <memory>
+#include <functional>
+
 #include "audio/types.h"
 
 namespace sep {
@@ -16,7 +18,6 @@ protected:
   AudioCapture() = default;
 };
 #else
-#include <functional>
 
 #include "audio/export.h"
 


### PR DESCRIPTION
## Summary
- ensure standard library headers are included outside `sep::audio` namespace

## Testing
- `cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=g++-14 -DSEP_HAS_CUDA=OFF ../..` *(fails: Could not find OpenSubdiv)*

------
https://chatgpt.com/codex/tasks/task_e_686d231e7aa0832aabe6b6b1748a8584