### PR TITLE
Fix CUDA test headers and constants

### DIFF
--- a/include/compat/constants.h
+++ b/include/compat/constants.h
@@ -17,7 +17,6 @@ inline constexpr std::uint32_t get_default_block_size() {
 inline constexpr std::uint32_t MAX_BLOCK_SIZE = 1024;
 inline constexpr std::uint32_t BITFIELD_WORDS = 64;
 inline constexpr std::uint32_t SYMMETRY_PAIRS = 32;
-inline constexpr std::uint32_t MAX_BLOCK_SIZE = 1024;
 inline constexpr std::uint32_t DEFAULT_BLOCK_SIZE = PATTERN_BLOCK_SIZE;
 inline constexpr std::uint32_t WARP_SIZE = 32;
 } // namespace constants

--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -17,15 +17,21 @@ add_executable(long_double_math_test
     long_double_math_test.cpp
 )
 
+# These tests use CUDA stubs when the full toolkit isn't available. Avoid
+# defining SEP_USE_CUDA so macros like SEP_GLOBAL expand to no-ops.
+target_compile_definitions(long_double_math_test PRIVATE SEP_USE_CUDA=0)
+
 set_source_files_properties(long_double_math_test.cpp PROPERTIES LANGUAGE CXX)
 
 add_executable(cuda_api_tests
     processing_api_test.cpp
 )
+target_compile_definitions(cuda_api_tests PRIVATE SEP_USE_CUDA=0)
 
 add_executable(increment_kernel_test
     increment_kernel_test.cpp
 )
+target_compile_definitions(increment_kernel_test PRIVATE SEP_USE_CUDA=0)
 target_include_directories(increment_kernel_test PRIVATE
     ${CMAKE_SOURCE_DIR}/_sep/testbed/cuda
 )

--- a/tests/cuda/increment_kernel_test.cpp
+++ b/tests/cuda/increment_kernel_test.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
 #include "compat/raii.h"
-#include "_sep/testbed/cuda/increment_kernel.hpp"
+#include "increment_kernel.hpp"
 
 TEST(TestbedCudaKernel, IncrementKernel) {
     const unsigned int n = 32;


### PR DESCRIPTION
## Summary
- remove duplicate MAX_BLOCK_SIZE constant
- include `increment_kernel.hpp` via include path
- disable `SEP_USE_CUDA` for CUDA tests so they build with stubs

## Testing
- `./build_no_cuda.sh`

------
https://chatgpt.com/codex/tasks/task_e_686d2a2b7e28832a8c26974e15d76d0f