### PR TITLE
Load config at startup and use it in demos

### DIFF
--- a/src/core/manager.cpp
+++ b/src/core/manager.cpp
@@ -1,67 +1,117 @@
 #include "core/manager.h"
 
-namespace sep::config {
+#include <fstream>
+#include <nlohmann/json.hpp>
 
-struct ConfigManager::Impl {
-    MemoryThresholdConfig mem_cfg{};
+#include "memory/memory_tier_manager_serialization.hpp"
+
+namespace sep::config
+{
+
+    struct ConfigManager::Impl
+    {
+        MemoryThresholdConfig mem_cfg{};
 #if SEP_BUILD_QUANTUM
-    QuantumThresholdConfig quantum_cfg{};
+        QuantumThresholdConfig quantum_cfg{};
 #endif
-};
+        bool loaded{false};
+    };
 
-ConfigManager::ConfigManager() : impl_(std::make_unique<Impl>()) {}
-ConfigManager::~ConfigManager() = default;
+    ConfigManager::ConfigManager() : impl_(std::make_unique<Impl>()) {}
+    ConfigManager::~ConfigManager() = default;
 
-void ConfigManager::initialize(int, char**) {}
-const SystemConfig& ConfigManager::getConfig() const {
-    static SystemConfig cfg{};
-    return cfg;
-}
-void ConfigManager::setConfig(const SystemConfig&) {}
-bool ConfigManager::loadFromFile(const sep::shim::string&) { return false; }
-bool ConfigManager::loadFromEnvironment() { return false; }
-bool ConfigManager::loadFromCommandLine(int, char**) { return false; }
-const APIConfig& ConfigManager::getAPIConfig() const {
-    static APIConfig cfg{};
-    return cfg;
-}
-const CudaConfig& ConfigManager::getCudaConfig() const {
-    static CudaConfig cfg{};
-    return cfg;
-}
-const LogConfig& ConfigManager::getLogConfig() const {
-    static LogConfig cfg{};
-    return cfg;
-}
-const MemoryThresholdConfig& ConfigManager::getMemoryConfig() const {
-    return impl_->mem_cfg;
-}
-const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const {
+    void ConfigManager::initialize(int, char**)
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (!impl_->loaded)
+        {
+            loadFromFile("config.json");
+            impl_->loaded = true;
+        }
+    }
+    const SystemConfig& ConfigManager::getConfig() const
+    {
+        static SystemConfig cfg{};
+        return cfg;
+    }
+    void ConfigManager::setConfig(const SystemConfig&) {}
+    bool ConfigManager::loadFromFile(const sep::shim::string& filename)
+    {
+        try
+        {
+            std::ifstream file(filename.c_str());
+            if (!file.is_open()) return false;
+            nlohmann::json j;
+            file >> j;
+            std::lock_guard<std::mutex> lock(mutex_);
+            if (j.contains("memory")) impl_->mem_cfg = j.at("memory").get<MemoryThresholdConfig>();
 #if SEP_BUILD_QUANTUM
-    return impl_->quantum_cfg;
+            if (j.contains("quantum"))
+            {
+                const auto& q = j.at("quantum");
+                impl_->quantum_cfg.ltm_coherence_threshold =
+                    q.value("ltm_coherence_threshold", impl_->quantum_cfg.ltm_coherence_threshold);
+                impl_->quantum_cfg.mtm_coherence_threshold =
+                    q.value("mtm_coherence_threshold", impl_->quantum_cfg.mtm_coherence_threshold);
+                impl_->quantum_cfg.stability_threshold =
+                    q.value("stability_threshold", impl_->quantum_cfg.stability_threshold);
+            }
+#endif
+            return true;
+        }
+        catch (...)
+        {
+            return false;
+        }
+    }
+    bool ConfigManager::loadFromEnvironment() { return false; }
+    bool ConfigManager::loadFromCommandLine(int, char**) { return false; }
+    const APIConfig& ConfigManager::getAPIConfig() const
+    {
+        static APIConfig cfg{};
+        return cfg;
+    }
+    const CudaConfig& ConfigManager::getCudaConfig() const
+    {
+        static CudaConfig cfg{};
+        return cfg;
+    }
+    const LogConfig& ConfigManager::getLogConfig() const
+    {
+        static LogConfig cfg{};
+        return cfg;
+    }
+    const MemoryThresholdConfig& ConfigManager::getMemoryConfig() const { return impl_->mem_cfg; }
+    const QuantumThresholdConfig& ConfigManager::getQuantumConfig() const
+    {
+#if SEP_BUILD_QUANTUM
+        return impl_->quantum_cfg;
 #else
-    static QuantumThresholdConfig cfg{};
-    return cfg;
+        static QuantumThresholdConfig cfg{};
+        return cfg;
 #endif
-}
-void ConfigManager::updateAPIConfig(const APIConfig&) {}
-void ConfigManager::updateCudaConfig(const CudaConfig&) {}
-void ConfigManager::updateLogConfig(const LogConfig&) {}
-void ConfigManager::updateMemoryConfig(const MemoryThresholdConfig& cfg) {
-    impl_->mem_cfg = cfg;
-}
-void ConfigManager::updateQuantumConfig(const QuantumThresholdConfig& cfg) {
+    }
+    void ConfigManager::updateAPIConfig(const APIConfig&) {}
+    void ConfigManager::updateCudaConfig(const CudaConfig&) {}
+    void ConfigManager::updateLogConfig(const LogConfig&) {}
+    void ConfigManager::updateMemoryConfig(const MemoryThresholdConfig& cfg)
+    {
+        impl_->mem_cfg = cfg;
+    }
+    void ConfigManager::updateQuantumConfig(const QuantumThresholdConfig& cfg)
+    {
 #if SEP_BUILD_QUANTUM
-    impl_->quantum_cfg = cfg;
+        impl_->quantum_cfg = cfg;
 #else
-    (void)cfg;
+        (void)cfg;
 #endif
-}
-void ConfigManager::resetToDefaults() {
-    impl_->mem_cfg = MemoryThresholdConfig{};
+    }
+    void ConfigManager::resetToDefaults()
+    {
+        impl_->mem_cfg = MemoryThresholdConfig{};
 #if SEP_BUILD_QUANTUM
-    impl_->quantum_cfg = QuantumThresholdConfig{};
+        impl_->quantum_cfg = QuantumThresholdConfig{};
 #endif
-}
+    }
 
-} // namespace sep::config
+}  // namespace sep::config

--- a/src/workbench/config.cpp
+++ b/src/workbench/config.cpp
@@ -1,290 +1,287 @@
 #include "config.hpp"
-#include <fstream>
+
 #include <spdlog/spdlog.h>
 
