### PR TITLE
Fix spdlog linkage in memory_minimal_tests

### DIFF
--- a/_sep/testbed/memory_minimal/CMakeLists.txt
+++ b/_sep/testbed/memory_minimal/CMakeLists.txt
@@ -15,11 +15,10 @@ add_executable(memory_minimal_tests
 
 find_package(GTest REQUIRED)
 find_package(fmt REQUIRED)
-find_package(spdlog)
-if(spdlog_FOUND)
-    message(STATUS "Using header-only spdlog for testbed")
-    add_compile_definitions(SPDLOG_HEADER_ONLY)
-endif()
+find_package(spdlog REQUIRED)
+message(STATUS "Using header-only spdlog for testbed")
+add_compile_definitions(SPDLOG_HEADER_ONLY)
+add_compile_options(-USPDLOG_COMPILED_LIB -USPDLOG_SHARED_LIB)
 find_package(Threads REQUIRED)
 
 set(SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../src)
@@ -49,9 +48,6 @@ target_link_libraries(memory_minimal_tests PRIVATE
     spdlog::spdlog_header_only
     Threads::Threads
 )
-if(spdlog_FOUND)
-    target_link_libraries(memory_minimal_tests PRIVATE spdlog::spdlog)
-endif()
 
 target_compile_definitions(memory_minimal_tests PRIVATE
     SEP_MEMORY_MINIMAL


### PR DESCRIPTION
## Summary
- use header-only spdlog cleanly in `_sep/testbed/memory_minimal`
- remove compiled spdlog linkage and undef conflicting flags

## Testing
- `./build_no_cuda.sh`
- `cmake --build build/minimal --target memory_minimal_tests`
- `./build/minimal/memory_minimal_tests`


------
https://chatgpt.com/codex/tasks/task_e_686d24fcb0bc832aac1132ba4f7fe5fe