### PR TITLE
Fix demo integration and add menu

### DIFF
--- a/src/workbench/CMakeLists.txt
+++ b/src/workbench/CMakeLists.txt
@@ -4,6 +4,7 @@ cmake_minimum_required(VERSION 3.16)
 file(GLOB_RECURSE WB_SOURCES
     "demos/*.cpp"
     "renderer.cpp"
+    "config.cpp"
     "${CMAKE_SOURCE_DIR}/third_party/imgui/*.cpp"
     "${CMAKE_SOURCE_DIR}/third_party/imgui/backends/imgui_impl_glfw.cpp"
     "${CMAKE_SOURCE_DIR}/third_party/imgui/backends/imgui_impl_opengl3.cpp"

--- a/src/workbench/demos/demo_manager.cpp
+++ b/src/workbench/demos/demo_manager.cpp
@@ -67,5 +67,14 @@ void DemoManager::on_key(int key) {
 
 std::string DemoManager::getCurrentDemo() const { return current_demo_name_; }
 
+std::vector<std::string> DemoManager::getRegisteredDemos() const
+{
+    std::vector<std::string> names;
+    names.reserve(demo_factories_.size());
+    for (const auto& pair : demo_factories_)
+        names.push_back(pair.first);
+    return names;
+}
+
 }  // namespace workbench
 }  // namespace sep

--- a/src/workbench/demos/demo_manager.hpp
+++ b/src/workbench/demos/demo_manager.hpp
@@ -4,6 +4,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "sep_engine_wrapper.h"
 #include "workbench/demos/demo_base.hpp"
@@ -27,6 +28,7 @@ namespace sep
             void on_unload();
             void on_key(int key);
             std::string getCurrentDemo() const;
+            std::vector<std::string> getRegisteredDemos() const;
 
         private:
             DemoManager() = default;  // Singleton

--- a/src/workbench_main.cpp
+++ b/src/workbench_main.cpp
@@ -166,8 +166,12 @@ int main() {
         // Initialize demo manager
         std::cout << "Initializing demo manager..." << std::endl;
         demoManager.initialize(engine.get(), renderer.get());
-        // Skip configuration loading for now (linker issues)
-        std::cout << "Using default configuration..." << std::endl;
+
+        // Load workbench configuration
+        auto& config = sep::workbench::Config::getInstance();
+        if (!config.load("src/workbench/config.json")) {
+            std::cout << "Using default configuration..." << std::endl;
+        }
         
         
         // Register demos
@@ -226,6 +230,20 @@ int main() {
             ImGui_ImplOpenGL3_NewFrame();
             ImGui_ImplGlfw_NewFrame();
             ImGui::NewFrame();
+
+            // Render global demo selection menu
+            if (ImGui::BeginMainMenuBar()) {
+                if (ImGui::BeginMenu("Demos")) {
+                    for (const auto& name : demoManager.getRegisteredDemos()) {
+                        bool selected = (demoManager.getCurrentDemo() == name);
+                        if (ImGui::MenuItem(name.c_str(), nullptr, selected)) {
+                            demoManager.switchToDemo(name);
+                        }
+                    }
+                    ImGui::EndMenu();
+                }
+                ImGui::EndMainMenuBar();
+            }
 
             demoManager.on_ui_render();
 


### PR DESCRIPTION
## Summary
- compile config.cpp into workbench library
- expose registered demo names through `DemoManager`
- load workbench configuration in main
- add an ImGui demo selector menu

## Testing
- `cmake -S . -B build -GNinja -DCUDAToolkit_ROOT=/tmp/cuda` *(fails: Could NOT find CUDAToolkit)*
- `ninja -C build` *(fails: no build.ninja file)*

------
https://chatgpt.com/codex/tasks/task_e_6873595f6eac832a861adcefec9dfb4b