### PR TITLE
types.h: qualify SEPResult

### DIFF
--- a/src/mock_types.h
+++ b/src/mock_types.h
@@ -31,7 +31,7 @@ namespace sep
                 return instance;
             }
 
-            SEPResult init(const Config& config) { return SEPResult::SUCCESS; }
+            sep::SEPResult init(const Config& config) { return sep::SEPResult::SUCCESS; }
         };
     }  // namespace memory
 
@@ -83,27 +83,27 @@ namespace sep
         {
         public:
             virtual ~Processor() = default;
-            virtual SEPResult init(void* userData) { return SEPResult::SUCCESS; }
-            virtual SEPResult processAll() { return SEPResult::SUCCESS; }
+            virtual sep::SEPResult init(void* userData) { return sep::SEPResult::SUCCESS; }
+            virtual sep::SEPResult processAll() { return sep::SEPResult::SUCCESS; }
 
             // Add missing methods needed by main.cpp
-            virtual SEPResult addPattern(const Pattern& pattern)
+            virtual sep::SEPResult addPattern(const Pattern& pattern)
             {
                 patterns.push_back(pattern);
-                return SEPResult::SUCCESS;
+                return sep::SEPResult::SUCCESS;
             }
 
-            virtual SEPResult evolvePattern(const std::string& id)
+            virtual sep::SEPResult evolvePattern(const std::string& id)
             {
                 for (auto& pattern : patterns)
                 {
                     if (pattern.id == id)
                     {
                         pattern.evolve(1.0f);
-                        return SEPResult::SUCCESS;
+                        return sep::SEPResult::SUCCESS;
                     }
                 }
-                return SEPResult::ERROR;
+                return sep::SEPResult::ERROR;
             }
 
             virtual std::vector<Pattern> getPatterns() { return patterns; }


### PR DESCRIPTION
## Summary
- ensure SEPResult uses the sep namespace in mock_types.h

## Testing
- `npm test` *(fails: jest not found)*
- `npm install jest` *(fails: network disabled)*

------
https://chatgpt.com/codex/tasks/task_e_6872e3081d64832a942ecd0cbad6459e