### PR TITLE
Fix tier utilization rounding

### DIFF
--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -197,8 +197,9 @@ float MemoryTierManager::getTierUtilization(MemoryTierEnum tier) const {
   // stray bytes accounted as used which results in values like
   // 0.000244 for a 4 KiB tier.  Treat anything below the epsilon as
   // empty so unit tests remain deterministic.
-  if (util <= kUtilizationEpsilon ||
-      util <= (1.0f / static_cast<float>(std::max<std::size_t>(1, t->getSize()))))
+  const float inverse_size =
+      1.0f / static_cast<float>(std::max<std::size_t>(1, t->getSize()));
+  if (util <= kUtilizationEpsilon || util <= inverse_size + kUtilizationEpsilon)
     return 0.0f;
 
   return std::clamp(util, 0.0f, 1.0f);


### PR DESCRIPTION
## Summary
- clamp tier utilization check with epsilon
- ensure near-zero utilization is reported as zero

## Testing
- `cmake -DCMAKE_BUILD_TYPE=Debug -DSEP_HAS_CUDA=OFF -DSEP_WITH_CYCLES=OFF -DSEP_WITH_OPENSUBDIV=OFF -DSEP_WITH_OPENPGL=OFF -DSEP_WITH_OCIO=OFF -DSEP_WITH_OPENIMAGEIO=OFF -DSEP_WITH_AUDIO=OFF -DSEP_WITH_EMBREE=OFF -DSEP_WITH_OSL=OFF -DSEP_WITH_ALEMBIC=OFF -DSEP_MINIMAL=ON ..`
- `make memory_manager_tests`
- `./tests/memory/memory_manager_tests`

------
https://chatgpt.com/codex/tasks/task_e_686d329a2104832a802daf04c94bd3ca