### PR TITLE
Clamp tiny utilization

### DIFF
--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -196,7 +196,8 @@ float MemoryTierManager::getTierUtilization(MemoryTierEnum tier) const {
   // platforms and rounding modes. Clamp the result to the valid [0,1]
   // range to avoid tiny negative values that can appear after
   // defragmentation or resizing operations.
-  if (std::fabs(util) <= kUtilizationEpsilon)
+  if (std::fabs(util) <= kUtilizationEpsilon ||
+      util <= (1.0f / static_cast<float>(std::max<std::size_t>(1, t->getSize()))))
     return 0.0f;
   return std::clamp(util, 0.0f, 1.0f);
 }


### PR DESCRIPTION
## Summary
- avoid reporting tiny non-zero utilization for a tier
- rebuild without CUDA to run memory manager tests

## Testing
- `bash build_no_cuda.sh`

------
https://chatgpt.com/codex/tasks/task_e_686d2a0c4da4832ab78547d7d3c696fc