### PR TITLE
Add renderer pointer in NeuroSimDemo

### DIFF
--- a/src/workbench/demos/neuro_sim.cpp
+++ b/src/workbench/demos/neuro_sim.cpp
@@ -22,7 +22,7 @@ namespace sep
         void NeuroSimDemo::on_load(sep::Engine* engine, sep::CyclesRenderer* renderer)
         {
             (void)engine;
-            (void)renderer;
+            renderer_ = renderer;
             const auto& cfg = sep::workbench::Config::getInstance().neural_demo();
             std::size_t neuron_count = cfg.network.neuron_count;
             threshold_ = cfg.neuron.threshold;

--- a/src/workbench/demos/neuro_sim.hpp
+++ b/src/workbench/demos/neuro_sim.hpp
@@ -54,6 +54,7 @@ namespace sep
             float input_strength_{0.5f};
             float learning_rate_{0.05f};
             float connection_prob_{0.2f};
+            sep::CyclesRenderer* renderer_{nullptr};
         };
 
     }  // namespace workbench


### PR DESCRIPTION
## Summary
- store a CyclesRenderer pointer inside `NeuroSimDemo`
- set `renderer_` during `on_load`

## Testing
- `npm test` *(fails: `jest` not found)*
- `ctest -C Release -VV`

------
https://chatgpt.com/codex/tasks/task_e_6872dcc62fc4832a933977d722000368