### PR TITLE
Implement CUDA compatibility wrappers

### DIFF
--- a/src/compat/cuda_helpers.h
+++ b/src/compat/cuda_helpers.h
@@ -19,10 +19,10 @@ SEP_HOST inline void logCudaError(const char* operation, cudaError_t error) {
 
 
 #ifndef CUDA_CHECK
-#define CUDA_CHECK(call)                             \
+#define CUDA_CHECK(call)                              \
     do {                                             \
-        cudaError_t error = call;                    \
-        if (error != cudaSuccess) {                  \
+        cudaError_t error = (call);                  \
+        if (error != SEP_cudaSuccess) {              \
             ::sep::cuda::logCudaError(#call, error); \
         }                                            \
     } while (0)

--- a/src/compat/cuda_impl.h
+++ b/src/compat/cuda_impl.h
@@ -22,10 +22,10 @@ struct CudaMemcpyParams {
 
 // Helper function for memory copies to avoid parameter similarity issues
 inline cudaError_t performCudaMemcpyAsync(const CudaMemcpyParams& params) {
-    // Use the namespaced wrapper to work both with CUDA and stub builds
-    return sep::cuda::cudaMemcpyAsync(params.destination, params.source,
-                                      params.sizeInBytes, params.direction,
-                                      params.stream);
+    // Use the SEP-prefixed wrapper to work both with CUDA and stub builds
+    return sep::cuda::SEP_cudaMemcpyAsync(params.destination, params.source,
+                                          params.sizeInBytes, params.direction,
+                                          params.stream);
 }
 
 namespace sep {

--- a/src/compat/cuda_runtime.h
+++ b/src/compat/cuda_runtime.h
@@ -5,6 +5,24 @@
 #include <cuda_runtime_api.h>
 #include <cuda_runtime.h>
 
+// Map SEP-prefixed names to CUDA enums/constants when CUDA is available
+#define SEP_cudaSuccess cudaSuccess
+#define SEP_cudaErrorInvalidValue cudaErrorInvalidValue
+#define SEP_cudaErrorMemoryAllocation cudaErrorMemoryAllocation
+#define SEP_cudaErrorInitializationError cudaErrorInitializationError
+#define SEP_cudaErrorInvalidDevicePointer cudaErrorInvalidDevicePointer
+#define SEP_cudaErrorInvalidMemcpyDirection cudaErrorInvalidMemcpyDirection
+#define SEP_cudaErrorNoDevice cudaErrorNoDevice
+#define SEP_cudaErrorInvalidDevice cudaErrorInvalidDevice
+#define SEP_cudaErrorDeviceUninitialized cudaErrorDeviceUninitialized
+#define SEP_cudaErrorDeviceAlreadyInUse cudaErrorDeviceAlreadyInUse
+#define SEP_cudaErrorInvalidResourceHandle cudaErrorInvalidResourceHandle
+#define SEP_cudaErrorNotReady cudaErrorNotReady
+#define SEP_cudaErrorSetOnActiveProcess cudaErrorSetOnActiveProcess
+#define SEP_cudaErrorStreamCaptureUnsupported cudaErrorStreamCaptureUnsupported
+#define SEP_cudaStreamDefault cudaStreamDefault
+#define SEP_cudaStreamNonBlocking cudaStreamNonBlocking
+
 namespace sep {
 namespace cuda {
 // Remove global scope constants and keep them only in namespace

--- a/src/compat/cuda_wrapper.h
+++ b/src/compat/cuda_wrapper.h
@@ -1,127 +1,119 @@
-/*
- * Copyright (c) 2025 SEP Engine Contributors
- * 
- * CUDA wrapper functions to avoid name collisions
- */
+#pragma once
 
-#ifndef CUDA_WRAPPER_H
-#define CUDA_WRAPPER_H
+#include <cuda_runtime_api.h>
 
-#include <cuda_runtime.h>
+namespace sep::cuda {
 
-// Wrapper functions for CUDA functions with different names
-namespace cuda_wrapper {
-
-// Use CUDA types
-using sep::cuda::cudaDeviceProp;
-
-// Stream functions
-inline cudaError_t StreamCreateWithFlags(void** stream, unsigned int flags) {
-    return cudaStreamCreateWithFlags(stream, flags);
+inline cudaError_t SEP_cudaStreamCreateWithFlags(cudaStream_t* stream, unsigned int flags) {
+    return ::cudaStreamCreateWithFlags(stream, flags);
 }
 
-inline cudaError_t StreamDestroy(void* stream) {
-    return cudaStreamDestroy(stream);
+inline cudaError_t SEP_cudaStreamDestroy(cudaStream_t stream) {
+    return ::cudaStreamDestroy(stream);
 }
 
-inline cudaError_t StreamSynchronize(void* stream) {
-    return cudaStreamSynchronize(stream);
+inline cudaError_t SEP_cudaStreamSynchronize(cudaStream_t stream) {
+    return ::cudaStreamSynchronize(stream);
 }
 
-inline cudaError_t StreamWaitEvent(void* stream, void* event, unsigned int flags) {
-    return cudaStreamWaitEvent(stream, event, flags);
+inline cudaError_t SEP_cudaStreamWaitEvent(cudaStream_t stream, cudaEvent_t event, unsigned int flags) {
+    return ::cudaStreamWaitEvent(stream, event, flags);
 }
 
-inline cudaError_t StreamAttachMemAsync(void* stream, void* devPtr, size_t length, unsigned int flags) {
-    return cudaStreamAttachMemAsync(stream, devPtr, length, flags);
+inline cudaError_t SEP_cudaStreamAttachMemAsync(cudaStream_t stream, void* devPtr, size_t length, unsigned int flags) {
+    return ::cudaStreamAttachMemAsync(stream, devPtr, length, flags);
 }
 
-// Event functions
-inline cudaError_t EventCreate(void** event) {
-    return cudaEventCreate(event);
+inline cudaError_t SEP_cudaEventCreate(cudaEvent_t* event) {
+    return ::cudaEventCreate(event);
 }
 
-inline cudaError_t EventDestroy(void* event) {
-    return cudaEventDestroy(event);
+inline cudaError_t SEP_cudaEventDestroy(cudaEvent_t event) {
+    return ::cudaEventDestroy(event);
 }
 
-inline cudaError_t EventSynchronize(void* event) {
-    return cudaEventSynchronize(event);
+inline cudaError_t SEP_cudaEventSynchronize(cudaEvent_t event) {
+    return ::cudaEventSynchronize(event);
 }
 
-inline cudaError_t EventRecord(void* event, void* stream) {
-    return cudaEventRecord(event, stream);
+inline cudaError_t SEP_cudaEventRecord(cudaEvent_t event, cudaStream_t stream) {
+    return ::cudaEventRecord(event, stream);
 }
 
-// Memory management functions
-inline cudaError_t Malloc(void** devPtr, size_t size) {
-    return cudaMalloc(devPtr, size);
+inline cudaError_t SEP_cudaMalloc(void** devPtr, size_t size) {
+    return ::cudaMalloc(devPtr, size);
 }
 
-inline cudaError_t Free(void* devPtr) {
-    return cudaFree(devPtr);
+inline cudaError_t SEP_cudaFree(void* devPtr) {
+    return ::cudaFree(devPtr);
 }
 
-inline cudaError_t MallocManaged(void** devPtr, size_t size, unsigned int flags) {
-    return cudaMallocManaged(devPtr, size, flags);
+inline cudaError_t SEP_cudaMallocManaged(void** devPtr, size_t size, unsigned int flags) {
+    return ::cudaMallocManaged(devPtr, size, flags);
 }
 
-// Added missing memory functions
-inline cudaError_t MallocHost(void** ptr, size_t size) {
-    return cudaMallocHost(ptr, size);
+inline cudaError_t SEP_cudaMallocHost(void** ptr, size_t size) {
+    return ::cudaMallocHost(ptr, size);
 }
 
-inline cudaError_t FreeHost(void* ptr) {
-    return cudaFreeHost(ptr);
+inline cudaError_t SEP_cudaFreeHost(void* ptr) {
+    return ::cudaFreeHost(ptr);
 }
 
-inline cudaError_t MemGetInfo(size_t* free, size_t* total) {
-    return cudaMemGetInfo(free, total);
+inline cudaError_t SEP_cudaMemGetInfo(size_t* free, size_t* total) {
+    return ::cudaMemGetInfo(free, total);
 }
 
-inline cudaError_t Memset(void* devPtr, int value, size_t count) {
-    return cudaMemset(devPtr, value, count);
+inline cudaError_t SEP_cudaMemset(void* devPtr, int value, size_t count) {
+    return ::cudaMemset(devPtr, value, count);
 }
 
-inline cudaError_t MemsetAsync(void* devPtr, int value, size_t count, void* stream) {
-    return cudaMemsetAsync(devPtr, value, count, (cudaStream_t)stream);
+inline cudaError_t SEP_cudaMemsetAsync(void* devPtr, int value, size_t count, cudaStream_t stream) {
+    return ::cudaMemsetAsync(devPtr, value, count, stream);
 }
 
-inline cudaError_t Memcpy(void* dst, const void* src, size_t count, cudaMemcpyKind kind) {
-    return cudaMemcpy(dst, src, count, kind);
+inline cudaError_t SEP_cudaMemcpy(void* dst, const void* src, size_t count, cudaMemcpyKind kind) {
+    return ::cudaMemcpy(dst, src, count, kind);
 }
 
-inline cudaError_t MemcpyAsync(void* dst, const void* src, size_t count, cudaMemcpyKind kind, void* stream) {
-    return cudaMemcpyAsync(dst, src, count, kind, (cudaStream_t)stream);
+inline cudaError_t SEP_cudaMemcpyAsync(void* dst, const void* src, size_t count, cudaMemcpyKind kind, cudaStream_t stream) {
+    return ::cudaMemcpyAsync(dst, src, count, kind, stream);
 }
 
-// Device management functions
-inline cudaError_t SetDevice(int device) { return cudaSetDevice(device); }
-
-inline cudaError_t GetDevice(int* device) { return cudaGetDevice(device); }
-
-inline cudaError_t GetDeviceCount(int* count) { return cudaGetDeviceCount(count); }
-
-inline cudaError_t DeviceSynchronize(void) { return cudaDeviceSynchronize(); }
-
-inline cudaError_t DeviceReset(void) { return cudaDeviceReset(); }
-
-inline cudaError_t SetDeviceFlags(unsigned int flags) { return cudaSetDeviceFlags(flags); }
-
-inline cudaError_t GetDeviceFlags(unsigned int* flags) { return cudaGetDeviceFlags(flags); }
-
-inline cudaError_t GetLastError(void) { return cudaGetLastError(); }
-
-// Error handling
-inline const char* GetErrorString(int error) {
-    return cudaGetErrorString(error);
+inline cudaError_t SEP_cudaSetDevice(int device) {
+    return ::cudaSetDevice(device);
 }
 
-// Constants
-static const cudaError_t Success = cudaSuccess;
-static const cudaError_t ErrorNotReady = cudaErrorNotReady;
-static const cudaError_t ErrorInvalidValue = cudaErrorInvalidValue;
+inline cudaError_t SEP_cudaGetDevice(int* device) {
+    return ::cudaGetDevice(device);
+}
 
-} // namespace cuda_wrapper
+inline cudaError_t SEP_cudaGetDeviceCount(int* count) {
+    return ::cudaGetDeviceCount(count);
+}
 
-#endif // CUDA_WRAPPER_H
+inline cudaError_t SEP_cudaDeviceSynchronize() {
+    return ::cudaDeviceSynchronize();
+}
+
+inline cudaError_t SEP_cudaDeviceReset() {
+    return ::cudaDeviceReset();
+}
+
+inline cudaError_t SEP_cudaSetDeviceFlags(unsigned int flags) {
+    return ::cudaSetDeviceFlags(flags);
+}
+
+inline cudaError_t SEP_cudaGetDeviceFlags(unsigned int* flags) {
+    return ::cudaGetDeviceFlags(flags);
+}
+
+inline cudaError_t SEP_cudaGetLastError() {
+    return ::cudaGetLastError();
+}
+
+inline const char* SEP_cudaGetErrorString(cudaError_t error) {
+    return ::cudaGetErrorString(error);
+}
+
+} // namespace sep::cuda

--- a/src/core/metrics_collector.cpp
+++ b/src/core/metrics_collector.cpp
@@ -36,18 +36,18 @@ class MetricsCollector::Impl {
 
   Impl() : running_(false), latency_window_size_(1000) {
     // Create events for timing
-        CUDA_CHECK(cudaEventCreate(&start_event_));
-    CUDA_CHECK(cudaEventCreate(&stop_event_));
+        CUDA_CHECK(SEP_cudaEventCreate(&start_event_));
+    CUDA_CHECK(SEP_cudaEventCreate(&stop_event_));
     
   }
 
   ~Impl() {
     stopCollection();
     if (start_event_) {
-      CUDA_CHECK(cudaEventDestroy(start_event_));
+      CUDA_CHECK(SEP_cudaEventDestroy(start_event_));
     }
     if (stop_event_) {
-      CUDA_CHECK(cudaEventDestroy(stop_event_));
+      CUDA_CHECK(SEP_cudaEventDestroy(stop_event_));
     }
   }
 
@@ -87,18 +87,18 @@ class MetricsCollector::Impl {
 
   void recordKernelStart() {
     if (start_event_) {
-      CUDA_CHECK(cudaEventRecord(start_event_, nullptr));
+      CUDA_CHECK(SEP_cudaEventRecord(start_event_, nullptr));
     }
   }
 
   void recordKernelStop() {
     if (stop_event_) {
-            CUDA_CHECK(cudaEventRecord(stop_event_, nullptr));
-      CUDA_CHECK(cudaEventSynchronize(stop_event_));
+            CUDA_CHECK(SEP_cudaEventRecord(stop_event_, nullptr));
+      CUDA_CHECK(SEP_cudaEventSynchronize(stop_event_));
 
       float elapsed_time = 0.0f;
       if (start_event_ && stop_event_) {
-        CUDA_CHECK(cudaEventElapsedTime(&elapsed_time, start_event_, stop_event_));
+        CUDA_CHECK(SEP_cudaEventElapsedTime(&elapsed_time, start_event_, stop_event_));
       }
       
 
@@ -168,7 +168,7 @@ class MetricsCollector::Impl {
 
     // Get CUDA memory info
     size_t free_mem, total_mem;
-    CUDA_CHECK(cudaMemGetInfo(&free_mem, &total_mem));
+    CUDA_CHECK(SEP_cudaMemGetInfo(&free_mem, &total_mem));
     float gpu_memory_usage = static_cast<float>(total_mem - free_mem) / total_mem * 100.0f;
     new_metrics.gpu_memory_usage = gpu_memory_usage;
     // GPU utilization requires more complex querying, set to 0 for now


### PR DESCRIPTION
## Summary
- add SEP-prefixed CUDA constant macros
- provide SEP_cuda* wrapper functions
- route CUDA_CHECK through SEP-prefixed APIs
- update metrics collector to use SEP CUDA wrappers
- fix memcpy helper to use SEP_cudaMemcpyAsync

## Testing
- `./build.sh` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6875d9313194832aae10cd2cf4b37011