### PR TITLE
Fix CUDA config namespace

### DIFF
--- a/src/quantum/manifold_config.cpp
+++ b/src/quantum/manifold_config.cpp
@@ -22,7 +22,7 @@ namespace sep::quantum::manifold {
     .stability_threshold = 0.8f
 };
 
-::sep::workbench::CudaConfig cuda{
+::sep::config::CudaConfig cuda{
     .use_gpu = true,
     .max_memory_mb = 8192,
     .batch_size = 1024,

--- a/src/quantum/manifold_config.h
+++ b/src/quantum/manifold_config.h
@@ -6,7 +6,7 @@ namespace sep::quantum::manifold {
 // Default configuration values used across the engine.
 extern ::sep::workbench::MemoryThresholdConfig memory;
 extern ::sep::workbench::QuantumThresholdConfig quantum;
-extern ::sep::workbench::CudaConfig cuda;
+extern ::sep::config::CudaConfig cuda;
 extern ::sep::workbench::LogConfig api;
 }
 

--- a/src/quantum/pattern_processor_interface.cpp
+++ b/src/quantum/pattern_processor_interface.cpp
@@ -11,6 +11,7 @@
 
 // Define namespace alias for clarity
 namespace logging = sep::logging;
+namespace cfg = sep::config;  // for CudaConfig
 
 
 namespace sep::pattern {


### PR DESCRIPTION
## Summary
- add config namespace alias in `pattern_processor_interface.cpp`
- use `sep::config::CudaConfig` for manifold defaults

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6872e2ea90c4832aa1ed8eb9af8d10af