### PR TITLE
Implement patch corrections

### DIFF
--- a/src/api/bridge_c.cpp
+++ b/src/api/bridge_c.cpp
@@ -92,7 +92,7 @@ SEP_API sep::SEPResult sep_process_context(const char *context_json, const char 
         }
       }
 
-      sep::quantum::BatchProcessingResult process_result;
+        sep::BatchProcessingResult process_result;
       process_result.success = true;
       process_result.error_code = 0;
       

--- a/src/api/client.h
+++ b/src/api/client.h
@@ -18,6 +18,12 @@
 #include "curl/curl.h"
 
 namespace sep {
+namespace config {
+struct OllamaConfig {
+    std::string host;
+    int port;
+};
+}
 namespace api {
 
 // Forward declare

--- a/src/api_main.cpp
+++ b/src/api_main.cpp
@@ -15,7 +15,7 @@ int main(int argc, char** argv) {
         renderer->initialize();
     }
 
-    sep::api::SEPApiServer server(apiConfig, renderer.get());
+    sep::api::SEPApiServer server(apiConfig, static_cast<blender::ccl::CyclesRenderer*>(renderer.get()));
     if (!server.run()) {
         std::cerr << "Failed to start API server" << std::endl;
         return 1;

--- a/src/blender/api.cpp
+++ b/src/blender/api.cpp
@@ -32,7 +32,7 @@ bool validateMesh(Object* obj, Mesh* mesh)
 }
 }  // namespace
 
-extern "C" sep::SEPResult sep_blender_init(sep::GPUContext* gpu_ctx, const SEPConfig* sep::pattern::PatternConfig, SEPBlenderBridge** bridge_out)
+extern "C" sep::SEPResult sep_blender_init(sep::GPUContext* gpu_ctx, const sep::pattern::PatternConfig& config, SEPBlenderBridge** bridge_out)
 {
     if (!gpu_ctx || !bridge_out)
     { 
@@ -40,8 +40,7 @@ extern "C" sep::SEPResult sep_blender_init(sep::GPUContext* gpu_ctx, const SEPCo
         return sep::SEPResult::INITIALIZATION_FAILED; 
     }
 
-    // Use sep::pattern::PatternConfig parameter to avoid unused warning
-    (void)sep::pattern::PatternConfig;
+    (void)config;
 
     auto bridge_ptr = std::make_unique<sep::SEPBlenderBridge>();
     if (!bridge_ptr)
@@ -75,13 +74,13 @@ sep_register_mesh(SEPBlenderBridge* bridge, Object* bl_object, Mesh* bl_mesh, se
         return sep::SEPResult::NOT_FOUND;
     }
 
-    sep::pattern::PatternConfig sep::pattern::PatternConfig{};
-    sep::pattern::PatternConfig.update_threshold = 0.1f;
-    sep::pattern::PatternConfig.enable_mutations = true;
-    sep::pattern::PatternConfig.max_patterns     = 1000;
-    sep::pattern::PatternConfig.batch_size       = 64;
+    sep::pattern::PatternConfig cfg{};
+    cfg.update_threshold = 0.1f;
+    cfg.enable_mutations = true;
+    cfg.max_patterns     = 1000;
+    cfg.batch_size       = 64;
 
-    auto result = bridge->impl->registerObject(bl_object, sep::pattern::PatternConfig, handle_out);
+    auto result = bridge->impl->registerObject(bl_object, cfg, handle_out);
     return static_cast<sep::SEPResult>(static_cast<int32_t>(result));
 }
 

--- a/src/blender/blender_integration.cpp
+++ b/src/blender/blender_integration.cpp
@@ -9,6 +9,9 @@
 using ::sep::memory::MemoryTierEnum;
 namespace sep {
 namespace pattern {
+static bool isValidConfig(const sep::pattern::PatternConfig& c) {
+    return c.max_patterns > 0;
+}
 // Use the core SEPResult enum instead of the pattern-specific one
 // Constructor implementation - Initialize members in the correct order
 BlenderBridge::BlenderBridge() : gpu_context_(nullptr), thread_running_(false)

--- a/src/blender/bridge.h
+++ b/src/blender/bridge.h
@@ -25,12 +25,19 @@
 namespace sep {
 namespace pattern {
 
-    struct PatternLimits
-    {
-        static constexpr size_t MAX_PATTERNS = 10000;
-        static constexpr float MIN_COHERENCE_VALUE = 0.0f;
-        static constexpr float MAX_COHERENCE = 1.0f;
-    };
+struct PatternLimits
+{
+    static constexpr size_t MAX_PATTERNS = 10000;
+    static constexpr float MIN_COHERENCE_VALUE = 0.0f;
+    static constexpr float MAX_COHERENCE = 1.0f;
+};
+
+struct PatternConfig {
+    float update_threshold{0.0f};
+    bool enable_mutations{false};
+    int max_patterns{0};
+    int batch_size{0};
+};
 
 // Forward declarations
 class PatternObserver;

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -72,8 +72,13 @@ struct Pattern {
     glm::vec4 attributes{0.0f};
     std::complex<float> amplitude{0.0f};
     quantum::QuantumState quantum_state{};
+    float coherence{0.0f};
+    float stability{0.0f};
+    float entropy{0.0f};
+    int mutation_count{0};
     std::vector<quantum::PatternRelationship> relationships;
     std::vector<float> data;
+    std::vector<float> values;
     std::vector<std::string> parent_ids;
     uint64_t timestamp{0};
     uint64_t last_accessed{0};

--- a/src/quantum/evolution.cpp
+++ b/src/quantum/evolution.cpp
@@ -9,6 +9,11 @@
 #include <cstdint>
 #include <cmath>
 
+// Convenience comparator for mixed string types
+bool operator==(const std::string& lhs, const sep::shim::string& rhs) {
+    return lhs == rhs.c_str();
+}
+
 namespace {
 inline float deterministicNoise(uint64_t& state) {
     state = state * 1664525u + 1013904223u;
@@ -297,8 +302,8 @@ private:
 
 EvolutionEngine::EvolutionEngine(Processor* processor) : impl_(std::make_unique<EvolutionEngineImpl>(processor)) {}
 
-BatchProcessingResult EvolutionEngine::evolve(const EvolutionParams& params) { return impl_->evolve(params); }
-BatchProcessingResult EvolutionEngine::evolveGeneration() { return impl_->evolveGeneration(); }
+sep::quantum::BatchProcessingResult EvolutionEngine::evolve(const EvolutionParams& params) { return impl_->evolve(params); }
+sep::quantum::BatchProcessingResult EvolutionEngine::evolveGeneration() { return impl_->evolveGeneration(); }
 Pattern EvolutionEngine::crossover(const Pattern& parent1, const Pattern& parent2) { return impl_->crossover(parent1, parent2); }
 Pattern EvolutionEngine::mutate(const Pattern& pattern) { return impl_->mutate(pattern); }
 std::vector<std::string> EvolutionEngine::selectElite(size_t count) { return impl_->selectElite(count); }

--- a/src/quantum/evolution.h
+++ b/src/quantum/evolution.h
@@ -8,6 +8,11 @@
 
 namespace sep::quantum {
 
+struct BatchProcessingResult {
+    bool success{};
+    std::string message{};
+};
+
 class Processor;
 
 class EvolutionEngine {
@@ -32,8 +37,8 @@ public:
 
     explicit EvolutionEngine(Processor* processor);
 
-    BatchProcessingResult evolve(const EvolutionParams& params);
-    BatchProcessingResult evolveGeneration();
+    sep::quantum::BatchProcessingResult evolve(const EvolutionParams& params);
+    sep::quantum::BatchProcessingResult evolveGeneration();
 
     Pattern crossover(const Pattern& parent1, const Pattern& parent2);
     Pattern mutate(const Pattern& pattern);

--- a/src/workbench/demos/genesis_pattern.hpp
+++ b/src/workbench/demos/genesis_pattern.hpp
@@ -48,7 +48,6 @@ private:
     sep::CyclesRenderer* renderer_{nullptr};
 
     sep::Engine* engine_{nullptr};
-    sep::CyclesRenderer* renderer_{nullptr};
 
     bool auto_evolve_{true};
     float evolution_rate_{0.1f};

--- a/src/workbench/renderer.cpp
+++ b/src/workbench/renderer.cpp
@@ -236,7 +236,7 @@ void sep::workbench::Renderer::render(const std::vector<sep::workbench::Pattern>
                 float s = 1.0f;
                 glm::vec4 c(1.0f);
                 glUniform4f(colorLoc, c.r, c.g, c.b, c.a);
-                if (p.quantum_state.memory_tier == 0)
+                if (p.quantum_state.memory_tier == sep::memory::MemoryTierEnum::SHORT_TERM)
                     renderSphere(8, 8, pos, s, c);
                 else
                     renderCube(pos, s, c);
@@ -252,7 +252,6 @@ void sep::workbench::Renderer::render(const std::vector<sep::workbench::Pattern>
     }
 }
 // Helper method to render a sphere
-}
 void sep::workbench::Renderer::renderSphere(int latitudes, int longitudes, const glm::vec3& pos,
                                             float scale, const glm::vec4& color)
 {


### PR DESCRIPTION
## Summary
- add missing BatchProcessingResult struct and use it in evolution engine
- patch genesis demo header
- adjust memory tier checks and cleanup in renderer
- define OllamaConfig and PatternConfig structures
- expose additional fields on Pattern and fix API functions
- implement basic config validation and helper operator

## Testing
- `npm test --silent` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687280f5ac40832a92739cfc161b545d