-namespace sep {
-namespace workbench {
+#include <fstream>
 
-bool Config::load(const std::filesystem::path& path) {
-    try {
-        std::ifstream file(path);
-        if (!file.is_open()) {
-            spdlog::error("Failed to open config file: {}", path.string());
-            return false;
-        }
-        nlohmann::json json;
-        file >> json;
+namespace sep
+{
+    namespace workbench
+    {
 
-        auto& window = json["window"];
-        window_ = {
-            window.value("title", std::string{"SEP"}),
-            window.value("width", 800),
-            window.value("height", 600),
-            window.value("fullscreen", false),
-            window.value("vsync", true)
-        };
-
-        auto& engine = json["engine"];
-        engine_ = {
-            engine.value("cuda_enabled", false),
-            engine.value("metrics_enabled", false),
-            engine.value("log_level", std::string{"info"})
-        };
-
-        auto& genesis = json["demos"]["genesis_pattern"];
-        auto& initial = genesis["initial_pattern"];
-        auto& viz = genesis["visualization"];
-        genesis_pattern_ = {
+        bool Config::load(const std::filesystem::path& path)
+        {
+            try
             {
-                { initial["dimensions"][0].get<int>(),
-                  initial["dimensions"][1].get<int>(),
-                  initial["dimensions"][2].get<int>() },
-                initial["evolution_rate"].get<float>(),
-                initial["coherence_threshold"].get<float>()
-            },
+                std::ifstream file(path);
+                if (!file.is_open())
+                {
+                    spdlog::error("Failed to open config file: {}", path.string());
+                    return false;
+                }
+                nlohmann::json json;
+                file >> json;
+
+                auto& window = json["window"];
+                window_ = {window.value("title", std::string{"SEP"}), window.value("width", 800),
+                           window.value("height", 600), window.value("fullscreen", false),
+                           window.value("vsync", true)};
+
+                auto& engine = json["engine"];
+                engine_ = {engine.value("cuda_enabled", false),
+                           engine.value("metrics_enabled", false),
+                           engine.value("log_level", std::string{"info"})};
+
+                auto& genesis = json["demos"]["genesis_pattern"];
+                auto& initial = genesis["initial_pattern"];
+                auto& viz = genesis["visualization"];
+                genesis_pattern_ = {
+                    {{initial["dimensions"][0].get<int>(), initial["dimensions"][1].get<int>(),
+                      initial["dimensions"][2].get<int>()},
+                     initial["evolution_rate"].get<float>(),
+                     initial["coherence_threshold"].get<float>()},
+                    {viz["color_mode"].get<std::string>(), viz["emission_mode"].get<std::string>(),
+                     viz["roughness_mode"].get<std::string>()}};
+
+                auto& audio = json["demos"]["audio_visualizer"];
+                auto& input = audio["input"];
+                auto& mapping = audio["pattern_mapping"];
+                audio_visualizer_ = {
+                    {input["device"].get<std::string>(), input["sample_rate"].get<int>(),
+                     input["buffer_size"].get<int>(), input["fft_size"].get<int>()},
+                    {mapping["frequency_scale"].get<float>(),
+                     mapping["amplitude_scale"].get<float>(),
+                     mapping["evolution_sensitivity"].get<float>()}};
+
+                auto& garden = json["demos"]["memory_garden"];
+                auto& layout = garden["layout"];
+                auto& viz_g = garden["visualization"];
+                memory_garden_ = {
+                    {layout["stm_radius"].get<float>(), layout["mtm_radius"].get<float>(),
+                     layout["ltm_radius"].get<float>()},
+                    {viz_g["show_connections"].get<bool>(),
+                     viz_g["connection_opacity"].get<float>(),
+                     viz_g["pattern_scale"].get<float>()}};
+
+                auto& anneal = json["demos"]["annealing"];
+                annealing_ = {anneal["initial_temperature"].get<float>(),
+                              anneal["cooling_rate"].get<float>(),
+                              anneal["particle_count"].get<int>()};
+
+                if (json["demos"].contains("annealing_sim"))
+                {
+                    auto& sim = json["demos"]["annealing_sim"];
+                    annealing_sim_.particle_count = sim["particle_count"].get<int>();
+                    for (auto& t : sim["temperature_schedule"])
+                        annealing_sim_.temperature_schedule.push_back(t.get<float>());
+                }
+
+                auto& renderer = json["renderer"];
+                auto& cycles = renderer["cycles"];
+                renderer_ = {{cycles["samples"].get<int>(), cycles["denoising"].get<bool>(),
+                              cycles["device"].get<std::string>()}};
+
+                auto& optimizer = json["optimizer"];
+                optimizer_ = {optimizer["iterations"].get<int>(),
+                              optimizer["mutation_rate"].get<float>()};
+
+                // Load drug discovery demo config
+                if (json["demos"].contains("drug_discovery"))
+                {
+                    auto& drug = json["demos"]["drug_discovery"];
+                    drug_discovery_.optimizer.iterations =
+                        drug["optimizer"]["iterations"].get<int>();
+                    drug_discovery_.optimizer.mutation_rate =
+                        drug["optimizer"]["mutation_rate"].get<float>();
+                }
+
+                // Load flocking demo config
+                if (json["demos"].contains("flocking"))
+                {
+                    auto& flock = json["demos"]["flocking"];
+                    flocking_.agent_count = flock["agent_count"].get<int>();
+                    flocking_.cohesion_weight = flock.value("cohesion_weight", 1.0f);
+                    flocking_.separation_weight = flock.value("separation_weight", 1.0f);
+                    flocking_.alignment_weight = flock.value("alignment_weight", 1.0f);
+                    flocking_.neighbor_radius = flock["neighbor_radius"].get<float>();
+                    flocking_.separation_distance = flock.value("separation_distance", 0.0f);
+                    flocking_.max_speed = flock["max_speed"].get<float>();
+                }
+
+                // Load neural demo config
+                if (json["demos"].contains("neural_demo"))
+                {
+                    auto& neural = json["demos"]["neural_demo"];
+                    neural_demo_.network.neuron_count =
+                        neural["network"]["neuron_count"].get<int>();
+                    neural_demo_.network.connection_prob =
+                        neural["network"]["connection_prob"].get<float>();
+                    neural_demo_.neuron.threshold = neural["neuron"]["threshold"].get<float>();
+                    neural_demo_.neuron.decay = neural["neuron"]["decay"].get<float>();
+                    neural_demo_.neuron.input_strength =
+                        neural["neuron"]["input_strength"].get<float>();
+                }
+
+                // Load digital physics demo config
+                if (json["demos"].contains("digital_physics"))
+                {
+                    auto& physics = json["demos"]["digital_physics"];
+                    digital_physics_.grid.width = physics["grid"]["width"].get<int>();
+                    digital_physics_.grid.height = physics["grid"]["height"].get<int>();
+
+                    if (physics["rules"].contains("birth"))
+                    {
+                        for (auto& b : physics["rules"]["birth"])
+                            digital_physics_.rules.birth.push_back(b.get<int>());
+                    }
+
+                    if (physics["rules"].contains("survival"))
+                    {
+                        for (auto& s : physics["rules"]["survival"])
+                            digital_physics_.rules.survival.push_back(s.get<int>());
+                    }
+                }
+
+                if (json.contains("cosmo"))
+                {
+                    auto& cosmo = json["cosmo"];
+                    cosmo_.box_size = cosmo["box_size"].get<float>();
+                    cosmo_.time_step = cosmo["time_step"].get<float>();
+                }
+
+                return true;
+            }
+            catch (const std::exception& e)
             {
-                viz["color_mode"].get<std::string>(),
-                viz["emission_mode"].get<std::string>(),
-                viz["roughness_mode"].get<std::string>()
-            }
-        };
-
-        auto& audio = json["demos"]["audio_visualizer"];
-        auto& input = audio["input"];
-        auto& mapping = audio["pattern_mapping"];
-        audio_visualizer_ = {
-            { input["device"].get<std::string>(),
-              input["sample_rate"].get<int>(),
-              input["buffer_size"].get<int>(),
-              input["fft_size"].get<int>() },
-            { mapping["frequency_scale"].get<float>(),
-              mapping["amplitude_scale"].get<float>(),
-              mapping["evolution_sensitivity"].get<float>() }
-        };
-
-        auto& garden = json["demos"]["memory_garden"];
-        auto& layout = garden["layout"];
-        auto& viz_g = garden["visualization"];
-        memory_garden_ = {
-            { layout["stm_radius"].get<float>(),
-              layout["mtm_radius"].get<float>(),
-              layout["ltm_radius"].get<float>() },
-            { viz_g["show_connections"].get<bool>(),
-              viz_g["connection_opacity"].get<float>(),
-              viz_g["pattern_scale"].get<float>() }
-        };
-
-        auto& anneal = json["demos"]["annealing"];
-        annealing_ = {
-            anneal["initial_temperature"].get<float>(),
-            anneal["cooling_rate"].get<float>(),
-            anneal["particle_count"].get<int>()
-        };
-
-        if (json["demos"].contains("annealing_sim")) {
-            auto& sim = json["demos"]["annealing_sim"];
-            annealing_sim_.particle_count = sim["particle_count"].get<int>();
-            for (auto& t : sim["temperature_schedule"])
-                annealing_sim_.temperature_schedule.push_back(t.get<float>());
-        }
-
-        auto& renderer = json["renderer"];
-        auto& cycles = renderer["cycles"];
-        renderer_ = {
-            { cycles["samples"].get<int>(),
-              cycles["denoising"].get<bool>(),
-              cycles["device"].get<std::string>() }
-        };
-
-        auto& optimizer = json["optimizer"];
-        optimizer_ = { optimizer["iterations"].get<int>(),
-                       optimizer["mutation_rate"].get<float>() };
-
-        // Load drug discovery demo config
-        if (json["demos"].contains("drug_discovery")) {
-            auto& drug = json["demos"]["drug_discovery"];
-            drug_discovery_.optimizer.iterations = drug["optimizer"]["iterations"].get<int>();
-            drug_discovery_.optimizer.mutation_rate = drug["optimizer"]["mutation_rate"].get<float>();
-        }
-
-        // Load flocking demo config
-        if (json["demos"].contains("flocking")) {
-            auto& flock = json["demos"]["flocking"];
-            flocking_.agent_count = flock["agent_count"].get<int>();
-            flocking_.cohesion_weight = flock.value("cohesion_weight", 1.0f);
-            flocking_.separation_weight = flock.value("separation_weight", 1.0f);
-            flocking_.alignment_weight = flock.value("alignment_weight", 1.0f);
-            flocking_.neighbor_radius = flock["neighbor_radius"].get<float>();
-            flocking_.separation_distance = flock.value("separation_distance", 0.0f);
-            flocking_.max_speed = flock["max_speed"].get<float>();
-        }
-
-        // Load neural demo config
-        if (json["demos"].contains("neural_demo")) {
-            auto& neural = json["demos"]["neural_demo"];
-            neural_demo_.network.neuron_count = neural["network"]["neuron_count"].get<int>();
-            neural_demo_.network.connection_prob = neural["network"]["connection_prob"].get<float>();
-            neural_demo_.neuron.threshold = neural["neuron"]["threshold"].get<float>();
-            neural_demo_.neuron.decay = neural["neuron"]["decay"].get<float>();
-            neural_demo_.neuron.input_strength = neural["neuron"]["input_strength"].get<float>();
-        }
-
-        // Load digital physics demo config
-        if (json["demos"].contains("digital_physics")) {
-            auto& physics = json["demos"]["digital_physics"];
-            digital_physics_.grid.width = physics["grid"]["width"].get<int>();
-            digital_physics_.grid.height = physics["grid"]["height"].get<int>();
-            
-            if (physics["rules"].contains("birth")) {
-                for (auto& b : physics["rules"]["birth"])
-                    digital_physics_.rules.birth.push_back(b.get<int>());
-            }
-            
-            if (physics["rules"].contains("survival")) {
-                for (auto& s : physics["rules"]["survival"])
-                    digital_physics_.rules.survival.push_back(s.get<int>());
+                spdlog::error("Failed to parse config file: {}", e.what());
+                return false;
             }
         }
 
-        return true;
-    } catch (const std::exception& e) {
-        spdlog::error("Failed to parse config file: {}", e.what());
-        return false;
-    }
-}
+        bool Config::save(const std::filesystem::path& path) const
+        {
+            try
+            {
+                nlohmann::json json;
 
-bool Config::save(const std::filesystem::path& path) const {
-    try {
-        nlohmann::json json;
+                json["window"] = {{"title", window_.title},
+                                  {"width", window_.width},
+                                  {"height", window_.height},
+                                  {"fullscreen", window_.fullscreen},
+                                  {"vsync", window_.vsync}};
 
-        json["window"] = {{"title", window_.title},
-                          {"width", window_.width},
-                          {"height", window_.height},
-                          {"fullscreen", window_.fullscreen},
-                          {"vsync", window_.vsync}};
+                json["engine"] = {{"cuda_enabled", engine_.cuda_enabled},
+                                  {"metrics_enabled", engine_.metrics_enabled},
+                                  {"log_level", engine_.log_level}};
 
-        json["engine"] = {{"cuda_enabled", engine_.cuda_enabled},
-                          {"metrics_enabled", engine_.metrics_enabled},
-                          {"log_level", engine_.log_level}};
+                json["demos"]["genesis_pattern"] = {
+                    {"initial_pattern",
+                     {{"dimensions",
+                       {genesis_pattern_.initial_pattern.dimensions[0],
+                        genesis_pattern_.initial_pattern.dimensions[1],
+                        genesis_pattern_.initial_pattern.dimensions[2]}},
+                      {"evolution_rate", genesis_pattern_.initial_pattern.evolution_rate},
+                      {"coherence_threshold",
+                       genesis_pattern_.initial_pattern.coherence_threshold}}},
+                    {"visualization",
+                     {{"color_mode", genesis_pattern_.visualization.color_mode},
+                      {"emission_mode", genesis_pattern_.visualization.emission_mode},
+                      {"roughness_mode", genesis_pattern_.visualization.roughness_mode}}}};
 
-        json["demos"]["genesis_pattern"] = {
-            {"initial_pattern",
-             {{"dimensions",
-               {genesis_pattern_.initial_pattern.dimensions[0],
-                genesis_pattern_.initial_pattern.dimensions[1],
-                genesis_pattern_.initial_pattern.dimensions[2]}},
-              {"evolution_rate", genesis_pattern_.initial_pattern.evolution_rate},
-              {"coherence_threshold",
-               genesis_pattern_.initial_pattern.coherence_threshold}}},
-            {"visualization",
-             {{"color_mode", genesis_pattern_.visualization.color_mode},
-              {"emission_mode", genesis_pattern_.visualization.emission_mode},
-              {"roughness_mode",
-               genesis_pattern_.visualization.roughness_mode}}}};
+                json["demos"]["audio_visualizer"] = {
+                    {"input",
+                     {{"device", audio_visualizer_.input.device},
+                      {"sample_rate", audio_visualizer_.input.sample_rate},
+                      {"buffer_size", audio_visualizer_.input.buffer_size},
+                      {"fft_size", audio_visualizer_.input.fft_size}}},
+                    {"pattern_mapping",
+                     {{"frequency_scale", audio_visualizer_.pattern_mapping.frequency_scale},
+                      {"amplitude_scale", audio_visualizer_.pattern_mapping.amplitude_scale},
+                      {"evolution_sensitivity",
+                       audio_visualizer_.pattern_mapping.evolution_sensitivity}}}};
 
-        json["demos"]["audio_visualizer"] = {
-            {"input",
-             {{"device", audio_visualizer_.input.device},
-              {"sample_rate", audio_visualizer_.input.sample_rate},
-              {"buffer_size", audio_visualizer_.input.buffer_size},
-              {"fft_size", audio_visualizer_.input.fft_size}}},
-            {"pattern_mapping",
-             {{"frequency_scale",
-               audio_visualizer_.pattern_mapping.frequency_scale},
-              {"amplitude_scale", audio_visualizer_.pattern_mapping.amplitude_scale},
-              {"evolution_sensitivity",
-               audio_visualizer_.pattern_mapping.evolution_sensitivity}}}};
+                json["demos"]["memory_garden"] = {
+                    {"layout",
+                     {{"stm_radius", memory_garden_.layout.stm_radius},
+                      {"mtm_radius", memory_garden_.layout.mtm_radius},
+                      {"ltm_radius", memory_garden_.layout.ltm_radius}}},
+                    {"visualization",
+                     {{"show_connections", memory_garden_.visualization.show_connections},
+                      {"connection_opacity", memory_garden_.visualization.connection_opacity},
+                      {"pattern_scale", memory_garden_.visualization.pattern_scale}}}};
 
-        json["demos"]["memory_garden"] = {
-            {"layout",
-             {{"stm_radius", memory_garden_.layout.stm_radius},
-              {"mtm_radius", memory_garden_.layout.mtm_radius},
-              {"ltm_radius", memory_garden_.layout.ltm_radius}}},
-            {"visualization",
-             {{"show_connections", memory_garden_.visualization.show_connections},
-              {"connection_opacity",
-               memory_garden_.visualization.connection_opacity},
-              {"pattern_scale", memory_garden_.visualization.pattern_scale}}}};
+                json["demos"]["annealing"] = {
+                    {"initial_temperature", annealing_.initial_temperature},
+                    {"cooling_rate", annealing_.cooling_rate},
+                    {"particle_count", annealing_.particle_count}};
 
-        json["demos"]["annealing"] = {
-            {"initial_temperature", annealing_.initial_temperature},
-            {"cooling_rate", annealing_.cooling_rate},
-            {"particle_count", annealing_.particle_count}};
+                if (!annealing_sim_.temperature_schedule.empty() ||
+                    annealing_sim_.particle_count != 0)
+                {
+                    json["demos"]["annealing_sim"] = {
+                        {"temperature_schedule", annealing_sim_.temperature_schedule},
+                        {"particle_count", annealing_sim_.particle_count}};
+                }
 
-        if (!annealing_sim_.temperature_schedule.empty() ||
-            annealing_sim_.particle_count != 0) {
-            json["demos"]["annealing_sim"] = {
-                {"temperature_schedule", annealing_sim_.temperature_schedule},
-                {"particle_count", annealing_sim_.particle_count}};
+                json["renderer"] = {{"cycles",
+                                     {{"samples", renderer_.cycles.samples},
+                                      {"denoising", renderer_.cycles.denoising},
+                                      {"device", renderer_.cycles.device}}}};
+
+                json["optimizer"] = {{"iterations", optimizer_.iterations},
+                                     {"mutation_rate", optimizer_.mutation_rate}};
+
+                // Save drug discovery demo config
+                json["demos"]["drug_discovery"] = {
+                    {"optimizer",
+                     {{"iterations", drug_discovery_.optimizer.iterations},
+                      {"mutation_rate", drug_discovery_.optimizer.mutation_rate}}}};
+
+                // Save flocking demo config
+                json["demos"]["flocking"] = {{"agent_count", flocking_.agent_count},
+                                             {"cohesion_weight", flocking_.cohesion_weight},
+                                             {"separation_weight", flocking_.separation_weight},
+                                             {"alignment_weight", flocking_.alignment_weight},
+                                             {"neighbor_radius", flocking_.neighbor_radius},
+                                             {"separation_distance", flocking_.separation_distance},
+                                             {"max_speed", flocking_.max_speed}};
+
+                // Save neural demo config
+                json["demos"]["neural_demo"] = {
+                    {"network",
+                     {{"neuron_count", neural_demo_.network.neuron_count},
+                      {"connection_prob", neural_demo_.network.connection_prob}}},
+                    {"neuron",
+                     {{"threshold", neural_demo_.neuron.threshold},
+                      {"decay", neural_demo_.neuron.decay},
+                      {"input_strength", neural_demo_.neuron.input_strength}}}};
+
+                // Save digital physics demo config
+                json["demos"]["digital_physics"] = {
+                    {"grid",
+                     {{"width", digital_physics_.grid.width},
+                      {"height", digital_physics_.grid.height}}},
+                    {"rules",
+                     {{"birth", digital_physics_.rules.birth},
+                      {"survival", digital_physics_.rules.survival}}}};
+
+                json["cosmo"] = {{"box_size", cosmo_.box_size}, {"time_step", cosmo_.time_step}};
+
+                std::ofstream file(path);
+                if (!file.is_open())
+                {
+                    spdlog::error("Failed to open config file for writing: {}", path.string());
+                    return false;
+                }
+                file << json.dump(2);
+                return true;
+            }
+            catch (const std::exception& e)
+            {
+                spdlog::error("Failed to save config file: {}", e.what());
+                return false;
+            }
         }
 
-        json["renderer"] = {
-            {"cycles",
-             {{"samples", renderer_.cycles.samples},
-              {"denoising", renderer_.cycles.denoising},
-              {"device", renderer_.cycles.device}}}};
-
-        json["optimizer"] = {
-            {"iterations", optimizer_.iterations},
-            {"mutation_rate", optimizer_.mutation_rate}};
-
-        // Save drug discovery demo config
-        json["demos"]["drug_discovery"] = {
-            {"optimizer", {
-                {"iterations", drug_discovery_.optimizer.iterations},
-                {"mutation_rate", drug_discovery_.optimizer.mutation_rate}
-            }}
-        };
-
-        // Save flocking demo config
-        json["demos"]["flocking"] = {
-            {"agent_count", flocking_.agent_count},
-            {"cohesion_weight", flocking_.cohesion_weight},
-            {"separation_weight", flocking_.separation_weight},
-            {"alignment_weight", flocking_.alignment_weight},
-            {"neighbor_radius", flocking_.neighbor_radius},
-            {"separation_distance", flocking_.separation_distance},
-            {"max_speed", flocking_.max_speed}
-        };
-
-        // Save neural demo config
-        json["demos"]["neural_demo"] = {
-            {"network", {
-                {"neuron_count", neural_demo_.network.neuron_count},
-                {"connection_prob", neural_demo_.network.connection_prob}
-            }},
-            {"neuron", {
-                {"threshold", neural_demo_.neuron.threshold},
-                {"decay", neural_demo_.neuron.decay},
-                {"input_strength", neural_demo_.neuron.input_strength}
-            }}
-        };
-
-        // Save digital physics demo config
-        json["demos"]["digital_physics"] = {
-            {"grid", {
-                {"width", digital_physics_.grid.width},
-                {"height", digital_physics_.grid.height}
-            }},
-            {"rules", {
-                {"birth", digital_physics_.rules.birth},
-                {"survival", digital_physics_.rules.survival}
-            }}
-        };
-
-        std::ofstream file(path);
-        if (!file.is_open()) {
-            spdlog::error("Failed to open config file for writing: {}",
-                          path.string());
-            return false;
-        }
-        file << json.dump(2);
-        return true;
-    } catch (const std::exception& e) {
-        spdlog::error("Failed to save config file: {}", e.what());
-        return false;
-    }
-}
-
-}  // namespace workbench
+    }  // namespace workbench
 }  // namespace sep

--- a/src/workbench/config.hpp
+++ b/src/workbench/config.hpp
@@ -6,184 +6,217 @@
 #include <string>
 #include <vector>
 
-namespace sep {
-namespace workbench {
+namespace sep
+{
+    namespace workbench
+    {
 
-struct WindowConfig {
-    std::string title;
-    int width;
-    int height;
-    bool fullscreen;
-    bool vsync;
-};
+        struct WindowConfig
+        {
+            std::string title;
+            int width;
+            int height;
+            bool fullscreen;
+            bool vsync;
+        };
 
-struct EngineConfig {
-    bool cuda_enabled;
-    bool metrics_enabled;
-    std::string log_level;
-};
+        struct EngineConfig
+        {
+            bool cuda_enabled;
+            bool metrics_enabled;
+            std::string log_level;
+        };
 
-struct GenesisPatternConfig {
-    struct InitialPattern {
-        std::array<int,3> dimensions;
-        float evolution_rate;
-        float coherence_threshold;
-    } initial_pattern;
+        struct GenesisPatternConfig
+        {
+            struct InitialPattern
+            {
+                std::array<int, 3> dimensions;
+                float evolution_rate;
+                float coherence_threshold;
+            } initial_pattern;
 
-    struct Visualization {
-        std::string color_mode;
-        std::string emission_mode;
-        std::string roughness_mode;
-    } visualization;
-};
+            struct Visualization
+            {
+                std::string color_mode;
+                std::string emission_mode;
+                std::string roughness_mode;
+            } visualization;
+        };
 
-struct AudioVisualizerConfig {
-    struct Input {
-        std::string device;
-        int sample_rate;
-        int buffer_size;
-        int fft_size;
-    } input;
+        struct AudioVisualizerConfig
+        {
+            struct Input
+            {
+                std::string device;
+                int sample_rate;
+                int buffer_size;
+                int fft_size;
+            } input;
 
-    struct PatternMapping {
-        float frequency_scale;
-        float amplitude_scale;
-        float evolution_sensitivity;
-    } pattern_mapping;
-};
+            struct PatternMapping
+            {
+                float frequency_scale;
+                float amplitude_scale;
+                float evolution_sensitivity;
+            } pattern_mapping;
+        };
 
-struct MemoryGardenConfig {
-    struct Layout {
-        float stm_radius;
-        float mtm_radius;
-        float ltm_radius;
-    } layout;
+        struct MemoryGardenConfig
+        {
+            struct Layout
+            {
+                float stm_radius;
+                float mtm_radius;
+                float ltm_radius;
+            } layout;
 
-    struct Visualization {
-        bool show_connections;
-        float connection_opacity;
-        float pattern_scale;
-    } visualization;
-};
+            struct Visualization
+            {
+                bool show_connections;
+                float connection_opacity;
+                float pattern_scale;
+            } visualization;
+        };
 
-struct AnnealingConfig {
-    float initial_temperature;
-    float cooling_rate;
-    int particle_count;
-};
+        struct AnnealingConfig
+        {
+            float initial_temperature;
+            float cooling_rate;
+            int particle_count;
+        };
 
-struct AnnealingSimConfig {
-    std::vector<float> temperature_schedule;
-    int particle_count{0};
-};
+        struct AnnealingSimConfig
+        {
+            std::vector<float> temperature_schedule;
+            int particle_count{0};
+        };
 
-struct DrugDiscoveryConfig {
-    struct {
-        int iterations;
-        float mutation_rate;
-    } optimizer;
-};
+        struct DrugDiscoveryConfig
+        {
+            struct
+            {
+                int iterations;
+                float mutation_rate;
+            } optimizer;
+        };
 
-struct NeuralDemoConfig {
-    struct {
-        int neuron_count;
-        float connection_prob;
-    } network;
-    struct {
-        float threshold;
-        float decay;
-        float input_strength;
-    } neuron;
-};
+        struct NeuralDemoConfig
+        {
+            struct
+            {
+                int neuron_count;
+                float connection_prob;
+            } network;
+            struct
+            {
+                float threshold;
+                float decay;
+                float input_strength;
+            } neuron;
+        };
 
-struct FlockingConfig {
-    int agent_count{0};
-    float cohesion_weight{1.0f};
-    float separation_weight{1.0f};
-    float alignment_weight{1.0f};
-    float neighbor_radius{0.0f};
-    float separation_distance{0.0f};
-    float max_speed{0.0f};
-};
+        struct FlockingConfig
+        {
+            int agent_count{0};
+            float cohesion_weight{1.0f};
+            float separation_weight{1.0f};
+            float alignment_weight{1.0f};
+            float neighbor_radius{0.0f};
+            float separation_distance{0.0f};
+            float max_speed{0.0f};
+        };
 
-struct DigitalPhysicsConfig {
-    struct {
-        int width;
-        int height;
-    } grid;
+        struct DigitalPhysicsConfig
+        {
+            struct
+            {
+                int width;
+                int height;
+            } grid;
 
-    struct {
-        std::vector<int> birth;
-        std::vector<int> survival;
-    } rules;
-};
+            struct
+            {
+                std::vector<int> birth;
+                std::vector<int> survival;
+            } rules;
+        };
 
-struct NeuralConfig {
-    int neuron_count;
-    float threshold;
-    float decay;
-    float input_strength;
-};
+        struct NeuralConfig
+        {
+            int neuron_count;
+            float threshold;
+            float decay;
+            float input_strength;
+        };
 
-struct CosmoConfig {
-    float box_size;
-    float time_step;
-};
+        struct CosmoConfig
+        {
+            float box_size;
+            float time_step;
+        };
 
-struct RendererConfig {
-    struct Cycles {
-        int samples;
-        bool denoising;
-        std::string device;
-    } cycles;
-};
+        struct RendererConfig
+        {
+            struct Cycles
+            {
+                int samples;
+                bool denoising;
+                std::string device;
+            } cycles;
+        };
 
-struct OptimizerConfig {
-    int iterations;
-    float mutation_rate;
-};
+        struct OptimizerConfig
+        {
+            int iterations;
+            float mutation_rate;
+        };
 
-class Config {
-public:
-    static Config& getInstance() {
-        static Config instance;
-        return instance;
-    }
+        class Config
+        {
+        public:
+            static Config& getInstance()
+            {
+                static Config instance;
+                return instance;
+            }
 
-    bool load(const std::filesystem::path& path);
-    bool save(const std::filesystem::path& path) const;
+            bool load(const std::filesystem::path& path);
+            bool save(const std::filesystem::path& path) const;
 
-    const WindowConfig& window() const { return window_; }
-    const EngineConfig& engine() const { return engine_; }
-    const GenesisPatternConfig& genesis_pattern() const { return genesis_pattern_; }
-    const AudioVisualizerConfig& audio_visualizer() const { return audio_visualizer_; }
-    const MemoryGardenConfig& memory_garden() const { return memory_garden_; }
-    const AnnealingConfig& annealing() const { return annealing_; }
-    const AnnealingSimConfig& annealing_sim() const { return annealing_sim_; }
-    const RendererConfig& renderer() const { return renderer_; }
-    const OptimizerConfig& optimizer() const { return optimizer_; }
-    const DrugDiscoveryConfig& drug_discovery() const { return drug_discovery_; }
-    const FlockingConfig& flocking() const { return flocking_; }
-    const NeuralDemoConfig& neural_demo() const { return neural_demo_; }
-    const DigitalPhysicsConfig& digital_physics() const { return digital_physics_; }
+            const WindowConfig& window() const { return window_; }
+            const EngineConfig& engine() const { return engine_; }
+            const GenesisPatternConfig& genesis_pattern() const { return genesis_pattern_; }
+            const AudioVisualizerConfig& audio_visualizer() const { return audio_visualizer_; }
+            const MemoryGardenConfig& memory_garden() const { return memory_garden_; }
+            const AnnealingConfig& annealing() const { return annealing_; }
+            const AnnealingSimConfig& annealing_sim() const { return annealing_sim_; }
+            const RendererConfig& renderer() const { return renderer_; }
+            const OptimizerConfig& optimizer() const { return optimizer_; }
+            const DrugDiscoveryConfig& drug_discovery() const { return drug_discovery_; }
+            const FlockingConfig& flocking() const { return flocking_; }
+            const NeuralDemoConfig& neural_demo() const { return neural_demo_; }
+            const DigitalPhysicsConfig& digital_physics() const { return digital_physics_; }
+            const CosmoConfig& cosmo() const { return cosmo_; }
 
-private:
-    Config() = default;
+        private:
+            Config() = default;
 
-    WindowConfig window_{};
-    EngineConfig engine_{};
-    GenesisPatternConfig genesis_pattern_{};
-    AudioVisualizerConfig audio_visualizer_{};
-    MemoryGardenConfig memory_garden_{};
-    AnnealingConfig annealing_{};
-    AnnealingSimConfig annealing_sim_{};
-    RendererConfig renderer_{};
-    OptimizerConfig optimizer_{};
-    DrugDiscoveryConfig drug_discovery_{};
-    FlockingConfig flocking_{};
-    NeuralDemoConfig neural_demo_{};
-    DigitalPhysicsConfig digital_physics_{};
-};
+            WindowConfig window_{};
+            EngineConfig engine_{};
+            GenesisPatternConfig genesis_pattern_{};
+            AudioVisualizerConfig audio_visualizer_{};
+            MemoryGardenConfig memory_garden_{};
+            AnnealingConfig annealing_{};
+            AnnealingSimConfig annealing_sim_{};
+            RendererConfig renderer_{};
+            OptimizerConfig optimizer_{};
+            DrugDiscoveryConfig drug_discovery_{};
+            FlockingConfig flocking_{};
+            NeuralDemoConfig neural_demo_{};
+            DigitalPhysicsConfig digital_physics_{};
+            CosmoConfig cosmo_{};
+        };
 
-} // namespace workbench
-} // namespace sep
+    }  // namespace workbench
+}  // namespace sep

--- a/src/workbench/demos/cosmo_sim.cpp
+++ b/src/workbench/demos/cosmo_sim.cpp
@@ -3,127 +3,138 @@
 #include <config.hpp>
 #include <cstdlib>
 // Include glm_config.h before any GLM headers to ensure GLM_ENABLE_EXPERIMENTAL is defined
-#include "compat/glm_config.h"
 #include <glm/gtx/norm.hpp>
 
 #include "../../workbench_demo_adapter.hpp"
+#include "compat/glm_config.h"
 
-namespace sep {
-namespace workbench {
-
-    void CosmoSim::on_load(sep::Engine* engine,
-                                                   sep::CyclesRenderer* renderer)
+namespace sep
+{
+    namespace workbench
     {
-        (void)engine;
-        (void)renderer;
-#ifdef SEP_WORKBENCH_DEMO
-    box_size_ = 50.0f;
-    time_step_ = 0.01f;
-#else
-    const auto& cfg = getConfigManager().getEngineConfig().cosmo();
-    box_size_ = cfg.box_size;
-    time_step_ = cfg.time_step;
-#endif
-    initBodies();
-    }
 
-void CosmoSim::initBodies() {
-    bodies_.clear();
-    std::size_t count = 100;
-    bodies_.reserve(count);
-    for (std::size_t i = 0; i < count; ++i) {
-        sep::pattern::PatternData d{};
-        d.position = glm::vec4(
-            static_cast<float>(std::rand()) / RAND_MAX * box_size_,
-            static_cast<float>(std::rand()) / RAND_MAX * box_size_,
-            static_cast<float>(std::rand()) / RAND_MAX * box_size_,
-            1.0f);
-        d.velocity = glm::vec4(0.0f);
-        d.attributes.x = 1.0f; // mass
-        bodies_.push_back(d);
-    }
-}
-
-void CosmoSim::integrate(float dt) {
-    const float eps = 1e-5f;
-    std::vector<glm::vec3> acc(bodies_.size(), glm::vec3(0.0f));
-    for (std::size_t i = 0; i < bodies_.size(); ++i) {
-        for (std::size_t j = i + 1; j < bodies_.size(); ++j) {
-            glm::vec3 diff = glm::vec3(bodies_[j].position) - glm::vec3(bodies_[i].position);
-            float dist2 = glm::dot(diff, diff) + eps;
-            float invDist3 = 1.0f / (glm::sqrt(dist2) * dist2);
-            float m1 = bodies_[i].attributes.x;
-            float m2 = bodies_[j].attributes.x;
-            glm::vec3 force = G_ * m1 * m2 * invDist3 * diff;
-            acc[i] += force / m1;
-            acc[j] -= force / m2;
+        void CosmoSim::on_load(sep::Engine* engine, sep::CyclesRenderer* renderer)
+        {
+            (void)engine;
+            (void)renderer;
+            const auto& cfg = Config::getInstance().cosmo();
+            box_size_ = cfg.box_size;
+            time_step_ = cfg.time_step;
+            initBodies();
         }
-    }
-    for (std::size_t i = 0; i < bodies_.size(); ++i) {
-        glm::vec3 vel = glm::vec3(bodies_[i].velocity) + acc[i] * dt;
-        glm::vec3 pos = glm::vec3(bodies_[i].position) + vel * dt;
-        bodies_[i].velocity = glm::vec4(vel, 0.0f);
-        bodies_[i].position = glm::vec4(pos, 1.0f);
-    }
-}
 
-void CosmoSim::updateCoherence() {
-    const float eps = 1e-5f;
-    for (std::size_t i = 0; i < bodies_.size(); ++i) {
-        float m = bodies_[i].attributes.x;
-        glm::vec3 vel = glm::vec3(bodies_[i].velocity);
-        float kinetic = 0.5f * m * glm::length2(vel);
-        float potential = 0.0f;
-        for (std::size_t j = 0; j < bodies_.size(); ++j) {
-            if (i == j) continue;
-            glm::vec3 diff = glm::vec3(bodies_[j].position) - glm::vec3(bodies_[i].position);
-            float dist = glm::length(diff) + eps;
-            float mj = bodies_[j].attributes.x;
-            potential -= G_ * m * mj / dist;
+        void CosmoSim::initBodies()
+        {
+            bodies_.clear();
+            std::size_t count = 100;
+            bodies_.reserve(count);
+            for (std::size_t i = 0; i < count; ++i)
+            {
+                sep::pattern::PatternData d{};
+                d.position =
+                    glm::vec4(static_cast<float>(std::rand()) / RAND_MAX * box_size_,
+                              static_cast<float>(std::rand()) / RAND_MAX * box_size_,
+                              static_cast<float>(std::rand()) / RAND_MAX * box_size_, 1.0f);
+                d.velocity = glm::vec4(0.0f);
+                d.attributes.x = 1.0f;  // mass
+                bodies_.push_back(d);
+            }
         }
-        float total = kinetic + std::abs(potential);
-        bodies_[i].coherence = total > 0.0f ? std::abs(potential) / total : 0.0f;
-    }
-}
 
-void CosmoSim::on_update(float) {
-    integrate(time_step_);
-    updateCoherence();
-}
+        void CosmoSim::integrate(float dt)
+        {
+            const float eps = 1e-5f;
+            std::vector<glm::vec3> acc(bodies_.size(), glm::vec3(0.0f));
+            for (std::size_t i = 0; i < bodies_.size(); ++i)
+            {
+                for (std::size_t j = i + 1; j < bodies_.size(); ++j)
+                {
+                    glm::vec3 diff =
+                        glm::vec3(bodies_[j].position) - glm::vec3(bodies_[i].position);
+                    float dist2 = glm::dot(diff, diff) + eps;
+                    float invDist3 = 1.0f / (glm::sqrt(dist2) * dist2);
+                    float m1 = bodies_[i].attributes.x;
+                    float m2 = bodies_[j].attributes.x;
+                    glm::vec3 force = G_ * m1 * m2 * invDist3 * diff;
+                    acc[i] += force / m1;
+                    acc[j] -= force / m2;
+                }
+            }
+            for (std::size_t i = 0; i < bodies_.size(); ++i)
+            {
+                glm::vec3 vel = glm::vec3(bodies_[i].velocity) + acc[i] * dt;
+                glm::vec3 pos = glm::vec3(bodies_[i].position) + vel * dt;
+                bodies_[i].velocity = glm::vec4(vel, 0.0f);
+                bodies_[i].position = glm::vec4(pos, 1.0f);
+            }
+        }
 
-void CosmoSim::on_render() {
-    if (!renderer_) return;
-    renderer_->setColorMode("temperature");
-    renderer_->setEmissionMode("density");
-    std::vector<glm::vec3> points;
-    points.reserve(bodies_.size());
-    for (const auto& b : bodies_) {
-        points.emplace_back(b.position.x / box_size_, b.position.y / box_size_, b.position.z / box_size_);
-    }
-    renderer_->renderPatternState(points);
-}
+        void CosmoSim::updateCoherence()
+        {
+            const float eps = 1e-5f;
+            for (std::size_t i = 0; i < bodies_.size(); ++i)
+            {
+                float m = bodies_[i].attributes.x;
+                glm::vec3 vel = glm::vec3(bodies_[i].velocity);
+                float kinetic = 0.5f * m * glm::length2(vel);
+                float potential = 0.0f;
+                for (std::size_t j = 0; j < bodies_.size(); ++j)
+                {
+                    if (i == j) continue;
+                    glm::vec3 diff =
+                        glm::vec3(bodies_[j].position) - glm::vec3(bodies_[i].position);
+                    float dist = glm::length(diff) + eps;
+                    float mj = bodies_[j].attributes.x;
+                    potential -= G_ * m * mj / dist;
+                }
+                float total = kinetic + std::abs(potential);
+                bodies_[i].coherence = total > 0.0f ? std::abs(potential) / total : 0.0f;
+            }
+        }
 
-void CosmoSim::on_unload() { bodies_.clear(); }
+        void CosmoSim::on_update(float)
+        {
+            integrate(time_step_);
+            updateCoherence();
+        }
 
-void CosmoSim::on_ui_render()
-{
-    ImGui::Begin("Neural Simulation Controls");
-    ImGui::SliderFloat("Threshold", &threshold_, 0.1f, 2.0f);
-    ImGui::SliderFloat("Decay Rate", &decay_, 0.01f, 0.5f);
-    ImGui::SliderFloat("Input Strength", &input_strength_, 0.1f, 1.0f);
-    ImGui::SliderFloat("Learning Rate", &learning_rate_, 0.01f, 0.2f);
-    ImGui::SliderFloat("Connection Probability", &connection_prob_, 0.1f, 0.5f);
-    ImGui::End();
-}
+        void CosmoSim::on_render()
+        {
+            if (!renderer_) return;
+            renderer_->setColorMode("temperature");
+            renderer_->setEmissionMode("density");
+            std::vector<glm::vec3> points;
+            points.reserve(bodies_.size());
+            for (const auto& b : bodies_)
+            {
+                points.emplace_back(b.position.x / box_size_, b.position.y / box_size_,
+                                    b.position.z / box_size_);
+            }
+            renderer_->renderPatternState(points);
+        }
 
-void CosmoSim::on_key_press(int key)
-{
-    if (key == 'r') {
-        initBodies();
-    }
-}
+        void CosmoSim::on_unload() { bodies_.clear(); }
 
-void CosmoSim::on_mouse(int, int, int) {}
+        void CosmoSim::on_ui_render()
+        {
+            ImGui::Begin("Neural Simulation Controls");
+            ImGui::SliderFloat("Threshold", &threshold_, 0.1f, 2.0f);
+            ImGui::SliderFloat("Decay Rate", &decay_, 0.01f, 0.5f);
+            ImGui::SliderFloat("Input Strength", &input_strength_, 0.1f, 1.0f);
+            ImGui::SliderFloat("Learning Rate", &learning_rate_, 0.01f, 0.2f);
+            ImGui::SliderFloat("Connection Probability", &connection_prob_, 0.1f, 0.5f);
+            ImGui::End();
+        }
 
-} // namespace workbench
-} // namespace sep
+        void CosmoSim::on_key_press(int key)
+        {
+            if (key == 'r')
+            {
+                initBodies();
+            }
+        }
+
+        void CosmoSim::on_mouse(int, int, int) {}
+
+    }  // namespace workbench
+}  // namespace sep

--- a/src/workbench/demos/demo_manager.hpp
+++ b/src/workbench/demos/demo_manager.hpp
@@ -1,9 +1,5 @@
 #pragma once
 
-#ifndef SEP_WORKBENCH_DEMO
-#define SEP_WORKBENCH_DEMO 1
-#endif
-
 #include <functional>
 #include <memory>
 #include <string>
@@ -17,7 +13,6 @@ namespace sep
 {
     namespace workbench
     {
-
 
         class DemoManager
         {

--- a/src/workbench/demos/drug_discovery_demo.cpp
+++ b/src/workbench/demos/drug_discovery_demo.cpp
@@ -6,92 +6,80 @@
 
 #include "../../workbench_demo_adapter.hpp"
 
-namespace sep {
-namespace workbench {
-
-    void DrugDiscoveryDemo::on_load(sep::Engine* engine, sep::CyclesRenderer* renderer)
-    {
-        (void)engine;
-        (void)renderer;
-#ifdef SEP_WORKBENCH_DEMO
-    // Default parameters for demo mode
-    iterations_ = 10;
-    mutation_rate_ = 0.05f;
-#else
-    const auto& cfg = ConfigManager::getInstance().getEngineConfig().drug_discovery();
-    iterations_ = cfg.iterations;
-    mutation_rate_ = cfg.mutation_rate;
-#endif
-
-    // Create a few initial poses
-    for (int i = 0; i < 5; ++i) {
-        Pose p;
-        p.position = glm::vec3((std::rand() % 100) * 0.01f);
-        p.orientation = glm::vec3(0.0f);
-        p.binding_affinity = 0.0f;
-        poses_.push_back(p);
-    }
-    }
-
-void DrugDiscoveryDemo::optimizePoses() {
-    for (int it = 0; it < iterations_; ++it) {
-        for (auto& p : poses_) {
-            // Simple random mutation of pose variables
-            p.position += mutation_rate_ * glm::vec3(
-                ((std::rand() % 200) - 100) * 0.001f,
-                ((std::rand() % 200) - 100) * 0.001f,
-                ((std::rand() % 200) - 100) * 0.001f);
-            p.orientation += mutation_rate_ * glm::vec3(
-                ((std::rand() % 200) - 100) * 0.001f,
-                ((std::rand() % 200) - 100) * 0.001f,
-                ((std::rand() % 200) - 100) * 0.001f);
-
-            // Mock binding affinity computation
-            float dist = glm::length(p.position);
-            p.binding_affinity = glm::clamp(1.0f - dist, 0.0f, 1.0f);
-        }
-    }
-}
-
-void DrugDiscoveryDemo::on_update(float) {
-    optimizePoses();
-}
-
-void DrugDiscoveryDemo::on_render() {
-#ifdef SEP_WORKBENCH_DEMO
-    if (renderer_) {
-        std::vector<glm::vec3> points;
-        for (const auto& p : poses_) {
-            points.push_back(p.position);
-        }
-        renderer_->renderPatternState(points);
-    }
-#else
-    if (!renderer_) return;
-    std::vector<glm::vec3> points;
-    for (const auto& p : poses_) {
-        points.push_back(p.position);
-    }
-    renderer_->renderPatternState(points);
-#endif
-}
-
-void DrugDiscoveryDemo::on_unload() { poses_.clear(); }
-
-void DrugDiscoveryDemo::on_ui_render()
+namespace sep
 {
-    ImGui::Begin("Neural Simulation Controls");
-    ImGui::SliderFloat("Threshold", &threshold_, 0.1f, 2.0f);
-    ImGui::SliderFloat("Decay Rate", &decay_, 0.01f, 0.5f);
-    ImGui::SliderFloat("Input Strength", &input_strength_, 0.1f, 1.0f);
-    ImGui::SliderFloat("Learning Rate", &learning_rate_, 0.01f, 0.2f);
-    ImGui::SliderFloat("Connection Probability", &connection_prob_, 0.1f, 0.5f);
-    ImGui::End();
-}
+    namespace workbench
+    {
 
-void DrugDiscoveryDemo::on_key_press(int key) { (void)key; }
-void DrugDiscoveryDemo::on_mouse(int, int, int) {}
+        void DrugDiscoveryDemo::on_load(sep::Engine* engine, sep::CyclesRenderer* renderer)
+        {
+            (void)engine;
+            (void)renderer;
+            const auto& cfg = Config::getInstance().drug_discovery();
+            iterations_ = cfg.optimizer.iterations;
+            mutation_rate_ = cfg.optimizer.mutation_rate;
 
-} // namespace workbench
-} // namespace sep
+            // Create a few initial poses
+            for (int i = 0; i < 5; ++i)
+            {
+                Pose p;
+                p.position = glm::vec3((std::rand() % 100) * 0.01f);
+                p.orientation = glm::vec3(0.0f);
+                p.binding_affinity = 0.0f;
+                poses_.push_back(p);
+            }
+        }
 
+        void DrugDiscoveryDemo::optimizePoses()
+        {
+            for (int it = 0; it < iterations_; ++it)
+            {
+                for (auto& p : poses_)
+                {
+                    // Simple random mutation of pose variables
+                    p.position += mutation_rate_ * glm::vec3(((std::rand() % 200) - 100) * 0.001f,
+                                                             ((std::rand() % 200) - 100) * 0.001f,
+                                                             ((std::rand() % 200) - 100) * 0.001f);
+                    p.orientation +=
+                        mutation_rate_ * glm::vec3(((std::rand() % 200) - 100) * 0.001f,
+                                                   ((std::rand() % 200) - 100) * 0.001f,
+                                                   ((std::rand() % 200) - 100) * 0.001f);
+
+                    // Mock binding affinity computation
+                    float dist = glm::length(p.position);
+                    p.binding_affinity = glm::clamp(1.0f - dist, 0.0f, 1.0f);
+                }
+            }
+        }
+
+        void DrugDiscoveryDemo::on_update(float) { optimizePoses(); }
+
+        void DrugDiscoveryDemo::on_render()
+        {
+            if (!renderer_) return;
+            std::vector<glm::vec3> points;
+            for (const auto& p : poses_)
+            {
+                points.push_back(p.position);
+            }
+            renderer_->renderPatternState(points);
+        }
+
+        void DrugDiscoveryDemo::on_unload() { poses_.clear(); }
+
+        void DrugDiscoveryDemo::on_ui_render()
+        {
+            ImGui::Begin("Neural Simulation Controls");
+            ImGui::SliderFloat("Threshold", &threshold_, 0.1f, 2.0f);
+            ImGui::SliderFloat("Decay Rate", &decay_, 0.01f, 0.5f);
+            ImGui::SliderFloat("Input Strength", &input_strength_, 0.1f, 1.0f);
+            ImGui::SliderFloat("Learning Rate", &learning_rate_, 0.01f, 0.2f);
+            ImGui::SliderFloat("Connection Probability", &connection_prob_, 0.1f, 0.5f);
+            ImGui::End();
+        }
+
+        void DrugDiscoveryDemo::on_key_press(int key) { (void)key; }
+        void DrugDiscoveryDemo::on_mouse(int, int, int) {}
+
+    }  // namespace workbench
+}  // namespace sep

--- a/src/workbench/demos/flocking_demo.cpp
+++ b/src/workbench/demos/flocking_demo.cpp
@@ -4,95 +4,101 @@
 #include <glm/glm.hpp>
 
 #include "../../workbench_demo_adapter.hpp"
+#include "config.hpp"
 
-namespace sep {
-namespace workbench {
-
-    void FlockingDemo::on_load(sep::Engine* engine,
-                                                       sep::CyclesRenderer* renderer)
+namespace sep
+{
+    namespace workbench
     {
-        (void)engine;
-        (void)renderer;
-#ifdef SEP_WORKBENCH_DEMO
-    std::size_t agent_count = 50;
-    max_speed_ = 2.0f;
-    neighbor_radius_ = 5.0f;
-#else
-    const auto& cfg = getConfigManager().getEngineConfig().flocking();
-    std::size_t agent_count = cfg.agent_count;
-    max_speed_ = cfg.max_speed;
-    neighbor_radius_ = cfg.neighbor_radius;
-#endif
-    agents_.resize(agent_count);
-    for (auto& a : agents_) {
-        float px = (static_cast<float>(std::rand()) / RAND_MAX - 0.5f) * 20.f;
-        float py = (static_cast<float>(std::rand()) / RAND_MAX - 0.5f) * 20.f;
-        float pz = (static_cast<float>(std::rand()) / RAND_MAX - 0.5f) * 20.f;
-        float vx = (static_cast<float>(std::rand()) / RAND_MAX - 0.5f) * 2.f;
-        float vy = (static_cast<float>(std::rand()) / RAND_MAX - 0.5f) * 2.f;
-        float vz = (static_cast<float>(std::rand()) / RAND_MAX - 0.5f) * 2.f;
-        a.position = glm::vec4(px, py, pz, 0.f);
-        a.velocity = glm::vec4(vx, vy, vz, 0.f);
-    }
-    }
 
-void FlockingDemo::on_update(float dt) {
-    for (auto& agent : agents_) {
-        glm::vec3 cohesion(0.f);
-        glm::vec3 alignment(0.f);
-        glm::vec3 separation(0.f);
-        int neighbors = 0;
-        for (const auto& other : agents_) {
-            if (&agent == &other) continue;
-            glm::vec3 diff = glm::vec3(other.position) - glm::vec3(agent.position);
-            float dist = glm::length(diff);
-            if (dist < neighbor_radius_) {
-                cohesion += glm::vec3(other.position);
-                alignment += glm::vec3(other.velocity);
-                separation -= diff / (dist + 0.01f);
-                neighbors++;
+        void FlockingDemo::on_load(sep::Engine* engine, sep::CyclesRenderer* renderer)
+        {
+            (void)engine;
+            (void)renderer;
+            const auto& cfg = Config::getInstance().flocking();
+            std::size_t agent_count = cfg.agent_count;
+            max_speed_ = cfg.max_speed;
+            neighbor_radius_ = cfg.neighbor_radius;
+            agents_.resize(agent_count);
+            for (auto& a : agents_)
+            {
+                float px = (static_cast<float>(std::rand()) / RAND_MAX - 0.5f) * 20.f;
+                float py = (static_cast<float>(std::rand()) / RAND_MAX - 0.5f) * 20.f;
+                float pz = (static_cast<float>(std::rand()) / RAND_MAX - 0.5f) * 20.f;
+                float vx = (static_cast<float>(std::rand()) / RAND_MAX - 0.5f) * 2.f;
+                float vy = (static_cast<float>(std::rand()) / RAND_MAX - 0.5f) * 2.f;
+                float vz = (static_cast<float>(std::rand()) / RAND_MAX - 0.5f) * 2.f;
+                a.position = glm::vec4(px, py, pz, 0.f);
+                a.velocity = glm::vec4(vx, vy, vz, 0.f);
             }
         }
-        if (neighbors > 0) {
-            cohesion = cohesion / static_cast<float>(neighbors) - glm::vec3(agent.position);
-            alignment = alignment / static_cast<float>(neighbors) - glm::vec3(agent.velocity);
+
+        void FlockingDemo::on_update(float dt)
+        {
+            for (auto& agent : agents_)
+            {
+                glm::vec3 cohesion(0.f);
+                glm::vec3 alignment(0.f);
+                glm::vec3 separation(0.f);
+                int neighbors = 0;
+                for (const auto& other : agents_)
+                {
+                    if (&agent == &other) continue;
+                    glm::vec3 diff = glm::vec3(other.position) - glm::vec3(agent.position);
+                    float dist = glm::length(diff);
+                    if (dist < neighbor_radius_)
+                    {
+                        cohesion += glm::vec3(other.position);
+                        alignment += glm::vec3(other.velocity);
+                        separation -= diff / (dist + 0.01f);
+                        neighbors++;
+                    }
+                }
+                if (neighbors > 0)
+                {
+                    cohesion = cohesion / static_cast<float>(neighbors) - glm::vec3(agent.position);
+                    alignment =
+                        alignment / static_cast<float>(neighbors) - glm::vec3(agent.velocity);
+                }
+                // Convert the vec3 sum to vec4 before adding it to agent.velocity
+                glm::vec4 force = glm::vec4(cohesion + alignment + separation, 0.0f) * 0.01f;
+                agent.velocity += force;
+                float velocity_magnitude = glm::length(glm::vec3(agent.velocity));
+                if (velocity_magnitude > max_speed_)
+                {
+                    glm::vec3 normalized_velocity =
+                        glm::normalize(glm::vec3(agent.velocity)) * max_speed_;
+                    agent.velocity = glm::vec4(normalized_velocity, agent.velocity.w);
+                }
+                agent.position += glm::vec4(glm::vec3(agent.velocity) * dt, 0.f);
+            }
         }
-        // Convert the vec3 sum to vec4 before adding it to agent.velocity
-        glm::vec4 force = glm::vec4(cohesion + alignment + separation, 0.0f) * 0.01f;
-        agent.velocity += force;
-        float velocity_magnitude = glm::length(glm::vec3(agent.velocity));
-        if (velocity_magnitude > max_speed_) {
-            glm::vec3 normalized_velocity = glm::normalize(glm::vec3(agent.velocity)) * max_speed_;
-            agent.velocity = glm::vec4(normalized_velocity, agent.velocity.w);
+
+        void FlockingDemo::on_render()
+        {
+            if (!renderer_) return;
+            std::vector<glm::vec3> points;
+            points.reserve(agents_.size());
+            for (const auto& a : agents_)
+            {
+                points.emplace_back(a.position.x, a.position.y, a.position.z);
+            }
+            renderer_->renderPatternState(points);
         }
-        agent.position += glm::vec4(glm::vec3(agent.velocity) * dt, 0.f);
-    }
-}
 
-void FlockingDemo::on_render() {
-    if (!renderer_) return;
-    std::vector<glm::vec3> points;
-    points.reserve(agents_.size());
-    for (const auto& a : agents_) {
-        points.emplace_back(a.position.x, a.position.y, a.position.z);
-    }
-    renderer_->renderPatternState(points);
-}
+        void FlockingDemo::on_unload() { agents_.clear(); }
 
-void FlockingDemo::on_unload() {
-    agents_.clear();
-}
+        void FlockingDemo::on_ui_render()
+        {
+            ImGui::Begin("Flocking Demo Controls");
+            ImGui::SliderFloat("Max Speed", &max_speed_, 0.1f, 5.0f);
+            ImGui::SliderFloat("Neighbor Radius", &neighbor_radius_, 1.0f, 20.0f);
+            ImGui::Text("Agents: %zu", agents_.size());
+            ImGui::End();
+        }
 
-void FlockingDemo::on_ui_render() {
-    ImGui::Begin("Flocking Demo Controls");
-    ImGui::SliderFloat("Max Speed", &max_speed_, 0.1f, 5.0f);
-    ImGui::SliderFloat("Neighbor Radius", &neighbor_radius_, 1.0f, 20.0f);
-    ImGui::Text("Agents: %zu", agents_.size());
-    ImGui::End();
-}
+        void FlockingDemo::on_key_press(int key) { (void)key; }
+        void FlockingDemo::on_mouse(int, int, int) {}
 
-void FlockingDemo::on_key_press(int key) { (void)key; }
-void FlockingDemo::on_mouse(int, int, int) {}
-
-} // namespace workbench
-} // namespace sep
+    }  // namespace workbench
+}  // namespace sep

--- a/src/workbench/demos/neural_demo.cpp
+++ b/src/workbench/demos/neural_demo.cpp
@@ -5,106 +5,103 @@
 #include "../../workbench_demo_adapter.hpp"
 #include "config.hpp"
 
-namespace sep {
-namespace workbench {
-
-    void NeuralDemo::on_load(sep::Engine* engine, sep::CyclesRenderer* renderer)
+namespace sep
+{
+    namespace workbench
     {
-        (void)engine;
-        (void)renderer;
-#ifdef SEP_WORKBENCH_DEMO
-    int count = 3;
-    threshold_ = 1.0f;
-    decay_ = 0.1f;
-    weight_ = 0.5f;
-#else
-    const auto& cfg = ConfigManager::getInstance().getEngineConfig().neural();
-    int count = cfg.neuron_count;
-    threshold_ = cfg.threshold;
-    decay_ = cfg.decay;
-    weight_ = cfg.connection_weight;
-#endif
 
-    neurons_.clear();
-    graph_ = dag::DagGraph();
-    for (int i = 0; i < count; ++i) {
-        uint64_t id = graph_.addNode(glm::vec3(0.0f), 0.f, {});
-        neurons_.push_back({id, 0.f});
-        if (i > 0) {
-            graph_.updateNodeParents(neurons_[i].id, {neurons_[i-1].id});
-        }
-    }
-    }
+        void NeuralDemo::on_load(sep::Engine* engine, sep::CyclesRenderer* renderer)
+        {
+            (void)engine;
+            (void)renderer;
+            const auto& cfg = Config::getInstance().neural_demo();
+            int count = cfg.network.neuron_count;
+            threshold_ = cfg.neuron.threshold;
+            decay_ = cfg.neuron.decay;
+            weight_ = cfg.network.connection_prob;
 
-void NeuralDemo::on_update(float dt) {
-    std::vector<float> inputs(neurons_.size(), 0.f);
-    for (size_t i = 0; i < neurons_.size(); ++i) {
-        auto parents = graph_.getParents(neurons_[i].id);
-        for (uint64_t pid : parents) {
-            auto it = std::find_if(neurons_.begin(), neurons_.end(), [pid](const Neuron& n){ return n.id == pid; });
-            if (it != neurons_.end()) {
-                inputs[i] += it->potential * weight_;
-            }
-        }
-    }
-
-    for (size_t i = 0; i < neurons_.size(); ++i) {
-        Neuron& n = neurons_[i];
-        n.potential += inputs[i];
-        n.potential -= decay_ * n.potential * dt;
-        if (n.potential >= threshold_) {
-            n.potential = 0.f;
-            for (size_t j = 0; j < neurons_.size(); ++j) {
-                auto parents = graph_.getParents(neurons_[j].id);
-                if (std::find(parents.begin(), parents.end(), n.id) != parents.end()) {
-                    neurons_[j].potential += 1.f;
+            neurons_.clear();
+            graph_ = dag::DagGraph();
+            for (int i = 0; i < count; ++i)
+            {
+                uint64_t id = graph_.addNode(glm::vec3(0.0f), 0.f, {});
+                neurons_.push_back({id, 0.f});
+                if (i > 0)
+                {
+                    graph_.updateNodeParents(neurons_[i].id, {neurons_[i - 1].id});
                 }
             }
         }
-        graph_.updateCoherence(n.id, n.potential / threshold_);
-    }
-}
 
-void NeuralDemo::on_render() {
-#ifdef SEP_WORKBENCH_DEMO
-    if (!renderer_) return;
-    std::vector<glm::vec3> points;
-    for (size_t i = 0; i < neurons_.size(); ++i) {
-        float y = neurons_[i].potential / threshold_;
-        points.push_back(glm::vec3(static_cast<float>(i), y, 0.f));
-    }
-    renderer_->renderPatternState(points);
-#else
-    if (!renderer_) return;
-    std::vector<glm::vec3> points;
-    for (size_t i = 0; i < neurons_.size(); ++i) {
-        float y = neurons_[i].potential / threshold_;
-        points.push_back(glm::vec3(static_cast<float>(i), y, 0.f));
-    }
-    renderer_->renderPatternState(points);
-#endif
-}
+        void NeuralDemo::on_update(float dt)
+        {
+            std::vector<float> inputs(neurons_.size(), 0.f);
+            for (size_t i = 0; i < neurons_.size(); ++i)
+            {
+                auto parents = graph_.getParents(neurons_[i].id);
+                for (uint64_t pid : parents)
+                {
+                    auto it = std::find_if(neurons_.begin(), neurons_.end(),
+                                           [pid](const Neuron& n) { return n.id == pid; });
+                    if (it != neurons_.end())
+                    {
+                        inputs[i] += it->potential * weight_;
+                    }
+                }
+            }
 
-void NeuralDemo::on_unload() {
-    neurons_.clear();
-    graph_ = dag::DagGraph();
-}
+            for (size_t i = 0; i < neurons_.size(); ++i)
+            {
+                Neuron& n = neurons_[i];
+                n.potential += inputs[i];
+                n.potential -= decay_ * n.potential * dt;
+                if (n.potential >= threshold_)
+                {
+                    n.potential = 0.f;
+                    for (size_t j = 0; j < neurons_.size(); ++j)
+                    {
+                        auto parents = graph_.getParents(neurons_[j].id);
+                        if (std::find(parents.begin(), parents.end(), n.id) != parents.end())
+                        {
+                            neurons_[j].potential += 1.f;
+                        }
+                    }
+                }
+                graph_.updateCoherence(n.id, n.potential / threshold_);
+            }
+        }
 
-void NeuralDemo::on_ui_render()
-{
-    ImGui::Begin("Neural Simulation Controls");
-    ImGui::SliderFloat("Threshold", &threshold_, 0.1f, 2.0f);
-    ImGui::SliderFloat("Decay Rate", &decay_, 0.01f, 0.5f);
-    ImGui::SliderFloat("Input Strength", &input_strength_, 0.1f, 1.0f);
-    ImGui::SliderFloat("Learning Rate", &learning_rate_, 0.01f, 0.2f);
-    ImGui::SliderFloat("Connection Probability", &connection_prob_, 0.1f, 0.5f);
-    ImGui::End();
-}
+        void NeuralDemo::on_render()
+        {
+            if (!renderer_) return;
+            std::vector<glm::vec3> points;
+            for (size_t i = 0; i < neurons_.size(); ++i)
+            {
+                float y = neurons_[i].potential / threshold_;
+                points.push_back(glm::vec3(static_cast<float>(i), y, 0.f));
+            }
+            renderer_->renderPatternState(points);
+        }
 
-void NeuralDemo::on_key_press(int key) {
-    (void)key;
-}
-void NeuralDemo::on_mouse(int, int, int) {}
+        void NeuralDemo::on_unload()
+        {
+            neurons_.clear();
+            graph_ = dag::DagGraph();
+        }
 
-} // namespace workbench
-} // namespace sep
+        void NeuralDemo::on_ui_render()
+        {
+            ImGui::Begin("Neural Simulation Controls");
+            ImGui::SliderFloat("Threshold", &threshold_, 0.1f, 2.0f);
+            ImGui::SliderFloat("Decay Rate", &decay_, 0.01f, 0.5f);
+            ImGui::SliderFloat("Input Strength", &input_strength_, 0.1f, 1.0f);
+            ImGui::SliderFloat("Learning Rate", &learning_rate_, 0.01f, 0.2f);
+            ImGui::SliderFloat("Connection Probability", &connection_prob_, 0.1f, 0.5f);
+            ImGui::End();
+        }
+
+        void NeuralDemo::on_key_press(int key) { (void)key; }
+        void NeuralDemo::on_mouse(int, int, int) {}
+
+    }  // namespace workbench
+}  // namespace sep


### PR DESCRIPTION
## Summary
- load `config.json` when `ConfigManager` initializes
- expose cosmo settings in `Config`
- remove hardcoded demo settings and pull values from the config

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bpy')*

------
https://chatgpt.com/codex/tasks/task_e_6871f71a8eac832a94ad536f30fb0dfb