### PR TITLE
Add demo framework testbed

### DIFF
--- a/_sep/testbed/examples/workbench/demos/audio_visualizer_demo.cpp
+++ b/_sep/testbed/examples/workbench/demos/audio_visualizer_demo.cpp
@@ -1,0 +1,21 @@
+#include "audio_visualizer_demo.hpp"
+
+namespace sep {
+namespace workbench {
+
+void AudioVisualizerDemo::on_load() {
+    sensitivity_ = 1.0f;
+}
+
+void AudioVisualizerDemo::on_update(float dt) {
+    (void)dt; // placeholder
+}
+
+void AudioVisualizerDemo::on_render() {
+    ImGui::Begin("Audio Visualizer");
+    ImGui::SliderFloat("Sensitivity", &sensitivity_, 0.1f, 5.0f);
+    ImGui::End();
+}
+
+} // namespace workbench
+} // namespace sep

--- a/_sep/testbed/examples/workbench/demos/audio_visualizer_demo.hpp
+++ b/_sep/testbed/examples/workbench/demos/audio_visualizer_demo.hpp
@@ -1,0 +1,25 @@
+#ifndef SEP_WORKBENCH_AUDIO_VISUALIZER_DEMO_HPP
+#define SEP_WORKBENCH_AUDIO_VISUALIZER_DEMO_HPP
+
+#include "demo.hpp"
+#include <imgui.h>
+
+namespace sep {
+namespace workbench {
+
+class AudioVisualizerDemo : public Demo {
+public:
+    void on_load() override;
+    void on_unload() override {}
+    void on_update(float dt) override;
+    void on_render() override;
+    void on_key_press(int key) override {}
+
+private:
+    float sensitivity_ = 1.0f;
+};
+
+} // namespace workbench
+} // namespace sep
+
+#endif // SEP_WORKBENCH_AUDIO_VISUALIZER_DEMO_HPP

--- a/_sep/testbed/examples/workbench/demos/demo.hpp
+++ b/_sep/testbed/examples/workbench/demos/demo.hpp
@@ -1,0 +1,18 @@
+#ifndef SEP_WORKBENCH_DEMO_HPP
+#define SEP_WORKBENCH_DEMO_HPP
+
+namespace sep {
+namespace workbench {
+class Demo {
+public:
+    virtual ~Demo() = default;
+    virtual void on_load() = 0;
+    virtual void on_unload() = 0;
+    virtual void on_update(float dt) = 0;
+    virtual void on_render() = 0;
+    virtual void on_key_press(int key) = 0;
+};
+} // namespace workbench
+} // namespace sep
+
+#endif // SEP_WORKBENCH_DEMO_HPP

--- a/_sep/testbed/examples/workbench/demos/demo_manager.cpp
+++ b/_sep/testbed/examples/workbench/demos/demo_manager.cpp
@@ -1,0 +1,38 @@
+#include "demo_manager.hpp"
+
+namespace sep {
+namespace workbench {
+
+DemoManager& DemoManager::instance() {
+    static DemoManager inst;
+    return inst;
+}
+
+void DemoManager::register_demo(const std::string& key, std::unique_ptr<Demo> demo) {
+    demos_[key] = std::move(demo);
+}
+
+bool DemoManager::switch_to(const std::string& key) {
+    auto it = demos_.find(key);
+    if (it == demos_.end()) return false;
+    if (active_) active_->on_unload();
+    active_ = it->second.get();
+    active_key_ = key;
+    active_->on_load();
+    return true;
+}
+
+void DemoManager::update(float dt) {
+    if (active_) active_->on_update(dt);
+}
+
+void DemoManager::render() {
+    if (active_) active_->on_render();
+}
+
+void DemoManager::key_press(int key) {
+    if (active_) active_->on_key_press(key);
+}
+
+} // namespace workbench
+} // namespace sep

--- a/_sep/testbed/examples/workbench/demos/demo_manager.hpp
+++ b/_sep/testbed/examples/workbench/demos/demo_manager.hpp
@@ -1,0 +1,29 @@
+#ifndef SEP_WORKBENCH_DEMO_MANAGER_HPP
+#define SEP_WORKBENCH_DEMO_MANAGER_HPP
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include "demo.hpp"
+
+namespace sep {
+namespace workbench {
+class DemoManager {
+public:
+    static DemoManager& instance();
+
+    void register_demo(const std::string& key, std::unique_ptr<Demo> demo);
+    bool switch_to(const std::string& key);
+    void update(float dt);
+    void render();
+    void key_press(int key);
+
+private:
+    std::unordered_map<std::string, std::unique_ptr<Demo>> demos_;
+    Demo* active_{nullptr};
+    std::string active_key_;
+};
+} // namespace workbench
+} // namespace sep
+
+#endif // SEP_WORKBENCH_DEMO_MANAGER_HPP

--- a/_sep/testbed/examples/workbench/demos/genesis_pattern_demo.cpp
+++ b/_sep/testbed/examples/workbench/demos/genesis_pattern_demo.cpp
@@ -1,0 +1,30 @@
+#include "genesis_pattern_demo.hpp"
+
+namespace sep {
+namespace workbench {
+
+void GenesisPatternDemo::on_load() {
+    auto_evolve_ = true;
+    evolution_rate_ = 0.1f;
+}
+
+void GenesisPatternDemo::on_update(float dt) {
+    if (auto_evolve_) {
+        // placeholder for evolution logic
+        (void)dt; // suppress unused warning
+    }
+}
+
+void GenesisPatternDemo::on_render() {
+    ImGui::Begin("Genesis Controls");
+    ImGui::Checkbox("Auto Evolve", &auto_evolve_);
+    ImGui::SliderFloat("Evolution Rate", &evolution_rate_, 0.01f, 1.0f);
+    ImGui::End();
+}
+
+void GenesisPatternDemo::on_key_press(int key) {
+    if (key == ' ') auto_evolve_ = !auto_evolve_;
+}
+
+} // namespace workbench
+} // namespace sep

