### PR TITLE
Fix build issues and update constants

### DIFF
--- a/include/compat/constants.h
+++ b/include/compat/constants.h
@@ -16,6 +16,9 @@ inline constexpr std::uint32_t get_default_block_size() {
 }
 inline constexpr std::uint32_t BITFIELD_WORDS = 64;
 inline constexpr std::uint32_t SYMMETRY_PAIRS = 32;
+inline constexpr std::uint32_t MAX_BLOCK_SIZE = 1024;
+inline constexpr std::uint32_t DEFAULT_BLOCK_SIZE = PATTERN_BLOCK_SIZE;
+inline constexpr std::uint32_t WARP_SIZE = 32;
 } // namespace constants
 } // namespace cuda
 } // namespace sep

--- a/include/core/manager.h
+++ b/include/core/manager.h
@@ -44,18 +44,14 @@ public:
   const CudaConfig &getCudaConfig() const;
   const LogConfig &getLogConfig() const;
   const MemoryThresholdConfig &getMemoryConfig() const;
-#if SEP_BUILD_QUANTUM
   const QuantumThresholdConfig &getQuantumConfig() const;
-#endif
 
   // Update specific components
   void updateAPIConfig(const APIConfig &config);
   void updateCudaConfig(const CudaConfig &config);
   void updateLogConfig(const LogConfig &config);
   void updateMemoryConfig(const MemoryThresholdConfig &config);
-#if SEP_BUILD_QUANTUM
   void updateQuantumConfig(const QuantumThresholdConfig &config);
-#endif
 
   // Reset configuration to defaults
   void resetToDefaults();

--- a/src/audio/pipewire_capture.cpp
+++ b/src/audio/pipewire_capture.cpp
@@ -490,7 +490,7 @@ AudioMetrics sep::audio::PipeWireCapture::getMetrics() const
     metrics.total_samples = metrics_.total_samples;
     metrics.dropped_samples = metrics_.dropped_samples;
     metrics.xruns = metrics_.xruns;
-    metrics.latency_ms = metrics_.latency;
+    metrics.latency_ms = metrics_.latency_ms;
     return metrics;
 }
 

--- a/src/core/config_manager_stub.cpp
+++ b/src/core/config_manager_stub.cpp
@@ -36,19 +36,24 @@ const LogConfig &ConfigManager::getLogConfig() const {
 const MemoryThresholdConfig &ConfigManager::getMemoryConfig() const {
     return impl_->mem_cfg;
 }
-#if SEP_BUILD_QUANTUM
 const QuantumThresholdConfig &ConfigManager::getQuantumConfig() const {
     static QuantumThresholdConfig cfg{};
+#if SEP_BUILD_QUANTUM
+    (void)cfg;
+#endif
     return cfg;
 }
-#endif
 void ConfigManager::updateAPIConfig(const APIConfig &) {}
 void ConfigManager::updateCudaConfig(const CudaConfig &) {}
 void ConfigManager::updateLogConfig(const LogConfig &) {}
 void ConfigManager::updateMemoryConfig(const MemoryThresholdConfig &cfg) { impl_->mem_cfg = cfg; }
+void ConfigManager::updateQuantumConfig(const QuantumThresholdConfig &cfg) {
 #if SEP_BUILD_QUANTUM
-void ConfigManager::updateQuantumConfig(const QuantumThresholdConfig &cfg) { impl_->quantum_cfg = cfg; }
+    impl_->quantum_cfg = cfg;
+#else
+    (void)cfg;
 #endif
+}
 void ConfigManager::resetToDefaults() {
     impl_->mem_cfg = MemoryThresholdConfig{};
 #if SEP_BUILD_QUANTUM

--- a/src/core/manager.cpp
+++ b/src/core/manager.cpp
@@ -36,17 +36,27 @@ const LogConfig& ConfigManager::getLogConfig() const {
 const MemoryThresholdConfig& ConfigManager::getMemoryConfig() const {
     return impl_->mem_cfg;
 }
+const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
+#if SEP_BUILD_QUANTUM
+    return impl_->quantum_cfg;
+#else
+    static QuantumThresholdConfig cfg{};
+    return cfg;
+#endif
+}
 void ConfigManager::updateAPIConfig(const APIConfig&) {}
 void ConfigManager::updateCudaConfig(const CudaConfig&) {}
 void ConfigManager::updateLogConfig(const LogConfig&) {}
 void ConfigManager::updateMemoryConfig(const MemoryThresholdConfig& cfg) {
     impl_->mem_cfg = cfg;
 }
-#if SEP_BUILD_QUANTUM
 void ConfigManager::updateQuantumConfig(const QuantumThresholdConfig& cfg) {
+#if SEP_BUILD_QUANTUM
     impl_->quantum_cfg = cfg;
-}
+#else
+    (void)cfg;
 #endif
+}
 void ConfigManager::resetToDefaults() {
     impl_->mem_cfg = MemoryThresholdConfig{};
 #if SEP_BUILD_QUANTUM

--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -16,6 +16,7 @@ endif()
 add_executable(long_double_math_test
     long_double_math_test.cpp
 )
+set_source_files_properties(long_double_math_test.cpp PROPERTIES LANGUAGE CUDA)
 
 add_executable(cuda_api_tests
     processing_api_test.cpp
@@ -38,6 +39,7 @@ target_include_directories(cuda_api_tests PRIVATE
 target_include_directories(increment_kernel_test PRIVATE
     ${CMAKE_SOURCE_DIR}/include
     ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/_sep/testbed/cuda
 )
 
 target_link_libraries(long_double_math_test PRIVATE


### PR DESCRIPTION
## Summary
- define CUDA constants `MAX_BLOCK_SIZE`, `DEFAULT_BLOCK_SIZE`, and `WARP_SIZE`
- expose quantum configuration helpers in `ConfigManager`
- return latency in milliseconds from `PipeWireCapture`
- always provide quantum config accessors even without quantum build flag
- compile CUDA math tests as CUDA sources and add header path for kernel tests

## Testing
- `cmake .. -DCMAKE_BUILD_TYPE=Debug && make` *(memory_minimal_tests)*
- `./memory_minimal_tests`

------
https://chatgpt.com/codex/tasks/task_e_686d25bd6c98832a920b75200b1b0b41