### PR TITLE
Fix compile issues in test suite

### DIFF
--- a/include/compat/constants.h
+++ b/include/compat/constants.h
@@ -14,6 +14,7 @@ namespace constants {
 inline constexpr std::uint32_t get_default_block_size() {
     return PATTERN_BLOCK_SIZE;
 }
+inline constexpr std::uint32_t MAX_BLOCK_SIZE = 1024;
 inline constexpr std::uint32_t BITFIELD_WORDS = 64;
 inline constexpr std::uint32_t SYMMETRY_PAIRS = 32;
 } // namespace constants

--- a/src/audio/pipewire_capture.cpp
+++ b/src/audio/pipewire_capture.cpp
@@ -490,7 +490,7 @@ AudioMetrics sep::audio::PipeWireCapture::getMetrics() const
     metrics.total_samples = metrics_.total_samples;
     metrics.dropped_samples = metrics_.dropped_samples;
     metrics.xruns = metrics_.xruns;
-    metrics.latency_ms = metrics_.latency;
+    metrics.latency_ms = metrics_.latency_ms;
     return metrics;
 }
 

--- a/src/quantum/CMakeLists.txt
+++ b/src/quantum/CMakeLists.txt
@@ -51,7 +51,9 @@ target_link_libraries(sep_quantum
 # Enable CUDA and handle exception specs
 target_compile_definitions(sep_quantum PRIVATE
     SEP_HAS_CUDA=1
-    SEP_CUDACC_DISABLE_EXCEPTION_SPEC_CHECKS=1)
+    SEP_CUDACC_DISABLE_EXCEPTION_SPEC_CHECKS=1
+    $<$<BOOL:${SEP_BUILD_QUANTUM}>:SEP_BUILD_QUANTUM=1>
+    $<$<NOT:$<BOOL:${SEP_BUILD_QUANTUM}>>:SEP_BUILD_QUANTUM=0>)
 
 # Set library properties
 set_target_properties(sep_quantum PROPERTIES

--- a/src/quantum/processor.cpp
+++ b/src/quantum/processor.cpp
@@ -214,7 +214,11 @@ public:
     void demotePatterns() {
         std::lock_guard<std::mutex> lock(mutex_);
         for (auto& pattern : patterns_) {
+#if SEP_BUILD_QUANTUM
             auto qcfg = sep::config::ConfigManager::getInstance().getQuantumConfig();
+#else
+            sep::config::QuantumThresholdConfig qcfg{};
+#endif
             if (pattern.quantum_state.coherence < qcfg.mtm_coherence_threshold) {
                 pattern.quantum_state.memory_tier = ::sep::memory::MemoryTierEnum::STM;
             } else if (pattern.quantum_state.coherence < qcfg.ltm_coherence_threshold) {
@@ -227,7 +231,11 @@ public:
         std::lock_guard<std::mutex> lock(mutex_);
         patterns_.erase(std::remove_if(patterns_.begin(), patterns_.end(),
             [this](const Pattern& p) {
+#if SEP_BUILD_QUANTUM
                 auto qcfg = sep::config::ConfigManager::getInstance().getQuantumConfig();
+#else
+                sep::config::QuantumThresholdConfig qcfg{};
+#endif
                 return p.quantum_state.coherence < qcfg.mtm_coherence_threshold / 2;
             }), patterns_.end());
         rebuildPatternMap();
@@ -316,7 +324,11 @@ private:
     void updateMemoryTier(Pattern& pattern) {
         auto& state = pattern.quantum_state;
         ::sep::memory::MemoryTierEnum previous_tier = state.memory_tier;
+#if SEP_BUILD_QUANTUM
         auto qcfg = sep::config::ConfigManager::getInstance().getQuantumConfig();
+#else
+        sep::config::QuantumThresholdConfig qcfg{};
+#endif
         if (state.coherence >= qcfg.ltm_coherence_threshold && state.stability >= qcfg.stability_threshold) {
             state.memory_tier = ::sep::memory::MemoryTierEnum::LTM;
         } else if (state.coherence >= qcfg.mtm_coherence_threshold) {
@@ -401,7 +413,11 @@ void Processor::updateConfig(const ProcessingConfig& config) { impl_->updateConf
 
 std::unique_ptr<Processor> createProcessor(const ProcessingConfig& config) {
     ProcessingConfig cfg = config;
+#if SEP_BUILD_QUANTUM
     const auto& qcfg = sep::config::ConfigManager::getInstance().getQuantumConfig();
+#else
+    sep::config::QuantumThresholdConfig qcfg{};
+#endif
     cfg.ltm_coherence_threshold = qcfg.ltm_coherence_threshold;
     cfg.mtm_coherence_threshold = qcfg.mtm_coherence_threshold;
     cfg.stability_threshold = qcfg.stability_threshold;
@@ -409,7 +425,11 @@ std::unique_ptr<Processor> createProcessor(const ProcessingConfig& config) {
 }
 
 std::unique_ptr<Processor> createProcessor() {
+#if SEP_BUILD_QUANTUM
     const auto& cfg = sep::config::ConfigManager::getInstance().getQuantumConfig();
+#else
+    sep::config::QuantumThresholdConfig cfg{};
+#endif
     ProcessingConfig pc;
     pc.ltm_coherence_threshold = cfg.ltm_coherence_threshold;
     pc.mtm_coherence_threshold = cfg.mtm_coherence_threshold;

--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -28,16 +28,19 @@ add_executable(increment_kernel_test
 target_include_directories(long_double_math_test PRIVATE
     ${CMAKE_SOURCE_DIR}/include
     ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/_sep/testbed
 )
 
 target_include_directories(cuda_api_tests PRIVATE
     ${CMAKE_SOURCE_DIR}/include
     ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/_sep/testbed
 )
 
 target_include_directories(increment_kernel_test PRIVATE
     ${CMAKE_SOURCE_DIR}/include
     ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/_sep/testbed
 )
 
 target_link_libraries(long_double_math_test PRIVATE

--- a/tests/cuda/long_double_math_test.cpp
+++ b/tests/cuda/long_double_math_test.cpp
@@ -1,12 +1,12 @@
 #include <gtest/gtest.h>
 #include <cmath>
 #include "compat/cuda_unified_fix.h"
+#include "compat/macros.h"
 
-__global__ void device_acosl(long double* out, long double x) {
+SEP_GLOBAL void device_acosl(long double* out, long double x) {
     out[0] = acosl(x);
 }
-
-__global__ void device_atan2l(long double* out, long double y, long double x) {
+SEP_GLOBAL void device_atan2l(long double* out, long double y, long double x) {
     out[0] = atan2l(y, x);
 }
 


### PR DESCRIPTION
## Summary
- expose `MAX_BLOCK_SIZE` constant
- include testbed headers for CUDA tests
- port CUDA math test to portable macros
- fix audio metrics member access
- propagate `SEP_BUILD_QUANTUM` definition
- guard quantum configuration when the feature is disabled

## Testing
- `cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=g++-14 ..` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_686d26f45d90832a8fd0d8f8613ab34b