### PR TITLE
Fix CUDA test configuration

### DIFF
--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -3,21 +3,19 @@ if(NOT BUILD_TESTING)
 endif()
 
 if(NOT SEP_HAS_CUDA)
+    message(STATUS "CUDA disabled; skipping CUDA tests")
     return()
 endif()
 
 find_package(GTest REQUIRED)
 
-if(NOT SEP_HAS_CUDA)
-    message(STATUS "CUDA disabled; skipping CUDA tests")
-    return()
-endif()
-
 add_executable(long_double_math_test
     long_double_math_test.cpp
 )
 
-set_source_files_properties(long_double_math_test.cpp PROPERTIES LANGUAGE CXX)
+if(SEP_HAS_CUDA)
+    set_source_files_properties(long_double_math_test.cpp PROPERTIES LANGUAGE CUDA)
+endif()
 
 add_executable(cuda_api_tests
     processing_api_test.cpp


### PR DESCRIPTION
## Summary
- skip CUDA tests when CUDA is disabled
- only set CUDA language for `long_double_math_test.cpp` when CUDA is enabled

## Testing
- `cmake -DCMAKE_BUILD_TYPE=Debug -DSEP_HAS_CUDA=OFF -DSEP_WITH_OPENSUBDIV=OFF -DSEP_WITH_OPENPGL=OFF -DSEP_WITH_OSL=OFF -DSEP_WITH_ALEMBIC=OFF ..`
- `make memory_manager_tests -j$(nproc)`
- `./tests/memory/memory_manager_tests`

------
https://chatgpt.com/codex/tasks/task_e_686d2a0c4da4832ab78547d7d3c696fc