### PR TITLE
Fix sample build errors

### DIFF
--- a/src/memory/memory_tier.hpp
+++ b/src/memory/memory_tier.hpp
@@ -100,6 +100,8 @@ public:
     float promote_stm_to_mtm{0.7f};
     float promote_mtm_to_ltm{0.9f};
     float demote_threshold{0.3f};
+    uint32_t stm_to_mtm_min_gen{};
+    uint32_t mtm_to_ltm_min_gen{};
     bool enable_compression{false};
   };
 

--- a/src/quantum/evolution.cpp
+++ b/src/quantum/evolution.cpp
@@ -469,22 +469,6 @@ inline float deterministicNoise(uint64_t& state)
             return 1.0f - std::abs(complexity - 0.5f) * 2.0f;
         }
 
-sep::quantum::BatchProcessingResult EvolutionEngine::evolve(const EvolutionParams& params) { return impl_->evolve(params); }
-sep::quantum::BatchProcessingResult EvolutionEngine::evolveGeneration() { return impl_->evolveGeneration(); }
-Pattern EvolutionEngine::crossover(const Pattern& parent1, const Pattern& parent2) { return impl_->crossover(parent1, parent2); }
-Pattern EvolutionEngine::mutate(const Pattern& pattern) { return impl_->mutate(pattern); }
-std::vector<std::string> EvolutionEngine::selectElite(size_t count) { return impl_->selectElite(count); }
-std::vector<std::string> EvolutionEngine::tournamentSelection(size_t tournament_size, size_t num_winners) {
-    return impl_->tournamentSelection(tournament_size, num_winners);
-}
-std::vector<std::string> EvolutionEngine::rouletteWheelSelection(size_t count) { return impl_->rouletteWheelSelection(count); }
-float EvolutionEngine::calculateFitness(const Pattern& pattern) const { return impl_->calculateFitness(pattern); }
-float EvolutionEngine::calculateDiversity(const std::vector<Pattern>& patterns) const { return impl_->calculateDiversity(patterns); }
-void EvolutionEngine::setParams(const EvolutionParams& params) { impl_->setParams(params); }
-EvolutionEngine::EvolutionParams EvolutionEngine::getParams() const { return impl_->getParams(); }
-EvolutionEngine::EvolutionStats EvolutionEngine::getStats() const { return impl_->getStats(); }
-std::vector<EvolutionEngine::EvolutionStats> EvolutionEngine::getHistory() const { return impl_->getHistory(); }
-
         void applySpike(Pattern& neuron, float input, float decay, float threshold)
         {
             float& c = neuron.quantum_state.coherence;

--- a/src/quantum/evolution.h
+++ b/src/quantum/evolution.h
@@ -10,7 +10,9 @@ namespace sep::quantum {
 
 struct BatchProcessingResult {
     bool success{false};
+    Pattern pattern{};
     std::string message{};
+    std::string error_message{};
 };
 
 class Processor;

--- a/src/workbench/demos/audio_visualizer.hpp
+++ b/src/workbench/demos/audio_visualizer.hpp
@@ -31,6 +31,8 @@ private:
     std::unique_ptr<audio::AudioPipeline> pipeline_;
     std::vector<glm::vec3> latest_patterns_;
     std::vector<glm::vec3> latest_visual_patterns_;
+    sep::Engine* engine_{nullptr};
+    sep::CyclesRenderer* renderer_{nullptr};
 
     struct {
         float frequency_scale{0.5f};

--- a/third_party/imgui/imgui_demo.cpp
+++ b/third_party/imgui/imgui_demo.cpp
@@ -5101,6 +5101,7 @@ static void DemoWindowLayout()
             const char* text_str = "Line 1 hello\nLine 2 clip me!";
             const ImVec2 text_pos = ImVec2(p0.x + offset.x, p0.y + offset.y);
             ImDrawList* draw_list = ImGui::GetWindowDrawList();
+            ImVec4 clip_rect{p0.x, p0.y, p1.x, p1.y};
             switch (n)
             {
             case 0:
@@ -5116,7 +5117,7 @@ static void DemoWindowLayout()
                 draw_list->PopClipRect();
                 break;
             case 2:
-                ImVec4 clip_rect{p0.x, p0.y, p1.x, p1.y}; // AddText() takes a ImVec4* here so let's convert.
+                // AddText() takes a ImVec4* here so let's convert.
                 draw_list->AddRectFilled(p0, p1, IM_COL32(90, 90, 120, 255));
                 draw_list->AddText(ImGui::GetFont(), ImGui::GetFontSize(), text_pos, IM_COL32_WHITE, text_str, NULL, 0.0f, &clip_rect);
                 break;

--- a/third_party/imgui/imgui_draw.cpp
+++ b/third_party/imgui/imgui_draw.cpp
@@ -3769,7 +3769,7 @@ void ImFontAtlasBakedDiscardFontGlyph(ImFontAtlas* atlas, ImFont* font, ImFontBa
 ImFontBaked* ImFontAtlasBakedAdd(ImFontAtlas* atlas, ImFont* font, float font_size, float font_rasterizer_density, ImGuiID baked_id)
 {
     IMGUI_DEBUG_LOG_FONT("[font] Created baked %.2fpx\n", font_size);
-    ImFontBaked* baked = atlas->Builder->BakedPool.push_back(ImFontBaked());
+    ImFontBaked* baked = atlas->Builder->BakedPool.push_back(ImFontBaked{});
     baked->Size = font_size;
     baked->RasterizerDensity = font_rasterizer_density;
     baked->BakedId = baked_id;


### PR DESCRIPTION
## Summary
- fix uninitialized variable error in imgui demo
- default construct baked font objects
- expand quantum BatchProcessingResult
- remove duplicate functions from evolution implementation
- extend AudioVisualizerDemo with engine and renderer pointers
- expose min generation settings in MemoryTier::Config

## Testing
- `cmake -S . -B build` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6872d59fef28832aa14e18d5dabc9ec1