### PR TITLE
Add CUDA inventory helper script

### DIFF
--- a/docs/TODO/cuda-wrapper-unification-guide.md
+++ b/docs/TODO/cuda-wrapper-unification-guide.md
@@ -37,6 +37,12 @@ grep -rh "sep::cuda::[a-zA-Z]*(" src/ --include="*.cpp" --include="*.h" | \
   sed 's/.*sep::cuda::\([a-zA-Z]*\)(.*/\1/' | sort | uniq -c | sort -nr
 ```
 
+Run the script from the repository root:
+
+```bash
+$ ./tools/cuda_inventory.sh
+```
+
 ### Step 2: Create the Unified Interface
 
 ```cpp

--- a/tools/cuda_inventory.sh
+++ b/tools/cuda_inventory.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# This script scans the source tree and lists all CUDA API calls used.
+# It groups them into three categories: direct CUDA calls, SEP wrapper
+# calls, and namespace-based calls.
+
+set -euo pipefail
+
+# change to repo root if run from within subdir
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+echo "=== Direct CUDA Calls ==="
+grep -rh "cuda[A-Z][a-zA-Z]*(" src/ --include="*.cpp" --include="*.h" | \
+  sed 's/.*\(cuda[A-Z][a-zA-Z]*\)(.*/\1/' | sort | uniq -c | sort -nr
+
+echo -e "\n=== SEP Wrapped Calls ==="
+grep -rh "SEP_cuda[a-zA-Z]*(" src/ --include="*.cpp" --include="*.h" | \
+  sed 's/.*\(SEP_cuda[a-zA-Z]*\)(.*/\1/' | sort | uniq -c | sort -nr
+
+echo -e "\n=== Namespace Calls ==="
+grep -rh "sep::cuda::[a-zA-Z]*(" src/ --include="*.cpp" --include="*.h" | \
+  sed 's/.*sep::cuda::\([a-zA-Z]*\)(.*/\1/' | sort | uniq -c | sort -nr


### PR DESCRIPTION
## Summary
- add `tools/cuda_inventory.sh` to list CUDA API usage
- show how to run the script in the CUDA wrapper unification guide

## Testing
- `ls -l tools/cuda_inventory.sh`

------
https://chatgpt.com/codex/tasks/task_e_68772b0bf1dc832a94c247bf0c995781