### PR TITLE
Fix include path for CUDA increment test

### DIFF
--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -38,6 +38,7 @@ target_include_directories(cuda_api_tests PRIVATE
 target_include_directories(increment_kernel_test PRIVATE
     ${CMAKE_SOURCE_DIR}/include
     ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/_sep/testbed/cuda
 )
 
 target_link_libraries(long_double_math_test PRIVATE

--- a/tests/cuda/increment_kernel_test.cpp
+++ b/tests/cuda/increment_kernel_test.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
 #include "compat/raii.h"
-#include "_sep/testbed/cuda/increment_kernel.hpp"
+#include "increment_kernel.hpp"
 
 TEST(TestbedCudaKernel, IncrementKernel) {
     const unsigned int n = 32;


### PR DESCRIPTION
## Summary
- adjust CUDA test include path for testbed header
- include testbed CUDA directory in test build

## Testing
- `cmake --build build/testbed_mem`
- `./build/testbed_mem/memory_minimal_tests`

------
https://chatgpt.com/codex/tasks/task_e_686d286799bc832aadb1508bf0142f68