### PR TITLE
Fix includes and define processing results

### DIFF
--- a/src/core/types.h
+++ b/src/core/types.h
@@ -85,6 +85,7 @@ struct Pattern {
 // Modules that used different names can use these type aliases.
 namespace pattern {
     using PatternData = sep::Pattern;
+    using PatternRelationship = sep::quantum::PatternRelationship;
 }
 namespace workbench {
     using Pattern = sep::Pattern;

--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -3,6 +3,8 @@
 #include "core/common.h"
 #include "core/types.h"
 #include "quantum/pattern.h"
+#include "quantum/processor.h"
+#include "quantum/pattern_processor.hpp"
 
 namespace sep {
 

--- a/src/quantum/evolution.cpp
+++ b/src/quantum/evolution.cpp
@@ -1,5 +1,7 @@
 #include "quantum/evolution.h"
 #include "quantum/processor.h"
+#include "quantum/pattern_processor.hpp"
+#include "core/types.h"
 #include <algorithm>
 #include <numeric>
 #include <stdexcept>

--- a/src/quantum/processor.h
+++ b/src/quantum/processor.h
@@ -15,6 +15,18 @@ namespace sep {
 
 // Constants for pattern processing
 namespace quantum {
+
+struct ProcessingResult {
+    bool success{false};
+    Pattern pattern{};
+    std::string error_message{};
+};
+
+struct BatchProcessingResult {
+    bool success{false};
+    std::vector<ProcessingResult> results{};
+    std::string error_message{};
+};
 constexpr float MIN_COHERENCE = 0.1f;
 constexpr float STABILITY_THRESHOLD = 0.85f;
 constexpr float COHERENCE_THRESHOLD = 0.7f;

--- a/src/quantum/types_serialization.cpp
+++ b/src/quantum/types_serialization.cpp
@@ -1,5 +1,6 @@
 #include "core/types.h"
 #include "memory/types.h" // Add include for MemoryTierEnum
+#include "quantum/processor.h"
 #include <nlohmann/json.hpp> 
 #include <cstring>
 

--- a/src/workbench/demos/digital_physics_demo.hpp
+++ b/src/workbench/demos/digital_physics_demo.hpp
@@ -22,7 +22,7 @@ public:
     void on_render() override;
     void on_unload() override;
     void on_key_press(int key) override;
-    void on_mouse(int x, int y, int button) override;
+    void on_mouse(int x, int y, int button);
 
 private:
     std::size_t width_{0};
@@ -35,6 +35,8 @@ private:
     float input_strength_{0.5f};
     float learning_rate_{0.05f};
     float connection_prob_{0.2f};
+
+    sep::CyclesRenderer* renderer_{nullptr};
 
     std::size_t index(std::size_t x, std::size_t y) const { return y * width_ + x; }
 };

--- a/src/workbench/demos/genesis_pattern.hpp
+++ b/src/workbench/demos/genesis_pattern.hpp
@@ -23,7 +23,7 @@ public:
     void on_ui_render() override;
     void on_unload() override;
     void on_key_press(int key) override;
-    void on_mouse(int x, int y, int button) override;
+    void on_mouse(int x, int y, int button);
 
 private:
     void initializePatterns();
@@ -45,6 +45,7 @@ private:
 
     std::unique_ptr<sep::quantum::Processor> pattern_processor_;
     std::unique_ptr<sep::memory::QuantumCoherenceManager> coherence_manager_;
+    sep::CyclesRenderer* renderer_{nullptr};
 
     bool auto_evolve_{true};
     float evolution_rate_{0.1f};


### PR DESCRIPTION
## Summary
- add missing `ProcessingResult` and `BatchProcessingResult` structs
- expose `PatternRelationship` alias in `core/types.h`
- include quantum headers where required
- store renderer pointer in some demos
- drop erroneous override specifiers

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687270eaef50832a87c2c8691655ca2f