### PR TITLE
Fix CUDA config namespace

### DIFF
--- a/src/quantum/quantum_manifold_optimizer.cpp
+++ b/src/quantum/quantum_manifold_optimizer.cpp
@@ -44,7 +44,10 @@ QuantumManifoldOptimizer::optimize(const QuantumState& initial_state,
     float step = config_.step_size;
     float current_coherence = initial_coherence;
     
-    for (int iter = 0; iter < 100 && current_coherence < target.target_coherence; ++iter) {
+    for (int iter = 0; iter < 100; ++iter) {
+        if (current_coherence >= target.target_coherence) {
+            break;
+        }
         // Sample tangent space for descent directions
         auto tangent_vectors = sampleTangentSpace(position, 8);
         

--- a/src/quantum/quantum_manifold_optimizer.h
+++ b/src/quantum/quantum_manifold_optimizer.h
@@ -64,7 +64,7 @@ class QuantumManifoldOptimizer {
 public:
     struct Config {
         MemoryTierEnum tier{MemoryTierEnum::STM};
-        workbench::CudaConfig cuda;
+        sep::config::CudaConfig cuda;
         workbench::LogConfig log;
         workbench::AnalyticsConfig analytics;
         float base_resonance_frequency{0.42f};
@@ -147,7 +147,7 @@ struct SemanticConfig {
 
 struct ManifoldConfig {
     SemanticConfig semantic;
-    workbench::CudaConfig cuda;
+    sep::config::CudaConfig cuda;
     workbench::LogConfig log;
     workbench::AnalyticsConfig analytics;
 };
@@ -212,7 +212,7 @@ private:
 // 3. CUDA ACCELERATION WITH HIERARCHICAL PARALLELIZATION
 class CUDAQuantumKernel {
 public:
-    explicit CUDAQuantumKernel(const workbench::CudaConfig &config);
+    explicit CUDAQuantumKernel(const sep::config::CudaConfig &config);
     ~CUDAQuantumKernel();
 
   // Warp-level primitive operations
@@ -231,7 +231,7 @@ public:
 private:
     cudaStream_t stream_;
     cufftHandle fft_plan_;
-    workbench::CudaConfig config_;
+    sep::config::CudaConfig config_;
 
     void* d_workspace_;
     size_t workspace_size_;


### PR DESCRIPTION
## Summary
- switch CudaConfig references to `sep::config::`
- break out target check in gradient descent loop

## Testing
- `npm test` *(fails: jest not found)*
- `cmake -S . -B build` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6872dcaa3868832a82c0ca6112dea9a1