### PR TITLE
Enable real Crow headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,8 +129,9 @@ add_compile_definitions(SEP_HAS_AUDIO=1)
 
 # Ensure our custom Crow wrappers take precedence over the third-party headers
 include_directories(BEFORE
-    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/extern/crow/include
     ${CMAKE_SOURCE_DIR}/extern/crow/src
+    ${CMAKE_SOURCE_DIR}/src
 )
 add_compile_definitions(CROW_USE_BOOST)
 

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -54,7 +54,7 @@ target_include_directories(sep_api
     PRIVATE
         $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src>
     SYSTEM PRIVATE
-        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/third_party/crow/include>
+        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/extern/crow/include>
         $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/extern/cycles/src>
 )
 


### PR DESCRIPTION
## Summary
- use the Crow headers from `extern/crow` before the stub versions
- update API library include paths accordingly

## Testing
- `cmake -B build -S .` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_68749690b6c0832aaec51a007024b62d