### PR TITLE
Fix build warnings in imgui and API

### DIFF
--- a/src/api/types.h
+++ b/src/api/types.h
@@ -132,9 +132,23 @@ struct RateLimitConfig {
     bool enabled = true;
 };
 
+struct CORSConfig {
+    bool enabled{false};
+    std::vector<std::string> tokens{};
+};
+
+struct ResponseModulationConfig {
+    bool enabled{false};
+};
+
 struct AuthConfig {
     bool enabled = false;
     std::vector<std::string> tokens;
+    ollama::OllamaConfig ollama;
+    uint16_t port{8080};
+    std::string log_level{"info"};
+    CORSConfig cors;
+    ResponseModulationConfig response_modulation;
 };
 
 } // namespace sep::api

--- a/src/core/config.h
+++ b/src/core/config.h
@@ -23,5 +23,12 @@ constexpr size_t DEFAULT_MEMORY_POOL_SIZE = 1024 * 1024 * 1024;  // 1GB
 constexpr size_t MIN_ALLOCATION_SIZE = 256;                       // 256B
 constexpr size_t MAX_ALLOCATION_SIZE = 1024 * 1024 * 1024;       // 1GB
 
+struct APIConfig {
+    uint16_t port{8080};
+    uint32_t threads{4};
+    std::string log_level{"info"};
+    bool enable_metrics{true};
+};
+
 }  // namespace config
 }  // namespace sep

--- a/src/core/manager.cpp
+++ b/src/core/manager.cpp
@@ -15,6 +15,7 @@ namespace sep::config
 #if SEP_BUILD_QUANTUM
         QuantumThresholdConfig quantum_cfg{};
 #endif
+        APIConfig api_cfg{};
         bool loaded{false};
     };
 
@@ -78,8 +79,8 @@ namespace sep::config
     bool ConfigManager::loadFromCommandLine(int, char**) { return false; }
     const APIConfig& ConfigManager::getAPIConfig() const
     {
-        static APIConfig cfg{};
-        return cfg;
+        std::lock_guard<std::mutex> lock(mutex_);
+        return impl_->api_cfg;
     }
     const CudaConfig& ConfigManager::getCudaConfig() const
     {
@@ -101,7 +102,11 @@ namespace sep::config
         return cfg;
 #endif
     }
-    void ConfigManager::updateAPIConfig(const APIConfig&) {}
+    void ConfigManager::updateAPIConfig(const APIConfig& cfg)
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        impl_->api_cfg = cfg;
+    }
     void ConfigManager::updateCudaConfig(const CudaConfig&) {}
     void ConfigManager::updateLogConfig(const LogConfig&) {}
     void ConfigManager::updateMemoryConfig(const MemoryThresholdConfig& cfg)

--- a/src/memory/memory_tier.hpp
+++ b/src/memory/memory_tier.hpp
@@ -101,6 +101,8 @@ public:
     float promote_mtm_to_ltm{0.9f};
     float demote_threshold{0.3f};
     bool enable_compression{false};
+    uint32_t stm_to_mtm_min_gen{};
+    uint32_t mtm_to_ltm_min_gen{};
   };
 
   explicit MemoryTier(const Config &config);

--- a/src/workbench/demos/audio_visualizer.hpp
+++ b/src/workbench/demos/audio_visualizer.hpp
@@ -27,6 +27,8 @@ public:
     void on_mouse(int x, int y, int button);
 
 private:
+    sep::Engine* engine_{nullptr};
+    sep::CyclesRenderer* renderer_{nullptr};
     std::unique_ptr<audio::AudioCapture> capture_;
     std::unique_ptr<audio::AudioPipeline> pipeline_;
     std::vector<glm::vec3> latest_patterns_;

--- a/third_party/imgui/imgui_demo.cpp
+++ b/third_party/imgui/imgui_demo.cpp
@@ -5101,6 +5101,8 @@ static void DemoWindowLayout()
             const char* text_str = "Line 1 hello\nLine 2 clip me!";
             const ImVec2 text_pos = ImVec2(p0.x + offset.x, p0.y + offset.y);
             ImDrawList* draw_list = ImGui::GetWindowDrawList();
+            ImVec4 clip_rect{p0.x, p0.y, p1.x, p1.y}; // AddText() takes a ImVec4* here so let's convert.
+
             switch (n)
             {
             case 0:
@@ -5116,7 +5118,6 @@ static void DemoWindowLayout()
                 draw_list->PopClipRect();
                 break;
             case 2:
-                ImVec4 clip_rect{p0.x, p0.y, p1.x, p1.y}; // AddText() takes a ImVec4* here so let's convert.
                 draw_list->AddRectFilled(p0, p1, IM_COL32(90, 90, 120, 255));
                 draw_list->AddText(ImGui::GetFont(), ImGui::GetFontSize(), text_pos, IM_COL32_WHITE, text_str, NULL, 0.0f, &clip_rect);
                 break;

--- a/third_party/imgui/imgui_draw.cpp
+++ b/third_party/imgui/imgui_draw.cpp
@@ -3769,7 +3769,7 @@ void ImFontAtlasBakedDiscardFontGlyph(ImFontAtlas* atlas, ImFont* font, ImFontBa
 ImFontBaked* ImFontAtlasBakedAdd(ImFontAtlas* atlas, ImFont* font, float font_size, float font_rasterizer_density, ImGuiID baked_id)
 {
     IMGUI_DEBUG_LOG_FONT("[font] Created baked %.2fpx\n", font_size);
-    ImFontBaked* baked = atlas->Builder->BakedPool.push_back(ImFontBaked());
+    ImFontBaked* baked = atlas->Builder->BakedPool.push_back(ImFontBaked{});
     baked->Size = font_size;
     baked->RasterizerDensity = font_rasterizer_density;
     baked->BakedId = baked_id;


### PR DESCRIPTION
## Summary
- fix clip_rect init in imgui_demo
- ensure stable vector push_back with brace init
- store engine/renderer pointers in AudioVisualizerDemo
- extend MemoryTier config fields
- add APIConfig and updated AuthConfig
- implement ConfigManager APIConfig getters

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872d59fef28832aa14e18d5dabc9ec1