### PR TITLE
Add renderer pointer to MemoryGardenDemo

### DIFF
--- a/src/workbench/demos/memory_garden.cpp
+++ b/src/workbench/demos/memory_garden.cpp
@@ -12,7 +12,7 @@ namespace workbench {
     void MemoryGardenDemo::on_load(sep::Engine* engine, sep::CyclesRenderer* renderer)
     {
         (void)engine;
-        (void)renderer;
+        renderer_ = renderer;
         const auto& cfg = Config::getInstance().memory_garden();
 
         memory_manager_ = &sep::memory::MemoryTierManager::getInstance();

--- a/src/workbench/demos/memory_garden.hpp
+++ b/src/workbench/demos/memory_garden.hpp
@@ -58,6 +58,8 @@ private:
     float learning_rate_{0.05f};
     float connection_prob_{0.3f};
 
+    sep::CyclesRenderer* renderer_{nullptr};
+
 private:
     void createInitialPatterns();
     void updateRelationships();


### PR DESCRIPTION
## Summary
- store renderer pointer in MemoryGardenDemo
- keep pointer in header and assign during `on_load`

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872e3034a08832a98b9f6455d383d0b