### PR TITLE
Fix CUDA tests build

### DIFF
--- a/include/compat/constants.h
+++ b/include/compat/constants.h
@@ -17,7 +17,6 @@ inline constexpr std::uint32_t get_default_block_size() {
 inline constexpr std::uint32_t MAX_BLOCK_SIZE = 1024;
 inline constexpr std::uint32_t BITFIELD_WORDS = 64;
 inline constexpr std::uint32_t SYMMETRY_PAIRS = 32;
-inline constexpr std::uint32_t MAX_BLOCK_SIZE = 1024;
 inline constexpr std::uint32_t DEFAULT_BLOCK_SIZE = PATTERN_BLOCK_SIZE;
 inline constexpr std::uint32_t WARP_SIZE = 32;
 } // namespace constants

--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -17,7 +17,7 @@ add_executable(long_double_math_test
     long_double_math_test.cpp
 )
 
-set_source_files_properties(long_double_math_test.cpp PROPERTIES LANGUAGE CXX)
+set_source_files_properties(long_double_math_test.cpp PROPERTIES LANGUAGE CUDA)
 
 add_executable(cuda_api_tests
     processing_api_test.cpp

--- a/tests/cuda/increment_kernel_test.cpp
+++ b/tests/cuda/increment_kernel_test.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
 #include "compat/raii.h"
-#include "_sep/testbed/cuda/increment_kernel.hpp"
+#include "increment_kernel.hpp"
 
 TEST(TestbedCudaKernel, IncrementKernel) {
     const unsigned int n = 32;


### PR DESCRIPTION
## Summary
- remove duplicate constant from `constants.h`
- fix include path in `increment_kernel_test`
- compile `long_double_math_test` with NVCC

## Testing
- `./scripts/build_no_cuda.sh`
- `./cmake-no-cuda/tests/memory/memory_manager_tests`

------
https://chatgpt.com/codex/tasks/task_e_686d2a2b7e28832a8c26974e15d76d0f