### PR TITLE
Implement demo classes under examples/workbench

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,4 @@ blender
 package-lock.json
 third_party/glm/
 cmake-nocuda/
+third_party/

--- a/examples/workbench/demos/audio_visualizer.cpp
+++ b/examples/workbench/demos/audio_visualizer.cpp
@@ -1,0 +1,26 @@
+#include "audio_visualizer.hpp"
+#include <imgui.h>
+#include <cmath>
+
+namespace sep {
+namespace workbench {
+
+void AudioVisualizerDemo::on_load() {
+    spectrum_.assign(64, 0.f);
+}
+
+void AudioVisualizerDemo::on_update(float dt) {
+    for (size_t i = 0; i < spectrum_.size(); ++i) {
+        spectrum_[i] = 0.5f + 0.5f*std::sin(static_cast<float>(i) + dt);
+    }
+}
+
+void AudioVisualizerDemo::on_render() {
+    ImGui::Begin("Audio Visualizer");
+    ImGui::SliderFloat("Sensitivity", &sensitivity_, 0.1f, 5.0f);
+    ImGui::Text("Spectrum bins: %zu", spectrum_.size());
+    ImGui::End();
+}
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/demos/audio_visualizer.hpp
+++ b/examples/workbench/demos/audio_visualizer.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "demo.hpp"
+#include <vector>
+
+namespace sep {
+namespace workbench {
+
+class AudioVisualizerDemo : public Demo {
+public:
+    void on_load() override;
+    void on_update(float dt) override;
+    void on_render() override;
+
+private:
+    std::vector<float> spectrum_;
+    float sensitivity_{1.0f};
+};
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/demos/demo.hpp
+++ b/examples/workbench/demos/demo.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <memory>
+#include <functional>
+
+namespace sep {
+namespace workbench {
+
+class Demo {
+public:
+    virtual ~Demo() = default;
+    virtual void on_load() {}
+    virtual void on_unload() {}
+    virtual void on_update(float dt) {}
+    virtual void on_render() {}
+};
+
+using DemoFactory = std::function<std::unique_ptr<Demo>()>;
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/demos/demo_manager.cpp
+++ b/examples/workbench/demos/demo_manager.cpp
@@ -1,0 +1,34 @@
+#include "demo_manager.hpp"
+
+namespace sep {
+namespace workbench {
+
+DemoManager& DemoManager::instance() {
+    static DemoManager inst;
+    return inst;
+}
+
+void DemoManager::register_demo(const std::string& key, DemoFactory factory) {
+    factories_[key] = std::move(factory);
+}
+
+bool DemoManager::switch_demo(const std::string& key) {
+    auto it = factories_.find(key);
+    if (it == factories_.end()) return false;
+
+    if (current_) current_->on_unload();
+    current_ = it->second();
+    if (current_) current_->on_load();
+    return static_cast<bool>(current_);
+}
+
+void DemoManager::update(float dt) {
+    if (current_) current_->on_update(dt);
+}
+
+void DemoManager::render() {
+    if (current_) current_->on_render();
+}
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/demos/demo_manager.hpp
+++ b/examples/workbench/demos/demo_manager.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "demo.hpp"
+#include <unordered_map>
+#include <string>
+
+namespace sep {
+namespace workbench {
+
+class DemoManager {
+public:
+    static DemoManager& instance();
+
+    void register_demo(const std::string& key, DemoFactory factory);
+    bool switch_demo(const std::string& key);
+
+    void update(float dt);
+    void render();
+
+private:
+    DemoManager() = default;
+
+    std::unordered_map<std::string, DemoFactory> factories_;
+    std::unique_ptr<Demo> current_;
+};
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/demos/genesis_pattern.cpp
+++ b/examples/workbench/demos/genesis_pattern.cpp
@@ -1,0 +1,28 @@
+#include "genesis_pattern.hpp"
+#include <imgui.h>
+
+namespace sep {
+namespace workbench {
+
+void GenesisPatternDemo::on_load() {
+    dummy_state_.assign(100, 0.5f);
+}
+
+void GenesisPatternDemo::evolve(float dt) {
+    for (auto& v : dummy_state_) v += dt * evolution_rate_;
+}
+
+void GenesisPatternDemo::on_update(float dt) {
+    if (auto_evolve_) evolve(dt);
+}
+
+void GenesisPatternDemo::on_render() {
+    ImGui::Begin("Genesis Pattern");
+    ImGui::SliderFloat("Evolution Rate", &evolution_rate_, 0.01f, 1.0f);
+    ImGui::Checkbox("Auto evolve", &auto_evolve_);
+    ImGui::Text("Patterns: %zu", dummy_state_.size());
+    ImGui::End();
+}
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/demos/genesis_pattern.hpp
+++ b/examples/workbench/demos/genesis_pattern.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "demo.hpp"
+#include <vector>
+
+namespace sep {
+namespace workbench {
+
+class GenesisPatternDemo : public Demo {
+public:
+    void on_load() override;
+    void on_update(float dt) override;
+    void on_render() override;
+
+private:
+    void evolve(float dt);
+
+    float evolution_rate_{0.2f};
+    bool auto_evolve_{true};
+    std::vector<float> dummy_state_;
+};
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/demos/memory_garden.cpp
+++ b/examples/workbench/demos/memory_garden.cpp
@@ -1,0 +1,27 @@
+#include "memory_garden.hpp"
+#include <imgui.h>
+#include <cstdlib>
+
+namespace sep {
+namespace workbench {
+
+void MemoryGardenDemo::on_load() {
+    nodes_.clear();
+    for (int i=0;i<5;++i) nodes_.push_back({static_cast<float>(i)/5.f});
+}
+
+void MemoryGardenDemo::on_update(float dt) {
+    for (auto& n : nodes_) {
+        n.coherence += ((std::rand()%100)/100.f - 0.5f)*dt;
+    }
+}
+
+void MemoryGardenDemo::on_render() {
+    ImGui::Begin("Memory Garden");
+    ImGui::Text("Node count: %zu", nodes_.size());
+    ImGui::SliderFloat("STM radius", &stm_radius_, 5.f, 50.f);
+    ImGui::End();
+}
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/demos/memory_garden.hpp
+++ b/examples/workbench/demos/memory_garden.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "demo.hpp"
+#include <vector>
+
+namespace sep {
+namespace workbench {
+
+class MemoryGardenDemo : public Demo {
+public:
+    void on_load() override;
+    void on_update(float dt) override;
+    void on_render() override;
+
+private:
+    struct Node { float coherence; };
+    std::vector<Node> nodes_;
+    float stm_radius_{10.f};
+};
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/main.cpp
+++ b/examples/workbench/main.cpp
@@ -1,0 +1,20 @@
+#include "demos/demo_manager.hpp"
+#include "demos/genesis_pattern.hpp"
+#include "demos/audio_visualizer.hpp"
+#include "demos/memory_garden.hpp"
+
+int main() {
+    using namespace sep::workbench;
+    auto& mgr = DemoManager::instance();
+    mgr.register_demo("genesis", []{ return std::make_unique<GenesisPatternDemo>(); });
+    mgr.register_demo("audio", []{ return std::make_unique<AudioVisualizerDemo>(); });
+    mgr.register_demo("memory", []{ return std::make_unique<MemoryGardenDemo>(); });
+
+    mgr.switch_demo("genesis");
+    // placeholder loop
+    for(int i=0;i<1;++i) {
+        mgr.update(0.016f);
+        mgr.render();
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add new Demo base class for workbench examples
- implement DemoManager to manage demo instances
- create GenesisPatternDemo with simple ImGui controls
- create AudioVisualizerDemo and MemoryGardenDemo with placeholder logic
- register these demos in a minimal main
- ignore `third_party/` in git

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686edbb40a98832abe0018587400735e