### PR TITLE
docs: add minimal build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,3 +165,17 @@ unit test targets:
 
 The script configures the project with optional dependencies disabled and
 executes the `memory_manager_tests` target automatically.
+
+If you prefer to invoke CMake manually, create a build directory and
+disable the heavyweight modules:
+
+```bash
+mkdir build && cd build
+cmake -DSEP_WITH_CYCLES=OFF -DSEP_WITH_AUDIO=OFF -DSEP_WITH_OPENSUBDIV=OFF \
+      -DSEP_MINIMAL=ON -DSEP_HAS_CUDA=OFF ..
+make memory_manager_tests
+./tests/memory/memory_manager_tests
+```
+
+This mirrors the configuration used by `build_no_cuda.sh` while giving
+you direct control over the build location.


### PR DESCRIPTION
## Summary
- document how to configure a minimal build via cmake

## Testing
- `cmake -DSEP_WITH_CYCLES=OFF -DSEP_WITH_OPENSUBDIV=OFF ...`
- `make -j$(nproc) memory_manager_tests`
- `./tests/memory/memory_manager_tests`


------
https://chatgpt.com/codex/tasks/task_e_686d232e46d4832aa4bcf40ca3f5ec8d