### PR TITLE
Fix memory tier utilization rounding

### DIFF
--- a/src/memory/memory_tier.cpp
+++ b/src/memory/memory_tier.cpp
@@ -217,7 +217,9 @@ void MemoryTier::deallocate(MemoryBlock *block) {
     if (blk.allocated)
       used_space_ += blk.size;
   }
-  if (used_space_ <= static_cast<std::size_t>(kUtilizationEpsilon * config_.size))
+  const float noise_threshold =
+      std::max(1.0f, kUtilizationEpsilon * static_cast<float>(config_.size));
+  if (static_cast<float>(used_space_) <= noise_threshold)
     used_space_ = 0;
 }
 
@@ -351,8 +353,9 @@ float MemoryTier::calculateUtilization() const {
   // promotions or defragmentation can leave a few bytes marked as used even
   // though the tier is effectively empty.  Clamping here avoids spurious
   // non-zero utilization in unit tests.
-  if (used == 0 ||
-      used <= static_cast<std::size_t>(kUtilizationEpsilon * config_.size))
+  const float noise_threshold =
+      std::max(1.0f, kUtilizationEpsilon * static_cast<float>(config_.size));
+  if (used == 0 || static_cast<float>(used) <= noise_threshold)
     return 0.0f;
 
   float util = static_cast<float>(used) / static_cast<float>(config_.size);
@@ -496,7 +499,9 @@ void MemoryTier::mergeAdjacentBlocks() {
       used_space_ += blk.size;
     }
   }
-  if (used_space_ <= static_cast<std::size_t>(kUtilizationEpsilon * config_.size))
+  const float noise_threshold =
+      std::max(1.0f, kUtilizationEpsilon * static_cast<float>(config_.size));
+  if (static_cast<float>(used_space_) <= noise_threshold)
     used_space_ = 0;
 }
 

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -196,8 +196,9 @@ float MemoryTierManager::getTierUtilization(MemoryTierEnum tier) const {
   // platforms and rounding modes. Clamp the result to the valid [0,1]
   // range to avoid tiny negative values that can appear after
   // defragmentation or resizing operations.
-  if (std::fabs(util) <= kUtilizationEpsilon ||
-      util <= (1.0f / static_cast<float>(std::max<std::size_t>(1, t->getSize()))))
+  const float rounding_threshold =
+      2.0f / static_cast<float>(std::max<std::size_t>(1, t->getSize()));
+  if (std::fabs(util) <= kUtilizationEpsilon || util <= rounding_threshold)
     return 0.0f;
   return std::clamp(util, 0.0f, 1.0f);
 }


### PR DESCRIPTION
## Summary
- treat tiny used-space values as rounding noise
- clamp per-tier utilization to account for rounding

## Testing
- `./build_no_cuda.sh`


------
https://chatgpt.com/codex/tasks/task_e_686d2fa45800832a838706e65b69652e