### PR TITLE
Improve memory tier utilization stability

### DIFF
--- a/include/memory/memory_tier.hpp
+++ b/include/memory/memory_tier.hpp
@@ -31,8 +31,9 @@ using PersistentPatternData = ::sep::persistence::PersistentPatternData;
 // Increase the epsilon slightly so that tiny residual values after tier
 // defragmentation or promotion don't trip equality checks in unit tests.
 // The tests expect near-zero utilization when the tiers are logically empty,
-// so clamp anything below ~1% to zero.
-inline constexpr float kUtilizationEpsilon = 1e-2f;
+// so clamp anything below ~0.5% to zero.  This strikes a balance between
+// numerical stability and visibility of small allocations in large tiers.
+inline constexpr float kUtilizationEpsilon = 5e-3f;
 
 // Memory tier types
 enum class TierType {


### PR DESCRIPTION
## Summary
- relax `kUtilizationEpsilon` to 0.5%
- rebuild project and run memory tests

## Testing
- `bash scripts/build_no_cuda.sh`
- `cmake-no-cuda/tests/memory/memory_manager_tests`

------
https://chatgpt.com/codex/tasks/task_e_686d2bc862a0832a9e11681e81ef07c6