### PR TITLE
Fix build and update CUDA tests

### DIFF
--- a/include/compat/constants.h
+++ b/include/compat/constants.h
@@ -16,6 +16,7 @@ inline constexpr std::uint32_t get_default_block_size() {
 }
 inline constexpr std::uint32_t BITFIELD_WORDS = 64;
 inline constexpr std::uint32_t SYMMETRY_PAIRS = 32;
+inline constexpr std::uint32_t MAX_BLOCK_SIZE = 1024;
 } // namespace constants
 } // namespace cuda
 } // namespace sep

--- a/include/core/manager.h
+++ b/include/core/manager.h
@@ -44,18 +44,14 @@ public:
   const CudaConfig &getCudaConfig() const;
   const LogConfig &getLogConfig() const;
   const MemoryThresholdConfig &getMemoryConfig() const;
-#if SEP_BUILD_QUANTUM
   const QuantumThresholdConfig &getQuantumConfig() const;
-#endif
 
   // Update specific components
   void updateAPIConfig(const APIConfig &config);
   void updateCudaConfig(const CudaConfig &config);
   void updateLogConfig(const LogConfig &config);
   void updateMemoryConfig(const MemoryThresholdConfig &config);
-#if SEP_BUILD_QUANTUM
   void updateQuantumConfig(const QuantumThresholdConfig &config);
-#endif
 
   // Reset configuration to defaults
   void resetToDefaults();

--- a/src/audio/pipewire_capture.cpp
+++ b/src/audio/pipewire_capture.cpp
@@ -490,7 +490,7 @@ AudioMetrics sep::audio::PipeWireCapture::getMetrics() const
     metrics.total_samples = metrics_.total_samples;
     metrics.dropped_samples = metrics_.dropped_samples;
     metrics.xruns = metrics_.xruns;
-    metrics.latency_ms = metrics_.latency;
+    metrics.latency_ms = metrics_.latency_ms;
     return metrics;
 }
 

--- a/src/core/config_manager_stub.cpp
+++ b/src/core/config_manager_stub.cpp
@@ -36,19 +36,26 @@ const LogConfig &ConfigManager::getLogConfig() const {
 const MemoryThresholdConfig &ConfigManager::getMemoryConfig() const {
     return impl_->mem_cfg;
 }
-#if SEP_BUILD_QUANTUM
 const QuantumThresholdConfig &ConfigManager::getQuantumConfig() const {
     static QuantumThresholdConfig cfg{};
+#if SEP_BUILD_QUANTUM
+    return impl_->quantum_cfg;
+#else
     return cfg;
-}
 #endif
+}
 void ConfigManager::updateAPIConfig(const APIConfig &) {}
 void ConfigManager::updateCudaConfig(const CudaConfig &) {}
 void ConfigManager::updateLogConfig(const LogConfig &) {}
 void ConfigManager::updateMemoryConfig(const MemoryThresholdConfig &cfg) { impl_->mem_cfg = cfg; }
+void ConfigManager::updateQuantumConfig(const QuantumThresholdConfig &cfg) {
 #if SEP_BUILD_QUANTUM
-void ConfigManager::updateQuantumConfig(const QuantumThresholdConfig &cfg) { impl_->quantum_cfg = cfg; }
+    impl_->quantum_cfg = cfg;
+#else
+    (void)cfg;
 #endif
+}
+
 void ConfigManager::resetToDefaults() {
     impl_->mem_cfg = MemoryThresholdConfig{};
 #if SEP_BUILD_QUANTUM

--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -16,6 +16,7 @@ endif()
 add_executable(long_double_math_test
     long_double_math_test.cpp
 )
+set_source_files_properties(long_double_math_test.cpp PROPERTIES LANGUAGE CUDA)
 
 add_executable(cuda_api_tests
     processing_api_test.cpp
@@ -23,6 +24,9 @@ add_executable(cuda_api_tests
 
 add_executable(increment_kernel_test
     increment_kernel_test.cpp
+)
+target_include_directories(increment_kernel_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/_sep/testbed/cuda
 )
 
 target_include_directories(long_double_math_test PRIVATE

--- a/tests/cuda/long_double_math_test.cpp
+++ b/tests/cuda/long_double_math_test.cpp
@@ -12,13 +12,13 @@ __global__ void device_atan2l(long double* out, long double y, long double x) {
 
 TEST(LongDoubleMathHost, AcoslAccuracy) {
     long double v = 0.5L;
-    long double expected = std::acosl(v);
+    long double expected = ::acosl(v);
     EXPECT_NEAR(static_cast<double>(acosl(v)), static_cast<double>(expected), 1e-9);
 }
 
 TEST(LongDoubleMathHost, Atan2lAccuracy) {
     long double y = 0.5L, x = -0.3L;
-    long double expected = std::atan2l(y, x);
+    long double expected = ::atan2l(y, x);
     EXPECT_NEAR(static_cast<double>(atan2l(y, x)), static_cast<double>(expected), 1e-9);
 }
 
@@ -30,7 +30,7 @@ TEST(LongDoubleMathDevice, AcoslAccuracy) {
     long double h_val;
     ASSERT_EQ(cudaMemcpy(&h_val, d_out, sizeof(long double), cudaMemcpyDeviceToHost), cudaSuccess);
     cudaFree(d_out);
-    long double expected = std::acosl(0.5L);
+    long double expected = ::acosl(0.5L);
     EXPECT_NEAR(static_cast<double>(h_val), static_cast<double>(expected), 1e-9);
 }
 
@@ -42,7 +42,7 @@ TEST(LongDoubleMathDevice, Atan2lAccuracy) {
     long double h_val;
     ASSERT_EQ(cudaMemcpy(&h_val, d_out, sizeof(long double), cudaMemcpyDeviceToHost), cudaSuccess);
     cudaFree(d_out);
-    long double expected = std::atan2l(0.5L, -0.3L);
+    long double expected = ::atan2l(0.5L, -0.3L);
     EXPECT_NEAR(static_cast<double>(h_val), static_cast<double>(expected), 1e-9);
 }
 


### PR DESCRIPTION
## Summary
- define `MAX_BLOCK_SIZE` constant
- correct metrics field name in `PipeWireCapture`
- always expose quantum config methods
- allow stubs to handle quantum config regardless of build flag
- compile CUDA long double tests with NVCC and adjust includes
- expose testbed headers to CUDA tests

## Testing
- `cmake .. -DSEP_WITH_AUDIO=OFF -DSEP_WITH_CYCLES=OFF -DSEP_BUILD_ENGINE=OFF -DSEP_BUILD_QUANTUM=OFF -DSEP_HAS_CUDA=OFF -DSEP_WITH_OPENSUBDIV=OFF -DSEP_WITH_OPENPGL=OFF -DSEP_WITH_OCIO=OFF -DSEP_WITH_OPENIMAGEIO=OFF -DSEP_WITH_EMBREE=OFF -DSEP_WITH_OSL=OFF -DSEP_WITH_ALEMBIC=OFF`
- `make memory_manager_tests`
- `./tests/memory/memory_manager_tests`


------
https://chatgpt.com/codex/tasks/task_e_686d25bd6c98832a920b75200b1b0b41