### PR TITLE
Fix memory_minimal build

### DIFF
--- a/_sep/testbed/memory_minimal/CMakeLists.txt
+++ b/_sep/testbed/memory_minimal/CMakeLists.txt
@@ -49,9 +49,7 @@ target_link_libraries(memory_minimal_tests PRIVATE
     spdlog::spdlog_header_only
     Threads::Threads
 )
-if(spdlog_FOUND)
-    target_link_libraries(memory_minimal_tests PRIVATE spdlog::spdlog)
-endif()
+# Using header-only spdlog; no additional library needed
 
 target_compile_definitions(memory_minimal_tests PRIVATE
     SEP_MEMORY_MINIMAL


### PR DESCRIPTION
## Summary
- remove spdlog::spdlog link from memory_minimal testbed

## Testing
- `ctest --output-on-failure -R memory_manager_tests`
- `ctest --output-on-failure -R memory_minimal_tests`


------
https://chatgpt.com/codex/tasks/task_e_686d2528ed30832a87fabf8aeeb0702a