### PR TITLE
Fix renderer grid calc & memory enum

### DIFF
--- a/src/memory/types.h
+++ b/src/memory/types.h
@@ -19,6 +19,7 @@ namespace memory {
         // Logical memory tiers
         STM,
         SHORT_TERM = STM,
+        SHORT_TERM_MEMORY = SHORT_TERM,
         MTM,
         LTM,
         // Physical memory locations

--- a/src/workbench/renderer.cpp
+++ b/src/workbench/renderer.cpp
@@ -222,7 +222,7 @@ void sep::workbench::Renderer::render(const std::vector<sep::workbench::Pattern>
             glUseProgram(shaderProgram);
             glBindVertexArray(vao);
             float spacing = 1.5f;
-            int perRow = static_cast<int>(std::sqrt(patterns.size())) + 1;
+            int perRow = static_cast<int>(std::sqrt(patterns.size()));
             float startX = -((perRow - 1) * spacing) / 2.0f;
             float startZ = -((perRow - 1) * spacing) / 2.0f;
             for (size_t i = 0; i < patterns.size() && i < 100; ++i)
@@ -236,7 +236,8 @@ void sep::workbench::Renderer::render(const std::vector<sep::workbench::Pattern>
                 float s = 1.0f;
                 glm::vec4 c(1.0f);
                 glUniform4f(colorLoc, c.r, c.g, c.b, c.a);
-                if (p.quantum_state.memory_tier == sep::memory::MemoryTierEnum::SHORT_TERM)
+                if (p.quantum_state.memory_tier ==
+                    sep::memory::MemoryTierEnum::SHORT_TERM_MEMORY)
                     renderSphere(8, 8, pos, s, c);
                 else
                     renderCube(pos, s, c);


### PR DESCRIPTION
## Summary
- adjust grid layout calculation in renderer
- add alias `SHORT_TERM_MEMORY` to `MemoryTierEnum`
- use the new alias when rendering spheres for short term patterns

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872e31afafc832aacb676fd17cbde5f