### PR TITLE
Fix spdlog header-only setup

### DIFF
--- a/_sep/testbed/memory_minimal/CMakeLists.txt
+++ b/_sep/testbed/memory_minimal/CMakeLists.txt
@@ -16,9 +16,12 @@ add_executable(memory_minimal_tests
 find_package(GTest REQUIRED)
 find_package(fmt REQUIRED)
 find_package(spdlog)
+# Always build the minimal testbed against the header-only
+# variant of spdlog.  This avoids link errors when the full
+# library is unavailable and keeps the build self-contained.
+add_compile_definitions(SPDLOG_HEADER_ONLY)
 if(spdlog_FOUND)
     message(STATUS "Using header-only spdlog for testbed")
-    add_compile_definitions(SPDLOG_HEADER_ONLY)
 endif()
 find_package(Threads REQUIRED)
 


### PR DESCRIPTION
## Summary
- always define `SPDLOG_HEADER_ONLY` for memory_minimal testbed
- keep optional linking to the shared spdlog library when available

## Testing
- `./build_no_cuda.sh`

------
https://chatgpt.com/codex/tasks/task_e_686d2528ed30832a87fabf8aeeb0702a