### PR TITLE
Fix memory tier utilization metric

### DIFF
--- a/src/memory/memory_tier.cpp
+++ b/src/memory/memory_tier.cpp
@@ -345,11 +345,18 @@ float MemoryTier::calculateUtilization() const {
   if (config_.size == 0)
     return 0.0f;
 
-  // Recalculate used space on demand to avoid stale values in unit tests
-  // used_space_ is maintained during allocate/deallocate so scanning the
-  // block list on every call is unnecessary. Recompute only if needed for
-  // deterministic unit tests.
-  std::size_t used = used_space_;
+  // Recompute used space directly from the block list to avoid stale values
+  // that can arise when promotion or defragmentation leaves used_space_
+  // slightly out of sync.  The extra work is negligible for the small sizes
+  // used in unit tests and ensures deterministic results.
+  std::size_t used = 0;
+  for (const auto &blk : blocks_) {
+    if (blk.allocated)
+      used += blk.size;
+  }
+  // Keep the cached value consistent so other helpers report accurate
+  // metrics even if they rely on used_space_.
+  const_cast<MemoryTier *>(this)->used_space_ = used;
 
   // Treat extremely small usage values as zero.  Byte-level rounding during
   // promotions or defragmentation can leave a few bytes marked as used even


### PR DESCRIPTION
## Summary
- ensure MemoryTier recomputes used space by scanning blocks
- update cached used_space_ for consistent metrics

## Testing
- `cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=g++-14 -DSEP_HAS_CUDA=OFF -DSEP_WITH_CYCLES=OFF -DSEP_WITH_OPENSUBDIV=OFF -DSEP_WITH_OPENPGL=OFF -DSEP_WITH_OCIO=OFF -DSEP_WITH_OPENIMAGEIO=OFF -DSEP_WITH_EMBREE=OFF -DSEP_WITH_OSL=OFF -DSEP_WITH_ALEMBIC=OFF -DSEP_WITH_AUDIO=OFF -DSEP_MINIMAL=ON -S .. -B .`
- `make -j$(nproc) memory_manager_tests`
- `./tests/memory/memory_manager_tests`

------
https://chatgpt.com/codex/tasks/task_e_686d329a2104832a802daf04c94bd3ca