### PR TITLE
Fix CUDA header constant alias issues

### DIFF
--- a/src/compat/cuda_runtime.h
+++ b/src/compat/cuda_runtime.h
@@ -5,6 +5,9 @@
 #include <cuda_runtime_api.h>
 #include <cuda_runtime.h>
 
+constexpr unsigned int cudaStreamNonBlocking = ::cudaStreamNonBlocking;  // 0x01
+constexpr unsigned int cudaStreamDefault = ::cudaStreamDefault;  // 0x00
+
 namespace sep {
 namespace cuda {
 // Alias CUDA types into our namespace
@@ -13,8 +16,6 @@ using ::cudaStream_t;
 using ::cudaEvent_t;
 using ::cudaMemcpyKind;
 using ::cudaSuccess;
-using ::cudaStreamNonBlocking;
-using ::cudaStreamDefault;
 } // namespace cuda
 } // namespace sep
 
@@ -24,8 +25,6 @@ using sep::cuda::cudaStream_t;
 using sep::cuda::cudaEvent_t;
 using sep::cuda::cudaMemcpyKind;
 using sep::cuda::cudaSuccess;
-using sep::cuda::cudaStreamNonBlocking;
-using sep::cuda::cudaStreamDefault;
 
 #else // !SEP_ENGINE_HAS_CUDA
 // Basic includes for non-CUDA builds
@@ -163,8 +162,6 @@ using sep::cuda::cudaErrorDeviceNotLicensed;
 using sep::cuda::cudaErrorDeviceUninitilialized;
 using sep::cuda::cudaErrorNoDevice;
 
-using sep::cuda::cudaStreamDefault;
-using sep::cuda::cudaStreamNonBlocking;
 using sep::cuda::cudaMemAttachGlobal;
 using sep::cuda::cudaMemAttachHost;
 using sep::cuda::cudaMemAttachSingle;

--- a/src/quantum/quantum_manifold_optimizer.h
+++ b/src/quantum/quantum_manifold_optimizer.h
@@ -5,6 +5,7 @@
 
 #include "core/config.h"
 #include <cuda_runtime.h>
+#include <cufft.h>
 #include "compat/cufft.h"
 #include "compat/cuda_api.hpp"
 #include "memory/types.h"
@@ -15,8 +16,7 @@
 // Forward declarations
 namespace sep::cuda {
 class CudaCore;
-struct cufftHandle_t;
-using cufftHandle = cufftHandle_t*;
+using cufftHandle = ::cufftHandle;
 }
 #include <algorithm>
 #include <array>


### PR DESCRIPTION
## Summary
- add constexpr aliases for `cudaStreamDefault` and `cudaStreamNonBlocking`
- remove invalid `using` declarations for CUDA stream constants
- adjust `quantum_manifold_optimizer` to use cuFFT handle type directly

## Testing
- `git status -s`

------
https://chatgpt.com/codex/tasks/task_e_6875ba3fcdb0832aa0d68206c26d4cf4