### PR TITLE
Fix processor structs and demo headers

### DIFF
--- a/extern/cycles/third_party/cuew/src/cuew.c
+++ b/extern/cycles/third_party/cuew/src/cuew.c
@@ -946,9 +946,7 @@ int cuewCompilerVersion(void)
   }
 
   /* get --version output */
-  strcat(command, "\"");
-  strncat(command, path, sizeof(command) - 1);
-  strncat(command, "\" --version", sizeof(command) - strlen(path) - 1);
+  snprintf(command, sizeof(command), "\"%s\" --version", path);
   pipe = popen(command, "r");
   if (!pipe) {
     fprintf(stderr, "CUDA: failed to run compiler to retrieve version");

--- a/extern/cycles/third_party/hipew/src/hipew.c
+++ b/extern/cycles/third_party/hipew/src/hipew.c
@@ -593,9 +593,7 @@ int hipewCompilerVersion(void) {
   }
 
   /* get --version output */
-  strcat(command, "\"");
-  strncat(command, path, sizeof(command) - 1);
-  strncat(command, "\" --version", sizeof(command) - strlen(path) - 1);
+  snprintf(command, sizeof(command), "\"%s\" --version", path);
   pipe = popen(command, "r");
   if (!pipe) {
     fprintf(stderr, "HIP: failed to run compiler to retrieve version");

--- a/src/quantum/processor.cpp
+++ b/src/quantum/processor.cpp
@@ -330,7 +330,6 @@ private:
 
     void updateMemoryTier(Pattern& pattern) {
         auto& state = pattern.quantum_state;
-        ::sep::memory::MemoryTierEnum previous_tier = state.memory_tier;
 #if SEP_BUILD_QUANTUM
         auto qcfg = sep::config::ConfigManager::getInstance().getQuantumConfig();
 #else
@@ -343,8 +342,11 @@ private:
         } else {
             state.memory_tier = ::sep::memory::MemoryTierEnum::STM;
         }
-        if (state.memory_tier != previous_tier) {
+        // Reset access frequency whenever the tier changes
+        static ::sep::memory::MemoryTierEnum last_tier = ::sep::memory::MemoryTierEnum::STM;
+        if (state.memory_tier != last_tier) {
             state.access_frequency = 1.0f;
+            last_tier = state.memory_tier;
         }
     }
 

--- a/src/quantum/processor.h
+++ b/src/quantum/processor.h
@@ -71,6 +71,17 @@ protected:
 } // namespace pattern
 
 namespace quantum {
+struct ProcessingResult {
+    bool success{false};
+    Pattern pattern{};
+    std::string error_message{};
+};
+
+struct BatchProcessingResult {
+    bool success{false};
+    std::vector<ProcessingResult> results{};
+    std::string error_message{};
+};
 namespace core { class SystemHooks; }
 
 class ProcessorImpl;

--- a/src/workbench/demos/annealing_demo.hpp
+++ b/src/workbench/demos/annealing_demo.hpp
@@ -21,7 +21,7 @@ public:
     void on_ui_render() override;
     void on_unload() override;
     void on_key_press(int key) override;
-    void on_mouse(int x, int y, int button) override;
+    void on_mouse(int x, int y, int button);
 
 private:
     struct Particle {

--- a/src/workbench/demos/annealing_sim.hpp
+++ b/src/workbench/demos/annealing_sim.hpp
@@ -23,7 +23,7 @@ public:
     void on_render() override;
     void on_unload() override;
     void on_key_press(int key) override;
-    void on_mouse(int x, int y, int button) override;
+    void on_mouse(int x, int y, int button);
 
 private:
     struct Particle {

--- a/src/workbench/demos/audio_visualizer.hpp
+++ b/src/workbench/demos/audio_visualizer.hpp
@@ -24,7 +24,7 @@ public:
     void on_ui_render() override;
     void on_unload() override;
     void on_key_press(int key) override;
-    void on_mouse(int x, int y, int button) override;
+    void on_mouse(int x, int y, int button);
 
 private:
     std::unique_ptr<audio::AudioCapture> capture_;

--- a/src/workbench/demos/cosmo_demo.hpp
+++ b/src/workbench/demos/cosmo_demo.hpp
@@ -21,7 +21,7 @@ public:
     void on_ui_render() override;
     void on_unload() override;
     void on_key_press(int key) override;
-    void on_mouse(int x, int y, int button) override;
+    void on_mouse(int x, int y, int button);
 
 private:
     struct Particle {
@@ -34,6 +34,9 @@ private:
 
     float box_size_{50.0f};
     float time_step_{0.01f};
+
+    sep::Engine* engine_{nullptr};
+    sep::CyclesRenderer* renderer_{nullptr};
 
     void initParticles();
     void integrate(float dt);

--- a/src/workbench/demos/cosmo_sim.hpp
+++ b/src/workbench/demos/cosmo_sim.hpp
@@ -22,7 +22,7 @@ public:
     void on_render() override;
     void on_unload() override;
     void on_key_press(int key) override;
-    void on_mouse(int x, int y, int button = 0) override;
+    void on_mouse(int x, int y, int button = 0);
 
 private:
     std::vector<sep::pattern::PatternData> bodies_;
@@ -34,6 +34,9 @@ private:
     float input_strength_{0.5f};
     float learning_rate_{0.05f};
     float connection_prob_{0.2f};
+
+    sep::Engine* engine_{nullptr};
+    sep::CyclesRenderer* renderer_{nullptr};
 
     void initBodies();
     void integrate(float dt);

--- a/src/workbench/demos/digital_physics_demo.hpp
+++ b/src/workbench/demos/digital_physics_demo.hpp
@@ -22,7 +22,7 @@ public:
     void on_render() override;
     void on_unload() override;
     void on_key_press(int key) override;
-    void on_mouse(int x, int y, int button) override;
+    void on_mouse(int x, int y, int button);
 
 private:
     std::size_t width_{0};

--- a/src/workbench/demos/drug_discovery_demo.hpp
+++ b/src/workbench/demos/drug_discovery_demo.hpp
@@ -28,7 +28,7 @@ public:
     void on_render() override;
     void on_unload() override;
     void on_key_press(int key) override;
-    void on_mouse(int x, int y, int button) override;
+    void on_mouse(int x, int y, int button);
 
 private:
     void optimizePoses();

--- a/src/workbench/demos/drug_optimizer.hpp
+++ b/src/workbench/demos/drug_optimizer.hpp
@@ -28,7 +28,7 @@ public:
     void on_render() override;
     void on_unload() override;
     void on_key_press(int key) override;
-    void on_mouse(int x, int y, int button) override;
+    void on_mouse(int x, int y, int button);
 
 private:
     float computeBindingScore(const MoleculePose& pose);

--- a/src/workbench/demos/flocking_demo.hpp
+++ b/src/workbench/demos/flocking_demo.hpp
@@ -22,7 +22,7 @@ public:
     void on_render() override;
     void on_unload() override;
     void on_key_press(int key) override;
-    void on_mouse(int x, int y, int button) override;
+    void on_mouse(int x, int y, int button);
 
 private:
     std::vector<pattern::PatternData> agents_;

--- a/src/workbench/demos/genesis_pattern.hpp
+++ b/src/workbench/demos/genesis_pattern.hpp
@@ -23,7 +23,7 @@ public:
     void on_ui_render() override;
     void on_unload() override;
     void on_key_press(int key) override;
-    void on_mouse(int x, int y, int button) override;
+    void on_mouse(int x, int y, int button);
 
 private:
     void initializePatterns();
@@ -45,6 +45,9 @@ private:
 
     std::unique_ptr<sep::quantum::Processor> pattern_processor_;
     std::unique_ptr<sep::memory::QuantumCoherenceManager> coherence_manager_;
+
+    sep::Engine* engine_{nullptr};
+    sep::CyclesRenderer* renderer_{nullptr};
 
     bool auto_evolve_{true};
     float evolution_rate_{0.1f};

--- a/src/workbench/demos/memory_garden.hpp
+++ b/src/workbench/demos/memory_garden.hpp
@@ -23,7 +23,7 @@ public:
     void on_render() override;
     void on_unload() override;
     void on_key_press(int key) override;
-    void on_mouse(int x, int y, int button) override;
+    void on_mouse(int x, int y, int button);
 
 private:
     struct Node {

--- a/src/workbench/demos/neural_demo.hpp
+++ b/src/workbench/demos/neural_demo.hpp
@@ -22,7 +22,7 @@ public:
     void on_render() override;
     void on_unload() override;
     void on_key_press(int key) override;
-    void on_mouse(int x, int y, int button) override;
+    void on_mouse(int x, int y, int button);
 
 private:
     struct Neuron {

--- a/src/workbench/demos/neuro_sim.hpp
+++ b/src/workbench/demos/neuro_sim.hpp
@@ -32,7 +32,7 @@ namespace sep
             void on_render() override;
             void on_unload() override;
             void on_key_press(int key) override;
-            void on_mouse(int x, int y, int button) override;
+            void on_mouse(int x, int y, int button);
 
         private:
             struct Neuron


### PR DESCRIPTION
## Summary
- define `ProcessingResult` and `BatchProcessingResult` in processor API
- simplify tier update logic in `Processor` implementation
- add engine and renderer pointers to workbench demos
- correct overflow-prone command creation in cuew/hipew
- drop invalid `override` specifiers in demo headers

## Testing
- `./build.sh` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_687270e2bac4832a804d3a533e037c63