### PR TITLE
Add tooling for CUDA and dependency analysis

### DIFF
--- a/docs/TODO/TODO.md
+++ b/docs/TODO/TODO.md
@@ -29,10 +29,10 @@ I've created a comprehensive guidance system for you with four major documents:
 ## Your Immediate Action Items
 
 ### Week 1 Critical Path:
-1. **Run the CUDA inventory script** (from the CUDA guide) to understand your exact API usage
+1. **Run the CUDA inventory script** (`tools/cuda_inventory.sh`) to understand your exact API usage
 2. **Fix the self-include in common.h** - this is a 1-line fix
-3. **Create the unified CUDA wrapper structure** - start with just the header
-4. **Run the circular dependency analyzer** to visualize your include graph
+3. **Create the unified CUDA wrapper structure** - start with just the header (`src/gpu/cuda_api_unified.h`)
+4. **Run the circular dependency analyzer** (`tools/analyze_includes.py`) to visualize your include graph
 
 ### Quick Wins (Can do TODAY):
 ```bash

--- a/src/gpu/cuda_api_unified.h
+++ b/src/gpu/cuda_api_unified.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#include <cstddef>
+#include <string>
+
+namespace sep {
+namespace gpu {
+
+struct CudaStream;
+struct CudaEvent;
+
+enum class MemcpyKind {
+    HostToHost,
+    HostToDevice,
+    DeviceToHost,
+    DeviceToDevice,
+    Default
+};
+
+enum class StreamFlags {
+    Default = 0x00,
+    NonBlocking = 0x01
+};
+
+class CudaError {
+public:
+    CudaError(int code, const std::string& msg) : code_(code), message_(msg) {}
+    bool is_success() const { return code_ == 0; }
+    const std::string& message() const { return message_; }
+    int code() const { return code_; }
+    static CudaError success() { return CudaError(0, "Success"); }
+private:
+    int code_;
+    std::string message_;
+};
+
+class CudaAPI {
+public:
+    static CudaAPI& instance();
+
+    CudaError malloc(void** ptr, std::size_t size);
+    CudaError free(void* ptr);
+    CudaError memcpy(void* dst, const void* src, std::size_t count, MemcpyKind kind);
+    CudaError memcpy_async(void* dst, const void* src, std::size_t count, MemcpyKind kind, CudaStream* stream);
+    CudaError memset(void* ptr, int value, std::size_t count);
+
+    CudaError create_stream(CudaStream** stream, StreamFlags flags = StreamFlags::Default);
+    CudaError destroy_stream(CudaStream* stream);
+    CudaError stream_synchronize(CudaStream* stream);
+    CudaError stream_wait_event(CudaStream* stream, CudaEvent* event);
+
+    CudaError get_device_count(int* count);
+    CudaError set_device(int device);
+    CudaError get_device(int* device);
+
+    CudaError get_last_error();
+    std::string error_string(const CudaError& error);
+
+private:
+    CudaAPI() = default;
+    ~CudaAPI() = default;
+    CudaAPI(const CudaAPI&) = delete;
+    CudaAPI& operator=(const CudaAPI&) = delete;
+};
+
+class CudaMemory {
+public:
+    explicit CudaMemory(std::size_t size);
+    ~CudaMemory();
+
+    void* get() { return ptr_; }
+    const void* get() const { return ptr_; }
+    std::size_t size() const { return size_; }
+
+    CudaMemory(CudaMemory&& other) noexcept;
+    CudaMemory& operator=(CudaMemory&& other) noexcept;
+
+    CudaMemory(const CudaMemory&) = delete;
+    CudaMemory& operator=(const CudaMemory&) = delete;
+
+private:
+    void* ptr_ = nullptr;
+    std::size_t size_ = 0;
+};
+
+} // namespace gpu
+} // namespace sep
+

--- a/tools/analyze_includes.py
+++ b/tools/analyze_includes.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Analyze C/C++ includes for circular dependencies and visualize the graph."""
+
+import os
+import re
+from collections import defaultdict
+import networkx as nx
+import matplotlib.pyplot as plt
+
+class IncludeAnalyzer:
+    def __init__(self, src_dir: str):
+        self.src_dir = src_dir
+        self.graph = nx.DiGraph()
+        self.cycles = []
+
+    def analyze(self):
+        for root, _dirs, files in os.walk(self.src_dir):
+            for file in files:
+                if file.endswith(('.h', '.hpp')):
+                    self._parse_includes(os.path.join(root, file))
+        self.cycles = list(nx.simple_cycles(self.graph))
+        return self
+
+    def _parse_includes(self, filepath: str):
+        relative = os.path.relpath(filepath, self.src_dir)
+        self.graph.add_node(relative)
+        with open(filepath, 'r', errors='ignore') as f:
+            content = f.read()
+        pattern = r'#include\s*[<"]([^>"]+)[>"]'
+        for include in re.findall(pattern, content):
+            if not include.startswith('/'):
+                path = os.path.normpath(os.path.join(os.path.dirname(relative), include))
+                if os.path.exists(os.path.join(self.src_dir, path)):
+                    self.graph.add_edge(relative, path)
+
+    def report_cycles(self):
+        print(f"Found {len(self.cycles)} circular dependencies:\n")
+        for i, cycle in enumerate(self.cycles, 1):
+            print(f"Cycle {i}:")
+            for j in range(len(cycle)):
+                print(f"  {cycle[j]} -> {cycle[(j + 1) % len(cycle)]}")
+            print()
+
+    def visualize(self, output_file: str = 'dependency_graph.png'):
+        plt.figure(figsize=(20, 20))
+        cyclic_nodes = set(n for c in self.cycles for n in c)
+        colors = ['red' if n in cyclic_nodes else 'lightblue' for n in self.graph.nodes()]
+        pos = nx.spring_layout(self.graph, k=2, iterations=50)
+        nx.draw(self.graph, pos, node_color=colors, with_labels=True, node_size=100, font_size=8,
+                arrows=True, edge_color='gray')
+        plt.savefig(output_file, dpi=300, bbox_inches='tight')
+        plt.close()
+
+if __name__ == '__main__':
+    src = os.path.join(os.path.dirname(__file__), '..', 'src')
+    IncludeAnalyzer(src).analyze().report_cycles()

--- a/tools/cuda_inventory.sh
+++ b/tools/cuda_inventory.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# tools/cuda_inventory.sh - Analyze CUDA API usage
+# Lists direct CUDA calls, SEP wrapper calls, and namespace calls
+
+set -e
+
+SRC_DIR="$(git rev-parse --show-toplevel)/src"
+
+echo "=== Direct CUDA Calls ==="
+grep -rh "cuda[A-Z][a-zA-Z]*(" "$SRC_DIR" --include="*.cpp" --include="*.h" | \
+  sed 's/.*\(cuda[A-Z][a-zA-Z]*\)(.*/\1/' | sort | uniq -c | sort -nr
+
+echo
+echo "=== SEP Wrapped Calls ==="
+grep -rh "SEP_cuda[a-zA-Z]*(" "$SRC_DIR" --include="*.cpp" --include="*.h" | \
+  sed 's/.*\(SEP_cuda[a-zA-Z]*\)(.*/\1/' | sort | uniq -c | sort -nr
+
+echo
+echo "=== Namespace Calls ==="
+grep -rh "sep::cuda::[a-zA-Z]*(" "$SRC_DIR" --include="*.cpp" --include="*.h" | \
+  sed 's/.*sep::cuda::\([a-zA-Z]*\)(.*/\1/' | sort | uniq -c | sort -nr
+

--- a/tools/dependency_metrics.sh
+++ b/tools/dependency_metrics.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# tools/dependency_metrics.sh - Summarize include statistics
+
+set -e
+
+SRC_DIR="$(git rev-parse --show-toplevel)/src"
+
+echo "=== Include Statistics ==="
+find "$SRC_DIR" -name "*.h" -o -name "*.hpp" | xargs grep -h "^#include" | wc -l
+
+echo
+echo "=== Most Included Files ==="
+find "$SRC_DIR" -name "*.h" -o -name "*.hpp" | xargs grep -h "^#include" | \
+  sed 's/#include.*[<"]\(.*\)[>"].*/\1/' | sort | uniq -c | sort -nr | head -20
+
+echo
+echo "=== Files With Most Includes ==="
+for file in $(find "$SRC_DIR" -name "*.h" -o -name "*.hpp"); do
+    count=$(grep -c "^#include" "$file" 2>/dev/null || echo 0)
+    echo "$count $file"
+done | sort -nr | head -20
+


### PR DESCRIPTION
## Summary
- add helper scripts for CUDA call inventory and include analysis
- add script to measure include statistics
- start a unified CUDA API header
- reference new tools in TODO instructions

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68772a4060a8832abcc1ef41ffb6729c