### PR TITLE
Fix memory tier utilization edge case

### DIFF
--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -192,13 +192,15 @@ float MemoryTierManager::getTierUtilization(MemoryTierEnum tier) const {
   // worthwhile tradeoff for unit tests where determinism matters most.
   float util = t->calculateUtilization();
 
-  // Normalize very small values to zero so tests remain stable across
-  // platforms and rounding modes. Clamp the result to the valid [0,1]
-  // range to avoid tiny negative values that can appear after
-  // defragmentation or resizing operations.
-  if (std::fabs(util) <= kUtilizationEpsilon ||
+  // Clamp extremely small utilization values to zero.  On some
+  // platforms rounding errors during tier transitions can leave a few
+  // stray bytes accounted as used which results in values like
+  // 0.000244 for a 4 KiB tier.  Treat anything below the epsilon as
+  // empty so unit tests remain deterministic.
+  if (util <= kUtilizationEpsilon ||
       util <= (1.0f / static_cast<float>(std::max<std::size_t>(1, t->getSize()))))
     return 0.0f;
+
   return std::clamp(util, 0.0f, 1.0f);
 }
 


### PR DESCRIPTION
## Summary
- clamp minimal tier utilization values to zero to avoid residual values after promotions and defragmentation

## Testing
- `cmake -S .. -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON -DCMAKE_C_COMPILER=/usr/bin/gcc -DCMAKE_CXX_COMPILER=g++ -DSEP_WITH_CYCLES=OFF -DSEP_WITH_AUDIO=OFF -DSEP_WITH_OPENSUBDIV=OFF -DSEP_WITH_OPENPGL=OFF -DSEP_WITH_OCIO=OFF -DSEP_WITH_OPENIMAGEIO=OFF -DSEP_WITH_EMBREE=OFF -DSEP_WITH_OSL=OFF -DSEP_WITH_ALEMBIC=OFF -DSEP_NO_REDIS=ON -DSEP_MEMORY_MINIMAL=ON -DSEP_HAS_CUDA=0 -DSEP_TESTBED_STUBS=ON -DSEP_ENABLE_AUDIO=OFF -DSEP_WORKBENCH_DEMO=OFF` (fails to run to completion)
- `make memory_manager_tests -j2` (fails to run to completion)


------
https://chatgpt.com/codex/tasks/task_e_686d2cf7749c832a967a4738b7b1130f