### PR TITLE
Add Ollama config to AuthConfig

### DIFF
--- a/src/api/types.h
+++ b/src/api/types.h
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <vector>
 #include <nlohmann/json.hpp>
+#include "api/ollama_types.h"
 
 namespace sep::api {
 
@@ -144,6 +145,7 @@ struct ResponseModulationConfig {
 struct AuthConfig {
     bool enabled = false;
     std::vector<std::string> tokens;
+    ollama::OllamaConfig ollama;
     uint16_t port{8080};
     std::string log_level{"info"};
     CORSConfig cors;


### PR DESCRIPTION
## Summary
- extend `AuthConfig` to include `ollama::OllamaConfig`
- include `api/ollama_types.h` for the new type

## Testing
- `cmake -S . -B build` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6872dc92bdac832aaa1606da170c8bd4