### PR TITLE
Fix CudaConfig namespace

### DIFF
--- a/src/memory/quantum_coherence_manager.cpp
+++ b/src/memory/quantum_coherence_manager.cpp
@@ -15,6 +15,7 @@
 
 
 using ::sep::memory::MemoryTierEnum;
+using ::sep::workbench::CudaConfig;
 #include "core/logging.h" 
 #include <tbb/parallel_for.h>
 #include <tbb/concurrent_hash_map.h>

--- a/src/quantum/quantum_manifold_optimizer.h
+++ b/src/quantum/quantum_manifold_optimizer.h
@@ -64,7 +64,7 @@ class QuantumManifoldOptimizer {
 public:
     struct Config {
         MemoryTierEnum tier{MemoryTierEnum::STM};
-        sep::config::CudaConfig cuda;
+        workbench::CudaConfig cuda;
         workbench::LogConfig log;
         workbench::AnalyticsConfig analytics;
         float base_resonance_frequency{0.42f};
@@ -147,7 +147,7 @@ struct SemanticConfig {
 
 struct ManifoldConfig {
     SemanticConfig semantic;
-    sep::config::CudaConfig cuda;
+    workbench::CudaConfig cuda;
     workbench::LogConfig log;
     workbench::AnalyticsConfig analytics;
 };
@@ -212,7 +212,7 @@ private:
 // 3. CUDA ACCELERATION WITH HIERARCHICAL PARALLELIZATION
 class CUDAQuantumKernel {
 public:
-    explicit CUDAQuantumKernel(const sep::config::CudaConfig &config);
+    explicit CUDAQuantumKernel(const workbench::CudaConfig &config);
     ~CUDAQuantumKernel();
 
   // Warp-level primitive operations
@@ -231,7 +231,7 @@ public:
 private:
     cudaStream_t stream_;
     cufftHandle fft_plan_;
-    sep::config::CudaConfig config_;
+    workbench::CudaConfig config_;
 
     void* d_workspace_;
     size_t workspace_size_;


### PR DESCRIPTION
## Summary
- correct CudaConfig namespace usage in quantum_manifold_optimizer
- include CudaConfig alias in quantum_coherence_manager

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6872e2f82c64832a95d07179f4a291e3