### PR TITLE
Refactor: namespace for CudaConfig

### DIFF
--- a/src/core/manager.cpp
+++ b/src/core/manager.cpp
@@ -83,9 +83,9 @@ namespace sep::config
         std::lock_guard<std::mutex> lock(mutex_);
         return impl_->api_cfg;
     }
-    const CudaConfig& ConfigManager::getCudaConfig() const
+    const sep::config::CudaConfig& ConfigManager::getCudaConfig() const
     {
-        static CudaConfig cfg{};
+        static sep::config::CudaConfig cfg{};
         return cfg;
     }
     const LogConfig& ConfigManager::getLogConfig() const
@@ -108,7 +108,7 @@ namespace sep::config
         std::lock_guard<std::mutex> lock(mutex_);
         impl_->api_cfg = cfg;
     }
-    void ConfigManager::updateCudaConfig(const CudaConfig&) {}
+    void ConfigManager::updateCudaConfig(const sep::config::CudaConfig&) {}
     void ConfigManager::updateLogConfig(const LogConfig&) {}
     void ConfigManager::updateMemoryConfig(const workbench::MemoryThresholdConfig& cfg)
     {

--- a/src/core/manager.h
+++ b/src/core/manager.h
@@ -35,7 +35,7 @@ public:
   // Access individual config sections
   const APIConfig &getAPIConfig() const;
 
-  void updateCudaConfig(const workbench::CudaConfig &config);
+  void updateCudaConfig(const sep::config::CudaConfig &config);
   void updateLogConfig(const workbench::LogConfig &config);
   void updateMemoryConfig(const workbench::MemoryThresholdConfig &config);
   void updateQuantumConfig(const workbench::QuantumThresholdConfig &config);

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -170,6 +170,11 @@ namespace sep
         {
             // Fields for analytics go here
         };
+    }  // namespace workbench
+
+    namespace config
+    {
+        using CudaConfig = workbench::CudaConfig;
     }  // namespace config
 
     namespace quantum

--- a/src/quantum/manifold_config.cpp
+++ b/src/quantum/manifold_config.cpp
@@ -22,7 +22,7 @@ namespace sep::quantum::manifold {
     .stability_threshold = 0.8f
 };
 
-::sep::workbench::CudaConfig cuda{
+::sep::config::CudaConfig cuda{
     .use_gpu = true,
     .max_memory_mb = 8192,
     .batch_size = 1024,

--- a/src/quantum/manifold_config.h
+++ b/src/quantum/manifold_config.h
@@ -6,7 +6,7 @@ namespace sep::quantum::manifold {
 // Default configuration values used across the engine.
 extern ::sep::workbench::MemoryThresholdConfig memory;
 extern ::sep::workbench::QuantumThresholdConfig quantum;
-extern ::sep::workbench::CudaConfig cuda;
+extern ::sep::config::CudaConfig cuda;
 extern ::sep::workbench::LogConfig api;
 }
 


### PR DESCRIPTION
## Summary
- alias `CudaConfig` under `sep::config`
- use new namespace in manager and manifold config

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872e2e78874832a827c08b3f260063d