### PR TITLE
Update docs on epsilon for memory tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,3 +193,8 @@ make memory_manager_tests
 
 This mirrors the configuration used by `build_no_cuda.sh` while giving
 you direct control over the build location.
+When running the unit tests you may observe tiny non-zero utilization values such
+as `0.000244` after promotion or defragmentation. The test suite treats any value
+below 1% as effectively zero by comparing against `kUtilizationEpsilon`. If you
+see failures around these checks ensure you are using the latest test sources or
+increase the epsilon accordingly.


### PR DESCRIPTION
## Summary
- clarify rounding expectations in the memory_manager_tests section of README

## Testing
- `./tests/memory/memory_manager_tests`

------
https://chatgpt.com/codex/tasks/task_e_686d2cb1addc832a85f6d148e82e0ca6