### PR TITLE
Refactor NeuroSim demo

### DIFF
--- a/examples/workbench/demos/neuro_sim.cpp
+++ b/examples/workbench/demos/neuro_sim.cpp
@@ -3,15 +3,13 @@
 #include <algorithm>
 #include <glm/glm.hpp>
 
-#include "memory/memory_tier_manager.hpp"
 #include "quantum/evolution.h"
 #include "memory/memory_tier_manager.hpp"
 #include "sep_engine_wrapper.h"
+#include <config.hpp>
 
-using sep::config::ConfigManager;
 using sep::memory::MemoryTierEnum;
 using sep::memory::MemoryTierManager;
-using sep::quantum::evolution;
 using sep::quantum::Pattern;
 
 namespace sep
@@ -21,13 +19,13 @@ namespace sep
 
         void NeuroSimDemo::on_load()
         {
-            const auto& cfg = ConfigManager::getInstance().getEngineConfig().neural_demo();
+            const auto& cfg = sep::workbench::Config::getInstance().neural_demo();
             std::size_t neuron_count = cfg.network.neuron_count;
             threshold_ = cfg.neuron.threshold;
             decay_ = cfg.neuron.decay;
             input_strength_ = cfg.neuron.input_strength;
             connection_prob_ = cfg.network.connection_prob;
-            memory_manager_ = std::make_unique<MemoryTierManager>();
+            memory_manager_ = std::make_unique<sep::memory::MemoryTierManager>();
             auto& dag = memory_manager_->getDagGraph();
 
             neurons_.resize(neuron_count);
@@ -64,7 +62,7 @@ namespace sep
             auto& dag = memory_manager_->getDagGraph();
             for (auto& n : neurons_)
             {
-                evolution::applySpike(n.pattern, input_strength_ * dt, decay_ * dt, threshold_);
+                sep::quantum::evolution::applySpike(n.pattern, input_strength_ * dt, decay_ * dt, threshold_);
                 if (n.pattern.quantum_state.coherence >= 1.0f)
                 {
                     for (auto& tgt : neurons_)
@@ -74,7 +72,7 @@ namespace sep
                         {
                             tgt.pattern.quantum_state.coherence =
                                 glm::clamp(tgt.pattern.quantum_state.coherence + 0.5f, 0.f, 1.f);
-                            evolution::hebbianUpdate(n.pattern, tgt.pattern, learning_rate_);
+                            sep::quantum::evolution::hebbianUpdate(n.pattern, tgt.pattern, learning_rate_);
                         }
                     }
                     n.pattern.quantum_state.coherence = 0.f;

--- a/examples/workbench/demos/neuro_sim.hpp
+++ b/examples/workbench/demos/neuro_sim.hpp
@@ -28,21 +28,12 @@ namespace sep
         private:
             struct Neuron
             {
-#ifdef SEP_WORKBENCH_DEMO
-                sep::Pattern pattern;  // In demo mode, Pattern is directly in sep namespace
-#else
-                sep::quantum::Pattern pattern;  // In non-demo mode, Pattern is in quantum namespace
-#endif
+                sep::quantum::Pattern pattern;
                 float potential{0.f};
                 uint64_t node_id{0};
             };
 
-            // Memory manager type depends on demo mode
-#ifdef SEP_WORKBENCH_DEMO
-            std::unique_ptr<sep::MemoryTierManager> memory_manager_;
-#else
-            sep::memory::MemoryTierManager* memory_manager_ = nullptr;
-#endif
+            std::unique_ptr<sep::memory::MemoryTierManager> memory_manager_;
 
             std::vector<Neuron> neurons_;
             std::random_device rd_;


### PR DESCRIPTION
## Summary
- simplify `Neuron` by dropping conditional types
- manage memory with `std::unique_ptr<sep::memory::MemoryTierManager>`
- use `Config::getInstance()` to fetch configuration
- fully qualify calls to quantum evolution API

## Testing
- `ctest --output-on-failure` *(fails: No tests were found)*
- `cmake -DSEP_WITH_CYCLES=OFF -DSEP_WITH_AUDIO=OFF -DSEP_WITH_OPENSUBDIV=OFF -DSEP_MINIMAL=ON -DSEP_HAS_CUDA=OFF ../..` *(fails: GLFWConfig.cmake not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f1040eb18832a890d74a08ef4be8d