### PR TITLE
Remove unused engine_ member in CosmoSim

### DIFF
--- a/src/workbench/demos/cosmo_sim.hpp
+++ b/src/workbench/demos/cosmo_sim.hpp
@@ -35,7 +35,6 @@ private:
     float learning_rate_{0.05f};
     float connection_prob_{0.2f};
 
-    sep::Engine* engine_{nullptr};
     sep::CyclesRenderer* renderer_{nullptr};
 
     void initBodies();


### PR DESCRIPTION
## Summary
- clean up `CosmoSim` by dropping the unused `engine_` pointer

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6872dcb3c040832a85a91cb7a93ff6dd