### PR TITLE
Fix includes for genesis pattern demo

### DIFF
--- a/examples/workbench/demos/genesis_pattern.hpp
+++ b/examples/workbench/demos/genesis_pattern.hpp
@@ -1,13 +1,12 @@
 #pragma once
 
 #include "demo_manager.hpp"
+#include "demos/pattern_processor.hpp"
+#include "memory/quantum_coherence_manager.h"
 #include <memory>
 
 namespace sep {
 namespace workbench {
-
-class PatternProcessor;
-class QuantumCoherenceManager;
 
 class GenesisPatternDemo : public Demo {
 public:


### PR DESCRIPTION
## Summary
- remove forward declarations in `genesis_pattern.hpp`
- include `demos/pattern_processor.hpp` and `memory/quantum_coherence_manager.h`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686efc35c0a4832ab086182b9b9b3d11