### PR TITLE
Fix warnings in imgui sources

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -272,25 +272,25 @@ These are less critical but important for maintainability and robustness.
 
 *   **Issue:** Using `memset` or `memcpy` on non-TriviallyCopyable C++ objects.
 *   **Location:** Widespread in `imgui*.cpp`.
-*   **Action:** This is a characteristic of the ImGui library's C-style C++ code. The "correct" fix is to replace `memset` with default member initializers or a constructor initializer list. For a third-party library, you might choose to suppress this warning for now to focus on your own code.
+*   **Action:** This is a characteristic of the ImGui library's C-style C++ code. The "correct" fix is to replace `memset` with default member initializers or a constructor initializer list. For a third-party library, we document the upstream usage and leave it unchanged for stability.
 
 **[ ] 2. `cert-err33-c` (MEDIUM)**
 
 *   **Issue:** Return value of functions like `snprintf` and `fflush` is ignored.
 *   **Location:** Widespread in `imgui*.cpp`.
-*   **Action:** This is another common issue in C-style code. The ideal fix is to check the return values. A pragmatic fix is to cast the call to void to signal that you are intentionally ignoring the return value: `(void)snprintf(...)`.
+*   **Action:** Added `(void)` casts in the ImGui sources to explicitly ignore these return values.
 
 **[ ] 3. `misc-header-include-cycle` (LOW)**
 
 *   **Issue:** Circular dependencies between headers (e.g., A.h includes B.h, and B.h includes A.h).
 *   **Location:** `pipewire` headers.
-*   **Action:** This is an issue within an external library. You can generally ignore this, but the proper fix is to use forward declarations in headers and move the `#include`s into the `.cpp` files where the full type definition is needed.
+*   **Action:** Repository snapshot does not currently include these headers. If reintroduced, use forward declarations in headers and move the `#include`s into the `.cpp` files where the full type definition is needed to avoid cycles.
 
 **[ ] 4. `clang-diagnostic-reserved-identifier` (MEDIUM)**
 
 *   **Issue:** Using identifiers that start with `_` or `__`.
 *   **Location:** `spa` headers.
-*   **Action:** This is an issue in a third-party library. It's best to leave it as-is to avoid breaking the library, but be aware that this is poor practice.
+*   **Action:** No `spa` headers are present in this snapshot. If added later, avoid reserved identifiers or wrap them when integrating third-party code.
 
 ---
 

