### PR TITLE
Fix static analysis warnings and add includes

### DIFF
--- a/src/workbench/renderer.cpp
+++ b/src/workbench/renderer.cpp
@@ -1,5 +1,6 @@
 #include "renderer.h"
 
+#include <glm/glm.hpp>
 #include <cmath>
 #include <iostream>
 

--- a/third_party/imgui/imgui.cpp
+++ b/third_party/imgui/imgui.cpp
@@ -1141,6 +1141,7 @@ IMPLEMENTING SUPPORT for ImGuiBackendFlags_RendererHasTextures:
 // System includes
 #include <stdio.h>      // vsnprintf, sscanf, printf
 #include <stdint.h>     // intptr_t
+#include <cmath>
 
 // [Windows] On non-Visual Studio compilers, we default to IMGUI_DISABLE_WIN32_DEFAULT_IME_FUNCTIONS unless explicitly enabled
 #if defined(_WIN32) && !defined(_MSC_VER) && !defined(IMGUI_ENABLE_WIN32_DEFAULT_IME_FUNCTIONS) && !defined(IMGUI_DISABLE_WIN32_DEFAULT_IME_FUNCTIONS)
@@ -3131,7 +3132,7 @@ static void ImGuiListClipper_SeekCursorAndSetupPrevLine(float pos_y, float line_
         if (table->IsInsideRow)
             ImGui::TableEndRow(table);
         table->RowPosY2 = window->DC.CursorPos.y;
-        const int row_increase = (int)((off_y / line_height) + 0.5f);
+        const int row_increase = static_cast<int>(std::lroundf(off_y / line_height));
         //table->CurrentRow += row_increase; // Can't do without fixing TableEndRow()
         table->RowBgColorCounter += row_increase;
     }
@@ -7146,7 +7147,7 @@ void ImGui::RenderWindowTitleBarContents(ImGuiWindow* window, const ImRect& titl
         if (marker_pos.x > layout_r.Min.x)
         {
             RenderBullet(window->DrawList, marker_pos, GetColorU32(ImGuiCol_Text));
-            clip_r.Max.x = ImMin(clip_r.Max.x, marker_pos.x - (int)(marker_size_x * 0.5f));
+            clip_r.Max.x = ImMin(clip_r.Max.x, marker_pos.x - static_cast<int>(std::lroundf(marker_size_x * 0.5f)));
         }
     }
     //if (g.IO.KeyShift) window->DrawList->AddRect(layout_r.Min, layout_r.Max, IM_COL32(255, 128, 0, 255)); // [DEBUG]
@@ -7314,7 +7315,7 @@ bool ImGui::Begin(const char* name, bool* p_open, ImGuiWindowFlags flags)
     {
         ImGuiPopupData& popup_ref = g.OpenPopupStack[g.BeginPopupStack.Size];
         popup_ref.Window = window;
-        popup_ref.ParentNavLayer = parent_window_in_stack->DC.NavLayerCurrent;
+        popup_ref.ParentNavLayer = parent_window_in_stack ? parent_window_in_stack->DC.NavLayerCurrent : ImGuiNavLayer_Main;
         g.BeginPopupStack.push_back(popup_ref);
         window->PopupId = popup_ref.PopupId;
     }
@@ -14124,10 +14125,13 @@ static void ImGui::NavUpdateWindowingApplyFocus(ImGuiWindow* apply_focus_window)
         ClearActiveID();
         SetNavCursorVisibleAfterMove();
         ClosePopupsOverWindow(apply_focus_window, false);
-        FocusWindow(apply_focus_window, ImGuiFocusRequestFlags_RestoreFocusedChild);
-        apply_focus_window = g.NavWindow;
-        if (apply_focus_window->NavLastIds[0] == 0)
-            NavInitWindow(apply_focus_window, false);
+        if (apply_focus_window)
+        {
+            FocusWindow(apply_focus_window, ImGuiFocusRequestFlags_RestoreFocusedChild);
+            apply_focus_window = g.NavWindow;
+            if (apply_focus_window && apply_focus_window->NavLastIds[0] == 0)
+                NavInitWindow(apply_focus_window, false);
+        }
 
         // If the window has ONLY a menu layer (no main layer), select it directly
         // Use NavLayersActiveMaskNext since windows didn't have a chance to be Begin()-ed on this frame,

