### PR TITLE
Fix include paths and demo adapter

### DIFF
--- a/src/compat/cuda.h
+++ b/src/compat/cuda.h
@@ -3,7 +3,7 @@
 // Forward declarations and includes
 #include "macros.h"
 
-#include "types.h"
+#include "core/types.h"
 #include <cstddef>
 #include <memory>
 #include <string>

--- a/src/compat/kernels.h
+++ b/src/compat/kernels.h
@@ -2,7 +2,7 @@
 #define SEP_CUDA_KERNELS_H
 
 #include "constants.h"
-#include "types.h"
+#include "core/types.h"
 #include <cstdint>
 
 #ifdef __CUDACC__

--- a/src/compat/memory.h
+++ b/src/compat/memory.h
@@ -9,7 +9,7 @@
 #include <cuda_runtime.h>
 #endif
 
-#include "types.h"
+#include "core/types.h"
 #include "compat/macros.h"
 #include "compat/cuda_common.h"
 #if SEP_CUDA_AVAILABLE

--- a/src/core/manager.h
+++ b/src/core/manager.h
@@ -1,7 +1,6 @@
 #ifndef SEP_CONFIG_MANAGER_H
 #define SEP_CONFIG_MANAGER_H
 
-#include "types.h"
 #include "memory/memory_tier_manager.hpp"
 #include "core/types.h"
 #include <memory>

--- a/src/memory/memory_tier.hpp
+++ b/src/memory/memory_tier.hpp
@@ -16,7 +16,6 @@
 #include "core/common.h"
 #include "core/types.h"
 #include "memory/persistent_pattern_data.hpp"