--- a/_sep/testbed/examples/workbench/demos/genesis_pattern_demo.hpp
+++ b/_sep/testbed/examples/workbench/demos/genesis_pattern_demo.hpp
@@ -1,0 +1,26 @@
+#ifndef SEP_WORKBENCH_GENESIS_PATTERN_DEMO_HPP
+#define SEP_WORKBENCH_GENESIS_PATTERN_DEMO_HPP
+
+#include "demo.hpp"
+#include <imgui.h>
+
+namespace sep {
+namespace workbench {
+
+class GenesisPatternDemo : public Demo {
+public:
+    void on_load() override;
+    void on_unload() override {}
+    void on_update(float dt) override;
+    void on_render() override;
+    void on_key_press(int key) override;
+
+private:
+    bool auto_evolve_ = true;
+    float evolution_rate_ = 0.1f;
+};
+
+} // namespace workbench
+} // namespace sep
+
+#endif // SEP_WORKBENCH_GENESIS_PATTERN_DEMO_HPP

--- a/_sep/testbed/examples/workbench/demos/memory_garden_demo.cpp
+++ b/_sep/testbed/examples/workbench/demos/memory_garden_demo.cpp
@@ -1,0 +1,33 @@
+#include "memory_garden_demo.hpp"
+#include <cmath>
+
+namespace sep {
+namespace workbench {
+
+void MemoryGardenDemo::on_load() {
+    nodes_.clear();
+    for (int i = 0; i < 5; ++i) {
+        float angle = i * 0.5f;
+        nodes_.push_back({{tier_radius_[0] * std::cos(angle), 0.f, tier_radius_[0] * std::sin(angle)}});
+    }
+}
+
+void MemoryGardenDemo::on_update(float dt) {
+    (void)dt;
+    // simple orbit update
+    for (size_t i = 0; i < nodes_.size(); ++i) {
+        float angle = static_cast<float>(i) * 0.5f + dt;
+        nodes_[i].pos.x = tier_radius_[i % 3] * std::cos(angle);
+        nodes_[i].pos.z = tier_radius_[i % 3] * std::sin(angle);
+    }
+}
+
+void MemoryGardenDemo::on_render() {
+    ImGui::Begin("Memory Garden");
+    ImGui::SliderFloat3("Tier Radii", tier_radius_, 1.f, 20.f);
+    ImGui::Text("Node count: %zu", nodes_.size());
+    ImGui::End();
+}
+
+} // namespace workbench
+} // namespace sep

--- a/_sep/testbed/examples/workbench/demos/memory_garden_demo.hpp
+++ b/_sep/testbed/examples/workbench/demos/memory_garden_demo.hpp
@@ -1,0 +1,29 @@
+#ifndef SEP_WORKBENCH_MEMORY_GARDEN_DEMO_HPP
+#define SEP_WORKBENCH_MEMORY_GARDEN_DEMO_HPP
+
+#include "demo.hpp"
+#include <imgui.h>
+#include <vector>
+#include <glm/vec3.hpp>
+
+namespace sep {
+namespace workbench {
+
+class MemoryGardenDemo : public Demo {
+public:
+    void on_load() override;
+    void on_unload() override {}
+    void on_update(float dt) override;
+    void on_render() override;
+    void on_key_press(int key) override {}
+
+private:
+    struct Node { glm::vec3 pos; };
+    std::vector<Node> nodes_;
+    float tier_radius_[3] = {5.f, 10.f, 15.f};
+};
+
+} // namespace workbench
+} // namespace sep
+
+#endif // SEP_WORKBENCH_MEMORY_GARDEN_DEMO_HPP

--- a/_sep/testbed/examples/workbench/demos/register_demos.cpp
+++ b/_sep/testbed/examples/workbench/demos/register_demos.cpp
@@ -1,0 +1,17 @@
+#include "demo_manager.hpp"
+#include "genesis_pattern_demo.hpp"
+#include "audio_visualizer_demo.hpp"
+#include "memory_garden_demo.hpp"
+
+namespace sep {
+namespace workbench {
+
+void register_demos() {
+    auto& mgr = DemoManager::instance();
+    mgr.register_demo("genesis", std::make_unique<GenesisPatternDemo>());
+    mgr.register_demo("audio", std::make_unique<AudioVisualizerDemo>());
+    mgr.register_demo("memory", std::make_unique<MemoryGardenDemo>());
+}
+
+} // namespace workbench
+} // namespace sep

--- a/_sep/testbed/examples/workbench/main.cpp
+++ b/_sep/testbed/examples/workbench/main.cpp
@@ -1,0 +1,13 @@
+#include "demos/demo_manager.hpp"
+#include "demos/register_demos.cpp"
+#include <iostream>
+
+int main() {
+    sep::workbench::register_demos();
+    auto& mgr = sep::workbench::DemoManager::instance();
+    mgr.switch_to("genesis");
+    mgr.update(0.0f);
+    mgr.render();
+    std::cout << "Testbed main executed" << std::endl;
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add testbed demo framework under `_sep/testbed`
- implement simplified demo classes with ImGui controls
- provide demo manager and demo registration

## Testing
- `cmake -S . -B build -DSEP_BUILD_TESTS=ON` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_686edbb40a98832abe0018587400735e