### PR TITLE
Expose CosmoConfig via Config

### DIFF
--- a/examples/workbench/config.hpp
+++ b/examples/workbench/config.hpp
@@ -7,10 +7,6 @@
 namespace sep {
 namespace workbench {
 
-struct CosmoConfig {
-    float box_size = 100.0f;
-    float time_step = 0.01f;
-};
 
 struct GenesisPatternConfig {
     struct InitialPattern {
@@ -55,6 +51,11 @@ struct GenesisPatternConfig {
 
 class Config {
 public:
+    struct CosmoConfig {
+        float box_size = 100.0f;
+        float time_step = 0.01f;
+    };
+
     static Config& getInstance() {
         static Config instance;
         return instance;


### PR DESCRIPTION
## Summary
- move `CosmoConfig` inside `Config` to better encapsulate settings
- keep getters returning the nested struct

## Testing
- `cmake -S examples/workbench -B examples/workbench/build` *(fails: could not find GLEW)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bpy')*

------
https://chatgpt.com/codex/tasks/task_e_686f1045ca50832a9f60ff2fc9874a82