### PR TITLE
Add file dialog UI and modern theme

### DIFF
--- a/src/workbench/core/file_dialog.cpp
+++ b/src/workbench/core/file_dialog.cpp
@@ -1,0 +1,64 @@
+#include "file_dialog.hpp"
+#include <imgui.h>
+#include <vector>
+#include <algorithm>
+
+namespace sep::workbench {
+
+void FileDialog::open(const std::string& start_dir) {
+    current_dir_ = start_dir.empty() ? std::filesystem::current_path() : std::filesystem::path(start_dir);
+    open_ = true;
+    selection_.clear();
+}
+
+bool FileDialog::render(std::string& selected_path) {
+    if (!open_) return false;
+    bool chosen = false;
+    ImGui::OpenPopup("File Browser");
+    if (ImGui::BeginPopupModal("File Browser", &open_, ImGuiWindowFlags_AlwaysAutoResize)) {
+        ImGui::TextUnformatted(current_dir_.string().c_str());
+        ImGui::Separator();
+
+        if (current_dir_ != current_dir_.root_path()) {
+            if (ImGui::Selectable("..", false)) {
+                current_dir_ = current_dir_.parent_path();
+            }
+        }
+
+        std::vector<std::filesystem::directory_entry> entries;
+        for (const auto& entry : std::filesystem::directory_iterator(current_dir_)) {
+            entries.push_back(entry);
+        }
+        std::sort(entries.begin(), entries.end(), [](const auto& a, const auto& b){
+            if (a.is_directory() != b.is_directory()) return a.is_directory() && !b.is_directory();
+            return a.path().filename() < b.path().filename();
+        });
+        for (const auto& entry : entries) {
+            const auto filename = entry.path().filename().string();
+            if (entry.is_directory()) {
+                if (ImGui::Selectable((filename + "/").c_str(), false)) {
+                    current_dir_ /= entry.path().filename();
+                }
+            } else {
+                bool selected = (selection_ == entry.path().string());
+                if (ImGui::Selectable(filename.c_str(), selected)) {
+                    selection_ = entry.path().string();
+                }
+            }
+        }
+        ImGui::Separator();
+        if (ImGui::Button("Select") && !selection_.empty()) {
+            selected_path = selection_;
+            chosen = true;
+            open_ = false;
+        }
+        ImGui::SameLine();
+        if (ImGui::Button("Cancel")) {
+            open_ = false;
+        }
+        ImGui::EndPopup();
+    }
+    return chosen;
+}
+
+} // namespace sep::workbench

--- a/src/workbench/core/file_dialog.hpp
+++ b/src/workbench/core/file_dialog.hpp
@@ -1,0 +1,18 @@
+#pragma once
+#include <string>
+#include <filesystem>
+
+namespace sep::workbench {
+
+class FileDialog {
+public:
+    void open(const std::string& start_dir = ".");
+    bool render(std::string& selected_path);
+    bool isOpen() const { return open_; }
+private:
+    bool open_{false};
+    std::filesystem::path current_dir_{};
+    std::string selection_{};
+};
+
+} // namespace sep::workbench

--- a/src/workbench/core/metrics_dashboard.cpp
+++ b/src/workbench/core/metrics_dashboard.cpp
@@ -1,9 +1,10 @@
 #include "metrics_dashboard.h"
 #include <imgui.h>
+#include <filesystem>
 // #include <implot.h> // TODO: Add implot to third_party
 #include <iostream>
 #include <algorithm>
-#include <filesystem>
+#include "file_dialog.hpp"
 
 namespace sep::workbench {
 
@@ -129,6 +130,12 @@ void MetricsDashboard::render() {
         }
     }
     ImGui::End();
+
+    std::string selected;
+    if (file_dialog_.render(selected)) {
+        strncpy(file_path_buffer_, selected.c_str(), sizeof(file_path_buffer_) - 1);
+        file_path_buffer_[sizeof(file_path_buffer_) - 1] = '\0';
+    }
 }
 
 void MetricsDashboard::renderControlPanel() {
@@ -330,7 +337,7 @@ void MetricsDashboard::renderDataSourceSelector() {
             ImGui::InputText("File Path", file_path_buffer_, sizeof(file_path_buffer_));
             ImGui::SameLine();
             if (ImGui::Button("Browse")) {
-                // Could open file dialog
+                file_dialog_.open(std::filesystem::path(file_path_buffer_).empty() ? "." : std::filesystem::path(file_path_buffer_).parent_path().string());
             }
             if (ImGui::Button("Load File", ImVec2(-1, 0))) {
                 handleDataLoad();

--- a/src/workbench/core/metrics_dashboard.h
+++ b/src/workbench/core/metrics_dashboard.h
@@ -2,6 +2,7 @@
 
 #include "metrics_monitor.h"
 #include "memory_monitor.hpp"
+#include "file_dialog.hpp"
 #include <memory>
 #include <vector>
 #include <string>
@@ -47,6 +48,7 @@ private:
 
     std::unique_ptr<MetricsMonitor> monitor_;
     std::unique_ptr<MemoryMonitor> memory_monitor_;
+    FileDialog file_dialog_;
     
     // UI State
     bool show_dashboard_{true};

--- a/src/workbench/core/workbench_core.cpp
+++ b/src/workbench/core/workbench_core.cpp
@@ -210,6 +210,22 @@ bool WorkbenchEngine::initializeImGui()
     
     // Setup style
     ImGui::StyleColorsDark();
+    auto applyModernTheme = [](){
+        ImGuiStyle& style = ImGui::GetStyle();
+        style.WindowRounding = 5.0f;
+        style.FrameRounding = 5.0f;
+        style.ScrollbarRounding = 5.0f;
+
+        ImVec4* colors = style.Colors;
+        colors[ImGuiCol_WindowBg] = ImVec4(0.1f, 0.105f, 0.11f, 1.0f);
+        colors[ImGuiCol_Header] = ImVec4(0.2f, 0.205f, 0.21f, 1.0f);
+        colors[ImGuiCol_HeaderHovered] = ImVec4(0.3f, 0.305f, 0.31f, 1.0f);
+        colors[ImGuiCol_HeaderActive] = ImVec4(0.25f, 0.255f, 0.26f, 1.0f);
+        colors[ImGuiCol_Button] = ImVec4(0.2f, 0.205f, 0.21f, 1.0f);
+        colors[ImGuiCol_ButtonHovered] = ImVec4(0.3f, 0.305f, 0.31f, 1.0f);
+        colors[ImGuiCol_ButtonActive] = ImVec4(0.15f, 0.1505f, 0.151f, 1.0f);
+    };
+    applyModernTheme();
     
     // Setup platform/renderer bindings
     ImGui_ImplGlfw_InitForOpenGL(window_, true);


### PR DESCRIPTION
## Summary
- introduce `FileDialog` utility for basic browsing
- hook file dialog into metrics dashboard
- update ImGui initialization to apply a modern dark theme

## Testing
- `./build.sh` *(fails: docker not found)*
- `python3 quick_alpha_test.py` *(fails: pattern metric executable missing)*

------
https://chatgpt.com/codex/tasks/task_e_687dd7a3c508832a8cfdd83c480a8524