### PR TITLE
Apply partial TODO cleanup

### DIFF
--- a/src/audio/pipewire_capture.cpp
+++ b/src/audio/pipewire_capture.cpp
@@ -311,19 +311,18 @@ AudioError sep::audio::PipeWireCapture::init(const AudioConfig& config)
         std::string check_cmd = "systemctl --user is-active " + std::string(service);
         pw_thread_loop_unlock(loop_);
         FILE* fp = popen(check_cmd.c_str(), "r");
-        pw_thread_loop_lock(loop_);
-        if (!fp) {
-            spdlog::error("Failed to check service status: {}", service);
-            continue; // Try next service
-        }
-
         char service_status[128];
         bool service_running = false;
-        if (fgets(service_status, sizeof(service_status), fp) != nullptr) {
-            service_running = (strncmp(service_status, "active", 6) == 0);
+        if (!fp) {
+            spdlog::error("Failed to check service status: {}", service);
+        } else {
+            if (fgets(service_status, sizeof(service_status), fp) != nullptr) {
+                service_running = (strncmp(service_status, "active", 6) == 0);
+            }
+            pclose(fp);
         }
-        pclose(fp);
-
+        pw_thread_loop_lock(loop_);
+        
         if (!service_running) {
             spdlog::info("Starting {}...", service);
             
@@ -336,7 +335,6 @@ AudioError sep::audio::PipeWireCapture::init(const AudioConfig& config)
                 std::string status_cmd = "systemctl --user status " + std::string(service);
                 pw_thread_loop_unlock(loop_);
                 FILE* status_fp = popen(status_cmd.c_str(), "r");
-                pw_thread_loop_lock(loop_);
                 if (status_fp) {
                     char status_buf[1024];
                     while (fgets(status_buf, sizeof(status_buf), status_fp)) {
@@ -348,6 +346,7 @@ AudioError sep::audio::PipeWireCapture::init(const AudioConfig& config)
                     }
                     pclose(status_fp);
                 }
+                pw_thread_loop_lock(loop_);
                 continue; // Try next service
             }
             
@@ -358,17 +357,17 @@ AudioError sep::audio::PipeWireCapture::init(const AudioConfig& config)
                 
                 pw_thread_loop_unlock(loop_);
                 FILE* check_fp = popen(check_cmd.c_str(), "r");
-                pw_thread_loop_lock(loop_);
                 if (check_fp) {
                     if (fgets(service_status, sizeof(service_status), check_fp) != nullptr) {
                         if (strncmp(service_status, "active", 6) == 0) {
                             service_running = true;
-                            pclose(check_fp);
-                            break;
                         }
                     }
                     pclose(check_fp);
                 }
+                pw_thread_loop_lock(loop_);
+                if (service_running)
+                    break;
                 retries--;
             }
             

--- a/src/crow/socket_adaptors.h
+++ b/src/crow/socket_adaptors.h
@@ -55,7 +55,7 @@ namespace crow {
                 return ec;
             }
             asio_stub::error_code asio_ec;
-            socket_.close(asio_ec);
+            (void)socket_.close(asio_ec);
             ec = asio_ec ? asio_ec.value() : 0;
             if (ec) {
                 // Log the error for debugging purposes
@@ -68,7 +68,7 @@ namespace crow {
         {
             error_t ec = 0;
             asio::error_code asio_ec;
-            socket_.shutdown(tcp::socket::shutdown_both, asio_ec);
+            (void)socket_.shutdown(tcp::socket::shutdown_both, asio_ec);
             ec = asio_ec ? asio_ec.value() : 0;
             if (ec) {
                 CROW_LOG_ERROR << "Socket shutdown_both error: " << ec << " - " << asio_ec.message();
@@ -80,7 +80,7 @@ namespace crow {
         {
             error_t ec = 0;
             asio::error_code asio_ec;
-            socket_.shutdown(tcp::socket::shutdown_send, asio_ec);
+            (void)socket_.shutdown(tcp::socket::shutdown_send, asio_ec);
             ec = asio_ec ? asio_ec.value() : 0;
             if (ec) {
                 CROW_LOG_ERROR << "Socket shutdown_send error: " << ec << " - " << asio_ec.message();
@@ -92,7 +92,7 @@ namespace crow {
         {
             error_t ec = 0;
             asio::error_code asio_ec;
-            socket_.shutdown(tcp::socket::shutdown_receive, asio_ec);
+            (void)socket_.shutdown(tcp::socket::shutdown_receive, asio_ec);
             ec = asio_ec ? asio_ec.value() : 0;
             if (ec) {
                 CROW_LOG_ERROR << "Socket shutdown_receive error: " << ec << " - " << asio_ec.message();
@@ -132,7 +132,7 @@ namespace crow {
                 ec = asio::error::not_connected;
                 CROW_LOG_ERROR << "SSL Socket close error: not connected";
             } else {
-                raw_socket().close(ec);
+                (void)raw_socket().close(ec);
                 if (ec) {
                     CROW_LOG_ERROR << "SSL Socket close error: " << ec << " - " << ec.message();
                 }
@@ -144,7 +144,7 @@ namespace crow {
         {
             error_t ec;
             if (is_open()) {
-                raw_socket().shutdown(tcp::socket::shutdown_both, ec);
+                (void)raw_socket().shutdown(tcp::socket::shutdown_both, ec);
                 if (ec) {
                     CROW_LOG_ERROR << "SSL Socket shutdown_both error: " << ec << " - " << ec.message();
                 }
@@ -156,7 +156,7 @@ namespace crow {
         {
             error_t ec;
             if (is_open()) {
-                raw_socket().shutdown(tcp::socket::shutdown_send, ec);
+                (void)raw_socket().shutdown(tcp::socket::shutdown_send, ec);
                 if (ec) {
                     CROW_LOG_ERROR << "SSL Socket shutdown_send error: " << ec << " - " << ec.message();
                 }
@@ -168,7 +168,7 @@ namespace crow {
         {
             error_t ec;
             if (is_open()) {
-                raw_socket().shutdown(tcp::socket::shutdown_receive, ec);
+                (void)raw_socket().shutdown(tcp::socket::shutdown_receive, ec);
                 if (ec) {
                     CROW_LOG_ERROR << "SSL Socket shutdown_receive error: " << ec << " - " << ec.message();
                 }


### PR DESCRIPTION
## Summary
- silence unused-return warnings in socket adaptor
- reduce lock scope around blocking PipeWire checks

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` *(fails: Could not find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_6875ddea389c832aaf54c4b64a8d8347