### PR TITLE
Fix CUDA tests and constants

### DIFF
--- a/include/compat/constants.h
+++ b/include/compat/constants.h
@@ -17,7 +17,6 @@ inline constexpr std::uint32_t get_default_block_size() {
 inline constexpr std::uint32_t MAX_BLOCK_SIZE = 1024;
 inline constexpr std::uint32_t BITFIELD_WORDS = 64;
 inline constexpr std::uint32_t SYMMETRY_PAIRS = 32;
-inline constexpr std::uint32_t MAX_BLOCK_SIZE = 1024;
 inline constexpr std::uint32_t DEFAULT_BLOCK_SIZE = PATTERN_BLOCK_SIZE;
 inline constexpr std::uint32_t WARP_SIZE = 32;
 } // namespace constants

--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -17,7 +17,7 @@ add_executable(long_double_math_test
     long_double_math_test.cpp
 )
 
-set_source_files_properties(long_double_math_test.cpp PROPERTIES LANGUAGE CXX)
+set_source_files_properties(long_double_math_test.cpp PROPERTIES LANGUAGE CUDA)
 
 add_executable(cuda_api_tests
     processing_api_test.cpp

--- a/tests/cuda/increment_kernel_test.cpp
+++ b/tests/cuda/increment_kernel_test.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
 #include "compat/raii.h"
-#include "_sep/testbed/cuda/increment_kernel.hpp"
+#include "increment_kernel.hpp"
 
 TEST(TestbedCudaKernel, IncrementKernel) {
     const unsigned int n = 32;

--- a/tests/cuda/long_double_math_test.cpp
+++ b/tests/cuda/long_double_math_test.cpp
@@ -25,7 +25,7 @@ TEST(LongDoubleMathHost, Atan2lAccuracy) {
 
 TEST(LongDoubleMathDevice, AcoslAccuracy) {
     long double* d_out;
-    ASSERT_EQ(cudaMalloc(&d_out, sizeof(long double)), cudaSuccess);
+    ASSERT_EQ(cudaMalloc(reinterpret_cast<void**>(&d_out), sizeof(long double)), cudaSuccess);
     device_acosl<<<1,1>>>(d_out, 0.5L);
     ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
     long double h_val;
@@ -37,7 +37,7 @@ TEST(LongDoubleMathDevice, AcoslAccuracy) {
 
 TEST(LongDoubleMathDevice, Atan2lAccuracy) {
     long double* d_out;
-    ASSERT_EQ(cudaMalloc(&d_out, sizeof(long double)), cudaSuccess);
+    ASSERT_EQ(cudaMalloc(reinterpret_cast<void**>(&d_out), sizeof(long double)), cudaSuccess);
     device_atan2l<<<1,1>>>(d_out, 0.5L, -0.3L);
     ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
     long double h_val;


### PR DESCRIPTION
## Summary
- remove duplicate `MAX_BLOCK_SIZE` definition
- fix include path for CUDA kernel test
- compile long double CUDA test with NVCC and fix pointer casts

## Testing
- `./build_no_cuda.sh`

------
https://chatgpt.com/codex/tasks/task_e_686d2a0c4da4832ab78547d7d3c696fc