### PR TITLE
Fix quantum processor result types

### DIFF
--- a/src/quantum/evolution.cpp
+++ b/src/quantum/evolution.cpp
@@ -1,5 +1,6 @@
 #include "quantum/evolution.h"
 #include "quantum/processor.h"
+#include "core/types.h"
 #include <algorithm>
 #include <numeric>
 #include <stdexcept>

--- a/src/quantum/processor.h
+++ b/src/quantum/processor.h
@@ -21,6 +21,19 @@ constexpr float COHERENCE_THRESHOLD = 0.7f;
 constexpr float DEMOTION_THRESHOLD = 0.3f;
 } // namespace quantum
 
+// Result objects returned by Processor operations
+struct ProcessingResult {
+    bool success{false};
+    Pattern pattern{};
+    std::string error_message{};
+};
+
+struct BatchProcessingResult {
+    bool success{false};
+    std::vector<ProcessingResult> results{};
+    std::string error_message{};
+};
+
 namespace pattern {
 
 // Base pattern processor class

--- a/src/quantum/types_serialization.cpp
+++ b/src/quantum/types_serialization.cpp
@@ -1,7 +1,12 @@
 #include "core/types.h"
 #include "memory/types.h" // Add include for MemoryTierEnum
+#include <string>
 #include <nlohmann/json.hpp> 
 #include <cstring>
+
+namespace sep {
+using PatternRelationship = quantum::PatternRelationship;
+}
 
 namespace sep::quantum {
 


### PR DESCRIPTION
## Summary
- define `ProcessingResult` and `BatchProcessingResult` in processor header
- include core types in `evolution.cpp`
- alias `sep::PatternRelationship` in `types_serialization.cpp`

## Testing
- `./build.sh` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_687270e2bac4832a804d3a533e037c63