### PR TITLE
Refactor imgui constructors

### DIFF
--- a/third_party/imgui/imgui.cpp
+++ b/third_party/imgui/imgui.cpp
@@ -1906,10 +1906,19 @@ void ImGuiIO::AddFocusEvent(bool focused)
 }
 
 ImGuiPlatformIO::ImGuiPlatformIO()
+    : Platform_GetClipboardTextFn{nullptr},
+      Platform_SetClipboardTextFn{nullptr},
+      Platform_ClipboardUserData{nullptr},
+      Platform_OpenInShellFn{nullptr},
+      Platform_OpenInShellUserData{nullptr},
+      Platform_SetImeDataFn{nullptr},
+      Platform_ImeUserData{nullptr},
+      Platform_LocaleDecimalPoint{'.'},
+      Renderer_TextureMaxWidth{0},
+      Renderer_TextureMaxHeight{0},
+      Renderer_RenderState{nullptr},
+      Textures{}
 {
-    // Most fields are initialized with zero
-    memset(this, 0, sizeof(*this));
-    Platform_LocaleDecimalPoint = '.';
 }
 
 //-----------------------------------------------------------------------------

--- a/third_party/imgui/imgui_widgets.cpp
+++ b/third_party/imgui/imgui_widgets.cpp
@@ -4210,9 +4210,25 @@ static void stb_textedit_replace(ImGuiInputTextState* str, STB_TexteditState* st
 
 // We added an extra indirection where 'Stb' is heap-allocated, in order facilitate the work of bindings generators.
 ImGuiInputTextState::ImGuiInputTextState()
+    : Ctx{nullptr},
+      Stb{IM_NEW(ImStbTexteditState)},
+      Flags{0},
+      ID{0},
+      TextLen{0},
+      TextSrc{nullptr},
+      TextA{},
+      TextToRevertTo{},
+      CallbackTextBackup{},
+      BufCapacity{0},
+      Scroll{0.0f, 0.0f},
+      CursorAnim{0.0f},
+      CursorFollow{false},
+      SelectedAllMouseLock{false},
+      Edited{false},
+      WantReloadUserBuf{false},
+      ReloadSelectionStart{0},
+      ReloadSelectionEnd{0}
 {
-    memset(this, 0, sizeof(*this));
-    Stb = IM_NEW(ImStbTexteditState);
     memset(Stb, 0, sizeof(*Stb));
 }
 
@@ -4253,8 +4269,20 @@ void ImGuiInputTextState::ReloadUserBufAndKeepSelection()   { WantReloadUserBuf 
 void ImGuiInputTextState::ReloadUserBufAndMoveToEnd()       { WantReloadUserBuf = true; ReloadSelectionStart = ReloadSelectionEnd = INT_MAX; }
 
 ImGuiInputTextCallbackData::ImGuiInputTextCallbackData()
+    : Ctx{nullptr},
+      EventFlag{ImGuiInputTextFlags_None},
+      Flags{0},
+      UserData{nullptr},
+      EventChar{0},
+      EventKey{ImGuiKey_None},
+      Buf{nullptr},
+      BufTextLen{0},
+      BufSize{0},
+      BufDirty{false},
+      CursorPos{0},
+      SelectionStart{0},
+      SelectionEnd{0}
 {
-    memset(this, 0, sizeof(*this));
 }
 
 // Public API to manipulate UTF-8 text from within a callback.
@@ -9360,7 +9388,7 @@ struct ImGuiTabBarSection
     float               Width;                  // Sum of width of tabs in this section (after shrinking down)
     float               Spacing;                // Horizontal spacing at the end of the section.
 
-    ImGuiTabBarSection() { memset(this, 0, sizeof(*this)); }
+    ImGuiTabBarSection() : TabCount{0}, Width{0.0f}, Spacing{0.0f} {}
 };
 
 namespace ImGui


### PR DESCRIPTION
## Summary
- switch a few imgui structs to member initializer lists instead of memset

## Testing
- `npm test` *(fails: jest not found)*
- `cmake ..` in `build/` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6871f7235298832aaa82bd33138e471f