--- a/third_party/imgui/backends/imgui_impl_glfw.cpp
+++ b/third_party/imgui/backends/imgui_impl_glfw.cpp
@@ -621,7 +621,7 @@ static bool ImGui_ImplGlfw_Init(GLFWwindow* window, bool install_callbacks, Glfw
 
     // Setup backend capabilities flags
     ImGui_ImplGlfw_Data* bd = IM_NEW(ImGui_ImplGlfw_Data)();
-    snprintf(bd->BackendPlatformName, sizeof(bd->BackendPlatformName), "imgui_impl_glfw (%d)", GLFW_VERSION_COMBINED);
+    (void)snprintf(bd->BackendPlatformName, sizeof(bd->BackendPlatformName), "imgui_impl_glfw (%d)", GLFW_VERSION_COMBINED);
     io.BackendPlatformUserData = (void*)bd;
     io.BackendPlatformName = bd->BackendPlatformName;
     io.BackendFlags |= ImGuiBackendFlags_HasMouseCursors;         // We can honor GetMouseCursor() values (optional)

--- a/third_party/imgui/imgui.cpp
+++ b/third_party/imgui/imgui.cpp
@@ -14934,7 +14934,7 @@ void ImGui::LogFinish()
     {
     case ImGuiLogFlags_OutputTTY:
 #ifndef IMGUI_DISABLE_TTY_FUNCTIONS
-        fflush(g.LogFile);
+        (void)fflush(g.LogFile);
 #endif
         break;
     case ImGuiLogFlags_OutputFile:

--- a/third_party/imgui/imgui_demo.cpp
+++ b/third_party/imgui/imgui_demo.cpp
@@ -764,7 +764,7 @@ static const ExampleMemberInfo ExampleTreeNodeMemberInfos[]
 static ExampleTreeNode* ExampleTree_CreateNode(const char* name, int uid, ExampleTreeNode* parent)
 {
     ExampleTreeNode* node = IM_NEW(ExampleTreeNode);
-    snprintf(node->Name, IM_ARRAYSIZE(node->Name), "%s", name);
+    (void)snprintf(node->Name, IM_ARRAYSIZE(node->Name), "%s", name);
     node->UID = uid;
     node->Parent = parent;
     node->IndexInParent = parent ? (unsigned short)parent->Childs.Size : 0;
@@ -792,17 +792,17 @@ static ExampleTreeNode* ExampleTree_CreateDemoTree()
     const int root_items_multiplier = 2;
     for (int idx_L0 = 0; idx_L0 < IM_ARRAYSIZE(root_names) * root_items_multiplier; idx_L0++)
     {
-        snprintf(name_buf, IM_ARRAYSIZE(name_buf), "%s %d", root_names[idx_L0 / root_items_multiplier], idx_L0 % root_items_multiplier);
+        (void)snprintf(name_buf, IM_ARRAYSIZE(name_buf), "%s %d", root_names[idx_L0 / root_items_multiplier], idx_L0 % root_items_multiplier);
         ExampleTreeNode* node_L1 = ExampleTree_CreateNode(name_buf, ++uid, node_L0);
         const int number_of_childs = (int)strlen(node_L1->Name);
         for (int idx_L1 = 0; idx_L1 < number_of_childs; idx_L1++)
         {
-            snprintf(name_buf, IM_ARRAYSIZE(name_buf), "Child %d", idx_L1);
+            (void)snprintf(name_buf, IM_ARRAYSIZE(name_buf), "Child %d", idx_L1);
             ExampleTreeNode* node_L2 = ExampleTree_CreateNode(name_buf, ++uid, node_L1);
             node_L2->HasData = true;
             if (idx_L1 == 0)
             {
-                snprintf(name_buf, IM_ARRAYSIZE(name_buf), "Sub-child %d", 0);
+                (void)snprintf(name_buf, IM_ARRAYSIZE(name_buf), "Sub-child %d", 0);
                 ExampleTreeNode* node_L3 = ExampleTree_CreateNode(name_buf, ++uid, node_L2);
                 node_L3->HasData = true;
             }
@@ -3506,7 +3506,7 @@ static void DemoWindowWidgetsTabs()
                 {
                     bool open = true;
                     char name[16];
-                    snprintf(name, IM_ARRAYSIZE(name), "%04d", active_tabs[n]);
+                    (void)snprintf(name, IM_ARRAYSIZE(name), "%04d", active_tabs[n]);
                     if (ImGui::BeginTabItem(name, &open, ImGuiTabItemFlags_None))
                     {
                         ImGui::Text("This is the %s tab!", name);
@@ -8784,7 +8784,7 @@ struct ExampleAppConsole
         char buf[1024];
         va_list args;
         va_start(args, fmt);
-        vsnprintf(buf, IM_ARRAYSIZE(buf), fmt, args);
+        (void)vsnprintf(buf, IM_ARRAYSIZE(buf), fmt, args);
         buf[IM_ARRAYSIZE(buf)-1] = 0;
         va_end(args);
         Items.push_back(Strdup(buf));
@@ -10117,7 +10117,7 @@ struct MyDocument
     MyDocument(int uid, const char* name, bool open = true, const ImVec4& color = ImVec4(1.0f, 1.0f, 1.0f, 1.0f))
     {
         UID = uid;
-        snprintf(Name, sizeof(Name), "%s", name);
+        (void)snprintf(Name, sizeof(Name), "%s", name);
         Open = OpenPrev = open;
         Dirty = false;
         Color = color;
@@ -10147,7 +10147,7 @@ struct ExampleAppDocuments
     // As we allow to change document name, we append a never-changing document ID so tabs are stable
     void GetTabName(MyDocument* doc, char* out_buf, size_t out_buf_size)
     {
-        snprintf(out_buf, out_buf_size, "%s###doc%d", doc->Name, doc->UID);
+        (void)snprintf(out_buf, out_buf_size, "%s###doc%d", doc->Name, doc->UID);
     }
 
     // Display placeholder contents for the Document


### PR DESCRIPTION
## Summary
- silence ignored return value warnings by casting to `(void)` in ImGui sources
- document third-party memory manipulation and missing libraries in TODO list

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687241284cec832abdacaa106e465449