### PR TITLE
Add GLFW/ImGui main loop skeleton

### DIFF
--- a/examples/workbench/main.cpp
+++ b/examples/workbench/main.cpp
@@ -1,47 +1,64 @@
-#include "window.h"
-#include "demos/demo_manager.hpp"
-#include "demos/genesis_pattern.hpp"
-#include "demos/digital_physics_demo.hpp"
-#include "demos/memory_garden.hpp"
-#include "demos/audio_visualizer.hpp"
-
 #include <GL/glew.h>
 #include <GLFW/glfw3.h>
-#include "imgui.h"
+
 #include "backends/imgui_impl_glfw.h"
 #include "backends/imgui_impl_opengl3.h"
+#include "demos/audio_visualizer.hpp"
+#include "demos/demo_manager.hpp"
+#include "demos/digital_physics_demo.hpp"
+#include "demos/genesis_pattern.hpp"
+#include "demos/memory_garden.hpp"
+#include "imgui.h"
 
-#include <chrono>
-#include <thread>
-
-int main() {
-    sep::workbench::Window window(1280, 720, "SEP Workbench");
-    window.makeContextCurrent();
-
-    if (glewInit() != GLEW_OK) {
+int main()
+{
+    if (!glfwInit())
+    {
         return -1;
     }
 
+    GLFWwindow* window = glfwCreateWindow(1280, 720, "SEP Workbench", nullptr, nullptr);
+    if (!window)
+    {
+        glfwTerminate();
+        return -1;
+    }
+
+    glfwMakeContextCurrent(window);
+    if (glewInit() != GLEW_OK)
+    {
+        glfwDestroyWindow(window);
+        glfwTerminate();
+        return -1;
+    }
+    glfwSwapInterval(1);
+
     IMGUI_CHECKVERSION();
     ImGui::CreateContext();
-    ImGui_ImplGlfw_InitForOpenGL(window.getHandle(), true);
+    ImGui::StyleColorsDark();
+    ImGui_ImplGlfw_InitForOpenGL(window, true);
     ImGui_ImplOpenGL3_Init();
 
-    auto &manager = sep::workbench::DemoManager::getInstance();
-    manager.registerDemo("genesis", []{ return std::make_unique<sep::workbench::GenesisPatternDemo>(); });
-    manager.registerDemo("digital", []{ return std::make_unique<sep::workbench::DigitalPhysicsDemo>(); });
-    manager.registerDemo("memory", []{ return std::make_unique<sep::workbench::MemoryGardenDemo>(); });
-    manager.registerDemo("audio", []{ return std::make_unique<sep::workbench::AudioVisualizerDemo>(); });
+    auto& manager = sep::workbench::DemoManager::getInstance();
+    manager.registerDemo("genesis",
+                         [] { return std::make_unique<sep::workbench::GenesisPatternDemo>(); });
+    manager.registerDemo("digital",
+                         [] { return std::make_unique<sep::workbench::DigitalPhysicsDemo>(); });
+    manager.registerDemo("memory",
+                         [] { return std::make_unique<sep::workbench::MemoryGardenDemo>(); });
+    manager.registerDemo("audio",
+                         [] { return std::make_unique<sep::workbench::AudioVisualizerDemo>(); });
     manager.switchToDemo("genesis");
 
-    while (!window.shouldClose()) {
+    while (!glfwWindowShouldClose(window))
+    {
         glfwPollEvents();
 
         ImGui_ImplOpenGL3_NewFrame();
         ImGui_ImplGlfw_NewFrame();
         ImGui::NewFrame();
 
-        glClearColor(0,0,0,1);
+        glClearColor(0.f, 0.f, 0.f, 1.f);
         glClear(GL_COLOR_BUFFER_BIT);
 
         ImGui::Begin("Demos");
@@ -57,11 +74,14 @@ int main() {
         ImGui::Render();
         ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
 
-        window.swapBuffers();
-        std::this_thread::sleep_for(std::chrono::milliseconds(16));
+        glfwSwapBuffers(window);
     }
 
+    manager.on_unload();
     ImGui_ImplOpenGL3_Shutdown();
     ImGui_ImplGlfw_Shutdown();
     ImGui::DestroyContext();
+    glfwDestroyWindow(window);
+    glfwTerminate();
+    return 0;
 }


### PR DESCRIPTION
## Summary
- implement a simple GLFW + ImGui main loop for the workbench example

## Testing
- `ctest --output-on-failure` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_686efe2e4f70832a868370685957b9fb