### PR TITLE
Add timeout_ms to LogConfig

### DIFF
--- a/src/core/types.h
+++ b/src/core/types.h
@@ -133,6 +133,7 @@ namespace sep
         struct LogConfig
         {
             int max_connections{0};
+            uint32_t timeout_ms{0};
             std::string log_level{"info"};
         };
 


### PR DESCRIPTION
## Summary
- expand `sep::workbench::LogConfig` with `timeout_ms` field

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6872e2d31778832aae8e9d37a651dde5