-#include "types.h"
 
 namespace sep {
 namespace memory {

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -2,7 +2,6 @@
 
 #include "core/common.h"
 #include "core/types.h"
-namespace sep { namespace quantum { using Pattern = ::sep::Pattern; } }
 #include "quantum/pattern.h"
 
 namespace sep {
@@ -547,30 +546,6 @@ namespace sep
                                                 const ::sep::pattern::PatternData &pattern)
         {
             pattern_registry_[id] = std::make_unique<::sep::pattern::PatternData>(pattern);
-        }
-
-        void MemoryTierManager::registerPattern(std::size_t id,
-                                                const ::sep::quantum::Pattern &pattern)
-        {
-            auto patternData = std::make_unique<::sep::pattern::PatternData>();
-            patternData->id = pattern.id;
-            patternData->generation = pattern.quantum_state.generation;
-            patternData->position = pattern.position;
-            patternData->velocity = glm::vec4(pattern.momentum, 0.0f); // Convert vec3 to vec4
-            patternData->attributes = glm::vec4(0.0f); // Default attributes
-            patternData->amplitude = std::complex<float>(0.0f, 0.0f); // Default amplitude
-            patternData->state = pattern.quantum_state.state;
-            patternData->phase = pattern.quantum_state.phase;
-            patternData->coherence = pattern.quantum_state.coherence;
-            patternData->stability = pattern.quantum_state.stability;
-            patternData->entropy = pattern.quantum_state.entropy;
-            patternData->mutation_rate = pattern.quantum_state.mutation_rate;
-            patternData->mutation_count = pattern.quantum_state.mutation_count;
-            patternData->memory_tier = pattern.quantum_state.memory_tier;
-            patternData->relationships = pattern.relationships;
-            patternData->data = pattern.data;
-            
-            pattern_registry_[id] = std::move(patternData);
         }
 
         const ::sep::pattern::PatternData *MemoryTierManager::getPatternData(std::size_t id) const

--- a/src/memory/memory_tier_manager.hpp
+++ b/src/memory/memory_tier_manager.hpp
@@ -12,7 +12,6 @@
 #include "core/common.h"
 #include "core/dag_graph.h"
 #include "core/types.h"
-namespace sep { namespace quantum { using Pattern = ::sep::Pattern; } }
 #include "memory/memory_tier.hpp"
 #include "memory/persistent_pattern_data.hpp"
 #include "memory/types.h"
@@ -112,7 +111,6 @@ namespace memory {
 
         // Pattern management
         void registerPattern(std::size_t id, const ::sep::pattern::PatternData &pattern);
-        void registerPattern(std::size_t id, const ::sep::quantum::Pattern &pattern);
         const ::sep::pattern::PatternData *getPatternData(std::size_t id) const;
         void removePattern(std::size_t id);
         void updateRelationship(std::size_t id_a, std::size_t id_b, float strength);

--- a/src/quantum/processor.h
+++ b/src/quantum/processor.h
@@ -2,13 +2,10 @@
 #define SEP_QUANTUM_PROCESSOR_H
 #pragma once
 
-#include "types.h"
 #include "core/common.h"
 #include "core/system_hooks.h"
-// Removed duplicate include of core/types.h
 #include "quantum/gpu_context.h"
 #include "core/types.h"
-namespace sep { namespace quantum { using Pattern = ::sep::Pattern; } }
 #include "memory/types.h"
 #include <memory>
 #include <vector>

--- a/src/quantum/resource_predictor.h
+++ b/src/quantum/resource_predictor.h
@@ -1,7 +1,7 @@
 #ifndef SEP_CONTEXT_RESOURCE_PREDICTOR_H
 #define SEP_CONTEXT_RESOURCE_PREDICTOR_H
 
-#include "types.h"
+#include "core/types.h"
 #include "compat/shim.h"
 #include <cstddef>
 #include <vector>

--- a/src/quantum/types_serialization.cpp
+++ b/src/quantum/types_serialization.cpp
@@ -1,5 +1,4 @@
 #include "core/types.h"
-namespace sep { namespace quantum { using Pattern = ::sep::Pattern; } }
 #include "memory/types.h" // Add include for MemoryTierEnum
 #include <nlohmann/json.hpp> 
 #include <cstring>
@@ -46,7 +45,7 @@ void from_json(const nlohmann::json& j, sep::quantum::PatternRelationship& rel) 
     rel.type = static_cast<RelationshipType>(j.value("type", 0)); 
 }
 
-void to_json(nlohmann::json& j, const Pattern& pattern) {
+void to_json(nlohmann::json& j, const sep::Pattern& pattern) {
     j = nlohmann::json{
         {"id", pattern.id},
         {"position", {pattern.position.x, pattern.position.y, pattern.position.z, pattern.position.w}},
@@ -61,7 +60,7 @@ void to_json(nlohmann::json& j, const Pattern& pattern) {
     };
 }
 
-void from_json(const nlohmann::json& j, Pattern& pattern) {
+void from_json(const nlohmann::json& j, sep::Pattern& pattern) {
     j.at("id").get_to(pattern.id);
     auto pos = j.at("position").get<std::vector<float>>();
     pattern.position = glm::vec4(pos[0], pos[1], pos[2], pos[3]);

--- a/src/workbench/demos/annealing_demo.cpp
+++ b/src/workbench/demos/annealing_demo.cpp
@@ -3,7 +3,7 @@
 #include <cmath>
 #include <cstdlib>
 
-#include "../../workbench_demo_adapter.hpp"
+#include "workbench_demo_adapter.hpp"
 #include "sep_engine_wrapper.h"
 
 namespace sep {

--- a/src/workbench/demos/annealing_demo.hpp
+++ b/src/workbench/demos/annealing_demo.hpp
@@ -3,7 +3,7 @@
 #include <glm/vec3.hpp>
 #include <vector>
 
-#include "../../workbench_demo_adapter.hpp"
+#include "workbench_demo_adapter.hpp"
 #include "demo_manager.hpp"
 #include "imgui.h"
 

--- a/src/workbench/demos/annealing_sim.cpp
+++ b/src/workbench/demos/annealing_sim.cpp
@@ -3,7 +3,7 @@
 #include <cmath>
 #include <glm/gtc/random.hpp>
 
-#include "../../workbench_demo_adapter.hpp"
+#include "workbench_demo_adapter.hpp"
 #include "sep_engine_wrapper.h"
 
 namespace sep {

--- a/src/workbench/demos/annealing_sim.hpp
+++ b/src/workbench/demos/annealing_sim.hpp
@@ -4,7 +4,7 @@
 #include <memory>
 #include <vector>
 
-#include "../../workbench_demo_adapter.hpp"
+#include "workbench_demo_adapter.hpp"
 #include "demo_manager.hpp"
 #include "memory/quantum_coherence_manager.h"
 #include "quantum/processor.h"

--- a/src/workbench/demos/audio_visualizer.cpp
+++ b/src/workbench/demos/audio_visualizer.cpp
@@ -2,7 +2,7 @@
 
 #include <glm/vec3.hpp>
 
-#include "../../workbench_demo_adapter.hpp"
+#include "workbench_demo_adapter.hpp"
 #include "audio/capture.h"
 #include "audio/pipeline.h"
 #include "config.hpp"

--- a/src/workbench/demos/audio_visualizer.hpp
+++ b/src/workbench/demos/audio_visualizer.hpp
@@ -4,7 +4,7 @@
 #include <memory>
 #include <vector>
 
-#include "../../workbench_demo_adapter.hpp"
+#include "workbench_demo_adapter.hpp"
 #include "audio/capture.h"
 #include "audio/pipeline.h"
 #include "demo_manager.hpp"

--- a/src/workbench/demos/cosmo_demo.cpp
+++ b/src/workbench/demos/cosmo_demo.cpp
@@ -3,7 +3,7 @@
 #include <cstdlib>
 #include <glm/glm.hpp>
 
-#include "../../workbench_demo_adapter.hpp"
+#include "workbench_demo_adapter.hpp"
 
 namespace sep {
 namespace workbench {

--- a/src/workbench/demos/cosmo_demo.hpp
+++ b/src/workbench/demos/cosmo_demo.hpp
@@ -3,7 +3,7 @@
 #include <glm/vec3.hpp>
 #include <vector>
 
-#include "../../workbench_demo_adapter.hpp"
+#include "workbench_demo_adapter.hpp"
 #include "demo_manager.hpp"
 #include "imgui.h"
 

--- a/src/workbench/demos/cosmo_sim.cpp
+++ b/src/workbench/demos/cosmo_sim.cpp
@@ -5,7 +5,7 @@
 // Include glm_config.h before any GLM headers to ensure GLM_ENABLE_EXPERIMENTAL is defined
 #include <glm/gtx/norm.hpp>
 
-#include "../../workbench_demo_adapter.hpp"
+#include "workbench_demo_adapter.hpp"
 #include "compat/glm_config.h"
 
 namespace sep

--- a/src/workbench/demos/cosmo_sim.hpp
+++ b/src/workbench/demos/cosmo_sim.hpp
@@ -3,7 +3,7 @@
 #include <glm/vec3.hpp>
 #include <vector>
 
-#include "../../workbench_demo_adapter.hpp"
+#include "workbench_demo_adapter.hpp"
 #include "demo_manager.hpp"
 #include "imgui.h"
 #include "core/types.h"

--- a/src/workbench/demos/demo_manager.cpp
+++ b/src/workbench/demos/demo_manager.cpp
@@ -1,6 +1,6 @@
 #include "demo_manager.hpp"
 
-#include "../../workbench_demo_adapter.hpp"
+#include "workbench_demo_adapter.hpp"
 
 namespace sep {
 namespace workbench {

--- a/src/workbench/demos/demo_manager.hpp
+++ b/src/workbench/demos/demo_manager.hpp
@@ -5,7 +5,7 @@
 #include <string>
 #include <unordered_map>
 
-#include "../../workbench_demo_adapter.hpp"
+#include "workbench_demo_adapter.hpp"
 #include "imgui.h"
 #include "sep_engine_wrapper.h"
 

--- a/src/workbench/demos/digital_physics_demo.cpp
+++ b/src/workbench/demos/digital_physics_demo.cpp
@@ -3,7 +3,7 @@
 #include <cstdlib>
 #include <glm/vec3.hpp>
 
-#include "../../workbench_demo_adapter.hpp"
+#include "workbench_demo_adapter.hpp"
 #include "config.hpp"
 
 namespace sep {

--- a/src/workbench/demos/digital_physics_demo.hpp
+++ b/src/workbench/demos/digital_physics_demo.hpp
@@ -3,7 +3,7 @@
 #include <algorithm>
 #include <vector>
 
-#include "../../workbench_demo_adapter.hpp"
+#include "workbench_demo_adapter.hpp"
 #include "demo_manager.hpp"
 #include "imgui.h"
 #include "core/types.h"

--- a/src/workbench/demos/drug_discovery_demo.cpp
+++ b/src/workbench/demos/drug_discovery_demo.cpp
@@ -4,7 +4,7 @@
 #include <cstdlib>
 #include <glm/glm.hpp>
 
-#include "../../workbench_demo_adapter.hpp"
+#include "workbench_demo_adapter.hpp"
 
 namespace sep
 {

--- a/src/workbench/demos/drug_discovery_demo.hpp
+++ b/src/workbench/demos/drug_discovery_demo.hpp
@@ -3,7 +3,7 @@
 #include <glm/vec3.hpp>
 #include <vector>
 
-#include "../../workbench_demo_adapter.hpp"
+#include "workbench_demo_adapter.hpp"
 #include "demo_manager.hpp"
 #include "imgui.h"
 #include "sep_engine_wrapper.h"

--- a/src/workbench/demos/drug_optimizer.cpp
+++ b/src/workbench/demos/drug_optimizer.cpp
@@ -5,7 +5,7 @@
 #include "compat/glm_config.h"
 #include <glm/gtx/norm.hpp>
 
-#include "../../workbench_demo_adapter.hpp"
+#include "workbench_demo_adapter.hpp"
 
 // Use namespace alias to avoid ambiguity
 namespace sq = sep::quantum;

--- a/src/workbench/demos/drug_optimizer.hpp
+++ b/src/workbench/demos/drug_optimizer.hpp
@@ -3,7 +3,7 @@
 #include <glm/vec3.hpp>
 #include <vector>
 
-#include "../../workbench_demo_adapter.hpp"
+#include "workbench_demo_adapter.hpp"
 #include "demo_manager.hpp"
 #include "imgui.h"
 #include "quantum/quantum_manifold_optimizer.h"

--- a/src/workbench/demos/flocking_demo.cpp
+++ b/src/workbench/demos/flocking_demo.cpp
@@ -3,7 +3,7 @@
 #include <cstdlib>
 #include <glm/glm.hpp>
 
-#include "../../workbench_demo_adapter.hpp"
+#include "workbench_demo_adapter.hpp"
 #include "config.hpp"
 
 namespace sep

--- a/src/workbench/demos/flocking_demo.hpp
+++ b/src/workbench/demos/flocking_demo.hpp
@@ -3,7 +3,7 @@
 #include <glm/vec3.hpp>
 #include <vector>
 
-#include "../../workbench_demo_adapter.hpp"
+#include "workbench_demo_adapter.hpp"
 #include "demo_manager.hpp"
 #include "imgui.h"
 #include "core/types.h"

--- a/src/workbench/demos/genesis_pattern.cpp
+++ b/src/workbench/demos/genesis_pattern.cpp
@@ -1,6 +1,6 @@
 #include "genesis_pattern.hpp"
 
-#include "../../workbench_demo_adapter.hpp"
+#include "workbench_demo_adapter.hpp"
 #include "blender/cycles_renderer.hpp"
 #include "config.hpp"
 #include "core/engine.h"

--- a/src/workbench/demos/genesis_pattern.hpp
+++ b/src/workbench/demos/genesis_pattern.hpp
@@ -2,7 +2,7 @@
 
 #include <memory>
 
-#include "../../workbench_demo_adapter.hpp"
+#include "workbench_demo_adapter.hpp"
 #include "demo_manager.hpp"
 #include "imgui.h"
 #include "memory/quantum_coherence_manager.h"

--- a/src/workbench/demos/memory_garden.cpp
+++ b/src/workbench/demos/memory_garden.cpp
@@ -2,7 +2,7 @@
 
 #include <glm/vec3.hpp>
 
-#include "../../workbench_demo_adapter.hpp"
+#include "workbench_demo_adapter.hpp"
 #include "config.hpp"
 #include "memory/memory_tier_manager.hpp"
 #include "memory/quantum_coherence_manager.h"

--- a/src/workbench/demos/memory_garden.hpp
+++ b/src/workbench/demos/memory_garden.hpp
@@ -3,7 +3,7 @@
 #include <memory>
 #include <vector>
 
-#include "../../workbench_demo_adapter.hpp"
+#include "workbench_demo_adapter.hpp"
 #include "demo_manager.hpp"
 #include "imgui.h"
 #include "memory/memory_tier_manager.hpp"

--- a/src/workbench/demos/neural_demo.cpp
+++ b/src/workbench/demos/neural_demo.cpp
@@ -2,7 +2,7 @@
 
 #include <algorithm>
 
-#include "../../workbench_demo_adapter.hpp"
+#include "workbench_demo_adapter.hpp"
 #include "config.hpp"
 
 namespace sep

--- a/src/workbench/demos/neural_demo.hpp
+++ b/src/workbench/demos/neural_demo.hpp
@@ -2,7 +2,7 @@
 
 #include <vector>
 
-#include "../../workbench_demo_adapter.hpp"
+#include "workbench_demo_adapter.hpp"
 #include "core/dag_graph.h"
 #include "demo_manager.hpp"
 #include "imgui.h"

--- a/src/workbench/demos/neuro_sim.cpp
+++ b/src/workbench/demos/neuro_sim.cpp
@@ -3,7 +3,7 @@
 #include <algorithm>
 #include <glm/glm.hpp>
 
-#include "../../workbench_demo_adapter.hpp"
+#include "workbench_demo_adapter.hpp"
 #include "config.hpp"
 #include "memory/memory_tier_manager.hpp"
 #include "quantum/evolution.h"

--- a/src/workbench/demos/neuro_sim.hpp
+++ b/src/workbench/demos/neuro_sim.hpp
@@ -5,7 +5,7 @@
 #include <random>
 #include <vector>
 
-#include "../../workbench_demo_adapter.hpp"
+#include "workbench_demo_adapter.hpp"
 #include "demo_manager.hpp"
 #include "imgui.h"
 #include "memory/memory_tier_manager.hpp"

--- a/src/workbench/demos/pattern_processor.hpp
+++ b/src/workbench/demos/pattern_processor.hpp
@@ -3,7 +3,7 @@
 #include <memory>
 #include <vector>
 
-#include "../../workbench_demo_adapter.hpp"
+#include "workbench_demo_adapter.hpp"
 #include "imgui.h"
 
 namespace sep {

--- a/src/workbench/demos/register_demos.cpp
+++ b/src/workbench/demos/register_demos.cpp
@@ -1,4 +1,4 @@
-#include "../../workbench_demo_adapter.hpp"
+#include "workbench_demo_adapter.hpp"
 #include "workbench/demos/audio_visualizer.hpp"
 #include "workbench/demos/cosmo_demo.hpp"
 #include "workbench/demos/cosmo_sim.hpp"

--- a/src/workbench/workbench_demo_adapter.hpp
+++ b/src/workbench/workbench_demo_adapter.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "demos/demo_base.hpp"
+#include "cycles_renderer_adapter.h"
+#include "renderer.h"
+#include "sep_engine_wrapper.h"
+
+// Common helpers for demos can be added here in the future


### PR DESCRIPTION
## Summary
- standardize includes on canonical `core/types.h`
- remove old type aliases and unused overloads
- add `workbench_demo_adapter.hpp` and update demo includes

## Testing
- `make build-cpp` *(fails: No rule to make target)*
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_687240f247bc832aa1275fdcf1e113ef