### PR TITLE
Fix missing CUDA init wrapper

### DIFF
--- a/src/compat/CMakeLists.txt
+++ b/src/compat/CMakeLists.txt
@@ -61,6 +61,7 @@ set(CPP_SOURCES
     hip_impl.cpp
     hip_compat.cpp
     cuda_impl.cpp
+    core_wrapper.cpp
 )
 
 # Create an OBJECT library for the CUDA sources

--- a/src/compat/core.cu
+++ b/src/compat/core.cu
@@ -315,9 +315,3 @@ Error CudaCore::launchBlend(DeviceMemory<float>& output, const DeviceMemory<floa
 
 }  // namespace sep::cuda
 
-// Add C-style wrapper function for CudaCore::initialize
-extern "C" {
-    sep::cuda::Error cuda_core_initialize(int device_id) {
-        return sep::cuda::CudaCore::instance().initialize(device_id);
-    }
-}

--- a/src/compat/core.h
+++ b/src/compat/core.h
@@ -21,6 +21,7 @@ struct CudaMetrics {
   uint32_t active_kernels{0};
 };
 
+
 class CudaCore {
  public:
   static CudaCore& instance() {
@@ -89,6 +90,7 @@ class CudaCore {
   Error initializeDevice(int device);
   Error queryDeviceProperties();
 };
+extern "C" sep::cuda::Error cuda_core_initialize(int device_id);
 
 
 }  // namespace sep::cuda

--- a/src/compat/core_wrapper.cpp
+++ b/src/compat/core_wrapper.cpp
@@ -1,0 +1,5 @@
+#include "compat/core.h"
+
+extern "C" sep::cuda::Error cuda_core_initialize(int device_id) {
+    return sep::cuda::CudaCore::instance().initialize(device_id);
+}


### PR DESCRIPTION
## Summary
- add a standalone `core_wrapper.cpp` to provide `cuda_core_initialize`
- declare the wrapper in `core.h`
- remove old inline wrapper from `core.cu`
- register the new file in CMake

## Testing
- `npm test` *(fails: jest not found)*
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_6874a0432bcc832a96aba039680f9e99