### PR TITLE
Fix memory tier promotion pointer aliasing

### DIFF
--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -426,9 +426,12 @@ SEPResult MemoryTierManager::promoteToTier(MemoryBlock *block,
 
   {
     std::lock_guard<std::mutex> lock(lookup_mutex);
-    // Preserve the old pointer as an alias so callers using stale addresses
-    // can still resolve the promoted block via findBlockByPtr.
-    lookup_map_[old_ptr] = out_block;
+    // Preserve the old pointer as an alias so callers using stale
+    // addresses can still resolve the promoted block via
+    // findBlockByPtr. Use the legacy map so rebuildLookup() can clear
+    // these entries on the next refresh without disturbing the primary
+    // lookup table.
+    legacy_lookup_map_[old_ptr] = out_block;
   }
 
   return SEPResult::SUCCESS;


### PR DESCRIPTION
## Summary
- ensure legacy lookup map stores alias to old pointers when promoting memory blocks
- maintain ability to resolve stale pointers during tier transitions
- confirm memory tier manager tests pass

## Testing
- `cmake .. -DCMAKE_BUILD_TYPE=Debug -DSEP_HAS_CUDA=OFF -DSEP_WITH_OPENSUBDIV=OFF -DSEP_WITH_OPENPGL=OFF -DSEP_WITH_OCIO=OFF -DSEP_WITH_OPENIMAGEIO=OFF -DSEP_WITH_EMBREE=OFF -DSEP_WITH_OSL=OFF -DSEP_WITH_ALEMBIC=OFF -DSEP_WITH_AUDIO=OFF -DSEP_WITH_CYCLES=OFF`
- `make memory_manager_tests`
- `./tests/memory/memory_manager_tests --gtest_filter=MemoryTierManagerTest.*`
- `./tests/memory/memory_manager_tests`

------
https://chatgpt.com/codex/tasks/task_e_686d286799bc832aadb1508bf0142f68