### PR TITLE
Fix CUDA RAII instantiation

### DIFF
--- a/src/compat/raii.cpp
+++ b/src/compat/raii.cpp
@@ -245,6 +245,7 @@ DeviceBufferRAII<T>& DeviceBufferRAII<T>::operator=(DeviceBufferRAII&& other) no
 // Explicit template instantiations for common types
 template class DeviceBufferRAII<std::uint32_t>;
 template class DeviceBufferRAII<std::uint64_t>;
+template class DeviceBufferRAII<int>;
 template class DeviceBufferRAII<float>;
 template class DeviceBufferRAII<double>;
 


### PR DESCRIPTION
## Summary
- export DeviceBufferRAII<int> to resolve CUDA test links

## Testing
- `bash build_no_cuda.sh`

------
https://chatgpt.com/codex/tasks/task_e_686d30bb2c78832a8226ea010b47c6ac