### PR TITLE
Fix missing ImGui sources for workbench build

### DIFF
--- a/src/workbench/CMakeLists.txt
+++ b/src/workbench/CMakeLists.txt
@@ -6,15 +6,27 @@ file(GLOB_RECURSE WB_SOURCES
     "renderer.cpp"
 )
 
-add_library(sep_workbench_lib STATIC ${WB_SOURCES})
+# ImGui sources are compiled directly into the workbench library
+set(IMGUI_SOURCES
+    ${CMAKE_SOURCE_DIR}/third_party/imgui/imgui.cpp
+    ${CMAKE_SOURCE_DIR}/third_party/imgui/imgui_draw.cpp
+    ${CMAKE_SOURCE_DIR}/third_party/imgui/imgui_tables.cpp
+    ${CMAKE_SOURCE_DIR}/third_party/imgui/imgui_widgets.cpp
+    ${CMAKE_SOURCE_DIR}/third_party/imgui/backends/imgui_impl_glfw.cpp
+    ${CMAKE_SOURCE_DIR}/third_party/imgui/backends/imgui_impl_opengl3.cpp
+)
+add_library(sep_workbench_lib STATIC ${WB_SOURCES} ${IMGUI_SOURCES})
 
 # Public include directories for consumers
  target_include_directories(sep_workbench_lib PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/third_party/imgui
 )
 
 # Link against core components
  target_link_libraries(sep_workbench_lib PRIVATE
     sep_core sep_quantum sep_memory
+    glfw
+    OpenGL::GL
 )


### PR DESCRIPTION
## Summary
- include ImGui backends and core files in `sep_workbench_lib`
- expose `third_party/imgui` headers
- link required OpenGL libraries

## Testing
- `cmake ..` *(fails: could not find package GLFW)*

------
https://chatgpt.com/codex/tasks/task_e_687002e3aa64832a835da2000abfcc78