### PR TITLE
Fix workbench build and add ImGui

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,9 +184,13 @@ endif()
 if(SEP_WITH_OSL)
     find_package(OSL REQUIRED)
 endif()
+
 if(SEP_WITH_ALEMBIC)
     find_package(Alembic REQUIRED)
 endif()
+
+# Build ImGui from the bundled third_party source
+add_subdirectory(third_party/imgui)
 
 # Add the src directory which contains all module subdirectories and workbench
 add_subdirectory(src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -60,6 +60,7 @@ if(SEP_BUILD_WORKBENCH)
         GLEW::GLEW
         glfw
         OpenGL::GL
+        imgui
         Threads::Threads
         ${CMAKE_DL_LIBS}
     )

--- a/src/workbench/demos/audio_visualizer_simple.cpp
+++ b/src/workbench/demos/audio_visualizer_simple.cpp
@@ -13,7 +13,10 @@ namespace audio {
         // Return a stub implementation for now
         class StubAudioCapture : public AudioCapture {
         public:
-            bool init(const AudioConfig& config) override { return true; }
+            bool init(const AudioConfig& config) override {
+                (void)config;
+                return true;
+            }
             bool start() override { return true; }
             void stop() override {}
         };
@@ -29,6 +32,7 @@ namespace audio {
             StubAudioPipeline(int size) : spectrum_size_(size) {}
             
             void processSamples(const std::vector<float>& samples) override {
+                (void)samples;
                 // Generate random visual patterns for demonstration
                 patterns_.clear();
                 patterns_.reserve(spectrum_size_);
@@ -56,7 +60,7 @@ namespace audio {
 }
 
 // AudioVisualizerDemo implementation
-void AudioVisualizerDemo::init() {
+void AudioVisualizerDemo::on_load() {
     std::cout << "Initializing Audio Visualizer Demo..." << std::endl;
     
     // Get configuration
@@ -82,7 +86,7 @@ void AudioVisualizerDemo::init() {
     std::cout << "Audio Visualizer Demo initialized successfully." << std::endl;
 }
 
-void AudioVisualizerDemo::update(float dt) {
+void AudioVisualizerDemo::on_update(float dt) {
     // Simulate audio processing (in a real implementation, this would use actual audio data)
     std::vector<float> dummy_samples(1024);
     for (size_t i = 0; i < dummy_samples.size(); i++) {
@@ -104,7 +108,7 @@ void AudioVisualizerDemo::update(float dt) {
     }
 }
 
-void AudioVisualizerDemo::render() {
+void AudioVisualizerDemo::on_render() {
     // Render patterns
     if (renderer_) {
         // Special visualization modes for audio would go here
@@ -125,7 +129,7 @@ void AudioVisualizerDemo::render() {
     }
 }
 
-void AudioVisualizerDemo::cleanup() {
+void AudioVisualizerDemo::on_unload() {
     if (capture_) {
         capture_->stop();
     }
@@ -133,7 +137,7 @@ void AudioVisualizerDemo::cleanup() {
     latest_patterns_.clear();
 }
 
-void AudioVisualizerDemo::handleKeyboard(unsigned char key) {
+void AudioVisualizerDemo::on_key_press(int key) {
     // Handle keyboard input for audio visualizer
     switch (key) {
         case '1':
@@ -145,7 +149,7 @@ void AudioVisualizerDemo::handleKeyboard(unsigned char key) {
     }
 }
 
-void AudioVisualizerDemo::handleMouse(int x, int y, int button) {
+void AudioVisualizerDemo::on_mouse(int x, int y, int button) {
     // Not used in this demo
 }
 

--- a/third_party/imgui/CMakeLists.txt
+++ b/third_party/imgui/CMakeLists.txt
@@ -1,0 +1,21 @@
+add_library(imgui STATIC
+    imgui.cpp
+    imgui_demo.cpp
+    imgui_draw.cpp
+    imgui_tables.cpp
+    imgui_widgets.cpp
+    backends/imgui_impl_glfw.cpp
+    backends/imgui_impl_opengl3.cpp
+)
+
+target_include_directories(imgui PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/backends
+)
+
+# ImGui backends require OpenGL and GLFW
+find_package(OpenGL REQUIRED)
+find_package(GLFW REQUIRED)
+
+# Link with system OpenGL and GLFW
+target_link_libraries(imgui PUBLIC OpenGL::GL glfw)


### PR DESCRIPTION
## Summary
- allow building bundled ImGui library
- link ImGui in workbench
- stub unused parameters in `AudioVisualizerDemo`
- update demo method names to match header

## Testing
- `cmake` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687002e9ec8c832a85f44cb0cc169982