### PR TITLE
Fix workbench build with ImGui

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,8 +142,10 @@ find_package(glm REQUIRED)
 find_package(spdlog)
 find_package(OpenGL REQUIRED)
 if(SEP_BUILD_WORKBENCH)
-    find_package(GLFW REQUIRED)
-    find_package(GLEW REQUIRED)
+    # GLFW package is typically exported as glfw3 on many systems
+    find_package(glfw3 REQUIRED)
+    find_package(PkgConfig)
+    pkg_search_module(GLEW REQUIRED glew)
 endif()
 if(spdlog_FOUND)
     message(STATUS "Using system spdlog")
@@ -187,6 +189,9 @@ endif()
 if(SEP_WITH_ALEMBIC)
     find_package(Alembic REQUIRED)
 endif()
+
+# Build ImGui library from third_party sources
+add_subdirectory(third_party/imgui)
 
 # Add the src directory which contains all module subdirectories and workbench
 add_subdirectory(src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,11 +53,12 @@ if(SEP_BUILD_WORKBENCH)
         workbench_main.cpp
     )
     set_target_properties(sep_workbench PROPERTIES CXX_STANDARD 17)
-    target_include_directories(sep_workbench PRIVATE ${SEP_INCLUDE_DIRS})
+    target_include_directories(sep_workbench PRIVATE ${SEP_INCLUDE_DIRS} ${GLEW_INCLUDE_DIRS})
     target_link_libraries(sep_workbench PRIVATE
         sep_workbench_lib
         sep_api sep_quantum sep_memory sep_core sep_compat
-        GLEW::GLEW
+        imgui
+        ${GLEW_LIBRARIES}
         glfw
         OpenGL::GL
         Threads::Threads

--- a/src/workbench/CMakeLists.txt
+++ b/src/workbench/CMakeLists.txt
@@ -6,6 +6,10 @@ file(GLOB_RECURSE WB_SOURCES
     "renderer.cpp"
 )
 
+if(NOT SEP_WITH_AUDIO)
+    list(FILTER WB_SOURCES EXCLUDE REGEX "audio_visualizer")
+endif()
+
 add_library(sep_workbench_lib STATIC ${WB_SOURCES})
 
 # Public include directories for consumers

--- a/third_party/imgui/CMakeLists.txt
+++ b/third_party/imgui/CMakeLists.txt
@@ -1,0 +1,20 @@
+add_library(imgui
+    imgui.cpp
+    imgui_draw.cpp
+    imgui_tables.cpp
+    imgui_widgets.cpp
+    imgui_demo.cpp
+    backends/imgui_impl_glfw.cpp
+    backends/imgui_impl_opengl3.cpp
+)
+
+# Provide include directories for consumers
+# The backends directory is needed for ImGui's GL/GLFW backends
+
+target_include_directories(imgui PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/backends
+)
+
+target_link_libraries(imgui PUBLIC glfw OpenGL::GL)
+


### PR DESCRIPTION
## Summary
- build imgui from third_party sources
- link imgui and glew via pkg-config
- add ImGui subdir before src build
- exclude audio demo when audio is off

## Testing
- `cmake .. -DSEP_HAS_CUDA=OFF -DSEP_WITH_OPENSUBDIV=OFF -DSEP_WITH_OPENPGL=OFF -DSEP_WITH_OCIO=OFF -DSEP_WITH_OPENIMAGEIO=OFF -DSEP_WITH_EMBREE=OFF -DSEP_WITH_OSL=OFF -DSEP_WITH_ALEMBIC=OFF -DSEP_WITH_CYCLES=OFF -DSEP_WITH_AUDIO=OFF`
- `make -j2` *(fails: invalid initialization of reference in physics_explorer_simple.cpp)*

------
https://chatgpt.com/codex/tasks/task_e_687002e9ec8c832a85f44cb0cc169982