### PR TITLE
Fix missing quantum headers and structs

### DIFF
--- a/src/core/types.h
+++ b/src/core/types.h
@@ -85,6 +85,7 @@ struct Pattern {
 // Modules that used different names can use these type aliases.
 namespace pattern {
     using PatternData = sep::Pattern;
+    using PatternRelationship = sep::quantum::PatternRelationship;
 }
 namespace workbench {
     using Pattern = sep::Pattern;

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -3,6 +3,8 @@
 #include "core/common.h"
 #include "core/types.h"
 #include "quantum/pattern.h"
+#include "quantum/processor.h"            // for sep::quantum types
+#include "quantum/pattern_processor.hpp"  // for sep::pattern utilities
 
 namespace sep {
 

--- a/src/quantum/evolution.cpp
+++ b/src/quantum/evolution.cpp
@@ -1,5 +1,7 @@
 #include "quantum/evolution.h"
 #include "quantum/processor.h"
+#include "core/types.h"                // for sep::Pattern definitions
+#include "quantum/pattern_processor.hpp" // for pattern utilities
 #include <algorithm>
 #include <numeric>
 #include <stdexcept>

--- a/src/quantum/processor.h
+++ b/src/quantum/processor.h
@@ -21,6 +21,22 @@ constexpr float COHERENCE_THRESHOLD = 0.7f;
 constexpr float DEMOTION_THRESHOLD = 0.3f;
 } // namespace quantum
 
+// Result structures used by the Processor API.  These were referenced in the
+// implementation but never defined in the original header which caused build
+// errors for any translation unit including only this header.  They live in the
+// `sep::quantum` namespace alongside the processor types.
+struct ProcessingResult {
+    bool success{false};
+    sep::Pattern pattern{};
+    std::string error_message{};
+};
+
+struct BatchProcessingResult {
+    bool success{false};
+    std::vector<ProcessingResult> results{};
+    std::string error_message{};
+};
+
 namespace pattern {
 
 // Base pattern processor class

--- a/src/quantum/types_serialization.cpp
+++ b/src/quantum/types_serialization.cpp
@@ -1,5 +1,6 @@
 #include "core/types.h"
 #include "memory/types.h" // Add include for MemoryTierEnum
+#include "quantum/pattern.h"   // for QuantumPattern and related
 #include <nlohmann/json.hpp> 
 #include <cstring>
 


### PR DESCRIPTION
## Summary
- define `ProcessingResult` and `BatchProcessingResult` in processor headers
- register `pattern::PatternRelationship` alias in core types
- include pattern/quantum headers where required

## Testing
- `cmake -S . -B build` *(fails: Could NOT find GLEW)*

------
https://chatgpt.com/codex/tasks/task_e_687270eaef50832a87c2c8691655ca2f