### PR TITLE
docs: clarify manual dependency installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,13 @@ This project represents an attempt to construct a first-principles, computationa
 Run `install.sh` to fetch compiler toolchains and third-party libraries. The script also installs helpful debugging tools like **valgrind** and **gdb**.
 
 Additional development libraries used by the build system include
-`libgflags-dev` and `libgoogle-glog-dev` (or `libglog-dev` on some
-distributions). These are now installed automatically by `install.sh`.
+`libgflags-dev`, `libgoogle-glog-dev` (or `libglog-dev` on some
+distributions) and the Boost headers.  These packages are installed
+automatically by `install.sh`.  If you prefer a manual setup run:
+
+```bash
+sudo apt-get update && sudo apt-get install libgflags-dev libgoogle-glog-dev libboost-dev
+```
 
 ```bash
 ./install.sh


### PR DESCRIPTION
## Summary
- clarify that gflags, glog and Boost can be installed manually
- provide explicit apt-get command for minimal setup

## Testing
- `./tests/memory/memory_manager_tests`

------
https://chatgpt.com/codex/tasks/task_e_686d28d1e484832aaa22e43acb4a1376