### PR TITLE
Fix incomplete type errors in genesis pattern demo

### DIFF
--- a/examples/workbench/demos/genesis_pattern.hpp
+++ b/examples/workbench/demos/genesis_pattern.hpp
@@ -1,13 +1,13 @@
 #pragma once
 
 #include "demo_manager.hpp"
+#include "demos/pattern_processor.hpp"
+#include "memory/quantum_coherence_manager.h"
 #include <memory>
 
 namespace sep {
 namespace workbench {
 
-class PatternProcessor;
-class QuantumCoherenceManager;
 
 class GenesisPatternDemo : public Demo {
 public:


### PR DESCRIPTION
## Summary
- include `demos/pattern_processor.hpp` and `memory/quantum_coherence_manager.h`
- remove forward declarations

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686efc35c0a4832ab086182b9b9b3d11