### PR TITLE
Fix PersistentPatternData namespace

### DIFF
--- a/src/memory/memory_tier_manager.cpp
+++ b/src/memory/memory_tier_manager.cpp
@@ -580,7 +580,7 @@ MemoryTierManager &MemoryTierManager::getInstance()
 
         void MemoryTierManager::storeDataToPersistence(
             [[maybe_unused]] const void *data,
-            [[maybe_unused]] const ::sep::persistence::PersistentPatternData &metadata)
+            [[maybe_unused]] const sep::persistence::PersistentPatternData &metadata)
         {
             // TODO: Implement
         }

--- a/src/memory/memory_tier_manager.hpp
+++ b/src/memory/memory_tier_manager.hpp
@@ -100,8 +100,9 @@ namespace memory {
         void pruneWeakRelationships();
         void calculateRelationshipScores();
         void loadDataFromPersistence();
-        void storeDataToPersistence(const void *data,
-                                    const ::sep::persistence::PersistentPatternData &metadata);
+        void storeDataToPersistence(
+            const void *data,
+            const sep::persistence::PersistentPatternData &metadata);
         void *findDataById(std::size_t id);
         const void *findDataById(std::size_t id) const;
         void registerGenericData(std::size_t id, const void *data);


### PR DESCRIPTION
## Summary
- fix namespace qualification for `PersistentPatternData` in `MemoryTierManager`
- keep hiredis include in `redis_manager.h`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6872e31528d8832a94b32913a2d7f662