### PR TITLE
Fix OpenGL header order and clean up demos

### DIFF
--- a/src/blender/mesh_handler.cpp
+++ b/src/blender/mesh_handler.cpp
@@ -301,7 +301,7 @@ float MeshHandler::calculateSurfaceArea() const {
       float cx = ay * bz - az * by;
       float cy = az * bx - ax * bz;
       float cz = ax * by - ay * bx;
-      area += 0.5 * std::sqrt(cx * cx + cy * cy + cz * cz);
+        area += 0.5 * std::sqrt(static_cast<double>(cx * cx + cy * cy + cz * cz));
     }
   }
   return static_cast<float>(area);
@@ -320,7 +320,7 @@ float MeshHandler::calculateAverageEdgeLength() const {
     float dx = v1[0] - v2[0];
     float dy = v1[1] - v2[1];
     float dz = v1[2] - v2[2];
-    total += std::sqrt(dx * dx + dy * dy + dz * dz);
+      total += std::sqrt(static_cast<double>(dx * dx + dy * dy + dz * dz));
   }
   return static_cast<float>(total / mesh_->totedge);
 }
@@ -346,7 +346,7 @@ float MeshHandler::calculateVertexInfluence(const sep::pattern::PatternData& pat
   float dx = vertex[0] - pattern.position.x;
   float dy = vertex[1] - pattern.position.y;
   float dz = vertex[2] - pattern.position.z;
-  float dist = std::sqrt(dx * dx + dy * dy + dz * dz);
+  float dist = std::sqrt(static_cast<double>(dx * dx + dy * dy + dz * dz));
   float weight = 1.0f / (1.0f + dist);
   return computeCoherenceWeight(weight);
 }

--- a/src/workbench/CMakeLists.txt
+++ b/src/workbench/CMakeLists.txt
@@ -32,6 +32,7 @@ target_include_directories(sep_workbench_lib PUBLIC
 # Add the IMGUI_IMPL_OPENGL_LOADER_GLAD define to ensure consistency with our OpenGL loader choice
 target_compile_definitions(sep_workbench_lib PRIVATE
     IMGUI_IMPL_OPENGL_LOADER_GLAD
+    GLFW_INCLUDE_NONE
 )
 
 # Link against core components

--- a/src/workbench/core/workbench_core.cpp
+++ b/src/workbench/core/workbench_core.cpp
@@ -1,3 +1,4 @@
+#include <glad/glad.h>
 #include "workbench_core.hpp"
 #include "workbench/renderer.h"
 #include "service_connector.hpp"

--- a/src/workbench/core/workbench_core.hpp
+++ b/src/workbench/core/workbench_core.hpp
@@ -5,6 +5,7 @@
 #include <string>
 #include <chrono>
 #include <functional>
+#define GLFW_INCLUDE_NONE
 #include <GLFW/glfw3.h>
 
 namespace sep::workbench {

--- a/src/workbench/demos/genesis_pattern.cpp
+++ b/src/workbench/demos/genesis_pattern.cpp
@@ -121,7 +121,7 @@ void GenesisPatternDemo::on_ui_render() {
     ImGui::Begin("Genesis Pattern Controls");
     
     ImGui::Text("Pattern Count: %zu", metrics_.pattern_count);
-    ImGui::Text("Global Coherence: %.3f", metrics_.coherence);
+    ImGui::Text("Global Coherence: %.3f", static_cast<double>(metrics_.coherence));
     ImGui::Text("Iterations: %zu", metrics_.iterations);
     
     ImGui::Separator();

--- a/src/workbench/demos/memory_garden.cpp
+++ b/src/workbench/demos/memory_garden.cpp
@@ -158,6 +158,8 @@ void MemoryGardenDemo::on_key_press(int key)
             relationships_.clear();
             createInitialPatterns();
             break;
+        default:
+            break;
     }
 }
 

--- a/src/workbench/demos/memory_garden.hpp
+++ b/src/workbench/demos/memory_garden.hpp
@@ -53,7 +53,6 @@ private:
     float decay_{0.1f};
     float input_strength_{0.5f};
     float learning_rate_{0.05f};
-    float connection_prob_{0.3f};
 
     sep::CyclesRenderer* renderer_{nullptr};
 


### PR DESCRIPTION
## Summary
- avoid GLFW including OpenGL by defining `GLFW_INCLUDE_NONE`
- include glad before glfw in workbench_core.cpp
- define `GLFW_INCLUDE_NONE` for the workbench target
- fix float to double promotions in mesh_handler and demos
- add default case to memory_garden demo and drop unused field

## Testing
- `cmake -S . -B build -G Ninja` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6873fab392b0832a87b5391882a7dbfb