### PR TITLE
Implement basic demo manager skeleton

### DIFF
--- a/examples/workbench/demos/demo_manager.cpp
+++ b/examples/workbench/demos/demo_manager.cpp
@@ -1,0 +1,49 @@
+#include "demo_manager.hpp"
+
+namespace sep {
+namespace workbench {
+
+DemoManager& DemoManager::instance() {
+    static DemoManager inst;
+    return inst;
+}
+
+void DemoManager::registerDemo(const std::string& key,
+                               std::function<std::unique_ptr<Demo>()> factory) {
+    factories_[key] = std::move(factory);
+}
+
+bool DemoManager::switchToDemo(const std::string& key) {
+    auto it = factories_.find(key);
+    if (it == factories_.end()) {
+        return false;
+    }
+
+    if (active_demo_) {
+        active_demo_->on_unload();
+    }
+
+    active_demo_ = it->second();
+    active_key_ = key;
+
+    if (active_demo_) {
+        active_demo_->on_load();
+        return true;
+    }
+    return false;
+}
+
+void DemoManager::update(float dt) {
+    if (active_demo_) {
+        active_demo_->on_update(dt);
+    }
+}
+
+void DemoManager::render() {
+    if (active_demo_) {
+        active_demo_->on_render();
+    }
+}
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/demos/demo_manager.hpp
+++ b/examples/workbench/demos/demo_manager.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+namespace sep {
+namespace workbench {
+
+class Demo {
+public:
+    virtual ~Demo() = default;
+    virtual void on_load() = 0;
+    virtual void on_unload() = 0;
+    virtual void on_update(float dt) = 0;
+    virtual void on_render() = 0;
+    virtual void on_key_press(int key) = 0;
+};
+
+class DemoManager {
+public:
+    static DemoManager& instance();
+
+    void registerDemo(const std::string& key,
+                      std::function<std::unique_ptr<Demo>()> factory);
+
+    bool switchToDemo(const std::string& key);
+    void update(float dt);
+    void render();
+
+private:
+    DemoManager() = default;
+
+    std::unordered_map<std::string, std::function<std::unique_ptr<Demo>()>> factories_;
+    std::unique_ptr<Demo> active_demo_;
+    std::string active_key_;
+};
+
+} // namespace workbench
+} // namespace sep

--- a/examples/workbench/main.cpp
+++ b/examples/workbench/main.cpp
@@ -1,0 +1,51 @@
+#include "demos/demo_manager.hpp"
+#include "../../src/demos/genesis_pattern.hpp"
+#include "../../src/demos/annealing_demo.hpp"
+#include "../../src/demos/cosmo_demo.hpp"
+#include "../../src/demos/flocking_demo.hpp"
+#include "../../src/demos/neural_demo.hpp"
+#include "../../src/demos/drug_discovery_demo.hpp"
+#include "../../src/demos/digital_physics_demo.hpp"
+#include "../../src/demos/memory_garden.hpp"
+
+int main() {
+    auto& manager = sep::workbench::DemoManager::instance();
+
+    manager.registerDemo("genesis", []() {
+        return std::make_unique<sep::workbench::GenesisPatternDemo>();
+    });
+
+    manager.registerDemo("annealing", []() {
+        return std::make_unique<sep::workbench::AnnealingDemo>();
+    });
+
+    manager.registerDemo("cosmos", []() {
+        return std::make_unique<sep::workbench::CosmoDemo>();
+    });
+
+    manager.registerDemo("flocking", []() {
+        return std::make_unique<sep::workbench::FlockingDemo>();
+    });
+
+    manager.registerDemo("neural", []() {
+        return std::make_unique<sep::workbench::NeuralDemo>();
+    });
+
+    manager.registerDemo("drug_discovery", []() {
+        return std::make_unique<sep::workbench::DrugDiscoveryDemo>();
+    });
+
+    manager.registerDemo("digital_physics", []() {
+        return std::make_unique<sep::workbench::DigitalPhysicsDemo>();
+    });
+
+    manager.registerDemo("memory_garden", []() {
+        return std::make_unique<sep::workbench::MemoryGardenDemo>();
+    });
+
+    manager.switchToDemo("genesis");
+
+    // Placeholder for the application loop
+    // In the real application this would call manager.update(dt) and manager.render()
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add simple `Demo` interface and manager in `examples/workbench`
- handle active demo switching and lifecycle
- register demos with lambdas in workbench main example

## Testing
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_686edbab8908832a99cdfa2697f27c0f