### PR TITLE
Fix CUDA test build issues

### DIFF
--- a/include/compat/constants.h
+++ b/include/compat/constants.h
@@ -16,6 +16,8 @@ inline constexpr std::uint32_t get_default_block_size() {
 }
 inline constexpr std::uint32_t BITFIELD_WORDS = 64;
 inline constexpr std::uint32_t SYMMETRY_PAIRS = 32;
+inline constexpr std::uint32_t MAX_BLOCK_SIZE = 1024;
+inline constexpr std::uint32_t DEFAULT_BLOCK_SIZE = PATTERN_BLOCK_SIZE;
 } // namespace constants
 } // namespace cuda
 } // namespace sep

--- a/src/audio/pipewire_capture.cpp
+++ b/src/audio/pipewire_capture.cpp
@@ -490,7 +490,7 @@ AudioMetrics sep::audio::PipeWireCapture::getMetrics() const
     metrics.total_samples = metrics_.total_samples;
     metrics.dropped_samples = metrics_.dropped_samples;
     metrics.xruns = metrics_.xruns;
-    metrics.latency_ms = metrics_.latency;
+    metrics.latency_ms = metrics_.latency_ms;
     return metrics;
 }
 

--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -17,6 +17,8 @@ add_executable(long_double_math_test
     long_double_math_test.cpp
 )
 
+set_source_files_properties(long_double_math_test.cpp PROPERTIES LANGUAGE CUDA)
+
 add_executable(cuda_api_tests
     processing_api_test.cpp
 )
@@ -38,6 +40,7 @@ target_include_directories(cuda_api_tests PRIVATE
 target_include_directories(increment_kernel_test PRIVATE
     ${CMAKE_SOURCE_DIR}/include
     ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/_sep/testbed
 )
 
 target_link_libraries(long_double_math_test PRIVATE

--- a/tests/cuda/long_double_math_test.cpp
+++ b/tests/cuda/long_double_math_test.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include <cmath>
+#include <cuda_runtime.h>
 #include "compat/cuda_unified_fix.h"
 
 __global__ void device_acosl(long double* out, long double x) {


### PR DESCRIPTION
## Summary
- allow CUDA math test to compile as CUDA
- expose basic CUDA constants for tests
- fix PipeWire metrics naming
- ensure CUDA increment kernel test can find headers

## Testing
- `cmake -S ../.. -B . -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=/usr/bin/gcc-14 -DCMAKE_CXX_COMPILER=/usr/bin/g++-14 -DSEP_HAS_CUDA=0 -DSEP_USE_CUDA=0 -DCMAKE_DISABLE_FIND_PACKAGE_CUDAToolkit=ON -DSEP_WITH_CYCLES=OFF -DSEP_WITH_AUDIO=OFF -DSEP_WITH_OPENSUBDIV=OFF -DSEP_WITH_OPENPGL=OFF -DSEP_WITH_OCIO=OFF -DSEP_WITH_OPENIMAGEIO=OFF -DSEP_WITH_EMBREE=OFF -DSEP_WITH_OPENVDB=OFF -DSEP_WITH_OSL=OFF -DSEP_WITH_ALEMBIC=OFF -DBUILD_TESTING=ON`
- `make memory_manager_tests -j$(nproc)`
- `./tests/memory/memory_manager_tests`

------
https://chatgpt.com/codex/tasks/task_e_686d26f45d90832a8fd0d8f8613ab34b