### PR TITLE
Fix audio headers to avoid namespace pollution

### DIFF
--- a/include/audio/capture.h
+++ b/include/audio/capture.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <memory>
+#include <functional>
 #include "audio/types.h"
+#include "audio/export.h"
 
 namespace sep {
 namespace audio {
@@ -16,9 +18,6 @@ protected:
   AudioCapture() = default;
 };
 #else
-#include <functional>
-
-#include "audio/export.h"
 
 class SEP_AUDIO_API AudioCapture {
 public:


### PR DESCRIPTION
## Summary
- include <functional> and export header before opening `sep::audio` namespace in `capture.h`
- update include order to prevent accidentally nesting standard library declarations

## Testing
- `cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=g++-14 -DSEP_HAS_CUDA=OFF -DSEP_WITH_OPENSUBDIV=OFF -DSEP_WITH_OPENPGL=OFF -DSEP_WITH_OSL=OFF -DSEP_WITH_ALEMBIC=OFF ..`
- `make memory_manager_tests`
- `./tests/memory/memory_manager_tests`

------
https://chatgpt.com/codex/tasks/task_e_686d232e46d4832aa4bcf40ca3f5ec8d