### PR TITLE
Adjust renderer usage in API and implement config reader

### DIFF
--- a/src/api/server.cpp
+++ b/src/api/server.cpp
@@ -40,7 +40,7 @@ namespace sep::api {
 
 // Static instance for signal handling
 SEPApiServer* SEPApiServer::instance_ = nullptr;
-SEPApiServer::SEPApiServer(const AuthConfig& config, sep::blender::ccl::CyclesRenderer* renderer)
+SEPApiServer::SEPApiServer(const AuthConfig& config, sep::CyclesRenderer* renderer)
     : config_(config),
       logger_(nullptr),
       app_(nullptr),

--- a/src/api/server.h
+++ b/src/api/server.h
@@ -29,6 +29,7 @@ namespace crow {
     class Crow;
 }  // namespace crow
 namespace sep {
+class CyclesRenderer;
 namespace blender { namespace ccl { class CyclesRenderer; } }
 }  // namespace sep
 namespace sep::api {
@@ -64,7 +65,7 @@ class SEPApiServer : public Server {
    * @param config The API configuration
    * @param renderer Cycles renderer
    */
-    explicit SEPApiServer(const AuthConfig &config, sep::blender::ccl::CyclesRenderer *renderer);
+    explicit SEPApiServer(const AuthConfig &config, sep::CyclesRenderer *renderer);
 
      /**
       * @brief Destructor
@@ -217,7 +218,7 @@ class SEPApiServer : public Server {
   // Clients
   std::unique_ptr<ollama::OllamaClient> ollama_client_;
 
-  sep::blender::ccl::CyclesRenderer* cycles_renderer_;
+  sep::CyclesRenderer* cycles_renderer_;
 };
 
 }  // namespace sep::api

--- a/src/api_main.cpp
+++ b/src/api_main.cpp
@@ -12,7 +12,7 @@ int main(int argc, char** argv)
     const auto& apiConfig = configMgr.getAPIConfig();
 
     // Create minimal renderer implementation
-    std::unique_ptr<sep::blender::ccl::CyclesRenderer> renderer = sep::createRenderer();
+    std::unique_ptr<sep::CyclesRenderer> renderer = sep::createRenderer();
     if (renderer) {
         renderer.get()->initialize();
     }

--- a/src/core/manager.cpp
+++ b/src/core/manager.cpp
@@ -3,6 +3,8 @@
 
 #include <fstream>
 #include <nlohmann/json.hpp>
+#include <cstdlib>
+#include "core/env_keys.h"
 
 #include "memory/memory_tier_manager_serialization.hpp"
 
@@ -81,6 +83,22 @@ namespace sep::config
     const APIConfig& ConfigManager::getAPIConfig() const
     {
         std::lock_guard<std::mutex> lock(mutex_);
+
+        const char* port = std::getenv(env_keys::ENV_API_PORT);
+        if (port) impl_->api_cfg.port = static_cast<uint16_t>(std::atoi(port));
+
+        const char* threads = std::getenv(env_keys::ENV_API_THREADS);
+        if (threads) impl_->api_cfg.threads = static_cast<uint32_t>(std::atoi(threads));
+
+        const char* metrics = std::getenv(env_keys::ENV_API_ENABLE_METRICS);
+        if (metrics) {
+            std::string val{metrics};
+            impl_->api_cfg.enable_metrics = !(val == "0" || val == "false" || val == "False");
+        }
+
+        const char* log_level = std::getenv(env_keys::ENV_LOG_LEVEL);
+        if (log_level) impl_->api_cfg.log_level = log_level;
+
         return impl_->api_cfg;
     }
     const CudaConfig& ConfigManager::getCudaConfig() const


### PR DESCRIPTION
## Summary
- use generic `CyclesRenderer` in api_main
- update API server to store generic renderer pointer
- parse environment variables in `ConfigManager::getAPIConfig`

## Testing
- `cmake -S . -B build` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6872e2f3c4d0832aa1a8062b3710f364