### PR TITLE
Fix spdlog usage in minimal testbed

### DIFF
--- a/_sep/testbed/memory_minimal/CMakeLists.txt
+++ b/_sep/testbed/memory_minimal/CMakeLists.txt
@@ -16,9 +16,11 @@ add_executable(memory_minimal_tests
 find_package(GTest REQUIRED)
 find_package(fmt REQUIRED)
 find_package(spdlog)
+# Always build the minimal testbed with spdlog's header-only mode to
+# avoid missing symbol errors when the full library is unavailable.
+add_compile_definitions(SPDLOG_HEADER_ONLY)
 if(spdlog_FOUND)
-    message(STATUS "Using header-only spdlog for testbed")
-    add_compile_definitions(SPDLOG_HEADER_ONLY)
+    message(STATUS "Using system spdlog")
 endif()
 find_package(Threads REQUIRED)
 


### PR DESCRIPTION
## Summary
- always build memory_minimal testbed in header-only mode
- fall back to system spdlog when available

## Testing
- `cmake -S _sep/testbed/memory_minimal -B build/minimal`
- `cmake --build build/minimal`
- `./build/minimal/memory_minimal_tests`

------
https://chatgpt.com/codex/tasks/task_e_686d2528ed30832a87fabf8aeeb0702a