### PR TITLE
Fix CUDA test include path

### DIFF
--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -38,6 +38,7 @@ target_include_directories(cuda_api_tests PRIVATE
 target_include_directories(increment_kernel_test PRIVATE
     ${CMAKE_SOURCE_DIR}/include
     ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/_sep/testbed
 )
 
 target_link_libraries(long_double_math_test PRIVATE


### PR DESCRIPTION
## Summary
- add `_sep/testbed` include directory for CUDA tests

## Testing
- `bash build_no_cuda.sh`

------
https://chatgpt.com/codex/tasks/task_e_686d26f45d90832a8fd0d8f8613ab34b