### PR TITLE
Implement workbench demo framework

### DIFF
--- a/examples/workbench/demos/demo_manager.cpp
+++ b/examples/workbench/demos/demo_manager.cpp
@@ -1,0 +1,57 @@
+#include "demo_manager.hpp"
+#include <utility>
+
+namespace sep {
+namespace workbench {
+
+void DemoManager::initialize(sep::Engine* engine, sep::CyclesRenderer* renderer) {
+    engine_ = engine;
+    renderer_ = renderer;
+}
+
+void DemoManager::registerDemo(const std::string& name,
+                               std::function<std::unique_ptr<Demo>()> factory) {
+    demo_factories_[name] = std::move(factory);
+}
+
+bool DemoManager::switchToDemo(const std::string& name) {
+    auto it = demo_factories_.find(name);
+    if (it == demo_factories_.end()) {
+        return false;
+    }
+
+    if (current_demo_) {
+        current_demo_->on_unload();
+        current_demo_.reset();
+    }
+
+    current_demo_ = it->second();
+    if (current_demo_) {
+        current_demo_->initialize(engine_, renderer_);
+        current_demo_name_ = name;
+        return true;
+    }
+    return false;
+}
+
+void DemoManager::update(float dt) {
+    if (current_demo_) {
+        current_demo_->on_update(dt);
+    }
+}
+
+void DemoManager::render() {
+    if (current_demo_) {
+        current_demo_->on_render();
+    }
+}
+
+void DemoManager::cleanup() {
+    if (current_demo_) {
+        current_demo_->on_unload();
+        current_demo_.reset();
+    }
+}
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/demos/demo_manager.hpp
+++ b/examples/workbench/demos/demo_manager.hpp
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "../../src/sep_engine_wrapper.h"
+#include <functional>
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+namespace sep {
+namespace workbench {
+
+class Demo {
+public:
+    virtual ~Demo() = default;
+
+    virtual void on_load() = 0;   // Called when the demo becomes active
+    virtual void on_unload() = 0; // Called when the demo is switched out
+    virtual void on_update(float dt) = 0;
+    virtual void on_render() = 0;
+    virtual void on_key_press(int key) = 0;
+
+    void initialize(sep::Engine* engine, sep::CyclesRenderer* renderer) {
+        engine_ = engine;
+        renderer_ = renderer;
+        on_load();
+    }
+
+protected:
+    sep::Engine* engine_{nullptr};
+    sep::CyclesRenderer* renderer_{nullptr};
+};
+
+class DemoManager {
+public:
+    static DemoManager& getInstance() {
+        static DemoManager instance;
+        return instance;
+    }
+
+    void initialize(sep::Engine* engine, sep::CyclesRenderer* renderer);
+    void registerDemo(const std::string& name,
+                      std::function<std::unique_ptr<Demo>()> factory);
+    bool switchToDemo(const std::string& name);
+    void update(float dt);
+    void render();
+    void cleanup();
+
+private:
+    DemoManager() = default;
+
+    sep::Engine* engine_{nullptr};
+    sep::CyclesRenderer* renderer_{nullptr};
+    std::unordered_map<std::string, std::function<std::unique_ptr<Demo>()>> demo_factories_;
+    std::unique_ptr<Demo> current_demo_;
+    std::string current_demo_name_;
+};
+
+} // namespace workbench
+} // namespace sep
+

--- a/examples/workbench/main.cpp
+++ b/examples/workbench/main.cpp
@@ -1,0 +1,68 @@
+#include "demos/demo_manager.hpp"
+#include "../../src/demos/genesis_pattern.hpp"
+#include "../../src/demos/annealing_demo.hpp"
+#include "../../src/demos/cosmo_demo.hpp"
+#include "../../src/demos/flocking_demo.hpp"
+#include "../../src/demos/neural_demo.hpp"
+#include "../../src/demos/drug_discovery_demo.hpp"
+#include "../../src/demos/digital_physics_demo.hpp"
+#include "../../src/demos/memory_garden.hpp"
+#include "../../src/window.h"
+#include "../../src/sep_engine_wrapper.h"
+
+#include <GL/glew.h>
+#include <GLFW/glfw3.h>
+#include <iostream>
+#include <memory>
+
+int main() {
+    if (!glfwInit()) {
+        std::cerr << "Failed to init GLFW" << std::endl;
+        return 1;
+    }
+
+    sep::workbench::Window window(1280, 720, "SEP Workbench");
+    if (!window.initialize()) {
+        std::cerr << "Failed to initialize window" << std::endl;
+        return 1;
+    }
+    window.makeContextCurrent();
+
+    glewExperimental = GL_TRUE;
+    if (glewInit() != GLEW_OK) {
+        std::cerr << "Failed to initialize GLEW" << std::endl;
+        return 1;
+    }
+
+    auto engine = std::make_unique<sep::EngineWrapper>(sep::config::EngineConfig{});
+    if (!engine->initialize()) {
+        std::cerr << "Failed to init engine" << std::endl;
+        return 1;
+    }
+
+    sep::workbench::DemoManager& manager = sep::workbench::DemoManager::getInstance();
+    manager.initialize(engine.get(), nullptr);
+
+    manager.registerDemo("genesis", [] { return std::make_unique<sep::workbench::GenesisPatternDemo>(); });
+    manager.registerDemo("annealing", [] { return std::make_unique<sep::workbench::AnnealingDemo>(); });
+    manager.registerDemo("cosmos", [] { return std::make_unique<sep::workbench::CosmoDemo>(); });
+    manager.registerDemo("flocking", [] { return std::make_unique<sep::workbench::FlockingDemo>(); });
+    manager.registerDemo("neural", [] { return std::make_unique<sep::workbench::NeuralDemo>(); });
+    manager.registerDemo("drug_discovery", [] { return std::make_unique<sep::workbench::DrugDiscoveryDemo>(); });
+    manager.registerDemo("digital_physics", [] { return std::make_unique<sep::workbench::DigitalPhysicsDemo>(); });
+    manager.registerDemo("memory_garden", [] { return std::make_unique<sep::workbench::MemoryGardenDemo>(); });
+
+    manager.switchToDemo("genesis");
+
+    while (!window.shouldClose()) {
+        manager.update(1.0f / 60.0f);
+        manager.render();
+        window.swapBuffers();
+        window.pollEvents();
+    }
+
+    manager.cleanup();
+    window.cleanup();
+    glfwTerminate();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add demo base class with lifecycle methods
- implement DemoManager to handle demo transitions
- create example main that registers demos via lambdas

## Testing
- `g++ -std=c++17 -I./examples/workbench -I./src -c examples/workbench/demos/demo_manager.cpp -o /tmp/demo_manager.o`
- `g++ -std=c++17 -I./examples/workbench -I./src -c examples/workbench/main.cpp -o /tmp/main.o` *(fails: `GL/glew.h` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686edbab8908832a99cdfa2697f27c0f