### PR TITLE
Fix API config and bridge set/get issues

### DIFF
--- a/src/api/bridge_c.cpp
+++ b/src/api/bridge_c.cpp
@@ -216,7 +216,7 @@ SEP_API sep::SEPResult sep_process_context(const char *context_json, const char 
                     }
                 }
 
-                (void)std::snprintf(result_buffer, sizeof(result_buffer), "%s", result_str.c_str());
+                (void)std::snprintf(result_buffer, buffer_size, "%s", result_str.c_str());
                 return sep::SEPResult::SUCCESS;
             }
             {
@@ -229,18 +229,18 @@ SEP_API sep::SEPResult sep_process_context(const char *context_json, const char 
             return sep::SEPResult::SUCCESS;
         }
 
-        SEP_API sep::SEPResult sep_bridge_set_config(const char *key, const char *value);
+        SEP_API sep::SEPResult sep_bridge_set_config(const char *key, const char *value)
         try
         {
             std::lock_guard<std::mutex> lock(sep::api::bridge::detail::g_bridge_mutex);
-                const char* k = key;
-                const char* v = value;
-                if (!k || !v)
-                {
-                    sep::api::bridge::detail::setLastError("Invalid parameters");
-                    return sep::SEPResult::UNKNOWN_ERROR;
-                }
-                std::string ks = k;
+            const char* k = key;
+            const char* v = value;
+            if (!k || !v)
+            {
+                sep::api::bridge::detail::setLastError("Invalid parameters");
+                return sep::SEPResult::UNKNOWN_ERROR;
+            }
+            std::string ks = k;
                 auto &cm = sep::config::ConfigManager::getInstance();
                 auto cfg = cm.getAPIConfig();
                 try
@@ -330,7 +330,7 @@ SEP_API sep::SEPResult sep_process_context(const char *context_json, const char 
                     sep::api::bridge::detail::setLastError("Config key not found");
                     return sep::SEPResult::INVALID_ARGUMENT;
                 }
-                (void)std::snprintf(buffer, sizeof(buffer), "%s", val.c_str());
+                (void)std::snprintf(buffer, buffer_size, "%s", val.c_str());
                 sep::api::bridge::detail::setLastError("");
                 return sep::SEPResult::SUCCESS;
             }

--- a/src/core/config.h
+++ b/src/core/config.h
@@ -25,10 +25,12 @@ constexpr size_t MAX_ALLOCATION_SIZE = 1024 * 1024 * 1024;       // 1GB
 
 struct APIConfig {
     /* members */
+    std::string host{"0.0.0.0"};
     uint16_t port{8080};
     uint32_t threads{4};
     std::string log_level{"info"};
     bool enable_metrics{true};
+    size_t keep_alive_timeout_ms{0};
 };
 
 }  // namespace config

--- a/src/core/manager.h
+++ b/src/core/manager.h
@@ -34,6 +34,7 @@ public:
 
   // Access individual config sections
   const APIConfig &getAPIConfig() const;
+  void updateAPIConfig(const APIConfig &config);
 
   void updateCudaConfig(const workbench::CudaConfig &config);
   void updateLogConfig(const workbench::LogConfig &config);


### PR DESCRIPTION
## Summary
- expand `APIConfig` with host and keep-alive timeout
- expose `updateAPIConfig` in header
- repair `sep_bridge_set_config` body and use proper buffer size
- fix snprintf usage when returning strings

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872e2fc4bc0832a91a2323708ae7105