### PR TITLE
Fix compilation issues in workbench demos

### DIFF
--- a/src/workbench/demos/audio_visualizer.cpp
+++ b/src/workbench/demos/audio_visualizer.cpp
@@ -65,7 +65,9 @@ void AudioVisualizerDemo::on_render() {
 
 void AudioVisualizerDemo::on_unload() {
     if (capture_) {
+#ifdef SEP_HAS_AUDIO
         capture_->stop();
+#endif
     }
     pipeline_.reset();
     capture_.reset();

--- a/src/workbench/demos/audio_visualizer_simple.cpp
+++ b/src/workbench/demos/audio_visualizer_simple.cpp
@@ -127,7 +127,9 @@ void AudioVisualizerDemo::render() {
 
 void AudioVisualizerDemo::cleanup() {
     if (capture_) {
+#ifdef SEP_HAS_AUDIO
         capture_->stop();
+#endif
     }
     
     latest_patterns_.clear();

--- a/src/workbench/demos/cosmo_sim.cpp
+++ b/src/workbench/demos/cosmo_sim.cpp
@@ -1,5 +1,6 @@
 #include "cosmo_sim.hpp"
 #include <config.hpp>
+#define GLM_ENABLE_EXPERIMENTAL
 #include <glm/gtx/norm.hpp>
 #include <cstdlib>
 

--- a/src/workbench/demos/drug_optimizer.cpp
+++ b/src/workbench/demos/drug_optimizer.cpp
@@ -1,4 +1,5 @@
 #include "drug_optimizer.hpp"
+#define GLM_ENABLE_EXPERIMENTAL
 #include <glm/gtx/norm.hpp>
 #include <cstdlib>
 

--- a/src/workbench/demos/flocking_sim_simple.cpp
+++ b/src/workbench/demos/flocking_sim_simple.cpp
@@ -4,6 +4,7 @@
 #include <ctime>
 #include <time.h>
 #include <glm/vec3.hpp>
+#define GLM_ENABLE_EXPERIMENTAL
 #include <glm/gtx/norm.hpp>
 
 #include "quantum/quantum_processor.h"

--- a/src/workbench/demos/physics_explorer_simple.cpp
+++ b/src/workbench/demos/physics_explorer_simple.cpp
@@ -7,17 +7,16 @@
 #include "memory/types.h"
 
 using namespace sep;
-using namespace sep::pattern;
 using namespace sep::quantum;
 
 int main() {
     const int grid = 10;
-    std::vector<PatternData> patterns;
+    std::vector<pattern::PatternData> patterns;
     patterns.reserve(grid * grid);
 
     for (int x = 0; x < grid; ++x) {
         for (int y = 0; y < grid; ++y) {
-            PatternData p;
+            pattern::PatternData p;
             p.id = "p_" + std::to_string(x) + "_" + std::to_string(y);
             p.position = glm::vec4(static_cast<float>(x), static_cast<float>(y), 0.0f, 1.0f);
             p.coherence = 0.5f;
@@ -31,8 +30,17 @@ int main() {
 
     for (int step = 0; step < 50; ++step) {
         for (auto &p : patterns) {
-            evolution::applyGravity(p, center, 0.02f);
-            evolution::randomPerturbation(p, 0.01f);
+            quantum::Pattern q;
+            q.id = p.id;
+            q.position = p.position;
+            q.momentum = glm::vec3(0.0f);
+            q.quantum_state.generation = p.generation;
+            q.quantum_state.state = quantum::QuantumState::Status::SUPERPOSITION;
+
+            evolution::applyGravity(q, center, 0.02f);
+            evolution::randomPerturbation(q, 0.01f);
+
+            p.position = q.position;
 
             if (glm::length(glm::vec3(p.position) - center) < 0.5f) {
                 p.coherence = std::min(1.0f, p.coherence + 0.05f);


### PR DESCRIPTION
## Summary
- enable experimental GLM extensions in simulation demos
- guard AudioCapture::stop calls when audio is disabled
- convert data before invoking quantum evolution functions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687002e3aa64832a835da2000abfcc78