--- a/third_party/imgui/imgui_demo.cpp
+++ b/third_party/imgui/imgui_demo.cpp
@@ -134,6 +134,7 @@ Index of this file:
 #include <ctype.h>          // toupper
 #include <limits.h>         // INT_MIN, INT_MAX
 #include <math.h>           // sqrtf, powf, cosf, sinf, floorf, ceilf
+#include <cmath>
 #include <stdio.h>          // vsnprintf, sscanf, printf
 #include <stdlib.h>         // NULL, malloc, free, atoi
 #include <stdint.h>         // intptr_t
@@ -9584,7 +9585,8 @@ static void ShowExampleAppConstrainedResize(bool* p_open)
         static void Step(ImGuiSizeCallbackData* data)
         {
             float step = *(float*)data->UserData;
-            data->DesiredSize = ImVec2((int)(data->DesiredSize.x / step + 0.5f) * step, (int)(data->DesiredSize.y / step + 0.5f) * step);
+            data->DesiredSize = ImVec2(static_cast<int>(std::lroundf(data->DesiredSize.x / step)) * step,
+                                       static_cast<int>(std::lroundf(data->DesiredSize.y / step)) * step);
         }
     };
 
@@ -9795,7 +9797,8 @@ static void PathConcaveShape(ImDrawList* draw_list, float x, float y, float sz)
 {
     const ImVec2 pos_norms[] = { { 0.0f, 0.0f }, { 0.3f, 0.0f }, { 0.3f, 0.7f }, { 0.7f, 0.7f }, { 0.7f, 0.0f }, { 1.0f, 0.0f }, { 1.0f, 1.0f }, { 0.0f, 1.0f } };
     for (const ImVec2& p : pos_norms)
-        draw_list->PathLineTo(ImVec2(x + 0.5f + (int)(sz * p.x), y + 0.5f + (int)(sz * p.y)));
+        draw_list->PathLineTo(ImVec2(x + 0.5f + static_cast<int>(std::lroundf(sz * p.x)),
+                                     y + 0.5f + static_cast<int>(std::lroundf(sz * p.y))));
 }
 
 // Demonstrate using the low-level ImDrawList to draw custom shapes.
@@ -10555,7 +10558,8 @@ struct ExampleAssetsBrowser
                     ClearItems();
                 ImGui::Separator();
                 if (ImGui::MenuItem("Close", NULL, false, p_open != NULL))
-                    *p_open = false;
+                    if (p_open)
+                        *p_open = false;
                 ImGui::EndMenu();
             }
             if (ImGui::BeginMenu("Edit"))

--- a/third_party/imgui/imgui_internal.h
+++ b/third_party/imgui/imgui_internal.h
@@ -57,6 +57,7 @@ Index of this file:
 #include <stdio.h>      // FILE*, sscanf
 #include <stdlib.h>     // NULL, malloc, free, qsort, atoi, atof
 #include <math.h>       // sqrtf, fabsf, fmodf, powf, floorf, ceilf, cosf, sinf
+#include <cmath>
 #include <limits.h>     // INT_MIN, INT_MAX
 
 // Enable SSE intrinsics if available
@@ -272,10 +273,10 @@ extern IMGUI_API ImGuiContext* GImGui;  // Current implicit context pointer
 #define IM_TABSIZE                      (4)
 #endif
 #define IM_MEMALIGN(_OFF,_ALIGN)        (((_OFF) + ((_ALIGN) - 1)) & ~((_ALIGN) - 1))           // Memory align e.g. IM_ALIGN(0,4)=0, IM_ALIGN(1,4)=4, IM_ALIGN(4,4)=4, IM_ALIGN(5,4)=8
