### PR TITLE
Ensure memory manager tests start clean

### DIFF
--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -106,6 +106,11 @@ void MemoryTierManager::shutdown() {
 void MemoryTierManager::resetForTesting(const Config &cfg) {
   shutdown();
   init(cfg);
+  // Ensure the lookup table reflects the freshly-initialized tiers so tests
+  // start from a completely clean state.  Without this step, stale entries
+  // from a previous configuration could linger when the tiers are resized,
+  // leading to inconsistent utilization metrics across runs.
+  rebuildLookup();
 }
 
 // --- Core Memory Operations ---


### PR DESCRIPTION
## Summary
- ensure `resetForTesting` rebuilds the lookup table for a clean slate

## Testing
- `./build_no_cuda.sh`
- `cmake --build cmake-nocuda -j$(nproc) --target memory_minimal_tests`
- `./cmake-nocuda/tests/_sep_testbed/memory_minimal/memory_minimal_tests`


------
https://chatgpt.com/codex/tasks/task_e_686d24fcb0bc832aac1132ba4f7fe5fe