### PR TITLE
Fix build issues and CUDA tests

### DIFF
--- a/include/compat/constants.h
+++ b/include/compat/constants.h
@@ -16,6 +16,9 @@ inline constexpr std::uint32_t get_default_block_size() {
 }
 inline constexpr std::uint32_t BITFIELD_WORDS = 64;
 inline constexpr std::uint32_t SYMMETRY_PAIRS = 32;
+inline constexpr std::uint32_t MAX_BLOCK_SIZE = 1024;
+inline constexpr std::uint32_t DEFAULT_BLOCK_SIZE = PATTERN_BLOCK_SIZE;
+inline constexpr std::uint32_t WARP_SIZE = 32;
 } // namespace constants
 } // namespace cuda
 } // namespace sep

--- a/src/audio/pipewire_capture.cpp
+++ b/src/audio/pipewire_capture.cpp
@@ -490,7 +490,7 @@ AudioMetrics sep::audio::PipeWireCapture::getMetrics() const
     metrics.total_samples = metrics_.total_samples;
     metrics.dropped_samples = metrics_.dropped_samples;
     metrics.xruns = metrics_.xruns;
-    metrics.latency_ms = metrics_.latency;
+    metrics.latency_ms = metrics_.latency_ms;
     return metrics;
 }
 

--- a/src/quantum/CMakeLists.txt
+++ b/src/quantum/CMakeLists.txt
@@ -51,7 +51,8 @@ target_link_libraries(sep_quantum
 # Enable CUDA and handle exception specs
 target_compile_definitions(sep_quantum PRIVATE
     SEP_HAS_CUDA=1
-    SEP_CUDACC_DISABLE_EXCEPTION_SPEC_CHECKS=1)
+    SEP_CUDACC_DISABLE_EXCEPTION_SPEC_CHECKS=1
+    SEP_BUILD_QUANTUM=1)
 
 # Set library properties
 set_target_properties(sep_quantum PROPERTIES

--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -16,6 +16,7 @@ endif()
 add_executable(long_double_math_test
     long_double_math_test.cpp
 )
+set_source_files_properties(long_double_math_test.cpp PROPERTIES LANGUAGE CUDA)
 
 add_executable(cuda_api_tests
     processing_api_test.cpp
@@ -38,6 +39,7 @@ target_include_directories(cuda_api_tests PRIVATE
 target_include_directories(increment_kernel_test PRIVATE
     ${CMAKE_SOURCE_DIR}/include
     ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/_sep/testbed/cuda
 )
 
 target_link_libraries(long_double_math_test PRIVATE


### PR DESCRIPTION
## Summary
- add CUDA constants for host tests
- fix audio metrics structure member name
- enable quantum compile flag
- compile CUDA tests with NVCC and add include path

## Testing
- `cmake -S . -B build_test -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=g++-14 -DSEP_WITH_CYCLES=OFF -DSEP_WITH_AUDIO=OFF -DSEP_WITH_OPENSUBDIV=OFF -DSEP_WITH_OPENPGL=OFF -DSEP_WITH_OCIO=OFF -DSEP_WITH_OPENIMAGEIO=OFF -DSEP_WITH_EMBREE=OFF -DSEP_WITH_OSL=OFF -DSEP_WITH_ALEMBIC=OFF -DSEP_MEMORY_MINIMAL=ON -DSEP_HAS_CUDA=0 -DSEP_TESTBED_STUBS=ON -DSEP_WORKBENCH_DEMO=OFF`
- `cmake --build build_test --target memory_manager_tests -j$(nproc)`
- `./build_test/tests/memory/memory_manager_tests`

------
https://chatgpt.com/codex/tasks/task_e_686d26a8e290832aac747acb66d98cd9