### PR TITLE
Fix PersistentPatternData qualification

### DIFF
--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -580,7 +580,7 @@ MemoryTierManager &MemoryTierManager::getInstance()
 
         void MemoryTierManager::storeDataToPersistence(
             [[maybe_unused]] const void *data,
-            [[maybe_unused]] const ::sep::persistence::PersistentPatternData &metadata)
+            [[maybe_unused]] const sep::persistence::PersistentPatternData &metadata)
         {
             // TODO: Implement
         }

--- a/src/memory/memory_tier_manager.hpp
+++ b/src/memory/memory_tier_manager.hpp
@@ -39,6 +39,7 @@ class SystemHooks;
 namespace memory {
 
     using ::sep::memory::MemoryTierEnum;
+    using sep::persistence::PersistentPatternData;
 
     class MemoryTierManager
     {
@@ -101,7 +102,7 @@ namespace memory {
         void calculateRelationshipScores();
         void loadDataFromPersistence();
         void storeDataToPersistence(const void *data,
-                                    const ::sep::persistence::PersistentPatternData &metadata);
+                                    const sep::persistence::PersistentPatternData &metadata);
         void *findDataById(std::size_t id);
         const void *findDataById(std::size_t id) const;
         void registerGenericData(std::size_t id, const void *data);


### PR DESCRIPTION
## Summary
- qualify PersistentPatternData as `sep::persistence::PersistentPatternData`
- keep redis_manager.h including `<hiredis/hiredis.h>`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6872e31528d8832a94b32913a2d7f662