### PR TITLE
Resolve duplicate MemoryTierEnum declarations

### DIFF
--- a/src/blender/types.h
+++ b/src/blender/types.h
@@ -1,59 +1,61 @@
 #pragma once
 
-#include "core/common.h"
-#include "blender/config.h"
 #include <memory>
 
-namespace sep {
-namespace memory {
-  enum class MemoryTierEnum : int;
-}
-using ::sep::memory::MemoryTierEnum;
-namespace pattern {
-  class BlenderBridge;
-}
+#include "blender/config.h"
+#include "core/common.h"
+#include "memory/types.h"
 
-inline const char* sep_result_to_string(sep::SEPResult result) {
-  switch (result) {
-    case sep::SEPResult::SUCCESS:
-      return "Success";
-    case sep::SEPResult::INVALID_ARGUMENT:
-      return "Invalid argument";
-    case sep::SEPResult::INVALID_STATE:
-      return "Invalid state";
-    case sep::SEPResult::INITIALIZATION_FAILED:
-      return "Not initialized";
-    case sep::SEPResult::ALREADY_EXISTS:
-      return "Already initialized";
-    case sep::SEPResult::UNKNOWN_ERROR:
-      return "Unknown error";
-    case sep::SEPResult::MEMORY_ERROR:
-      return "Memory error";
-    case sep::SEPResult::OUT_OF_MEMORY:
-      return "Allocation failed";
-    case sep::SEPResult::ALLOCATION_FAILED:
-      return "Allocation failed";
-    case sep::SEPResult::PROCESSING_ERROR:
-      return "Processing error";
-    case sep::SEPResult::NOT_FOUND:
-      return "Object not found";
-    case sep::SEPResult::PATTERN_MATCH_FAILED:
-      return "Pattern error";
-    case sep::SEPResult::CUDA_ERROR:
-      return "CUDA initialization failed";
-    case sep::SEPResult::FILE_NOT_FOUND:
-      return "File not found";
-    default:
-      return "UNKNOWN_SEP_RESULT";
-  }
-}
+namespace sep
+{
+    namespace pattern
+    {
+        class BlenderBridge;
+    }
 
-struct SEPBlenderBridge {
-    std::shared_ptr<pattern::BlenderBridge> impl;
-    SEPAudioMetrics                         audio_metrics{};
-    SEPPatternMetrics                       pattern_metrics{};
-};
+    inline const char* sep_result_to_string(sep::SEPResult result)
+    {
+        switch (result)
+        {
+            case sep::SEPResult::SUCCESS:
+                return "Success";
+            case sep::SEPResult::INVALID_ARGUMENT:
+                return "Invalid argument";
+            case sep::SEPResult::INVALID_STATE:
+                return "Invalid state";
+            case sep::SEPResult::INITIALIZATION_FAILED:
+                return "Not initialized";
+            case sep::SEPResult::ALREADY_EXISTS:
+                return "Already initialized";
+            case sep::SEPResult::UNKNOWN_ERROR:
+                return "Unknown error";
+            case sep::SEPResult::MEMORY_ERROR:
+                return "Memory error";
+            case sep::SEPResult::OUT_OF_MEMORY:
+                return "Allocation failed";
+            case sep::SEPResult::ALLOCATION_FAILED:
+                return "Allocation failed";
+            case sep::SEPResult::PROCESSING_ERROR:
+                return "Processing error";
+            case sep::SEPResult::NOT_FOUND:
+                return "Object not found";
+            case sep::SEPResult::PATTERN_MATCH_FAILED:
+                return "Pattern error";
+            case sep::SEPResult::CUDA_ERROR:
+                return "CUDA initialization failed";
+            case sep::SEPResult::FILE_NOT_FOUND:
+                return "File not found";
+            default:
+                return "UNKNOWN_SEP_RESULT";
+        }
+    }
+
+    struct SEPBlenderBridge
+    {
+        std::shared_ptr<pattern::BlenderBridge> impl;
+        SEPAudioMetrics audio_metrics{};
+        SEPPatternMetrics pattern_metrics{};
+    };
 }  // namespace sep
 
 using SEPBlenderBridge = sep::SEPBlenderBridge;
-

--- a/src/sep_engine_wrapper.h
+++ b/src/sep_engine_wrapper.h
@@ -15,13 +15,15 @@
 #include <glm/glm.hpp>
 #include <glm/gtc/constants.hpp>
 
+#include "memory/types.h"
+
 namespace sep
 {
 
     // Forward declarations for both modes
     struct Pattern;
     struct QuantumState;
-    enum class MemoryTierEnum;
+    using memory::MemoryTierEnum;
 
     // Base class definitions that are common to both modes
     class Engine
@@ -85,14 +87,6 @@ namespace sep
         float dimensions[3]{1.0f, 1.0f, 1.0f};
     };
 
-    // Memory tier enum
-    enum class MemoryTierEnum
-    {
-        STM,
-        MTM,
-        LTM
-    };
-
     // Pattern structure
     struct Pattern
     {
@@ -124,7 +118,11 @@ namespace sep
         bool shouldClose() override { return false; }
 
         void setWindowTitle(const std::string& title) override { (void)title; }
-        void setWindowSize(int width, int height) override { (void)width; (void)height; }
+        void setWindowSize(int width, int height) override
+        {
+            (void)width;
+            (void)height;
+        }
         void setFullscreen(bool fullscreen) override { (void)fullscreen; }
         void setVSync(bool vsync) override { (void)vsync; }
         void setSamples(int samples) override { (void)samples; }


### PR DESCRIPTION
## Summary
- include canonical enum for memory tiers
- drop local enum declarations in `sep_engine_wrapper.h` and `blender/types.h`

## Testing
- `clang-format -i src/blender/types.h src/sep_engine_wrapper.h`

------
https://chatgpt.com/codex/tasks/task_e_686efc4044a8832a86a80524df335a03