### PR TITLE
Fix CUDA test include path and CMake language

### DIFF
--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -16,9 +16,7 @@ endif()
 add_executable(long_double_math_test
     long_double_math_test.cpp
 )
-set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/long_double_math_test.cpp PROPERTIES LANGUAGE CXX)
-
-set_source_files_properties(long_double_math_test.cpp PROPERTIES LANGUAGE CXX)
+set_source_files_properties(long_double_math_test.cpp PROPERTIES LANGUAGE CUDA)
 
 add_executable(cuda_api_tests
     processing_api_test.cpp

--- a/tests/cuda/increment_kernel_test.cpp
+++ b/tests/cuda/increment_kernel_test.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
 #include "compat/raii.h"
-#include "increment_kernel.hpp"
+#include "_sep/testbed/cuda/increment_kernel.hpp"
 
 TEST(TestbedCudaKernel, IncrementKernel) {
     const unsigned int n = 32;


### PR DESCRIPTION
## Summary
- correct path to increment kernel header in test
- compile long_double_math_test as CUDA

## Testing
- `cmake ..` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_686d2cb1addc832a85f6d148e82e0ca6