### PR TITLE
Fix config manager and pattern structures

### DIFF
--- a/src/api/client.h
+++ b/src/api/client.h
@@ -20,8 +20,8 @@
 namespace sep {
 namespace config {
 struct OllamaConfig {
-    std::string host;
-    int port;
+    std::string host{"localhost"};
+    int port{11434};
 };
 }
 namespace api {
@@ -125,14 +125,6 @@ namespace api {
 
 } // namespace api
 
-namespace config {
-
-struct OllamaConfig {
-    std::string host{"localhost"};
-    int port{11434};
-};
-
-} // namespace config
 namespace ollama {
 
         class OllamaClient

--- a/src/core/config_manager_stub.cpp
+++ b/src/core/config_manager_stub.cpp
@@ -1,4 +1,5 @@
 #include "core/manager.h"
+#include "core/types.h"
 
 namespace sep::config {
 

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -124,38 +124,6 @@ namespace sep
     }
     // Note: The original sep::Pattern is now sep::Pattern
 
-// This is the SINGLE canonical definition of a Pattern.
-struct Pattern {
-    shim::string id;
-    int generation{0};
-    glm::vec4 position{0.0f};
-    glm::vec4 velocity{0.0f};
-    glm::vec4 attributes{0.0f};
-    std::complex<float> amplitude{0.0f};
-    std::vector<float> values;
-    float coherence{0.0f};
-    float stability{0.0f};
-    float entropy{0.0f};
-    int mutation_count{0};
-    quantum::QuantumState quantum_state{};
-    float coherence{0.0f};
-    float stability{0.0f};
-    float entropy{0.0f};
-    int mutation_count{0};
-    std::vector<quantum::PatternRelationship> relationships;
-    std::vector<float> data;
-    std::vector<float> values;
-    std::vector<std::string> parent_ids;
-    uint64_t timestamp{0};
-    uint64_t last_accessed{0};
-    uint64_t last_modified{0};
-    glm::vec3 momentum{0.0f};
-    float coherence{0.0f};
-    float stability{0.0f};
-    float entropy{0.0f};
-    int mutation_count{0};
-};
-
         struct CudaConfig
         {
             bool use_gpu{true};

--- a/src/memory/types.h
+++ b/src/memory/types.h
@@ -7,6 +7,11 @@
 #include <vector>
 
 namespace sep {
+
+namespace persistence {
+    class IRedisManager;
+}
+
 namespace memory {
 
     // Memory tier types that are used across multiple modules
@@ -22,11 +27,7 @@ namespace memory {
         UNIFIED = 102  // Unified memory (accessible by both CPU and GPU)
     };
 
-    // Forward declarations
-    namespace persistence
-    {
-        class IRedisManager;
-}
+
 
 // Convert MemoryTierEnum to string representation
 inline std::string memoryTierToString(MemoryTierEnum tier) {


### PR DESCRIPTION
## Summary
- remove duplicate Pattern structure
- adjust OllamaConfig defaults and remove redefinition
- include types header in config_manager_stub
- move IRedisManager forward declaration to sep::persistence

## Testing
- `cmake ..` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6872b5fc1878832aa372ea1a32ec4565