### PR TITLE
Document utilization epsilon for memory tiers

### DIFF
--- a/docs/architecture/diagrams/src-memory.md
+++ b/docs/architecture/diagrams/src-memory.md
@@ -45,6 +45,9 @@ The core module supplies:
 - `dag::DagGraph` for tracking relationships between patterns.
 - Logging via `logging::Manager`.
 - Allocation metrics and error handling utilities.
+- Utilization metrics use a small epsilon (~1%) so that tiny rounding
+  errors after tier defragmentation don't appear as lingering usage in
+  tests.
 
 ## File Locations
 


### PR DESCRIPTION
## Summary
- clarify that tier utilization uses a small epsilon to clamp rounding errors

## Testing
- `./build_no_cuda.sh`

------
https://chatgpt.com/codex/tasks/task_e_686d2bc862a0832a9e11681e81ef07c6