### PR TITLE
Add coherence field and tweak cosmo sim

### DIFF
--- a/src/core/types.h
+++ b/src/core/types.h
@@ -100,6 +100,7 @@ namespace sep
         glm::vec4 velocity{0.0f};
         glm::vec4 attributes{0.0f};
         std::complex<float> amplitude{0.0f};
+        float coherence{0.0f};
         quantum::QuantumState quantum_state{};
         std::vector<quantum::PatternRelationship> relationships;
         std::vector<float> data;

--- a/src/workbench/demos/cosmo_sim.cpp
+++ b/src/workbench/demos/cosmo_sim.cpp
@@ -13,8 +13,8 @@ namespace sep
 
         void CosmoSim::on_load(sep::Engine* engine, sep::CyclesRenderer* renderer)
         {
-            (void)engine;
             engine_ = engine;
+            ;
             renderer_ = renderer;
             const auto& cfg = Config::getInstance().cosmo();
             box_size_ = cfg.box_size;


### PR DESCRIPTION
## Summary
- capture engine pointer in cosmo_sim
- add `coherence` attribute to the core `Pattern`

## Testing
- `npm test` *(fails: jest not found)*
- `cmake ..` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6872e2ffbbac832ab158b8a31973a8ac