### PR TITLE
Fix GLM build issues

### DIFF
--- a/src/workbench/demos/cosmo_sim.cpp
+++ b/src/workbench/demos/cosmo_sim.cpp
@@ -1,5 +1,6 @@
 #include "cosmo_sim.hpp"
 #include <config.hpp>
+#include "compat/glm_config.h"
 #include <glm/gtx/norm.hpp>
 #include <cstdlib>
 

--- a/src/workbench/demos/drug_optimizer.cpp
+++ b/src/workbench/demos/drug_optimizer.cpp
@@ -1,4 +1,5 @@
 #include "drug_optimizer.hpp"
+#include "compat/glm_config.h"
 #include <glm/gtx/norm.hpp>
 #include <cstdlib>
 

--- a/src/workbench/demos/flocking_sim_simple.cpp
+++ b/src/workbench/demos/flocking_sim_simple.cpp
@@ -3,6 +3,8 @@
 #include <random>
 #include <ctime>
 #include <time.h>
+
+#include "compat/glm_config.h"
 #include <glm/vec3.hpp>
 #include <glm/gtx/norm.hpp>
 


### PR DESCRIPTION
## Summary
- include `compat/glm_config.h` before `<glm/gtx/norm.hpp>` in demo sources so GLM
  experimental headers compile
- attempt to run the build which fails earlier because CUDA tools aren't found

## Testing
- `./build.sh` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_687002e9ec8c832a85f44cb0cc169982