### PR TITLE
Fix struct types and demo overrides

### DIFF
--- a/src/core/types.h
+++ b/src/core/types.h
@@ -85,6 +85,7 @@ struct Pattern {
 // Modules that used different names can use these type aliases.
 namespace pattern {
     using PatternData = sep::Pattern;
+    using PatternRelationship = sep::quantum::PatternRelationship;
 }
 namespace workbench {
     using Pattern = sep::Pattern;

--- a/src/quantum/processor.h
+++ b/src/quantum/processor.h
@@ -73,6 +73,19 @@ protected:
 namespace quantum {
 namespace core { class SystemHooks; }
 
+struct ProcessingResult {
+    bool success{false};
+    Pattern pattern{};
+    std::string error_message{};
+};
+
+struct BatchProcessingResult {
+    bool success{false};
+    int error_code{0};
+    std::string error_message{};
+    std::vector<ProcessingResult> results;
+};
+
 class ProcessorImpl;
 
 // Processor is thread-safe. All mutations of internal state are

--- a/src/workbench/demos/annealing_demo.hpp
+++ b/src/workbench/demos/annealing_demo.hpp
@@ -21,7 +21,7 @@ public:
     void on_ui_render() override;
     void on_unload() override;
     void on_key_press(int key) override;
-    void on_mouse(int x, int y, int button) override;
+    void on_mouse(int x, int y, int button);
 
 private:
     struct Particle {

--- a/src/workbench/demos/annealing_sim.hpp
+++ b/src/workbench/demos/annealing_sim.hpp
@@ -23,7 +23,7 @@ public:
     void on_render() override;
     void on_unload() override;
     void on_key_press(int key) override;
-    void on_mouse(int x, int y, int button) override;
+    void on_mouse(int x, int y, int button);
 
 private:
     struct Particle {

--- a/src/workbench/demos/audio_visualizer.hpp
+++ b/src/workbench/demos/audio_visualizer.hpp
@@ -24,7 +24,7 @@ public:
     void on_ui_render() override;
     void on_unload() override;
     void on_key_press(int key) override;
-    void on_mouse(int x, int y, int button) override;
+    void on_mouse(int x, int y, int button);
 
 private:
     std::unique_ptr<audio::AudioCapture> capture_;

--- a/src/workbench/demos/cosmo_demo.hpp
+++ b/src/workbench/demos/cosmo_demo.hpp
@@ -21,7 +21,7 @@ public:
     void on_ui_render() override;
     void on_unload() override;
     void on_key_press(int key) override;
-    void on_mouse(int x, int y, int button) override;
+    void on_mouse(int x, int y, int button);
 
 private:
     struct Particle {

--- a/src/workbench/demos/cosmo_sim.hpp
+++ b/src/workbench/demos/cosmo_sim.hpp
@@ -22,7 +22,7 @@ public:
     void on_render() override;
     void on_unload() override;
     void on_key_press(int key) override;
-    void on_mouse(int x, int y, int button = 0) override;
+    void on_mouse(int x, int y, int button = 0);
 
 private:
     std::vector<sep::pattern::PatternData> bodies_;

--- a/src/workbench/demos/digital_physics_demo.hpp
+++ b/src/workbench/demos/digital_physics_demo.hpp
@@ -22,7 +22,7 @@ public:
     void on_render() override;
     void on_unload() override;
     void on_key_press(int key) override;
-    void on_mouse(int x, int y, int button) override;
+    void on_mouse(int x, int y, int button);
 
 private:
     std::size_t width_{0};

--- a/src/workbench/demos/drug_discovery_demo.hpp
+++ b/src/workbench/demos/drug_discovery_demo.hpp
@@ -28,7 +28,7 @@ public:
     void on_render() override;
     void on_unload() override;
     void on_key_press(int key) override;
-    void on_mouse(int x, int y, int button) override;
+    void on_mouse(int x, int y, int button);
 
 private:
     void optimizePoses();

--- a/src/workbench/demos/drug_optimizer.hpp
+++ b/src/workbench/demos/drug_optimizer.hpp
@@ -28,7 +28,7 @@ public:
     void on_render() override;
     void on_unload() override;
     void on_key_press(int key) override;
-    void on_mouse(int x, int y, int button) override;
+    void on_mouse(int x, int y, int button);
 
 private:
     float computeBindingScore(const MoleculePose& pose);

--- a/src/workbench/demos/flocking_demo.hpp
+++ b/src/workbench/demos/flocking_demo.hpp
@@ -22,7 +22,7 @@ public:
     void on_render() override;
     void on_unload() override;
     void on_key_press(int key) override;
-    void on_mouse(int x, int y, int button) override;
+    void on_mouse(int x, int y, int button);
 
 private:
     std::vector<pattern::PatternData> agents_;

--- a/src/workbench/demos/genesis_pattern.hpp
+++ b/src/workbench/demos/genesis_pattern.hpp
@@ -23,7 +23,7 @@ public:
     void on_ui_render() override;
     void on_unload() override;
     void on_key_press(int key) override;
-    void on_mouse(int x, int y, int button) override;
+    void on_mouse(int x, int y, int button);
 
 private:
     void initializePatterns();
@@ -42,6 +42,9 @@ private:
         float evolution_rate{0.f};
         std::size_t iterations{0};
     } metrics_;
+
+    sep::Engine* engine_{nullptr};
+    sep::CyclesRenderer* renderer_{nullptr};
 
     std::unique_ptr<sep::quantum::Processor> pattern_processor_;
     std::unique_ptr<sep::memory::QuantumCoherenceManager> coherence_manager_;

--- a/src/workbench/demos/memory_garden.hpp
+++ b/src/workbench/demos/memory_garden.hpp
@@ -23,7 +23,7 @@ public:
     void on_render() override;
     void on_unload() override;
     void on_key_press(int key) override;
-    void on_mouse(int x, int y, int button) override;
+    void on_mouse(int x, int y, int button);
 
 private:
     struct Node {

--- a/src/workbench/demos/neural_demo.hpp
+++ b/src/workbench/demos/neural_demo.hpp
@@ -22,7 +22,7 @@ public:
     void on_render() override;
     void on_unload() override;
     void on_key_press(int key) override;
-    void on_mouse(int x, int y, int button) override;
+    void on_mouse(int x, int y, int button);
 
 private:
     struct Neuron {

--- a/src/workbench/demos/neuro_sim.hpp
+++ b/src/workbench/demos/neuro_sim.hpp
@@ -32,7 +32,7 @@ namespace sep
             void on_render() override;
             void on_unload() override;
             void on_key_press(int key) override;
-            void on_mouse(int x, int y, int button) override;
+            void on_mouse(int x, int y, int button);
 
         private:
             struct Neuron


### PR DESCRIPTION
## Summary
- define `ProcessingResult` and `BatchProcessingResult` in `processor.h`
- expose `PatternRelationship` alias
- store engine and renderer pointers in `GenesisPatternDemo`
- remove erroneous `override` keywords from mouse handlers in demos

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687270eaef50832a87c2c8691655ca2f