### PR TITLE
docs: mention asio dependency

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -135,11 +135,12 @@ Run `install.sh` to fetch compiler toolchains and third-party libraries. The scr
 
 Additional development libraries used by the build system include
 `libgflags-dev`, `libgoogle-glog-dev` (or `libglog-dev` on some
-distributions) and the Boost headers.  These packages are installed
-automatically by `install.sh`.  If you prefer a manual setup run:
+distributions), the Boost headers, and the standalone Asio headers
+provided by `libasio-dev`.  These packages are installed automatically
+by `install.sh`.  If you prefer a manual setup run:
 
 ```bash
-sudo apt-get update && sudo apt-get install libgflags-dev libgoogle-glog-dev libboost-dev
+sudo apt-get update && sudo apt-get install libgflags-dev libgoogle-glog-dev libboost-dev libasio-dev
 ```
 
 ```bash


### PR DESCRIPTION
## Summary
- document that the API server requires the `libasio-dev` headers

## Testing
- `make -C ~/.cache/sep/build -j4`


------
https://chatgpt.com/codex/tasks/task_e_687002e9ec8c832a85f44cb0cc169982