### PR TITLE
Add standalone API server executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository contains the SEP Engine, a high-performance C++ framework for qu
 
 - **C++ Components**: The core SEP Engine is written in C++ and built using CMake
 - **JavaScript/TypeScript Components**: Supporting tools written in TypeScript/JavaScript
+- **API Server**: Built as a separate executable (`sep_api_server`)
 
 ## Build System
 
@@ -87,3 +88,4 @@ The codebase search tool is available as an MCP server that can be used with com
 - **SEP Engine**: Core C++ engine for pattern analysis
 - **MCP Tool**: TypeScript tool for Model Context Protocol integration
 - **Codebase Search**: Semantic search tool for the codebase
+- **API Server**: Headless HTTP server built from `src/api_main.cpp`.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -97,3 +97,21 @@ if(SEP_BUILD_WORKBENCH)
         ${CMAKE_DL_LIBS}
     )
 endif()
+
+add_executable(sep_api_server
+    api_main.cpp
+)
+set_target_properties(sep_api_server PROPERTIES CXX_STANDARD 17)
+
+target_include_directories(sep_api_server PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_SOURCE_DIR}/src
+)
+
+target_link_libraries(sep_api_server PRIVATE
+    sep_api
+    sep_blender
+    sep_core
+    sep_compat
+    Threads::Threads
+)

--- a/src/api_main.cpp
+++ b/src/api_main.cpp
@@ -1,0 +1,26 @@
+#include "core/manager.h"
+#include "sep_engine_wrapper.h"
+#include "api/server.h"
+#include <memory>
+#include <iostream>
+
+int main(int argc, char** argv) {
+    auto& configMgr = sep::config::ConfigManager::getInstance();
+    configMgr.initialize(argc, argv);
+    const auto& apiConfig = configMgr.getAPIConfig();
+
+    // Create minimal renderer implementation
+    std::unique_ptr<sep::CyclesRenderer> renderer = sep::createRenderer();
+    if (renderer) {
+        renderer->initialize();
+    }
+
+    sep::api::SEPApiServer server(apiConfig, renderer.get());
+    if (!server.run()) {
+        std::cerr << "Failed to start API server" << std::endl;
+        return 1;
+    }
+
+    server.waitForShutdown();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- create `src/api_main.cpp` entry point
- build the server as new `sep_api_server` executable
- mention the new target in the README

## Testing
- `cmake ..` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6871f71f0a08832a9972d08fac3c532c