### PR TITLE
Fix CUDA test link errors

### DIFF
--- a/src/compat/raii.cpp
+++ b/src/compat/raii.cpp
@@ -247,6 +247,7 @@ template class DeviceBufferRAII<std::uint32_t>;
 template class DeviceBufferRAII<std::uint64_t>;
 template class DeviceBufferRAII<float>;
 template class DeviceBufferRAII<double>;
+template class DeviceBufferRAII<int>;
 
 // Implementation of memory management functions
 void* allocateDeviceMemory(std::size_t size) {


### PR DESCRIPTION
## Summary
- instantiate DeviceBufferRAII<int> so CUDA testbed builds

## Testing
- `cmake ../../_sep/testbed/memory_minimal`
- `make -j$(nproc)`
- `./memory_minimal_tests`

------
https://chatgpt.com/codex/tasks/task_e_686d30bb2c78832a8226ea010b47c6ac