### PR TITLE
Fix CUDA test includes and constants

### DIFF
--- a/include/compat/constants.h
+++ b/include/compat/constants.h
@@ -17,7 +17,6 @@ inline constexpr std::uint32_t get_default_block_size() {
 inline constexpr std::uint32_t MAX_BLOCK_SIZE = 1024;
 inline constexpr std::uint32_t BITFIELD_WORDS = 64;
 inline constexpr std::uint32_t SYMMETRY_PAIRS = 32;
-inline constexpr std::uint32_t MAX_BLOCK_SIZE = 1024;
 inline constexpr std::uint32_t DEFAULT_BLOCK_SIZE = PATTERN_BLOCK_SIZE;
 inline constexpr std::uint32_t WARP_SIZE = 32;
 } // namespace constants

--- a/tests/cuda/increment_kernel_test.cpp
+++ b/tests/cuda/increment_kernel_test.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
 #include "compat/raii.h"
-#include "_sep/testbed/cuda/increment_kernel.hpp"
+#include "increment_kernel.hpp"
 
 TEST(TestbedCudaKernel, IncrementKernel) {
     const unsigned int n = 32;
@@ -8,13 +8,13 @@ TEST(TestbedCudaKernel, IncrementKernel) {
     ASSERT_TRUE(d_data.valid());
 
     std::vector<int> host(n, 1);
-    EXPECT_EQ(cudaMemcpy(d_data.get(), host.data(), n * sizeof(int), cudaMemcpyHostToDevice), cudaSuccess);
+    EXPECT_EQ(cudaMemcpy(d_data.get(), host.data(), n * sizeof(int), sep::cuda::cudaMemcpyHostToDevice), cudaSuccess);
 
     EXPECT_EQ(launch_increment_kernel(d_data.get(), n, 0), cudaSuccess);
     EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
 
     host.assign(n, 0);
-    EXPECT_EQ(cudaMemcpy(host.data(), d_data.get(), n * sizeof(int), cudaMemcpyDeviceToHost), cudaSuccess);
+    EXPECT_EQ(cudaMemcpy(host.data(), d_data.get(), n * sizeof(int), sep::cuda::cudaMemcpyDeviceToHost), cudaSuccess);
 
     for (int v : host) {
         EXPECT_EQ(v, 2); // original 1 + 1

--- a/tests/cuda/long_double_math_test.cpp
+++ b/tests/cuda/long_double_math_test.cpp
@@ -23,13 +23,14 @@ TEST(LongDoubleMathHost, Atan2lAccuracy) {
     EXPECT_NEAR(static_cast<double>(atan2l(y, x)), static_cast<double>(expected), 1e-9);
 }
 
+#if SEP_ENGINE_HAS_CUDA
 TEST(LongDoubleMathDevice, AcoslAccuracy) {
     long double* d_out;
-    ASSERT_EQ(cudaMalloc(&d_out, sizeof(long double)), cudaSuccess);
+    ASSERT_EQ(cudaMalloc(reinterpret_cast<void**>(&d_out), sizeof(long double)), cudaSuccess);
     device_acosl<<<1,1>>>(d_out, 0.5L);
     ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
     long double h_val;
-    ASSERT_EQ(cudaMemcpy(&h_val, d_out, sizeof(long double), cudaMemcpyDeviceToHost), cudaSuccess);
+    ASSERT_EQ(cudaMemcpy(&h_val, d_out, sizeof(long double), sep::cuda::cudaMemcpyDeviceToHost), cudaSuccess);
     cudaFree(d_out);
     long double expected = ::acosl(0.5L);
     EXPECT_NEAR(static_cast<double>(h_val), static_cast<double>(expected), 1e-9);
@@ -37,15 +38,16 @@ TEST(LongDoubleMathDevice, AcoslAccuracy) {
 
 TEST(LongDoubleMathDevice, Atan2lAccuracy) {
     long double* d_out;
-    ASSERT_EQ(cudaMalloc(&d_out, sizeof(long double)), cudaSuccess);
+    ASSERT_EQ(cudaMalloc(reinterpret_cast<void**>(&d_out), sizeof(long double)), cudaSuccess);
     device_atan2l<<<1,1>>>(d_out, 0.5L, -0.3L);
     ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
     long double h_val;
-    ASSERT_EQ(cudaMemcpy(&h_val, d_out, sizeof(long double), cudaMemcpyDeviceToHost), cudaSuccess);
+    ASSERT_EQ(cudaMemcpy(&h_val, d_out, sizeof(long double), sep::cuda::cudaMemcpyDeviceToHost), cudaSuccess);
     cudaFree(d_out);
     long double expected = ::atan2l(0.5L, -0.3L);
     EXPECT_NEAR(static_cast<double>(h_val), static_cast<double>(expected), 1e-9);
 }
+#endif
 
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
## Summary
- remove duplicate `MAX_BLOCK_SIZE` definition
- include the correct header for CUDA testbed kernel
- guard CUDA long double device tests and adjust cudaMemcpy enums

## Testing
- `g++ -Isrc -Iinclude -I_sep/testbed/cuda -I. -std=c++17 -c tests/cuda/increment_kernel_test.cpp -o /tmp/x.o`
- `g++ -Isrc -Iinclude -I. -std=c++17 -c tests/cuda/long_double_math_test.cpp -o /tmp/l.o`

------
https://chatgpt.com/codex/tasks/task_e_686d2a2b7e28832a8c26974e15d76d0f