### PR TITLE
Fix APIConfig accessor and update renderer types

### DIFF
--- a/src/api/server.cpp
+++ b/src/api/server.cpp
@@ -40,7 +40,7 @@ namespace sep::api {
 
 // Static instance for signal handling
 SEPApiServer* SEPApiServer::instance_ = nullptr;
-SEPApiServer::SEPApiServer(const AuthConfig& config, blender::ccl::CyclesRenderer* renderer)
+SEPApiServer::SEPApiServer(const AuthConfig& config, sep::blender::ccl::CyclesRenderer* renderer)
     : config_(config),
       logger_(nullptr),
       app_(nullptr),

--- a/src/api/server.h
+++ b/src/api/server.h
@@ -64,7 +64,7 @@ class SEPApiServer : public Server {
    * @param config The API configuration
    * @param renderer Cycles renderer
    */
-     explicit SEPApiServer(const AuthConfig &config, blender::ccl::CyclesRenderer *renderer);
+    explicit SEPApiServer(const AuthConfig &config, sep::blender::ccl::CyclesRenderer *renderer);
 
      /**
       * @brief Destructor

--- a/src/api_main.cpp
+++ b/src/api_main.cpp
@@ -14,7 +14,7 @@ int main(int argc, char** argv)
     // Create minimal renderer implementation
     std::unique_ptr<sep::blender::ccl::CyclesRenderer> renderer = sep::createRenderer();
     if (renderer) {
-        renderer->initialize();
+        renderer.get()->initialize();
     }
 
     sep::api::SEPApiServer server(apiConfig, renderer.get());

--- a/src/core/manager.h
+++ b/src/core/manager.h
@@ -3,6 +3,7 @@
 
 #include "memory/memory_tier_manager.hpp"
 #include "core/types.h"
+#include "core/config.h"
 #include <memory>
 #include <mutex>
 #include <string>
@@ -30,6 +31,9 @@ public:
   bool loadFromFile(const sep::shim::string &filename);
   bool loadFromEnvironment();
   bool loadFromCommandLine(int argc, char *argv[]);
+
+  // Access individual config sections
+  const APIConfig &getAPIConfig() const;
 
   void updateCudaConfig(const workbench::CudaConfig &config);
   void updateLogConfig(const workbench::LogConfig &config);


### PR DESCRIPTION
## Summary
- expose `getAPIConfig()` in `ConfigManager`
- fix renderer pointer namespace in `SEPApiServer`
- call `initialize()` via raw pointer in `api_main.cpp`

## Testing
- `cmake -S . -B build` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6872dc78bb14832aa46af100540d4469