### PR TITLE
Address static analysis warnings

### DIFF
--- a/src/api/server.cpp
+++ b/src/api/server.cpp
@@ -120,7 +120,8 @@ void SEPApiServer::stop() {
     return;
   }
 
-  logger_->info("Stopping SEP API Server");
+  if (logger_)
+    logger_->info("Stopping SEP API Server");
   running_ = false;
 
   if (app_) {
@@ -129,13 +130,15 @@ void SEPApiServer::stop() {
     
     // Wait for server thread to finish
     if (server_thread_ && server_thread_->joinable()) {
-      logger_->debug("Waiting for server thread to join...");
+      if (logger_)
+        logger_->debug("Waiting for server thread to join...");
       server_thread_->join();
       server_thread_.reset();
     }
   }
 
-  logger_->info("SEP API Server stopped");
+  if (logger_)
+    logger_->info("SEP API Server stopped");
 }
 
 void SEPApiServer::waitForShutdown() {
@@ -147,7 +150,8 @@ void SEPApiServer::waitForShutdown() {
 void SEPApiServer::updateConfig(const ::sep::config::APIConfig& new_config) {
   std::lock_guard<std::mutex> lock(metrics_mutex_);
   config_ = new_config;
-  logger_->info("Configuration updated");
+  if (logger_)
+    logger_->info("Configuration updated");
 }
 
 
@@ -184,7 +188,8 @@ std::string SEPApiServer::handleError(const std::string& message, int code) {
                                     std::chrono::system_clock::now().time_since_epoch())
                                     .count();
 
-  logger_->error("API Error [{}]: {}", code, message);
+  if (logger_)
+    logger_->error("API Error [{}]: {}", code, message);
 
   std::lock_guard<std::mutex> lock(metrics_mutex_);
   metrics_.failedRequests++;
@@ -218,8 +223,9 @@ void SEPApiServer::logRequest(const HttpRequest& req, int code, const std::strin
 
   metrics_.lastResponseTime = std::chrono::milliseconds(duration);
 
-  logger_->info("Request: {} {} - Status: {} - Duration: {}ms",
-                req.method(), req.url(), code, duration);
+  if (logger_)
+    logger_->info("Request: {} {} - Status: {} - Duration: {}ms",
+                  req.method(), req.url(), code, duration);
 }
 
 std::string SEPApiServer::getErrorResponse(const std::string& message, int status) {
@@ -245,7 +251,8 @@ nlohmann::json SEPApiServer::handleCrowError(const std::string& message,
            std::chrono::system_clock::now().time_since_epoch())
            .count()}};
 
-  logger_->error("API Error [{}]: {}", status_code, message);
+  if (logger_)
+    logger_->error("API Error [{}]: {}", status_code, message);
 
   std::lock_guard<std::mutex> lock(metrics_mutex_);
   metrics_.failedRequests++;
@@ -283,8 +290,9 @@ void SEPApiServer::logRequest(const crow::request& req, int status_code,
   std::string method_name = std::string(crow::method_name(req.method));
   std::string url = std::string(req.url);
 
-  logger_->info("Request: {} {} - Status: {} - Duration: {}ms",
-                method_name, url, status_code, duration_ms);
+  if (logger_)
+    logger_->info("Request: {} {} - Status: {} - Duration: {}ms",
+                  method_name, url, status_code, duration_ms);
 }
 
 void SEPApiServer::setup_logging() {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,7 @@
 
 #include <chrono>
 #include <iostream>
+#include <cmath>
 #include <memory>
 #include <thread>
 
@@ -193,8 +194,8 @@ void mouse_button_callback(GLFWwindow* window, int button, int action, int mods)
 }
 
 void cursor_position_callback(GLFWwindow* window, double xpos, double ypos) {
-    g_mouse_x = static_cast<int>(xpos);
-    g_mouse_y = static_cast<int>(ypos);
+    g_mouse_x = static_cast<int>(std::lround(xpos));
+    g_mouse_y = static_cast<int>(std::lround(ypos));
     
     if (g_mouse_button >= 0 && g_demo_manager) {
         g_demo_manager->handleMouse(g_mouse_x, g_mouse_y, g_mouse_button);

--- a/third_party/imgui/imgui_internal.h
+++ b/third_party/imgui/imgui_internal.h
@@ -1332,7 +1332,7 @@ struct ImGuiNextItemData
     ImGuiDataTypeStorage        RefVal;             // Not exposed yet, for ImGuiInputTextFlags_ParseEmptyAsRefVal
     ImGuiID                     StorageId;          // Set by SetNextItemStorageID()
 
-    ImGuiNextItemData()         { memset(this, 0, sizeof(*this)); SelectionUserData = -1; }
+    ImGuiNextItemData()         { *this = {}; SelectionUserData = -1; }
     inline void ClearFlags()    { HasFlags = ImGuiNextItemDataFlags_None; ItemFlags = ImGuiItemFlags_None; } // Also cleared manually by ItemAdd()!
 };
 
@@ -1349,7 +1349,7 @@ struct ImGuiLastItemData
     ImRect                  ClipRect;           // Clip rectangle at the time of submitting item. ONLY VALID IF (StatusFlags & ImGuiItemStatusFlags_HasClipRect) is set..
     ImGuiKeyChord           Shortcut;           // Shortcut at the time of submitting item. ONLY VALID IF (StatusFlags & ImGuiItemStatusFlags_HasShortcut) is set..
 
-    ImGuiLastItemData()     { memset(this, 0, sizeof(*this)); }
+    ImGuiLastItemData()     { *this = {}; }
 };
 
 // Store data emitted by TreeNode() for usage by TreePop()
@@ -1521,7 +1521,7 @@ struct ImGuiInputEvent
     };
     bool                            AddedByTestEngine;
 
-    ImGuiInputEvent() { memset(this, 0, sizeof(*this)); }
+    ImGuiInputEvent() { *this = {}; }
 };
 
 // Input function taking an 'ImGuiID owner_id' argument defaults to (ImGuiKeyOwner_Any == 0) aka don't test ownership, which matches legacy behavior.


### PR DESCRIPTION
## Summary
- avoid null dereference if logging fails
- round mouse coordinates safely
- replace memset constructors in imgui

## Testing
- `cmake -S . -B build -DBUILD_TESTING=ON` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6871f72dade8832a95ec738ed8998213