### PR TITLE
Fix memory tier utilization epsilon

### DIFF
--- a/src/memory/memory_tier.cpp
+++ b/src/memory/memory_tier.cpp
@@ -217,7 +217,11 @@ void MemoryTier::deallocate(MemoryBlock *block) {
     if (blk.allocated)
       used_space_ += blk.size;
   }
-  if (used_space_ <= static_cast<std::size_t>(kUtilizationEpsilon * config_.size))
+  constexpr std::size_t kMinBytes = 1;
+  if (used_space_ <=
+      std::max<std::size_t>(kMinBytes,
+                             static_cast<std::size_t>(kUtilizationEpsilon *
+                                                     config_.size)))
     used_space_ = 0;
 }
 
@@ -351,8 +355,12 @@ float MemoryTier::calculateUtilization() const {
   // promotions or defragmentation can leave a few bytes marked as used even
   // though the tier is effectively empty.  Clamping here avoids spurious
   // non-zero utilization in unit tests.
+  constexpr std::size_t kMinBytes = 1;
   if (used == 0 ||
-      used <= static_cast<std::size_t>(kUtilizationEpsilon * config_.size))
+      used <=
+          std::max<std::size_t>(kMinBytes,
+                                static_cast<std::size_t>(kUtilizationEpsilon *
+                                                        config_.size)))
     return 0.0f;
 
   float util = static_cast<float>(used) / static_cast<float>(config_.size);
@@ -496,7 +504,11 @@ void MemoryTier::mergeAdjacentBlocks() {
       used_space_ += blk.size;
     }
   }
-  if (used_space_ <= static_cast<std::size_t>(kUtilizationEpsilon * config_.size))
+  constexpr std::size_t kMinBytes = 1;
+  if (used_space_ <=
+      std::max<std::size_t>(kMinBytes,
+                             static_cast<std::size_t>(kUtilizationEpsilon *
+                                                     config_.size)))
     used_space_ = 0;
 }
 

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -196,8 +196,11 @@ float MemoryTierManager::getTierUtilization(MemoryTierEnum tier) const {
   // platforms and rounding modes. Clamp the result to the valid [0,1]
   // range to avoid tiny negative values that can appear after
   // defragmentation or resizing operations.
-  if (std::fabs(util) <= kUtilizationEpsilon ||
-      util <= (1.0f / static_cast<float>(std::max<std::size_t>(1, t->getSize()))))
+  constexpr float kSizeEpsilon = 1e-6f;
+  float size_threshold =
+      (1.0f / static_cast<float>(std::max<std::size_t>(1, t->getSize()))) +
+      kSizeEpsilon;
+  if (std::fabs(util) <= kUtilizationEpsilon || util <= size_threshold)
     return 0.0f;
   return std::clamp(util, 0.0f, 1.0f);
 }


### PR DESCRIPTION
## Summary
- clamp residual usage to zero when one byte remains
- make tier manager more tolerant of tiny utilization values

## Testing
- `cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=g++-14 -DSEP_HAS_CUDA=OFF -DSEP_BUILD_ENGINE=OFF -DSEP_MINIMAL=ON -DSEP_WITH_OPENSUBDIV=OFF -DSEP_WITH_OPENPGL=OFF -DSEP_WITH_OCIO=OFF -DSEP_WITH_OPENIMAGEIO=OFF -DSEP_WITH_EMBREE=OFF -DSEP_WITH_OSL=OFF -DSEP_WITH_ALEMBIC=OFF -DSEP_WITH_AUDIO=OFF -B sep_build/build -S ..`
- `make memory_manager_tests`
- `./tests/memory/memory_manager_tests`

------
https://chatgpt.com/codex/tasks/task_e_686d2fa45800832a838706e65b69652e