### PR TITLE
Add renderer pointer fields

### DIFF
--- a/src/workbench/demos/annealing_demo.hpp
+++ b/src/workbench/demos/annealing_demo.hpp
@@ -24,6 +24,7 @@ public:
     void on_mouse(int x, int y, int button);
 
 private:
+    sep::CyclesRenderer* renderer_{nullptr};
     struct Particle {
         glm::vec3 position{0.0f};
         glm::vec3 velocity{0.0f};

--- a/src/workbench/demos/annealing_sim.hpp
+++ b/src/workbench/demos/annealing_sim.hpp
@@ -26,6 +26,7 @@ public:
     void on_mouse(int x, int y, int button);
 
 private:
+    sep::CyclesRenderer* renderer_{nullptr};
     struct Particle {
         glm::vec3 position{0.0f};
         glm::vec3 velocity{0.0f};

--- a/src/workbench/demos/cosmo_sim.cpp
+++ b/src/workbench/demos/cosmo_sim.cpp
@@ -14,7 +14,8 @@ namespace sep
         void CosmoSim::on_load(sep::Engine* engine, sep::CyclesRenderer* renderer)
         {
             (void)engine;
-            (void)renderer;
+            engine_ = engine;
+            renderer_ = renderer;
             const auto& cfg = Config::getInstance().cosmo();
             box_size_ = cfg.box_size;
             time_step_ = cfg.time_step;

--- a/src/workbench/demos/drug_discovery_demo.cpp
+++ b/src/workbench/demos/drug_discovery_demo.cpp
@@ -12,7 +12,7 @@ namespace sep
         void DrugDiscoveryDemo::on_load(sep::Engine* engine, sep::CyclesRenderer* renderer)
         {
             (void)engine;
-            (void)renderer;
+            renderer_ = renderer;
             const auto& cfg = Config::getInstance().drug_discovery();
             iterations_ = cfg.optimizer.iterations;
             mutation_rate_ = cfg.optimizer.mutation_rate;

--- a/src/workbench/demos/drug_discovery_demo.hpp
+++ b/src/workbench/demos/drug_discovery_demo.hpp
@@ -41,6 +41,7 @@ private:
     float input_strength_{0.5f};
     float learning_rate_{0.05f};
     float connection_prob_{0.2f};
+    sep::CyclesRenderer* renderer_{nullptr};
 };
 
 } // namespace workbench

--- a/src/workbench/demos/flocking_demo.cpp
+++ b/src/workbench/demos/flocking_demo.cpp
@@ -13,7 +13,7 @@ namespace sep
         void FlockingDemo::on_load(sep::Engine* engine, sep::CyclesRenderer* renderer)
         {
             (void)engine;
-            (void)renderer;
+            renderer_ = renderer;
             const auto& cfg = Config::getInstance().flocking();
             std::size_t agent_count = cfg.agent_count;
             max_speed_ = cfg.max_speed;

--- a/src/workbench/demos/flocking_demo.hpp
+++ b/src/workbench/demos/flocking_demo.hpp
@@ -28,6 +28,7 @@ private:
     std::vector<pattern::PatternData> agents_;
     float max_speed_{2.0f};
     float neighbor_radius_{5.0f};
+    sep::CyclesRenderer* renderer_{nullptr};
 };
 
 } // namespace workbench

--- a/src/workbench/demos/neural_demo.cpp
+++ b/src/workbench/demos/neural_demo.cpp
@@ -12,7 +12,7 @@ namespace sep
         void NeuralDemo::on_load(sep::Engine* engine, sep::CyclesRenderer* renderer)
         {
             (void)engine;
-            (void)renderer;
+            renderer_ = renderer;
             const auto& cfg = Config::getInstance().neural_demo();
             int count = cfg.network.neuron_count;
             threshold_ = cfg.neuron.threshold;

--- a/src/workbench/demos/neural_demo.hpp
+++ b/src/workbench/demos/neural_demo.hpp
@@ -38,6 +38,7 @@ private:
     float input_strength_{0.5f};
     float learning_rate_{0.05f};
     float connection_prob_{0.2f};
+    sep::CyclesRenderer* renderer_{nullptr};
 };
 
 } // namespace workbench


### PR DESCRIPTION
## Summary
- add a `sep::CyclesRenderer* renderer_{nullptr}` member to several demo classes
- store the renderer pointer during `on_load` for affected demos

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872dcae25bc832aa1720c007dcb9fd2