### PR TITLE
Fix namespace pollution in PipeWire capture

### DIFF
--- a/src/audio/pipewire_capture.cpp
+++ b/src/audio/pipewire_capture.cpp
@@ -47,8 +47,6 @@ extern "C" {
 namespace sep {
 namespace audio {
 
-using namespace std; // Add this to fix namespace issues
-
 
 sep::audio::PipeWireCapture::PipeWireCapture() : stream_events_{} {}
 


### PR DESCRIPTION
## Summary
- remove accidental `using namespace std` that polluted the `sep::audio` namespace

## Testing
- `cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=g++-14 ..` *(fails: cannot find -lsep_memory)*

------
https://chatgpt.com/codex/tasks/task_e_686d232e46d4832aa4bcf40ca3f5ec8d