### PR TITLE
Fix CUDA runtime includes

### DIFF
--- a/src/compat/cuda_runtime.h
+++ b/src/compat/cuda_runtime.h
@@ -2,6 +2,7 @@
 #define SEP_COMPAT_CUDA_RUNTIME_H
 
 #if SEP_ENGINE_HAS_CUDA
+#include <cuda_runtime_api.h>
 #include <cuda_runtime.h>
 
 namespace sep {


### PR DESCRIPTION
## Summary
- ensure CUDA types are defined by including `cuda_runtime_api.h`

## Testing
- `cmake --version`


------
https://chatgpt.com/codex/tasks/task_e_6875b8c026d4832a9595f8a962564e93