### PR TITLE
Remove duplicate engine_

### DIFF
--- a/src/workbench/demos/genesis_pattern.hpp
+++ b/src/workbench/demos/genesis_pattern.hpp
@@ -50,7 +50,5 @@ namespace sep
 
             sep::Engine* engine_{nullptr};
 
-    sep::Engine* engine_{nullptr};
-
     }  // namespace workbench
 }  // namespace sep


### PR DESCRIPTION
## Summary
- remove extra `engine_` field from `GenesisPatternDemo`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6872dcb871e0832a858bcc62a5073939