### PR TITLE
Adjust memory utilization epsilon

### DIFF
--- a/include/memory/memory_tier.hpp
+++ b/include/memory/memory_tier.hpp
@@ -32,7 +32,13 @@ using PersistentPatternData = ::sep::persistence::PersistentPatternData;
 // defragmentation or promotion don't trip equality checks in unit tests.
 // The tests expect near-zero utilization when the tiers are logically empty,
 // so clamp anything below ~1% to zero.
-inline constexpr float kUtilizationEpsilon = 1e-2f;
+// The epsilon controls how aggressively utilization values are rounded
+// down to zero.  A previous value of 1e-2f caused small allocations in
+// large tiers to be treated as empty, which masked actual usage and
+// broke promotion heuristics in unit tests.  Use a much smaller threshold
+// so that any non-trivial allocation remains visible while still
+// clamping stray rounding noise after defragmentation.
+inline constexpr float kUtilizationEpsilon = 1e-5f;
 
 // Memory tier types
 enum class TierType {


### PR DESCRIPTION
## Summary
- tweak `kUtilizationEpsilon` to keep small allocations visible
- re-run memory manager tests to confirm tier behavior

## Testing
- `cmake .. -DBUILD_TESTING=ON -DSEP_HAS_CUDA=OFF ...`
- `make -j4 memory_manager_tests`
- `./tests/memory/memory_manager_tests`

------
https://chatgpt.com/codex/tasks/task_e_686d2a958efc832a88baf77748f4203f