### PR TITLE
Fix build issues in workbench

### DIFF
--- a/src/workbench/CMakeLists.txt
+++ b/src/workbench/CMakeLists.txt
@@ -4,14 +4,19 @@ cmake_minimum_required(VERSION 3.16)
 file(GLOB_RECURSE WB_SOURCES
     "demos/*.cpp"
     "renderer.cpp"
+    "${CMAKE_SOURCE_DIR}/third_party/imgui/*.cpp"
+    "${CMAKE_SOURCE_DIR}/third_party/imgui/backends/imgui_impl_glfw.cpp"
+    "${CMAKE_SOURCE_DIR}/third_party/imgui/backends/imgui_impl_opengl3.cpp"
 )
 
 add_library(sep_workbench_lib STATIC ${WB_SOURCES})
 
 # Public include directories for consumers
- target_include_directories(sep_workbench_lib PUBLIC
+target_include_directories(sep_workbench_lib PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/third_party/imgui
+    ${CMAKE_SOURCE_DIR}/third_party/imgui/backends
 )
 
 # Link against core components

--- a/src/workbench/demos/audio_visualizer_simple.cpp
+++ b/src/workbench/demos/audio_visualizer_simple.cpp
@@ -56,7 +56,7 @@ namespace audio {
 }
 
 // AudioVisualizerDemo implementation
-void AudioVisualizerDemo::init() {
+void AudioVisualizerDemo::on_load() {
     std::cout << "Initializing Audio Visualizer Demo..." << std::endl;
     
     // Get configuration
@@ -82,7 +82,7 @@ void AudioVisualizerDemo::init() {
     std::cout << "Audio Visualizer Demo initialized successfully." << std::endl;
 }
 
-void AudioVisualizerDemo::update(float dt) {
+void AudioVisualizerDemo::on_update(float dt) {
     // Simulate audio processing (in a real implementation, this would use actual audio data)
     std::vector<float> dummy_samples(1024);
     for (size_t i = 0; i < dummy_samples.size(); i++) {
@@ -104,7 +104,7 @@ void AudioVisualizerDemo::update(float dt) {
     }
 }
 
-void AudioVisualizerDemo::render() {
+void AudioVisualizerDemo::on_render() {
     // Render patterns
     if (renderer_) {
         // Special visualization modes for audio would go here
@@ -125,7 +125,7 @@ void AudioVisualizerDemo::render() {
     }
 }
 
-void AudioVisualizerDemo::cleanup() {
+void AudioVisualizerDemo::on_unload() {
     if (capture_) {
         capture_->stop();
     }
@@ -133,7 +133,7 @@ void AudioVisualizerDemo::cleanup() {
     latest_patterns_.clear();
 }
 
-void AudioVisualizerDemo::handleKeyboard(unsigned char key) {
+void AudioVisualizerDemo::on_key_press(int key) {
     // Handle keyboard input for audio visualizer
     switch (key) {
         case '1':
@@ -145,7 +145,7 @@ void AudioVisualizerDemo::handleKeyboard(unsigned char key) {
     }
 }
 
-void AudioVisualizerDemo::handleMouse(int x, int y, int button) {
+void AudioVisualizerDemo::on_mouse(int x, int y, int button) {
     // Not used in this demo
 }
 

--- a/src/workbench/demos/cosmo_sim.cpp
+++ b/src/workbench/demos/cosmo_sim.cpp
@@ -1,5 +1,6 @@
 #include "cosmo_sim.hpp"
 #include <config.hpp>
+#define GLM_ENABLE_EXPERIMENTAL
 #include <glm/gtx/norm.hpp>
 #include <cstdlib>
 

--- a/src/workbench/demos/drug_optimizer.cpp
+++ b/src/workbench/demos/drug_optimizer.cpp
@@ -1,4 +1,5 @@
 #include "drug_optimizer.hpp"
+#define GLM_ENABLE_EXPERIMENTAL
 #include <glm/gtx/norm.hpp>
 #include <cstdlib>
 

--- a/src/workbench/demos/flocking_sim_simple.cpp
+++ b/src/workbench/demos/flocking_sim_simple.cpp
@@ -3,6 +3,7 @@
 #include <random>
 #include <ctime>
 #include <time.h>
+#define GLM_ENABLE_EXPERIMENTAL
 #include <glm/vec3.hpp>
 #include <glm/gtx/norm.hpp>
 

--- a/src/workbench/demos/physics_explorer_simple.cpp
+++ b/src/workbench/demos/physics_explorer_simple.cpp
@@ -12,12 +12,12 @@ using namespace sep::quantum;
 
 int main() {
     const int grid = 10;
-    std::vector<PatternData> patterns;
+    std::vector<Pattern> patterns;
     patterns.reserve(grid * grid);
 
     for (int x = 0; x < grid; ++x) {
         for (int y = 0; y < grid; ++y) {
-            PatternData p;
+            Pattern p;
             p.id = "p_" + std::to_string(x) + "_" + std::to_string(y);
             p.position = glm::vec4(static_cast<float>(x), static_cast<float>(y), 0.0f, 1.0f);
             p.coherence = 0.5f;

--- a/src/workbench_main.cpp
+++ b/src/workbench_main.cpp
@@ -3,8 +3,8 @@
 
 #include <iostream>
 
-#include "backends/imgui_impl_glfw.h"
-#include "backends/imgui_impl_opengl3.h"
+#include "imgui/backends/imgui_impl_glfw.h"
+#include "imgui/backends/imgui_impl_opengl3.h"
 #include "core/logging.h"  // For our logger
 #include "imgui.h"
 


### PR DESCRIPTION
## Summary
- include ImGui sources in workbench build
- fix include paths for ImGui headers
- enable GLM experimental extensions where needed
- use `Pattern` instead of `PatternData` in physics explorer demo
- align audio visualizer stub with header naming

## Testing
- `cmake ../../.. -DSEP_BUILD_WORKBENCH=ON -DSEP_WITH_AUDIO=OFF -G Ninja` *(fails: Could not find package configuration file provided by "GLFW")*

------
https://chatgpt.com/codex/tasks/task_e_687002e3aa64832a835da2000abfcc78