### PR TITLE
Fix lookup rebuild after block optimization

### DIFF
--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -287,6 +287,10 @@ void MemoryTierManager::optimizeBlocks() {
   process_tier(stm_.get());
   process_tier(mtm_.get());
   process_tier(ltm_.get());
+
+  // Rebuild lookup tables after potential tier changes so subsequent
+  // calls to findBlockByPtr reflect the updated block locations.
+  rebuildLookup();
 }
 
 // Convenience helpers used in tests


### PR DESCRIPTION
## Summary
- keep MemoryTierManager lookup table in sync after optimizeBlocks

## Testing
- `./build_no_cuda.sh`

------
https://chatgpt.com/codex/tasks/task_e_686d26a8e290832aac747acb66d98cd9