### PR TITLE
Fix configuration includes and namespace

### DIFF
--- a/src/api/client.h
+++ b/src/api/client.h
@@ -20,8 +20,8 @@
 namespace sep {
 namespace config {
 struct OllamaConfig {
-    std::string host;
-    int port;
+    std::string host{"localhost"};
+    int port{11434};
 };
 }
 namespace api {
@@ -125,14 +125,6 @@ namespace api {
 
 } // namespace api
 
-namespace config {
-
-struct OllamaConfig {
-    std::string host{"localhost"};
-    int port{11434};
-};
-
-} // namespace config
 namespace ollama {
 
         class OllamaClient

--- a/src/api_main.cpp
+++ b/src/api_main.cpp
@@ -12,12 +12,12 @@ int main(int argc, char** argv)
     const auto& apiConfig = configMgr.getAPIConfig();
 
     // Create minimal renderer implementation
-    std::unique_ptr<blender::ccl::CyclesRenderer> renderer = sep::createRenderer();
+    std::unique_ptr<sep::blender::ccl::CyclesRenderer> renderer = sep::createRenderer();
     if (renderer) {
         renderer->initialize();
     }
 
-    sep::api::SEPApiServer server(apiConfig, static_cast<blender::ccl::CyclesRenderer*>(renderer.get()));
+    sep::api::SEPApiServer server(apiConfig, static_cast<sep::blender::ccl::CyclesRenderer*>(renderer.get()));
     if (!server.run()) {
         std::cerr << "Failed to start API server" << std::endl;
         return 1;

--- a/src/core/config_manager_stub.cpp
+++ b/src/core/config_manager_stub.cpp
@@ -1,4 +1,6 @@
 #include "core/manager.h"
+#include "core/types.h"
+#include "core/config.h"
 
 namespace sep::config {
 

--- a/src/core/manager.cpp
+++ b/src/core/manager.cpp
@@ -1,4 +1,5 @@
 #include "core/manager.h"
+#include "core/config.h"
 
 #include <fstream>
 #include <nlohmann/json.hpp>
@@ -34,7 +35,16 @@ namespace sep::config
         static SystemConfig cfg{};
         return cfg;
     }
-    void ConfigManager::setConfig(const SystemConfig&) {}
+    void ConfigManager::setConfig(const SystemConfig& cfg)
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        impl_->mem_cfg = cfg.memory;
+#if SEP_BUILD_QUANTUM
+        impl_->quantum_cfg = cfg.quantum;
+#else
+        (void)cfg;
+#endif
+    }
     bool ConfigManager::loadFromFile(const sep::shim::string& filename)
     {
         try

--- a/src/memory/memory_tier_manager_serialization.cpp
+++ b/src/memory/memory_tier_manager_serialization.cpp
@@ -1,4 +1,5 @@
 #include "memory/memory_tier_manager.hpp"
+#include "persistence/persistent_pattern_data.hpp"
 #include <nlohmann/json.hpp>
 
 namespace sep {

--- a/src/memory/types.h
+++ b/src/memory/types.h
@@ -7,6 +7,10 @@
 #include <vector>
 
 namespace sep {
+namespace persistence {
+class IRedisManager;
+} // namespace persistence
+
 namespace memory {
 
     // Memory tier types that are used across multiple modules
@@ -22,11 +26,7 @@ namespace memory {
         UNIFIED = 102  // Unified memory (accessible by both CPU and GPU)
     };
 
-    // Forward declarations
-    namespace persistence
-    {
-        class IRedisManager;
-}
+    // Forward declaration moved to global sep::persistence namespace
 
 // Convert MemoryTierEnum to string representation
 inline std::string memoryTierToString(MemoryTierEnum tier) {


### PR DESCRIPTION
## Summary
- clean up `OllamaConfig` duplication in `client.h`
- ensure persistence forward declarations in `types.h`
- add missing config headers and implement `setConfig`
- include persistent pattern data in serialization
- update renderer namespace use in `api_main`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872b5fc1878832aa372ea1a32ec4565