### PR TITLE
Fix demo registration namespace

### DIFF
--- a/src/workbench/demos/register_demos.cpp
+++ b/src/workbench/demos/register_demos.cpp
@@ -10,50 +10,37 @@
 #include "workbench/demos/memory_garden.hpp"
 #include "workbench/demos/neural_demo.hpp"
 
-namespace sep
+namespace sep::workbench
 {
-    namespace workbench
+    void registerDemos()
     {
-        void registerDemos()
-        {
-            auto& manager = DemoManager::getInstance();
-            
-            // Register all available demos with their factory functions
-            manager.registerDemo(
-                "genesis",
-                [] { return std::make_unique<sep::workbench::GenesisPatternDemo>(); });
-            
-            manager.registerDemo(
-                "neural",
-                [] { return std::make_unique<sep::workbench::NeuralDemo>(); });
-            
-            manager.registerDemo(
-                "memory",
-                [] { return std::make_unique<sep::workbench::MemoryGardenDemo>(); });
-            
-            manager.registerDemo(
-                "flocking",
-                [] { return std::make_unique<sep::workbench::FlockingDemo>(); });
-            
-            manager.registerDemo(
-                "cosmo",
-                [] { return std::make_unique<sep::workbench::CosmoDemo>(); });
-            
-            manager.registerDemo(
-                "cosmo_sim",
-                [] { return std::make_unique<sep::workbench::CosmoSim>(); });
-            
-            manager.registerDemo(
-                "physics",
-                [] { return std::make_unique<sep::workbench::DigitalPhysicsDemo>(); });
-            
-            manager.registerDemo(
-                "drug",
-                [] { return std::make_unique<sep::workbench::DrugDiscoveryDemo>(); });
-            
-            manager.registerDemo(
-                "audio",
-                [] { return std::make_unique<sep::workbench::AudioVisualizerDemo>(); });
-        }
-    }  // namespace workbench
-}  // namespace sep
+        auto& manager = DemoManager::getInstance();
+
+        // Register all available demos with their factory functions
+        manager.registerDemo("genesis",
+                             [] { return std::make_unique<sep::workbench::GenesisPatternDemo>(); });
+
+        manager.registerDemo("neural",
+                             [] { return std::make_unique<sep::workbench::NeuralDemo>(); });
+
+        manager.registerDemo("memory",
+                             [] { return std::make_unique<sep::workbench::MemoryGardenDemo>(); });
+
+        manager.registerDemo("flocking",
+                             [] { return std::make_unique<sep::workbench::FlockingDemo>(); });
+
+        manager.registerDemo("cosmo", [] { return std::make_unique<sep::workbench::CosmoDemo>(); });
+
+        manager.registerDemo("cosmo_sim",
+                             [] { return std::make_unique<sep::workbench::CosmoSim>(); });
+
+        manager.registerDemo("physics",
+                             [] { return std::make_unique<sep::workbench::DigitalPhysicsDemo>(); });
+
+        manager.registerDemo("drug",
+                             [] { return std::make_unique<sep::workbench::DrugDiscoveryDemo>(); });
+
+        manager.registerDemo(
+            "audio", [] { return std::make_unique<sep::workbench::AudioVisualizerDemo>(); });
+    }
+}  // namespace sep::workbench


### PR DESCRIPTION
## Summary
- qualify workbench demos with `sep::workbench`
- clean up namespace scope in register_demos

## Testing
- `clang-format -i src/workbench/demos/register_demos.cpp`

------
https://chatgpt.com/codex/tasks/task_e_6872dc8bdf3c832a858b4ef73eeee2dc