### PR TITLE
Add memory threshold struct and const serialization

### DIFF
--- a/src/memory/memory_tier_manager_serialization.hpp
+++ b/src/memory/memory_tier_manager_serialization.hpp
@@ -7,6 +7,20 @@
 namespace sep {
 namespace config {
 
+struct MemoryThresholdConfig {
+    uint32_t stm_size;
+    uint32_t mtm_size;
+    uint32_t ltm_size;
+    float promote_stm_to_mtm;
+    float promote_mtm_to_ltm;
+    float demote_threshold;
+    float fragmentation_threshold;
+    bool use_unified_memory;
+    bool enable_compression;
+    uint32_t stm_to_mtm_min_gen;
+    uint32_t mtm_to_ltm_min_gen;
+};
+
 inline void to_json(nlohmann::json& j, const MemoryThresholdConfig& c) {
     j = nlohmann::json{
         {"stm_size", c.stm_size},
@@ -23,18 +37,19 @@ inline void to_json(nlohmann::json& j, const MemoryThresholdConfig& c) {
     };
 }
 
-inline void from_json(const nlohmann::json& j, MemoryThresholdConfig& c) {
-    c.stm_size = j.value("stm_size", static_cast<std::size_t>(1 << 20));
-    c.mtm_size = j.value("mtm_size", static_cast<std::size_t>(4 << 20));
-    c.ltm_size = j.value("ltm_size", static_cast<std::size_t>(16 << 20));
-    c.promote_stm_to_mtm = j.value("promote_stm_to_mtm", 0.7f);
-    c.promote_mtm_to_ltm = j.value("promote_mtm_to_ltm", 0.9f);
-    c.demote_threshold = j.value("demote_threshold", 0.3f);
-    c.fragmentation_threshold = j.value("fragmentation_threshold", 0.3f);
-    c.use_unified_memory = j.value("use_unified_memory", true);
-    c.enable_compression = j.value("enable_compression", true);
-    c.stm_to_mtm_min_gen = j.value("stm_to_mtm_min_gen", 5u);
-    c.mtm_to_ltm_min_gen = j.value("mtm_to_ltm_min_gen", 100u);
+inline void from_json(const nlohmann::json& j, const MemoryThresholdConfig& c) {
+    auto& cfg = const_cast<MemoryThresholdConfig&>(c);
+    cfg.stm_size = j.value("stm_size", static_cast<uint32_t>(1 << 20));
+    cfg.mtm_size = j.value("mtm_size", static_cast<uint32_t>(4 << 20));
+    cfg.ltm_size = j.value("ltm_size", static_cast<uint32_t>(16 << 20));
+    cfg.promote_stm_to_mtm = j.value("promote_stm_to_mtm", 0.7f);
+    cfg.promote_mtm_to_ltm = j.value("promote_mtm_to_ltm", 0.9f);
+    cfg.demote_threshold = j.value("demote_threshold", 0.3f);
+    cfg.fragmentation_threshold = j.value("fragmentation_threshold", 0.3f);
+    cfg.use_unified_memory = j.value("use_unified_memory", true);
+    cfg.enable_compression = j.value("enable_compression", true);
+    cfg.stm_to_mtm_min_gen = j.value("stm_to_mtm_min_gen", 5u);
+    cfg.mtm_to_ltm_min_gen = j.value("mtm_to_ltm_min_gen", 100u);
 }
 
 } // namespace config


### PR DESCRIPTION
## Summary
- define `MemoryThresholdConfig` in `memory_tier_manager_serialization.hpp`
- serialize the new struct
- make `from_json` accept a const reference and populate via `const_cast`

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872dc86e580832a8c66d1bda69e42f3