### PR TITLE
Fix CUDA init linkage

### DIFF
--- a/src/api/sep_engine.cpp
+++ b/src/api/sep_engine.cpp
@@ -34,7 +34,7 @@
 #include "tests/simple_embedding_model.h"
 
 // Forward declaration of the wrapper function for CUDA initialization
-sep::cuda::Error cuda_core_initialize(int device_id);
+extern "C" sep::cuda::Error cuda_core_initialize(int device_id);
 
 using json = nlohmann::json;
 


### PR DESCRIPTION
## Summary
- fix symbol mismatch by declaring `cuda_core_initialize` with `extern "C"`

## Testing
- `cmake -S . -B build -DSEP_WITH_CYCLES=OFF -DSEP_BUILD_WORKBENCH=OFF` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_68749ed538c8832ab521514c46e895db