### PR TITLE
Fix cuda init linkage

### DIFF
--- a/src/api/sep_engine.cpp
+++ b/src/api/sep_engine.cpp
@@ -34,7 +34,7 @@
 #include "tests/simple_embedding_model.h"
 
 // Forward declaration of the wrapper function for CUDA initialization
-sep::cuda::Error cuda_core_initialize(int device_id);
+extern "C" sep::cuda::Error cuda_core_initialize(int device_id);
 
 using json = nlohmann::json;
 


### PR DESCRIPTION
## Summary
- align forward declaration of `cuda_core_initialize` with its `extern "C"` implementation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68749fb11b74832aaf5a15e61091e1ff