### PR TITLE
Fix processor result types and enumeration counts

### DIFF
--- a/extern/cycles/third_party/cuew/src/cuew.c
+++ b/extern/cycles/third_party/cuew/src/cuew.c
@@ -947,8 +947,8 @@ int cuewCompilerVersion(void)
 
   /* get --version output */
   strcat(command, "\"");
-  strncat(command, path, sizeof(command) - 1);
-  strncat(command, "\" --version", sizeof(command) - strlen(path) - 1);
+  strncat(command, path, sizeof(command) - strlen(command) - 1);
+  strncat(command, "\" --version", sizeof(command) - strlen(command) - 1);
   pipe = popen(command, "r");
   if (!pipe) {
     fprintf(stderr, "CUDA: failed to run compiler to retrieve version");

--- a/extern/cycles/third_party/hipew/src/hipew.c
+++ b/extern/cycles/third_party/hipew/src/hipew.c
@@ -594,8 +594,8 @@ int hipewCompilerVersion(void) {
 
   /* get --version output */
   strcat(command, "\"");
-  strncat(command, path, sizeof(command) - 1);
-  strncat(command, "\" --version", sizeof(command) - strlen(path) - 1);
+  strncat(command, path, sizeof(command) - strlen(command) - 1);
+  strncat(command, "\" --version", sizeof(command) - strlen(command) - 1);
   pipe = popen(command, "r");
   if (!pipe) {
     fprintf(stderr, "HIP: failed to run compiler to retrieve version");

--- a/src/quantum/processor.cpp
+++ b/src/quantum/processor.cpp
@@ -281,20 +281,24 @@ public:
         status += "  Max patterns: " + std::to_string(config_.max_patterns) + "\n";
         status += "  GPU enabled: " + std::string(config_.enable_cuda ? "Yes" : "No") + "\n";
         size_t stm_count = 0, mtm_count = 0, ltm_count = 0;
+        size_t host_count = 0, device_count = 0, unified_count = 0;
         for (const auto& pattern : patterns_) {
             switch (pattern.quantum_state.memory_tier) {
                 case ::sep::memory::MemoryTierEnum::STM: stm_count++; break;
                 case ::sep::memory::MemoryTierEnum::MTM: mtm_count++; break;
                 case ::sep::memory::MemoryTierEnum::LTM: ltm_count++; break;
-                case ::sep::memory::MemoryTierEnum::UNIFIED:
-                case ::sep::memory::MemoryTierEnum::HOST:
-                case ::sep::memory::MemoryTierEnum::DEVICE:
-                    break;
+                case ::sep::memory::MemoryTierEnum::HOST: host_count++; break;
+                case ::sep::memory::MemoryTierEnum::DEVICE: device_count++; break;
+                case ::sep::memory::MemoryTierEnum::UNIFIED: unified_count++; break;
+                default: break;
             }
         }
         status += "  STM patterns: " + std::to_string(stm_count) + "\n";
         status += "  MTM patterns: " + std::to_string(mtm_count) + "\n";
         status += "  LTM patterns: " + std::to_string(ltm_count) + "\n";
+        status += "  HOST patterns: " + std::to_string(host_count) + "\n";
+        status += "  DEVICE patterns: " + std::to_string(device_count) + "\n";
+        status += "  UNIFIED patterns: " + std::to_string(unified_count) + "\n";
         return status;
     }
 

--- a/src/quantum/processor.h
+++ b/src/quantum/processor.h
@@ -71,6 +71,17 @@ protected:
 } // namespace pattern
 
 namespace quantum {
+struct ProcessingResult {
+    bool success{false};
+    ::sep::Pattern pattern{};
+    std::string error_message{};
+};
+
+struct BatchProcessingResult {
+    bool success{false};
+    std::vector<ProcessingResult> results{};
+    std::string error_message{};
+};
 namespace core { class SystemHooks; }
 
 class ProcessorImpl;

--- a/src/quantum/types_serialization.cpp
+++ b/src/quantum/types_serialization.cpp
@@ -1,7 +1,12 @@
 #include "core/types.h"
 #include "memory/types.h" // Add include for MemoryTierEnum
+#include <vector>
 #include <nlohmann/json.hpp> 
 #include <cstring>
+
+namespace sep {
+using PatternRelationship = quantum::PatternRelationship;
+}
 
 namespace sep::quantum {
 


### PR DESCRIPTION
## Summary
- define `ProcessingResult` and `BatchProcessingResult` structs
- fix `MemoryTierEnum` counting in processor status
- alias `sep::PatternRelationship` for JSON helpers
- harden strncat usage for cuew and hipew

## Testing
- `npm test --silent` *(fails: jest: not found)*
- `cmake ..` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_687270e2bac4832a804d3a533e037c63