### PR TITLE
Fix ImGui null checks and CRC32 cast

### DIFF
--- a/third_party/imgui/imgui.cpp
+++ b/third_party/imgui/imgui.cpp
@@ -2329,7 +2329,7 @@ ImGuiID ImHashData(const void* data_p, size_t data_size, ImGuiID seed)
 #ifndef IMGUI_ENABLE_SSE4_2_CRC
     const ImU32* crc32_lut = GCrc32LookupTable;
     while (data < data_end)
-        crc = (crc >> 8) ^ crc32_lut[(crc & 0xFF) ^ *data++];
+        crc = (crc >> 8) ^ crc32_lut[(crc & 0xFF) ^ (unsigned char)(*data++)];
     return ~crc;
 #else
     while (data + 4 <= data_end)

--- a/third_party/imgui/imgui_draw.cpp
+++ b/third_party/imgui/imgui_draw.cpp
@@ -1744,7 +1744,7 @@ void ImDrawList::AddText(ImFont* font, float font_size, const ImVec2& pos, ImU32
     if (font == NULL)
         font = _Data->Font;
     if (!font)
-        return;
+        return; // avoid calling RenderText with a null font
     if (font_size == 0.0f)
         font_size = _Data->FontSize;
 

--- a/third_party/imgui/imgui_widgets.cpp
+++ b/third_party/imgui/imgui_widgets.cpp
@@ -8321,6 +8321,8 @@ static int IMGUI_CDECL PairComparerByValueInt(const void* lhs, const void* rhs)
 bool ImGuiSelectionBasicStorage::GetNextSelectedItem(void** opaque_it, ImGuiID* out_id)
 {
     ImGuiStoragePair* it = (ImGuiStoragePair*)*opaque_it;
+    if (it == NULL)
+        return false; // avoid dereferencing a null iterator
     ImGuiStoragePair* it_end = _Storage.Data.Data + _Storage.Data.Size;
     if (PreserveOrder && it == NULL && it_end != NULL)
         ImQsort(_Storage.Data.Data, (size_t)_Storage.Data.Size, sizeof(ImGuiStoragePair), PairComparerByValueInt); // ~ImGuiStorage::BuildSortByValueInt()

--- a/third_party/imgui/imstb_textedit.h
+++ b/third_party/imgui/imstb_textedit.h
@@ -980,7 +980,7 @@ retry:
 
          // compute current position of cursor point
          stb_textedit_clamp(str, state);
-         find.prev_first = 0;  // Initialize before use
+        find.prev_first = 0;  // Initialize before use to avoid garbage comparison
          stb_textedit_find_charpos(&find, str, state->cursor, state->single_line);
 
          for (j = 0; j < row_count; ++j) {


### PR DESCRIPTION
## Summary
- ensure CRC32 index uses unsigned char
- clarify null check before font RenderText
- guard against null iterator in ImGuiSelectionBasicStorage
- document initialization in stb_textedit

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875d935aa7c832a91ef0b15702779da