### PR TITLE
Add APIConfig struct and init method

### DIFF
--- a/src/core/config.h
+++ b/src/core/config.h
@@ -24,6 +24,7 @@ constexpr size_t MIN_ALLOCATION_SIZE = 256;                       // 256B
 constexpr size_t MAX_ALLOCATION_SIZE = 1024 * 1024 * 1024;       // 1GB
 
 struct APIConfig {
+    /* members */
     uint16_t port{8080};
     uint32_t threads{4};
     std::string log_level{"info"};

--- a/src/core/engine.cpp
+++ b/src/core/engine.cpp
@@ -40,6 +40,7 @@
 #include "compat/stream.h"
 #include "core/common.h"  // defines sep::SEPResult
 #include "core/engine.h"
+#include "core/config.h"
 #include "core/error_handler.h"
 #include "core/logging.h"  // This is actually the logging manager
 #include "core/types.h"

--- a/src/core/engine.h
+++ b/src/core/engine.h
@@ -10,6 +10,7 @@
 #include "core/common.h"
 
 #include "core/types.h"
+#include "core/config.h"
 #include "blender/types.h"  // SEPBlenderBridge definition
 #include "compat/types.h"  // for QSHResult
 #include "quantum/qbsa.h"
@@ -40,6 +41,8 @@ class Engine {
  public:
   Engine() noexcept(false);
   ~Engine();
+
+  bool init(const ::sep::config::APIConfig &config);
 
   // Delete copy operations
   Engine(const Engine &) = delete;


### PR DESCRIPTION
## Summary
- add placeholder comment inside `APIConfig`
- declare `Engine::init` and include config header
- include config header in engine implementation

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872dc9763ac832aa75d1a47dc869363