### PR TITLE
Fix memory tier tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,12 @@ unit test targets:
 ./install.sh --minimal
 ./build_no_cuda.sh
 ```
+If you prefer installing the development headers manually, install the
+packages via `apt` first and then configure the build:
+
+```bash
+sudo apt-get install libgflags-dev libgoogle-glog-dev libboost-dev
+```
 
 The script configures the project with optional dependencies disabled and
 executes the `memory_manager_tests` target automatically.


### PR DESCRIPTION
## Summary
- document apt install of gflags, glog and Boost for unit tests

## Testing
- `make memory_manager_tests`
- `./tests/memory/memory_manager_tests`
- `make memory_minimal_tests`
- `./tests/_sep_testbed/memory_minimal/memory_minimal_tests`


------
https://chatgpt.com/codex/tasks/task_e_686d28d1e484832aaa22e43acb4a1376