### PR TITLE
Add experimental coordinated MCP helper

### DIFF
--- a/_sep/testbed/experimental_mcp/index.ts
+++ b/_sep/testbed/experimental_mcp/index.ts
@@ -1,0 +1,63 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { EventEmitter } from 'events';
+import { z } from 'zod';
+import { RedisService } from './services/redis.js';
+import { SepService } from './services/sep.js';
+
+export class CoordinatedHelper extends EventEmitter {
+  private mcp: McpServer;
+  private redis: RedisService;
+  private sep: SepService;
+  private connected = false;
+
+  constructor() {
+    super();
+    this.redis = new RedisService({
+      url: process.env.REDIS_URL || 'redis://localhost:6379',
+      prefix: 'coordinated:'
+    });
+    this.sep = new SepService({ baseURL: process.env.SEP_ENGINE_URL || 'http://localhost:8080' });
+    this.mcp = new McpServer({ name: 'coordinated-helper', version: '0.0.1' });
+    this.registerTools();
+  }
+
+  private registerTools() {
+    this.mcp.tool(
+      'coordinated_ping',
+      {},
+      async () => ({ content: [{ type: 'text', text: 'pong' }] })
+    );
+
+    this.mcp.tool(
+      'store_context',
+      {
+        context: z.object({
+          id: z.string(),
+          patterns: z.array(z.any()),
+          metadata: z.record(z.any())
+        })
+      },
+      async (args) => {
+        await this.redis.storeContext(args.context);
+        return { content: [{ type: 'text', text: 'context stored' }] };
+      }
+    );
+  }
+
+  async start() {
+    await this.redis.connect();
+    const transport = new StdioServerTransport();
+    await this.mcp.connect(transport);
+    this.connected = true;
+    console.error('Coordinated helper running on stdio');
+  }
+}
+
+if (process.argv[1] === new URL(import.meta.url).pathname) {
+  const helper = new CoordinatedHelper();
+  helper.start().catch((err) => {
+    console.error('Failed to start coordinated helper:', err);
+    process.exit(1);
+  });
+}

--- a/_sep/testbed/experimental_mcp/package.json
+++ b/_sep/testbed/experimental_mcp/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "experimental-coordinated-helper",
+  "version": "0.0.1",
+  "type": "module",
+  "main": "build/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node build/index.js"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.15.0",
+    "axios": "^1.9.0",
+    "redis": "^4.6.7",
+    "zod": "^3.25.48"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.2",
+    "@types/node": "^20.17.57"
+  }
+}

--- a/_sep/testbed/experimental_mcp/services/redis.ts
+++ b/_sep/testbed/experimental_mcp/services/redis.ts
@@ -1,0 +1,29 @@
+import { createClient, RedisClientType } from 'redis';
+
+export class RedisService {
+  private client: RedisClientType;
+  private prefix: string;
+
+  constructor(config: { url: string; prefix: string }) {
+    this.client = createClient({ url: config.url });
+    this.prefix = config.prefix;
+  }
+
+  async connect(): Promise<void> {
+    await this.client.connect();
+  }
+
+  async ping(): Promise<string> {
+    return await this.client.ping();
+  }
+
+  async storePattern(pattern: any): Promise<void> {
+    const key = `${this.prefix}pattern:${pattern.id}`;
+    await this.client.set(key, JSON.stringify(pattern));
+  }
+
+  async storeContext(context: any): Promise<void> {
+    const key = `${this.prefix}context:${context.id}`;
+    await this.client.set(key, JSON.stringify(context));
+  }
+}

--- a/_sep/testbed/experimental_mcp/services/sep.ts
+++ b/_sep/testbed/experimental_mcp/services/sep.ts
@@ -1,0 +1,90 @@
+import axios, { AxiosInstance } from 'axios';
+
+export class SepService {
+  private client: AxiosInstance;
+
+  constructor(config: { baseURL: string }) {
+    this.client = axios.create({
+      baseURL: config.baseURL,
+      timeout: 5000
+    });
+  }
+
+  async healthCheck(): Promise<boolean> {
+    try {
+      const response = await this.client.get('/health');
+      return response.status === 200;
+    } catch (error) {
+      return false;
+    }
+  }
+
+  async monitorPatterns(contextId: string, duration?: number): Promise<any> {
+    const response = await this.client.post('/patterns/monitor', {
+      contextId,
+      duration
+    });
+    return response.data;
+  }
+
+  async getInsights(contextId: string, patternIds?: string[]): Promise<any> {
+    const response = await this.client.post('/patterns/insights', {
+      contextId,
+      patternIds
+    });
+    return response.data;
+  }
+
+  async trackEvolution(contextId: string, startTime?: string): Promise<any> {
+    const response = await this.client.post('/patterns/evolution', {
+      contextId,
+      startTime
+    });
+    return response.data;
+  }
+
+  async processContext(context: any): Promise<any> {
+    const response = await this.client.post('/context/process', context);
+    return response.data;
+  }
+
+  async analyzeContext(contextId: string): Promise<any> {
+    const response = await this.client.get(`/context/${contextId}/analyze`);
+    return response.data;
+  }
+
+  async evolvePatterns(contextId: string, generations?: number): Promise<any> {
+    const response = await this.client.post('/patterns/evolve', {
+      contextId,
+      generations
+    });
+    return response.data;
+  }
+
+  async analyzePatterns(patterns: any[]): Promise<any> {
+    const response = await this.client.post('/patterns/analyze', { patterns });
+    return response.data;
+  }
+
+  async bridgePatterns(sourceId: string, targetId: string, bridgeType: string): Promise<any> {
+    const response = await this.client.post('/patterns/bridge', {
+      sourceId,
+      targetId,
+      bridgeType
+    });
+    return response.data;
+  }
+
+  async transformPatterns(patterns: any[], transformType: string): Promise<any> {
+    const response = await this.client.post('/patterns/transform', {
+      patterns,
+      transformType
+    });
+    return response.data;
+  }
+
+  async processPatterns(patterns: any[]): Promise<any> {
+    const response = await this.client.post('/patterns/process', { patterns });
+    return response.data;
+  }
+}

--- a/_sep/testbed/experimental_mcp/tsconfig.json
+++ b/_sep/testbed/experimental_mcp/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2020"],
+    "rootDir": "./",
+    "outDir": "build",
+    "strict": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["./**/*.ts"],
+  "exclude": ["node_modules", "build"]
+}


### PR DESCRIPTION
## Summary
- prototype a new coordinated MCP helper in `_sep/testbed`
- include minimal toolset and services
- provide package and tsconfig for building in the testbed

## Testing
- `npm install`
- `npm run build`
- `node build/index.js` *(fails: ECONNREFUSED to redis)*

------
https://chatgpt.com/codex/tasks/task_e_686f9c37690c832aaf2187e5e803f665