### PR TITLE
Fix pattern types and update ImGui warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ set(CMAKE_TOOLCHAIN_FILE ${CMAKE_SOURCE_DIR}/cmake/cuda-toolchain.cmake)
 # Set C++ standard before project declaration
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+add_compile_definitions(GLM_ENABLE_EXPERIMENTAL)
 
 
 project(sep_engine VERSION 1.0.0 LANGUAGES C CXX)

--- a/src/api/sep_engine.cpp
+++ b/src/api/sep_engine.cpp
@@ -342,10 +342,11 @@ nlohmann::json SepEngine::getPatternHistory(const nlohmann::json& request_data)
     for (const auto& p : patterns) { 
         // Apply filters if specified
         
-        if (p.coherence >= min_coherence && p.stability >= min_stability) {
+        if (p.quantum_state.coherence >= min_coherence &&
+            p.quantum_state.stability >= min_stability) {
             json e;
-            e["coherence"] = p.coherence;
-            e["stability"] = p.stability;
+            e["coherence"] = p.quantum_state.coherence;
+            e["stability"] = p.quantum_state.stability;
             history.push_back(e);
         }
     }

--- a/src/blender/mesh_handler.cpp
+++ b/src/blender/mesh_handler.cpp
@@ -46,7 +46,7 @@ sep::SEPResult MeshHandler::update(const sep::pattern::PatternData& pattern_data
     return sep::SEPResult::INVALID_ARGUMENT;
   }
 
-  pattern_state_.coherence = pattern_data.coherence;
+  pattern_state_.coherence = pattern_data.quantum_state.coherence;
 
   sep::SEPResult res = updateVertices(pattern_data);
   if (res != sep::SEPResult::SUCCESS) {
@@ -262,7 +262,8 @@ sep::SEPResult MeshHandler::notifyDepsgraph() {
 bool MeshHandler::validateMesh() const { return initialized_ && mesh_ != nullptr; }
 
 bool MeshHandler::validatePattern(const sep::pattern::PatternData& pattern_data) const {
-  return pattern_data.coherence >= 0.0f && pattern_data.coherence <= 1.0f;
+  return pattern_data.quantum_state.coherence >= 0.0f &&
+         pattern_data.quantum_state.coherence <= 1.0f;
 }
 
 void MeshHandler::cleanupCustomData() { custom_layers_.clear(); }

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -5,20 +5,9 @@
 #include "quantum/pattern.h"
 
 namespace sep {
-namespace pattern {
-    struct PatternData;
+namespace config {
+    class ConfigManager;
 }
-namespace quantum {
-    struct Pattern;
-}
-}
-
-namespace sep
-{
-    namespace config
-    {
-        class ConfigManager;
-    }
 }
 
 #include <algorithm>

--- a/src/memory/quantum_coherence_manager.cpp
+++ b/src/memory/quantum_coherence_manager.cpp
@@ -73,7 +73,7 @@ public:
         }
     }
     
-    CoherenceResult updateCoherence(const std::vector<sep::quantum::Pattern>& patterns) {
+    CoherenceResult updateCoherence(const std::vector<sep::Pattern>& patterns) {
         CoherenceResult result;
         global_tick_++;
         
@@ -143,7 +143,7 @@ public:
         return migrations;
     }
     
-    EntanglementGraph computeEntanglementGraph(const std::vector<sep::quantum::Pattern>& patterns) {
+    EntanglementGraph computeEntanglementGraph(const std::vector<sep::Pattern>& patterns) {
         EntanglementGraph graph;
         graph.nodes.reserve(patterns.size());
         
@@ -294,7 +294,7 @@ private:
         }
     }
     
-    void updatePatternCoherence(const sep::quantum::Pattern& pattern) {
+    void updatePatternCoherence(const sep::Pattern& pattern) {
         CoherenceMap::accessor accessor;
         
         if (coherence_map_.find(accessor, pattern.id)) {
@@ -397,7 +397,7 @@ private:
             static_cast<float>(total_entanglements) / (pattern_count * (pattern_count - 1)) : 0.0f;
     }
     
-    std::vector<CoherenceAnomaly> detectCoherenceAnomalies(const std::vector<sep::quantum::Pattern>& patterns) {
+    std::vector<CoherenceAnomaly> detectCoherenceAnomalies(const std::vector<sep::Pattern>& patterns) {
         std::vector<CoherenceAnomaly> anomalies;
         
         // Statistical anomaly detection
@@ -479,7 +479,7 @@ private:
         return migrations;
     }
     
-    void updateEntanglementGraph(const std::vector<sep::quantum::Pattern>& patterns) {
+    void updateEntanglementGraph(const std::vector<sep::Pattern>& patterns) {
         // Clear existing entanglements
         for (auto it = coherence_map_.begin(); it != coherence_map_.end(); ++it) {
             auto& pair = *it;
@@ -612,7 +612,7 @@ private:
         return (count > 0) ? variance / count : 0.0f;
     }
     
-    float computeEntanglement(const sep::quantum::Pattern& p1, const sep::quantum::Pattern& p2) const {
+    float computeEntanglement(const sep::Pattern& p1, const sep::Pattern& p2) const {
         // Quantum entanglement measure based on state overlap
         float spatial_overlap = std::exp(-glm::length(p1.position - p2.position));
         float phase_correlation = std::cos(p1.quantum_state.phase - p2.quantum_state.phase);
@@ -621,7 +621,7 @@ private:
         return coherence_product * spatial_overlap * std::abs(phase_correlation);
     }
     
-    float computePhaseCorrelation(const sep::quantum::Pattern& p1, const sep::quantum::Pattern& p2) const {
+    float computePhaseCorrelation(const sep::Pattern& p1, const sep::Pattern& p2) const {
         return std::cos(p1.quantum_state.phase - p2.quantum_state.phase);
     }
     
@@ -726,7 +726,7 @@ QuantumCoherenceManager::QuantumCoherenceManager(const Config& config)
 QuantumCoherenceManager::~QuantumCoherenceManager() = default;
 
 QuantumCoherenceManager::CoherenceResult 
-QuantumCoherenceManager::updateCoherence(const std::vector<sep::quantum::Pattern>& patterns) {
+QuantumCoherenceManager::updateCoherence(const std::vector<sep::Pattern>& patterns) {
     return impl_->updateCoherence(patterns);
 }
 
@@ -736,7 +736,7 @@ QuantumCoherenceManager::optimizeMemoryLayout() {
 }
 
 QuantumCoherenceManager::EntanglementGraph 
-QuantumCoherenceManager::computeEntanglementGraph(const std::vector<sep::quantum::Pattern>& patterns) {
+QuantumCoherenceManager::computeEntanglementGraph(const std::vector<sep::Pattern>& patterns) {
     return impl_->computeEntanglementGraph(patterns);
 }
 

--- a/src/memory/quantum_coherence_manager.h
+++ b/src/memory/quantum_coherence_manager.h
@@ -121,9 +121,9 @@ class QuantumCoherenceManager {
     explicit QuantumCoherenceManager(const Config& config);
     ~QuantumCoherenceManager();
 
-    CoherenceResult updateCoherence(const std::vector<sep::quantum::Pattern>& patterns);
+    CoherenceResult updateCoherence(const std::vector<sep::Pattern>& patterns);
     std::vector<TierMigration> optimizeMemoryLayout();
-    EntanglementGraph computeEntanglementGraph(const std::vector<sep::quantum::Pattern>& patterns);
+    EntanglementGraph computeEntanglementGraph(const std::vector<sep::Pattern>& patterns);
     void applyCoherenceDecay(float decay_factor);
     CoherenceSnapshot createSnapshot() const;
     bool restoreFromSnapshot(const CoherenceSnapshot& snapshot);

--- a/src/quantum/coherence_manager.cpp
+++ b/src/quantum/coherence_manager.cpp
@@ -1,4 +1,5 @@
 #include "quantum/coherence_manager.h"
+#include "core/types.h"
 
 #include <cuda_runtime.h>
 #include <tbb/concurrent_hash_map.h>
@@ -68,7 +69,7 @@ public:
         }
     }
     
-    CoherenceResult updateCoherence(const std::vector<sep::quantum::Pattern>& patterns) {
+    CoherenceResult updateCoherence(const std::vector<sep::Pattern>& patterns) {
         CoherenceResult result;
         global_tick_++;
         
@@ -138,7 +139,7 @@ public:
         return migrations;
     }
     
-    EntanglementGraph computeEntanglementGraph(const std::vector<sep::quantum::Pattern>& patterns) {
+    EntanglementGraph computeEntanglementGraph(const std::vector<sep::Pattern>& patterns) {
         EntanglementGraph graph;
         graph.nodes.reserve(patterns.size());
         
@@ -288,7 +289,7 @@ private:
         }
     }
     
-    void updatePatternCoherence(const sep::quantum::Pattern& pattern) {
+    void updatePatternCoherence(const sep::Pattern& pattern) {
         CoherenceMap::accessor accessor;
         
         if (coherence_map_.find(accessor, pattern.id)) {
@@ -391,7 +392,7 @@ private:
             static_cast<float>(total_entanglements) / (pattern_count * (pattern_count - 1)) : 0.0f;
     }
     
-    std::vector<CoherenceAnomaly> detectCoherenceAnomalies(const std::vector<sep::quantum::Pattern>& patterns) {
+    std::vector<CoherenceAnomaly> detectCoherenceAnomalies(const std::vector<sep::Pattern>& patterns) {
         std::vector<CoherenceAnomaly> anomalies;
         
         // Statistical anomaly detection
@@ -473,7 +474,7 @@ private:
         return migrations;
     }
     
-    void updateEntanglementGraph(const std::vector<sep::quantum::Pattern>& patterns) {
+    void updateEntanglementGraph(const std::vector<sep::Pattern>& patterns) {
         // Clear existing entanglements
         for (auto it = coherence_map_.begin(); it != coherence_map_.end(); ++it) {
             auto& pair = *it;
@@ -606,7 +607,7 @@ private:
         return (count > 1) ? (sum_squared_diff / (count - 1)) : 0.0f;
     }
     
-    float computeEntanglement(const sep::quantum::Pattern& p1, const sep::quantum::Pattern& p2) const {
+    float computeEntanglement(const sep::Pattern& p1, const sep::Pattern& p2) const {
         // Quantum entanglement calculation - simplified example using inverse distance
         float distance = glm::distance(p1.position, p2.position);
         float phase_correlation = std::abs(std::cos(p1.quantum_state.phase - p2.quantum_state.phase));
@@ -615,7 +616,7 @@ private:
         return glm::mix(1.0f / (1.0f + distance), phase_correlation, 0.5f);
     }
     
-    float computePhaseCorrelation(const sep::quantum::Pattern& p1, const sep::quantum::Pattern& p2) const {
+    float computePhaseCorrelation(const sep::Pattern& p1, const sep::Pattern& p2) const {
         // Example phase correlation computation
         return std::abs(std::cos(p1.quantum_state.phase - p2.quantum_state.phase));
     }
@@ -744,7 +745,7 @@ CoherenceManager::CoherenceManager(const Config& config)
 CoherenceManager::~CoherenceManager() = default;
 
 CoherenceManager::CoherenceResult CoherenceManager::updateCoherence(
-    const std::vector<sep::quantum::Pattern>& patterns) {
+    const std::vector<sep::Pattern>& patterns) {
     return impl_->updateCoherence(patterns);
 }
 
@@ -753,7 +754,7 @@ std::vector<CoherenceManager::TierMigration> CoherenceManager::optimizeMemoryLay
 }
 
 CoherenceManager::EntanglementGraph CoherenceManager::computeEntanglementGraph(
-    const std::vector<sep::quantum::Pattern>& patterns) {
+    const std::vector<sep::Pattern>& patterns) {
     return impl_->computeEntanglementGraph(patterns);
 }
 

--- a/src/quantum/coherence_manager.h
+++ b/src/quantum/coherence_manager.h
@@ -121,9 +121,9 @@ class CoherenceManager {
     explicit CoherenceManager(const Config& config);
     ~CoherenceManager();
 
-    CoherenceResult updateCoherence(const std::vector<sep::quantum::Pattern>& patterns);
+    CoherenceResult updateCoherence(const std::vector<sep::Pattern>& patterns);
     std::vector<TierMigration> optimizeMemoryLayout();
-    EntanglementGraph computeEntanglementGraph(const std::vector<sep::quantum::Pattern>& patterns);
+    EntanglementGraph computeEntanglementGraph(const std::vector<sep::Pattern>& patterns);
     void applyCoherenceDecay(float decay_factor);
     CoherenceSnapshot createSnapshot() const;
     bool restoreFromSnapshot(const CoherenceSnapshot& snapshot);

--- a/src/quantum/pattern_evolution.cpp
+++ b/src/quantum/pattern_evolution.cpp
@@ -55,10 +55,10 @@ sep::pattern::PatternData sep::quantum::mcp::PatternEvolution::evolvePattern(con
     }
     
     // Set metadata properties
-    pattern.coherence = coherence;
-    pattern.stability = stability;
-    pattern.entropy = entropy;
-    pattern.mutation_rate = mutation_rate;
+    pattern.quantum_state.coherence = coherence;
+    pattern.quantum_state.stability = stability;
+    pattern.quantum_state.entropy = entropy;
+    pattern.quantum_state.mutation_rate = mutation_rate;
     
     // Set generation count
     pattern.generation = config.value("generation", 0) + 1;
@@ -68,7 +68,7 @@ sep::pattern::PatternData sep::quantum::mcp::PatternEvolution::evolvePattern(con
     {
         for (const auto& rel_json : config["relationships"])
         {
-            ::sep::quantum::PatternRelationship rel;
+            ::sep::PatternRelationship rel;
             
             std::string target_id = rel_json.value("target", "");
             if (!target_id.empty())
@@ -97,7 +97,8 @@ std::vector<sep::pattern::PatternData> sep::quantum::mcp::PatternEvolution::getP
         {
             p.id = shim::string(api::SepEngine::generateId("pat").c_str());
         }
-        if (p.coherence >= min_coherence && p.stability >= min_stability)
+        if (p.quantum_state.coherence >= min_coherence &&
+            p.quantum_state.stability >= min_stability)
         {
             patterns.push_back(p);
         }
@@ -129,13 +130,13 @@ sep::pattern::PatternResult sep::quantum::mcp::PatternEvolution::processPatterns
     {
         output[i] = input[i];
         output[i].generation++;
-        output[i].coherence = std::clamp(input[i].coherence * (1.0f + config.update_threshold), 0.0f, 1.0f);
-        output[i].stability = std::clamp(input[i].stability * (1.0f - config.update_threshold / 2.0f), 0.0f, 1.0f);
-        output[i].entropy = std::clamp(input[i].entropy + 0.01f, 0.0f, 1.0f);
-        output[i].mutation_count += config.enable_mutations ? 1u : 0u;
-        output[i].memory_tier = tier_helper.determineMemoryTier(output[i].coherence,
-                                                                output[i].stability,
-                                                                output[i].generation);
+        output[i].quantum_state.coherence = std::clamp(input[i].quantum_state.coherence * (1.0f + config.update_threshold), 0.0f, 1.0f);
+        output[i].quantum_state.stability = std::clamp(input[i].quantum_state.stability * (1.0f - config.update_threshold / 2.0f), 0.0f, 1.0f);
+        output[i].quantum_state.entropy = std::clamp(input[i].quantum_state.entropy + 0.01f, 0.0f, 1.0f);
+        output[i].quantum_state.mutation_count += config.enable_mutations ? 1u : 0u;
+        output[i].quantum_state.memory_tier = tier_helper.determineMemoryTier(output[i].quantum_state.coherence,
+                                                                              output[i].quantum_state.stability,
+                                                                              output[i].generation);
         output[i].id = shim::string(api::SepEngine::generateId("pat").c_str());
     }
 
@@ -151,9 +152,9 @@ float sep::quantum::mcp::PatternEvolution::calculateRelationshipStrength(const s
     float data_similarity = 1.0f / (1.0f + distance);
     
     // Calculate metadata similarity
-    float coherence_diff = std::abs(pattern1.coherence - pattern2.coherence);
-    float stability_diff = std::abs(pattern1.stability - pattern2.stability);
-    float entropy_diff = std::abs(pattern1.entropy - pattern2.entropy);
+    float coherence_diff = std::abs(pattern1.quantum_state.coherence - pattern2.quantum_state.coherence);
+    float stability_diff = std::abs(pattern1.quantum_state.stability - pattern2.quantum_state.stability);
+    float entropy_diff = std::abs(pattern1.quantum_state.entropy - pattern2.quantum_state.entropy);
     
     float metadata_similarity = 1.0f - (coherence_diff + stability_diff + entropy_diff) / 3.0f;
     
@@ -176,10 +177,10 @@ nlohmann::json sep::quantum::mcp::PatternEvolution::toJson(const sep::pattern::P
     };
     
     // Export metadata
-    j["coherence"] = pattern.coherence;
-    j["stability"] = pattern.stability;
-    j["entropy"] = pattern.entropy;
-    j["mutation_rate"] = pattern.mutation_rate;
+    j["coherence"] = pattern.quantum_state.coherence;
+    j["stability"] = pattern.quantum_state.stability;
+    j["entropy"] = pattern.quantum_state.entropy;
+    j["mutation_rate"] = pattern.quantum_state.mutation_rate;
     
     // Export relationships
     if (!pattern.relationships.empty())
@@ -223,17 +224,17 @@ sep::pattern::PatternData sep::quantum::mcp::PatternEvolution::fromJson(const nl
     }
     
     // Import metadata
-    p.coherence = j.value("coherence", 0.0f);
-    p.stability = j.value("stability", 0.0f);
-    p.entropy = j.value("entropy", 0.0f);
-    p.mutation_rate = j.value("mutation_rate", 0.0f);
+    p.quantum_state.coherence = j.value("coherence", 0.0f);
+    p.quantum_state.stability = j.value("stability", 0.0f);
+    p.quantum_state.entropy = j.value("entropy", 0.0f);
+    p.quantum_state.mutation_rate = j.value("mutation_rate", 0.0f);
     
     // Import relationships
     if (j.contains("relationships") && j["relationships"].is_array())
     {
         for (const auto& rel_json : j["relationships"])
         {
-            ::sep::quantum::PatternRelationship rel;
+            ::sep::PatternRelationship rel;
             
             if (rel_json.contains("target") && rel_json["target"].is_string())
             {

--- a/src/quantum/pattern_processor.cpp
+++ b/src/quantum/pattern_processor.cpp
@@ -22,7 +22,7 @@ public:
         : quantum_processor_(createQuantumProcessor(config)) {}
 
     sep::quantum::ProcessingResult processPattern(
-        const sep::quantum::Pattern& pattern) {
+        const sep::Pattern& pattern) {
         sep::quantum::ProcessingResult result;
         result.pattern = pattern;
         result.pattern.quantum_state.memory_tier = ::sep::memory::MemoryTierEnum::STM;
@@ -65,7 +65,7 @@ public:
     }
 
     std::vector<sep::quantum::ProcessingResult> processBatch(
-        const std::vector<sep::quantum::Pattern>& patterns) {
+        const std::vector<sep::Pattern>& patterns) {
         std::vector<sep::quantum::ProcessingResult> results;
         results.reserve(patterns.size());
         

--- a/src/quantum/processor.h
+++ b/src/quantum/processor.h
@@ -91,8 +91,8 @@ public:
     SEPResult removePattern(const std::string& pattern_id);
     SEPResult updatePattern(const std::string& pattern_id, const Pattern& pattern);
     Pattern getPattern(const std::string& pattern_id) const;
-    std::vector<sep::quantum::Pattern> getPatterns() const;
-    std::vector<sep::quantum::Pattern> getPatternsByTier(sep::memory::MemoryTierEnum tier) const;
+    std::vector<sep::Pattern> getPatterns() const;
+    std::vector<sep::Pattern> getPatternsByTier(sep::memory::MemoryTierEnum tier) const;
     size_t getPatternCount() const;
 
     ProcessingResult processPattern(const std::string& pattern_id);

--- a/src/quantum/quantum_manifold_optimizer.cpp
+++ b/src/quantum/quantum_manifold_optimizer.cpp
@@ -1,4 +1,5 @@
 #include "quantum/quantum_manifold_optimizer.h"
+#include "core/types.h"
 #include "quantum/quantum_processor_qfh.h"
 #include "quantum/pattern_evolution_bridge.h"
 #include <numeric>
@@ -11,7 +12,7 @@
 namespace sep::quantum::manifold {
 
 QuantumManifoldOptimizer::Config QuantumManifoldOptimizer::createManifoldConfig(
-    const ::sep::quantum::PatternEvolutionBridge::Config& cfg) {
+    const ::sep::PatternEvolutionBridge::Config& cfg) {
     Config mc{};
     mc.convergence_threshold = cfg.convergence_threshold;
     mc.step_size = cfg.evolution_step_size;

--- a/src/quantum/quantum_manifold_optimizer.h
+++ b/src/quantum/quantum_manifold_optimizer.h
@@ -95,7 +95,7 @@ public:
     explicit QuantumManifoldOptimizer(const Config& config);
 
     static Config createManifoldConfig(
-        const ::sep::quantum::PatternEvolutionBridge::Config& cfg);
+        const ::sep::PatternEvolutionBridge::Config& cfg);
 
     OptimizationResult optimize(const QuantumState& initial_state,
                                 const OptimizationTarget& target);

--- a/src/quantum/types_serialization.cpp
+++ b/src/quantum/types_serialization.cpp
@@ -31,7 +31,7 @@ void from_json(const nlohmann::json& j, QuantumState& state) {
     state.state = static_cast<QuantumState::Status>(j.value("state", 0));
 }
 
-void to_json(nlohmann::json& j, const sep::quantum::PatternRelationship& rel) {
+void to_json(nlohmann::json& j, const sep::PatternRelationship& rel) {
     j = nlohmann::json{
         {"targetId", rel.targetId},
         {"strength", rel.strength},
@@ -39,7 +39,7 @@ void to_json(nlohmann::json& j, const sep::quantum::PatternRelationship& rel) {
     };
 }
 
-void from_json(const nlohmann::json& j, sep::quantum::PatternRelationship& rel) {
+void from_json(const nlohmann::json& j, sep::PatternRelationship& rel) {
     j.at("targetId").get_to(rel.targetId);
     j.at("strength").get_to(rel.strength);
     rel.type = static_cast<RelationshipType>(j.value("type", 0)); 

--- a/src/workbench/demos/annealing_demo.hpp
+++ b/src/workbench/demos/annealing_demo.hpp
@@ -1,3 +1,4 @@
+#include "workbench/demos/demo_base.hpp"
 #pragma once
 
 #include <glm/vec3.hpp>

--- a/src/workbench/demos/annealing_sim.cpp
+++ b/src/workbench/demos/annealing_sim.cpp
@@ -1,5 +1,7 @@
 #include "annealing_sim.hpp"
 
+#include "core/types.h"
+
 #include <cmath>
 #include <glm/gtc/random.hpp>
 
@@ -55,9 +57,9 @@ void AnnealingSimDemo::on_update(float dt) {
     }
     processor_->evolvePatterns();
     const auto& patterns = processor_->getPatterns();
-    std::vector<sep::quantum::Pattern> quantum_patterns;
+    std::vector<sep::Pattern> quantum_patterns;
     for (const auto& p : patterns) {
-        sep::quantum::Pattern qp;
+        sep::Pattern qp;
         qp.data = p.data;
         quantum_patterns.push_back(qp);
     }

--- a/src/workbench/demos/annealing_sim.hpp
+++ b/src/workbench/demos/annealing_sim.hpp
@@ -1,3 +1,4 @@
+#include "workbench/demos/demo_base.hpp"
 #pragma once
 
 #include <glm/vec3.hpp>

--- a/src/workbench/demos/audio_visualizer.hpp
+++ b/src/workbench/demos/audio_visualizer.hpp
@@ -1,3 +1,4 @@
+#include "workbench/demos/demo_base.hpp"
 #pragma once
 
 #include <glm/vec3.hpp>

--- a/src/workbench/demos/cosmo_demo.hpp
+++ b/src/workbench/demos/cosmo_demo.hpp
@@ -1,3 +1,4 @@
+#include "workbench/demos/demo_base.hpp"
 #pragma once
 
 #include <glm/vec3.hpp>

--- a/src/workbench/demos/cosmo_sim.hpp
+++ b/src/workbench/demos/cosmo_sim.hpp
@@ -1,3 +1,4 @@
+#include "workbench/demos/demo_base.hpp"
 #pragma once
 
 #include <glm/vec3.hpp>

--- a/src/workbench/demos/demo_manager.hpp
+++ b/src/workbench/demos/demo_manager.hpp
@@ -1,3 +1,4 @@
+#include "workbench/demos/demo_base.hpp"
 #pragma once
 
 #include <functional>

--- a/src/workbench/demos/digital_physics_demo.hpp
+++ b/src/workbench/demos/digital_physics_demo.hpp
@@ -1,3 +1,4 @@
+#include "workbench/demos/demo_base.hpp"
 #pragma once
 
 #include <algorithm>

--- a/src/workbench/demos/drug_discovery_demo.hpp
+++ b/src/workbench/demos/drug_discovery_demo.hpp
@@ -1,3 +1,4 @@
+#include "workbench/demos/demo_base.hpp"
 #pragma once
 
 #include <glm/vec3.hpp>

--- a/src/workbench/demos/drug_optimizer.hpp
+++ b/src/workbench/demos/drug_optimizer.hpp
@@ -1,3 +1,4 @@
+#include "workbench/demos/demo_base.hpp"
 #pragma once
 
 #include <glm/vec3.hpp>

--- a/src/workbench/demos/flocking_demo.hpp
+++ b/src/workbench/demos/flocking_demo.hpp
@@ -1,3 +1,4 @@
+#include "workbench/demos/demo_base.hpp"
 #pragma once
 
 #include <glm/vec3.hpp>

--- a/src/workbench/demos/genesis_pattern.cpp
+++ b/src/workbench/demos/genesis_pattern.cpp
@@ -33,7 +33,7 @@ void GenesisPatternDemo::on_load(sep::Engine* engine, sep::CyclesRenderer* rende
 void GenesisPatternDemo::initializePatterns()
 {
     // Initialize base quantum pattern
-    sep::quantum::Pattern pattern;
+    sep::Pattern pattern;
     pattern.id = "seed";
     pattern.position = glm::vec4(0.0f);
     pattern.quantum_state.evolution_rate = evolution_rate_;

--- a/src/workbench/demos/genesis_pattern.hpp
+++ b/src/workbench/demos/genesis_pattern.hpp
@@ -1,3 +1,4 @@
+#include "workbench/demos/demo_base.hpp"
 #pragma once
 
 #include <memory>

--- a/src/workbench/demos/memory_garden.hpp
+++ b/src/workbench/demos/memory_garden.hpp
@@ -1,3 +1,4 @@
+#include "workbench/demos/demo_base.hpp"
 #pragma once
 
 #include <memory>

--- a/src/workbench/demos/neural_demo.hpp
+++ b/src/workbench/demos/neural_demo.hpp
@@ -1,3 +1,4 @@
+#include "workbench/demos/demo_base.hpp"
 #pragma once
 
 #include <vector>

--- a/src/workbench/demos/neuro_sim.cpp
+++ b/src/workbench/demos/neuro_sim.cpp
@@ -1,5 +1,7 @@
 #include "neuro_sim.hpp"
 
+#include "core/types.h"
+
 #include <algorithm>
 #include <glm/glm.hpp>
 
@@ -10,7 +12,7 @@
 
 using sep::memory::MemoryTierEnum;
 using sep::memory::MemoryTierManager;
-using sep::quantum::Pattern;
+using sep::Pattern;
 
 namespace sep
 {

--- a/src/workbench/demos/neuro_sim.hpp
+++ b/src/workbench/demos/neuro_sim.hpp
@@ -1,3 +1,4 @@
+#include "workbench/demos/demo_base.hpp"
 #pragma once
 
 #include <array>
@@ -33,7 +34,7 @@ namespace sep
         private:
             struct Neuron
             {
-                sep::quantum::Pattern pattern;
+                sep::Pattern pattern;
                 float potential{0.f};
                 uint64_t node_id{0};
             };

--- a/src/workbench/demos/pattern_processor.hpp
+++ b/src/workbench/demos/pattern_processor.hpp
@@ -1,3 +1,4 @@
+#include "workbench/demos/demo_base.hpp"
 #pragma once
 
 #include <memory>

--- a/third_party/imgui/backends/imgui_impl_glfw.cpp
+++ b/third_party/imgui/backends/imgui_impl_glfw.cpp
@@ -629,7 +629,7 @@ static bool ImGui_ImplGlfw_Init(GLFWwindow* window, bool install_callbacks, Glfw
 
     bd->Context = ImGui::GetCurrentContext();
     bd->Window = window;
-    bd->Time = 0.0;
+    bd->Time = 0.0f;
     ImGui_ImplGlfw_ContextMap_Add(window, bd->Context);
 
     ImGuiPlatformIO& platform_io = ImGui::GetPlatformIO();

--- a/third_party/imgui/imgui.cpp
+++ b/third_party/imgui/imgui.cpp
@@ -5820,7 +5820,13 @@ void ImGui::EndFrame()
 
     // Notify Platform/OS when our Input Method Editor cursor has moved (e.g. CJK inputs using Microsoft IME)
     ImGuiPlatformImeData* ime_data = &g.PlatformImeData;
-    if (g.PlatformIO.Platform_SetImeDataFn != NULL && memcmp(ime_data, &g.PlatformImeDataPrev, sizeof(ImGuiPlatformImeData)) != 0)
+    if (g.PlatformIO.Platform_SetImeDataFn != NULL &&
+        (ime_data->WantVisible != g.PlatformImeDataPrev.WantVisible ||
+         ime_data->WantTextInput != g.PlatformImeDataPrev.WantTextInput ||
+         ime_data->InputPos.x != g.PlatformImeDataPrev.InputPos.x ||
+         ime_data->InputPos.y != g.PlatformImeDataPrev.InputPos.y ||
+         ime_data->InputLineHeight != g.PlatformImeDataPrev.InputLineHeight ||
+         ime_data->ViewportId != g.PlatformImeDataPrev.ViewportId))
     {
         IMGUI_DEBUG_LOG_IO("[io] Calling Platform_SetImeDataFn(): WantVisible: %d, InputPos (%.2f,%.2f)\n", ime_data->WantVisible, ime_data->InputPos.x, ime_data->InputPos.y);
         IM_ASSERT(ime_data->ViewportId == IMGUI_VIEWPORT_DEFAULT_ID); // master branch
@@ -6825,7 +6831,11 @@ static int ImGui::UpdateWindowManualResize(ImGuiWindow* window, const ImVec2& si
                 g.WindowResizeBorderExpectedRect = border_rect;
                 g.WindowResizeRelativeMode = false;
             }
-            if ((window->Flags & ImGuiWindowFlags_ChildWindow) && memcmp(&g.WindowResizeBorderExpectedRect, &border_rect, sizeof(ImRect)) != 0)
+            if ((window->Flags & ImGuiWindowFlags_ChildWindow) &&
+                (g.WindowResizeBorderExpectedRect.Min.x != border_rect.Min.x ||
+                 g.WindowResizeBorderExpectedRect.Min.y != border_rect.Min.y ||
+                 g.WindowResizeBorderExpectedRect.Max.x != border_rect.Max.x ||
+                 g.WindowResizeBorderExpectedRect.Max.y != border_rect.Max.y))
                 g.WindowResizeRelativeMode = true;
 
             const ImVec2 border_curr = (window->Pos + ImMin(def.SegmentN1, def.SegmentN2) * window->Size);

--- a/third_party/imgui/imgui_demo.cpp
+++ b/third_party/imgui/imgui_demo.cpp
@@ -2009,7 +2009,7 @@ static void DemoWindowWidgetsPlotting()
                 average += values[n];
             average /= (float)IM_ARRAYSIZE(values);
             char overlay[32];
-            sprintf(overlay, "avg %f", average);
+            (void)sprintf(overlay, "avg %f", average);
             ImGui::PlotLines("Lines", values, IM_ARRAYSIZE(values), values_offset, overlay, -1.0f, 1.0f, ImVec2(0, 80.0f));
         }
 
@@ -2058,7 +2058,7 @@ static void DemoWindowWidgetsProgressBars()
 
         float progress_saturated = IM_CLAMP(progress, 0.0f, 1.0f);
         char buf[32];
-        sprintf(buf, "%d/%d", (int)(progress_saturated * 1753), 1753);
+        (void)sprintf(buf, "%d/%d", (int)(progress_saturated * 1753), 1753);
         ImGui::ProgressBar(progress, ImVec2(0.f, 0.f), buf);
 
         // Pass an animated negative value, e.g. -1.0f * (float)ImGui::GetTime() is the recommended value.
@@ -2323,7 +2323,7 @@ static void DemoWindowWidgetsSelectables()
                 for (int i = 0; i < 10; i++)
                 {
                     char label[32];
-                    sprintf(label, "Item %d", i);
+                    (void)sprintf(label, "Item %d", i);
                     ImGui::TableNextColumn();
                     ImGui::Selectable(label, &selected[i]); // FIXME-TABLE: Selection overlap
                 }
@@ -2335,7 +2335,7 @@ static void DemoWindowWidgetsSelectables()
                 for (int i = 0; i < 10; i++)
                 {
                     char label[32];
-                    sprintf(label, "Item %d", i);
+                    (void)sprintf(label, "Item %d", i);
                     ImGui::TableNextRow();
                     ImGui::TableNextColumn();
                     ImGui::Selectable(label, &selected[i], ImGuiSelectableFlags_SpanAllColumns);
@@ -2396,7 +2396,7 @@ static void DemoWindowWidgetsSelectables()
                 {
                     ImVec2 alignment = ImVec2((float)x / 2.0f, (float)y / 2.0f);
                     char name[32];
-                    sprintf(name, "(%.1f,%.1f)", alignment.x, alignment.y);
+                    (void)sprintf(name, "(%.1f,%.1f)", alignment.x, alignment.y);
                     if (x > 0) ImGui::SameLine();
                     ImGui::PushStyleVar(ImGuiStyleVar_SelectableTextAlign, alignment);
                     ImGui::Selectable(name, &selected[3 * y + x], ImGuiSelectableFlags_None, ImVec2(80, 80));
@@ -2656,7 +2656,7 @@ static void DemoWindowWidgetsSelectionAndMultiSelect(ImGuiDemoWindowData* demo_d
             for (int n = 0; n < 5; n++)
             {
                 char buf[32];
-                sprintf(buf, "Object %d", n);
+                (void)sprintf(buf, "Object %d", n);
                 if (ImGui::Selectable(buf, selected == n))
                     selected = n;
             }
@@ -2673,7 +2673,7 @@ static void DemoWindowWidgetsSelectionAndMultiSelect(ImGuiDemoWindowData* demo_d
             for (int n = 0; n < 5; n++)
             {
                 char buf[32];
-                sprintf(buf, "Object %d", n);
+                (void)sprintf(buf, "Object %d", n);
                 if (ImGui::Selectable(buf, selection[n]))
                 {
                     if (!ImGui::GetIO().KeyCtrl) // Clear selection when CTRL is not held
@@ -2714,7 +2714,7 @@ static void DemoWindowWidgetsSelectionAndMultiSelect(ImGuiDemoWindowData* demo_d
                 for (int n = 0; n < ITEMS_COUNT; n++)
                 {
                     char label[64];
-                    sprintf(label, "Object %05d: %s", n, ExampleNames[n % IM_ARRAYSIZE(ExampleNames)]);
+                    (void)sprintf(label, "Object %05d: %s", n, ExampleNames[n % IM_ARRAYSIZE(ExampleNames)]);
                     bool item_is_selected = selection.Contains((ImGuiID)n);
                     ImGui::SetNextItemSelectionUserData(n);
                     ImGui::Selectable(label, item_is_selected);
@@ -2754,7 +2754,7 @@ static void DemoWindowWidgetsSelectionAndMultiSelect(ImGuiDemoWindowData* demo_d
                     for (int n = clipper.DisplayStart; n < clipper.DisplayEnd; n++)
                     {
                         char label[64];
-                        sprintf(label, "Object %05d: %s", n, ExampleNames[n % IM_ARRAYSIZE(ExampleNames)]);
+                        (void)sprintf(label, "Object %05d: %s", n, ExampleNames[n % IM_ARRAYSIZE(ExampleNames)]);
                         bool item_is_selected = selection.Contains((ImGuiID)n);
                         ImGui::SetNextItemSelectionUserData(n);
                         ImGui::Selectable(label, item_is_selected);
@@ -2816,7 +2816,7 @@ static void DemoWindowWidgetsSelectionAndMultiSelect(ImGuiDemoWindowData* demo_d
                 {
                     const ImGuiID item_id = items[n];
                     char label[64];
-                    sprintf(label, "Object %05u: %s", item_id, ExampleNames[item_id % IM_ARRAYSIZE(ExampleNames)]);
+                    (void)sprintf(label, "Object %05u: %s", item_id, ExampleNames[item_id % IM_ARRAYSIZE(ExampleNames)]);
 
                     bool item_is_selected = selection.Contains(item_id);
                     ImGui::SetNextItemSelectionUserData(n);
@@ -2881,7 +2881,7 @@ static void DemoWindowWidgetsSelectionAndMultiSelect(ImGuiDemoWindowData* demo_d
                         ImGui::TableNextRow();
                         ImGui::TableNextColumn();
                         char label[64];
-                        sprintf(label, "Object %05d: %s", n, ExampleNames[n % IM_ARRAYSIZE(ExampleNames)]);
+                        (void)sprintf(label, "Object %05d: %s", n, ExampleNames[n % IM_ARRAYSIZE(ExampleNames)]);
                         bool item_is_selected = selection.Contains((ImGuiID)n);
                         ImGui::SetNextItemSelectionUserData(n);
                         ImGui::Selectable(label, item_is_selected, ImGuiSelectableFlags_SpanAllColumns | ImGuiSelectableFlags_AllowOverlap);
@@ -2922,7 +2922,7 @@ static void DemoWindowWidgetsSelectionAndMultiSelect(ImGuiDemoWindowData* demo_d
                 for (int n = 0; n < 20; n++)
                 {
                     char label[32];
-                    sprintf(label, "Item %d", n);
+                    (void)sprintf(label, "Item %d", n);
                     ImGui::SetNextItemSelectionUserData(n);
                     ImGui::Checkbox(label, &items[n]);
                 }
@@ -2965,7 +2965,7 @@ static void DemoWindowWidgetsSelectionAndMultiSelect(ImGuiDemoWindowData* demo_d
                 for (int n = 0; n < ITEMS_COUNT; n++)
                 {
                     char label[64];
-                    sprintf(label, "Object %05d: %s", n, ExampleNames[n % IM_ARRAYSIZE(ExampleNames)]);
+                    (void)sprintf(label, "Object %05d: %s", n, ExampleNames[n % IM_ARRAYSIZE(ExampleNames)]);
                     bool item_is_selected = selection->Contains((ImGuiID)n);
                     ImGui::SetNextItemSelectionUserData(n);
                     ImGui::Selectable(label, item_is_selected);
@@ -3255,7 +3255,7 @@ static void DemoWindowWidgetsSelectionAndMultiSelect(ImGuiDemoWindowData* demo_d
                         const int item_id = items[n];
                         const char* item_category = ExampleNames[item_id % IM_ARRAYSIZE(ExampleNames)];
                         char label[64];
-                        sprintf(label, "Object %05d: %s", item_id, item_category);
+                        (void)sprintf(label, "Object %05d: %s", item_id, item_category);
 
                         // IMPORTANT: for deletion refocus to work we need object ID to be stable,
                         // aka not depend on their index in the list. Here we use our persistent item_id
@@ -3329,7 +3329,7 @@ static void DemoWindowWidgetsSelectionAndMultiSelect(ImGuiDemoWindowData* demo_d
                         if (ImGui::BeginPopupContextItem())
                         {
                             ImGui::BeginDisabled(!use_deletion || selection.Size == 0);
-                            sprintf(label, "Delete %d item(s)###DeleteSelected", selection.Size);
+                            (void)sprintf(label, "Delete %d item(s)###DeleteSelected", selection.Size);
                             if (ImGui::Selectable(label))
                                 request_deletion_from_menu = true;
                             ImGui::EndDisabled();
@@ -3576,8 +3576,9 @@ static void DemoWindowWidgetsText()
             ImGui::PopFont();
 
             ImGui::SeparatorText("");
-            for (float scaling = 0.5f; scaling <= 4.0f; scaling += 0.5f)
+            for (int i = 1; i <= 8; ++i)
             {
+                float scaling = i * 0.5f;
                 ImGui::PushFont(NULL, style.FontSizeBase * scaling);
                 ImGui::Text("FontSize = %.2f (== style.FontSizeBase * %.2f * global_scale)", ImGui::GetFontSize(), scaling);
                 ImGui::PopFont();
@@ -4336,7 +4337,7 @@ static void DemoWindowLayout()
                 for (int i = 0; i < 100; i++)
                 {
                     char buf[32];
-                    sprintf(buf, "%03d", i);
+                    (void)sprintf(buf, "%03d", i);
                     ImGui::TableNextColumn();
                     ImGui::Button(buf, ImVec2(-FLT_MIN, 0.0f));
                 }
@@ -4918,7 +4919,7 @@ static void DemoWindowLayout()
                 if (n > 0) ImGui::SameLine();
                 ImGui::PushID(n + line * 1000);
                 char num_buf[16];
-                sprintf(num_buf, "%d", n);
+                (void)sprintf(num_buf, "%d", n);
                 const char* label = (!(n % 15)) ? "FizzBuzz" : (!(n % 3)) ? "Fizz" : (!(n % 5)) ? "Buzz" : num_buf;
                 float hue = n * 0.05f;
                 ImGui::PushStyleColor(ImGuiCol_Button, (ImVec4)ImColor::HSV(hue, 0.6f, 0.6f));
@@ -5118,6 +5119,8 @@ static void DemoWindowLayout()
                 ImVec4 clip_rect(p0.x, p0.y, p1.x, p1.y); // AddText() takes a ImVec4* here so let's convert.
                 draw_list->AddRectFilled(p0, p1, IM_COL32(90, 90, 120, 255));
                 draw_list->AddText(ImGui::GetFont(), ImGui::GetFontSize(), text_pos, IM_COL32_WHITE, text_str, NULL, 0.0f, &clip_rect);
+                break;
+            default:
                 break;
             }
         }
@@ -5349,7 +5352,7 @@ static void DemoWindowPopups()
             HelpMarker("Showcase using a popup ID linked to item ID, with the item having a changing label + stable ID using the ### operator.");
             static char name[32] = "Label1";
             char buf[64];
-            sprintf(buf, "Button: %s###Button", name); // ### operator override ID ignoring the preceding label
+            (void)sprintf(buf, "Button: %s###Button", name); // ### operator override ID ignoring the preceding label
             ImGui::Button(buf);
             if (ImGui::BeginPopupContextItem())
             {
@@ -5788,7 +5791,7 @@ static void DemoWindowTables()
                 {
                     ImGui::TableSetColumnIndex(column);
                     char buf[32];
-                    sprintf(buf, "Hello %d,%d", column, row);
+                    (void)sprintf(buf, "Hello %d,%d", column, row);
                     if (contents_type == CT_Text)
                         ImGui::TextUnformatted(buf);
                     else if (contents_type == CT_FillButton)
@@ -6187,6 +6190,7 @@ static void DemoWindowTables()
                 case CT_Button:     ImGui::Button(label); break;
                 case CT_FillButton: ImGui::Button(label, ImVec2(-FLT_MIN, 0.0f)); break;
                 case CT_InputText:  ImGui::SetNextItemWidth(-FLT_MIN); ImGui::InputText("##", text_buf, IM_ARRAYSIZE(text_buf)); break;
+                default: break;
                 }
                 ImGui::PopID();
             }
@@ -8231,6 +8235,7 @@ bool ImGui::ShowStyleSelector(const char* label)
         case 0: ImGui::StyleColorsDark(); break;
         case 1: ImGui::StyleColorsLight(); break;
         case 2: ImGui::StyleColorsClassic(); break;
+        default: break;
         }
         return true;
     }
@@ -8420,7 +8425,11 @@ void ImGui::ShowStyleEditor(ImGuiStyle* ref)
                 {
                     const ImVec4& col = style.Colors[i];
                     const char* name = GetStyleColorName(i);
-                    if (!output_only_modified || memcmp(&col, &ref->Colors[i], sizeof(ImVec4)) != 0)
+                    if (!output_only_modified ||
+                        col.x != ref->Colors[i].x ||
+                        col.y != ref->Colors[i].y ||
+                        col.z != ref->Colors[i].z ||
+                        col.w != ref->Colors[i].w)
                         LogText("colors[ImGuiCol_%s]%*s= ImVec4(%.2ff, %.2ff, %.2ff, %.2ff);" IM_NEWLINE,
                             name, 23 - (int)strlen(name), "", col.x, col.y, col.z, col.w);
                 }
@@ -8457,7 +8466,10 @@ void ImGui::ShowStyleEditor(ImGuiStyle* ref)
                 SameLine();
 #endif
                 ColorEdit4("##color", (float*)&style.Colors[i], ImGuiColorEditFlags_AlphaBar | alpha_flags);
-                if (memcmp(&style.Colors[i], &ref->Colors[i], sizeof(ImVec4)) != 0)
+                if (style.Colors[i].x != ref->Colors[i].x ||
+                    style.Colors[i].y != ref->Colors[i].y ||
+                    style.Colors[i].z != ref->Colors[i].z ||
+                    style.Colors[i].w != ref->Colors[i].w)
                 {
                     // Tips: in a real user application, you may want to merge and use an icon font into the main font,
                     // so instead of "Save"/"Revert" you'd use icons!
@@ -10030,10 +10042,16 @@ static void ShowExampleAppCustomRendering(bool* p_open)
             if (opt_enable_grid)
             {
                 const float GRID_STEP = 64.0f;
-                for (float x = fmodf(scrolling.x, GRID_STEP); x < canvas_sz.x; x += GRID_STEP)
+                for (int xi = (int)fmodf(scrolling.x, GRID_STEP); xi < canvas_sz.x; xi += (int)GRID_STEP)
+                {
+                    float x = (float)xi;
                     draw_list->AddLine(ImVec2(canvas_p0.x + x, canvas_p0.y), ImVec2(canvas_p0.x + x, canvas_p1.y), IM_COL32(200, 200, 200, 40));
-                for (float y = fmodf(scrolling.y, GRID_STEP); y < canvas_sz.y; y += GRID_STEP)
+                }
+                for (int yi = (int)fmodf(scrolling.y, GRID_STEP); yi < canvas_sz.y; yi += (int)GRID_STEP)
+                {
+                    float y = (float)yi;
                     draw_list->AddLine(ImVec2(canvas_p0.x, canvas_p0.y + y), ImVec2(canvas_p1.x, canvas_p0.y + y), IM_COL32(200, 200, 200, 40));
+                }
             }
             for (int n = 0; n < points.Size; n += 2)
                 draw_list->AddLine(ImVec2(origin.x + points[n].x, origin.y + points[n].y), ImVec2(origin.x + points[n + 1].x, origin.y + points[n + 1].y), IM_COL32(255, 255, 0, 255), 2.0f);


### PR DESCRIPTION
## Summary
- use `sep::Pattern` consistently across source
- adjust pattern member access via `quantum_state`
- include required headers for pattern types
- clean up stray forward declarations
- include demo base header for all workbench demos
- enable GLM experimental features
- fix float-loop counters and memcmp comparisons in ImGui code

## Testing
- `./build.sh` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_68724a2f6014832aa4008001ccb2b0a0