### PR TITLE
Fix CUDA test build failure

### DIFF
--- a/include/compat/constants.h
+++ b/include/compat/constants.h
@@ -16,6 +16,7 @@ inline constexpr std::uint32_t get_default_block_size() {
 }
 inline constexpr std::uint32_t BITFIELD_WORDS = 64;
 inline constexpr std::uint32_t SYMMETRY_PAIRS = 32;
+inline constexpr std::uint32_t MAX_BLOCK_SIZE = 1024;
 } // namespace constants
 } // namespace cuda
 } // namespace sep

--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -16,6 +16,7 @@ endif()
 add_executable(long_double_math_test
     long_double_math_test.cpp
 )
+set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/long_double_math_test.cpp PROPERTIES LANGUAGE CUDA)
 
 add_executable(cuda_api_tests
     processing_api_test.cpp
@@ -38,6 +39,7 @@ target_include_directories(cuda_api_tests PRIVATE
 target_include_directories(increment_kernel_test PRIVATE
     ${CMAKE_SOURCE_DIR}/include
     ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/_sep/testbed/cuda
 )
 
 target_link_libraries(long_double_math_test PRIVATE


### PR DESCRIPTION
## Summary
- expose `MAX_BLOCK_SIZE` constant for CUDA tests
- compile CUDA math test with NVCC
- add testbed include path for CUDA kernel tests

## Testing
- `bash scripts/build_no_cuda.sh`
- `./tests/memory/memory_manager_tests`

------
https://chatgpt.com/codex/tasks/task_e_686d26f45d90832a8fd0d8f8613ab34b