### PR TITLE
Fix memory utilization clamping

### DIFF
--- a/src/memory/memory_tier.cpp
+++ b/src/memory/memory_tier.cpp
@@ -348,7 +348,10 @@ float MemoryTier::calculateUtilization() const {
   if (std::fabs(util) <= kUtilizationEpsilon)
     return 0.0f;
 
-  return util > 1.0f ? 1.0f : util; // Cap at 100%
+  // Clamp the value to the valid [0,1] range just like the tier manager's
+  // helper to avoid any slight overshoot when used_space_ temporarily exceeds
+  // the configured size during resizing operations.
+  return std::clamp(util, 0.0f, 1.0f);
 }
 
 std::size_t MemoryTier::getFreeSpace() const {


### PR DESCRIPTION
## Summary
- clamp utilization values in `MemoryTier` to avoid rounding drift
- this keeps metrics in range when tiers are resized

## Testing
- `cmake ../.. -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON -DSEP_BUILD_ENGINE=OFF -DSEP_BUILD_QUANTUM=OFF -DSEP_WITH_CYCLES=OFF -DSEP_WITH_AUDIO=OFF -DSEP_WITH_OPENSUBDIV=OFF -DSEP_WITH_OPENPGL=OFF -DSEP_WITH_OCIO=OFF -DSEP_WITH_OPENIMAGEIO=OFF -DSEP_WITH_EMBREE=OFF -DSEP_WITH_OSL=OFF -DSEP_WITH_ALEMBIC=OFF -DSEP_HAS_CUDA=OFF`
- `make memory_manager_tests`
- `./tests/memory/memory_manager_tests`
- `make memory_minimal_tests`
- `./tests/_sep_testbed/memory_minimal/memory_minimal_tests`


------
https://chatgpt.com/codex/tasks/task_e_686d28d1e484832aaa22e43acb4a1376