### PR TITLE
Fix APIConfig include in sep_engine.cpp

### DIFF
--- a/src/api/sep_engine.cpp
+++ b/src/api/sep_engine.cpp
@@ -26,6 +26,7 @@
 #include "compat/math_common.h"  // Include math common for sqrt_safe
 #include "compat/types.h"
 #include "core/logging.h"  // Include logging header first
+#include "core/config.h"   // For sep::config::APIConfig
 #include "memory/memory_tier_manager.hpp"
 #include "quantum/quantum_processor.h"
 #include "core/types.h"  // For quantum::Pattern::generation


### PR DESCRIPTION
## Summary
- include `core/config.h` for `sep::config::APIConfig`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6872dc9e43e4832aae0f12d34ce0b427