-#define IM_F32_TO_INT8_UNBOUND(_VAL)    ((int)((_VAL) * 255.0f + ((_VAL)>=0 ? 0.5f : -0.5f)))   // Unsaturated, for display purpose
-#define IM_F32_TO_INT8_SAT(_VAL)        ((int)(ImSaturate(_VAL) * 255.0f + 0.5f))               // Saturated, always output 0..255
+#define IM_F32_TO_INT8_UNBOUND(_VAL)    (static_cast<int>(std::lroundf((_VAL) * 255.0f)))   // Unsaturated, for display purpose
+#define IM_F32_TO_INT8_SAT(_VAL)        (static_cast<int>(std::lroundf(ImSaturate(_VAL) * 255.0f)))               // Saturated, always output 0..255
 #define IM_TRUNC(_VAL)                  ((float)(int)(_VAL))                                    // ImTrunc() is not inlined in MSVC debug builds
-#define IM_ROUND(_VAL)                  ((float)(int)((_VAL) + 0.5f))                           //
+#define IM_ROUND(_VAL)                  (static_cast<float>(std::lroundf(_VAL)))
 #define IM_STRINGIFY_HELPER(_X)         #_X
 #define IM_STRINGIFY(_X)                IM_STRINGIFY_HELPER(_X)                                 // Preprocessor idiom to stringify e.g. an integer.
 #ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS

--- a/third_party/imgui/imgui_widgets.cpp
+++ b/third_party/imgui/imgui_widgets.cpp
@@ -46,6 +46,7 @@ Index of this file:
 
 // System includes
 #include <stdint.h>     // intptr_t
+#include <cmath>
 
 //-------------------------------------------------------------------------
 // Warnings
@@ -8668,7 +8669,7 @@ int ImGui::PlotEx(ImGuiPlotType plot_type, const char* label, float (*values_get
         for (int n = 0; n < res_w; n++)
         {
             const float t1 = t0 + t_step;
-            const int v1_idx = (int)(t0 * item_count + 0.5f);
+            const int v1_idx = static_cast<int>(std::lroundf(t0 * item_count));
             IM_ASSERT(v1_idx >= 0 && v1_idx < values_count);
             const float v1 = values_getter(data, (v1_idx + values_offset + 1) % values_count);
             const ImVec2 tp1 = ImVec2( t1, 1.0f - ImSaturate((v1 - scale_min) * inv_scale) );

--- a/third_party/imgui/imstb_rectpack.h
+++ b/third_party/imgui/imstb_rectpack.h
@@ -553,7 +553,7 @@ STBRP_DEF int stbrp_pack_rects(stbrp_context *context, stbrp_rect *rects, int nu
    }
 
    // sort according to heuristic
-   STBRP_SORT(rects, num_rects, sizeof(rects[0]), rect_height_compare);
+   STBRP_SORT(rects, num_rects, sizeof(*rects), rect_height_compare);
 
    for (i=0; i < num_rects; ++i) {
       if (rects[i].w == 0 || rects[i].h == 0) {
@@ -570,7 +570,7 @@ STBRP_DEF int stbrp_pack_rects(stbrp_context *context, stbrp_rect *rects, int nu
    }
 
    // unsort
-   STBRP_SORT(rects, num_rects, sizeof(rects[0]), rect_original_order);
+   STBRP_SORT(rects, num_rects, sizeof(*rects), rect_original_order);
 
    // set was_packed flags and all_rects_packed status
    for (i=0; i < num_rects; ++i) {


### PR DESCRIPTION
## Summary
- include `<glm/glm.hpp>` in workbench renderer
- add safety checks for `p_open`, `parent_window_in_stack` and `apply_focus_window`
- replace integer rounding patterns with `std::lroundf`
- update rectpack sorting to use `sizeof(*rects)`
- add `<cmath>` includes and rounding helpers

## Testing
- `cmake -S . -B build` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_68724106f878832aa998c82484355c60