### PR TITLE
Implement new evolution parameters

### DIFF
--- a/src/quantum/evolution.cpp
+++ b/src/quantum/evolution.cpp
@@ -15,6 +15,10 @@ bool operator==(const std::string& lhs, const sep::shim::string& rhs)
 {
     return lhs == rhs.c_str();
 }
+bool operator==(const sep::shim::string& lhs, const std::string& rhs)
+{
+    return lhs == rhs.c_str();
+}
 
 namespace
 {
@@ -82,7 +86,7 @@ inline float deterministicNoise(uint64_t& state)
                 }
                 else if (!parent_ids.empty())
                 {
-                    BatchProcessingResult result = processor_->mutatePattern(parent_ids[0]);
+                    ProcessingResult result = processor_->mutatePattern(parent_ids[0]);
                     if (result.success)
                     {
                         next_generation_ids.push_back(result.pattern.id);

--- a/src/quantum/evolution.h
+++ b/src/quantum/evolution.h
@@ -9,15 +9,16 @@
 
 namespace sep::quantum {
 
-struct BatchProcessingResult {
-    bool success{false};
+struct BatchProcessingResult : public ProcessingResult {
     std::string message{};
-    std::string error_message{};
-    Pattern pattern{};
+    std::vector<ProcessingResult> results{};
 };
 
 
 struct EvolutionParams {
+    float mutation_rate{0.1f};
+    float crossover_rate{0.7f};
+    uint32_t generations{100};
     size_t elite_count{5};
     size_t tournament_size{3};
     float coherence_weight{1.0f};
@@ -38,7 +39,7 @@ public:
     };
 
 
-    explicit EvolutionEngine(Processor* processor);
+    explicit EvolutionEngine(sep::quantum::Processor* processor);
 
     BatchProcessingResult evolve(const EvolutionParams& params);
     BatchProcessingResult evolveGeneration();

--- a/src/quantum/processor.h
+++ b/src/quantum/processor.h
@@ -28,10 +28,8 @@ struct ProcessingResult {
     std::string error_message{};
 };
 
-struct BatchProcessingResult {
-    bool success{false};
+struct BatchProcessingResult : public ProcessingResult {
     std::vector<ProcessingResult> results{};
-    std::string error_message{};
 };
 
 namespace pattern {


### PR DESCRIPTION
## Summary
- expand `EvolutionParams` with mutation and crossover controls
- derive `BatchProcessingResult` from `ProcessingResult`
- overload mixed string equality helpers
- fix mutate pattern call to use `ProcessingResult`
- qualify `Processor` type in `EvolutionEngine`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872e2d75084832aaebea9670fad5c19