### PR TITLE
Fix site asset paths and update dashboard text

### DIFF
--- a/main.js
+++ b/main.js
@@ -3,7 +3,10 @@ document.addEventListener('DOMContentLoaded', () => {
     const searchInput = document.getElementById('search-input');
     let allConcepts = [];
 
-    fetch('public/concepts.json')
+    // Load the generated concepts list from the repository root.
+    // This path was previously "public/concepts.json" but the file
+    // was moved to the project root to simplify deployment.
+    fetch('concepts.json')
         .then(response => {
             if (!response.ok) {
                 throw new Error(`HTTP error! status: ${response.status}`);

--- a/parse_docs.py
+++ b/parse_docs.py
@@ -55,9 +55,12 @@ def parse_cpp_headers(source_dir):
 def main():
     source_dir = 'src'
     concepts = parse_cpp_headers(source_dir)
-    with open('public/concepts.json', 'w') as f:
+    # Write the concepts file to the repository root so it can be
+    # served directly alongside index.html. Previously this script
+    # wrote to the old `public/` directory.
+    with open('concepts.json', 'w') as f:
         json.dump({'concepts': concepts}, f, indent=4)
-    print(f"Generated public/concepts.json with {len(concepts)} concepts.")
+    print(f"Generated concepts.json with {len(concepts)} concepts.")
 
 if __name__ == '__main__':
     main()

--- a/src/workbench/core/metrics_dashboard.cpp
+++ b/src/workbench/core/metrics_dashboard.cpp
@@ -1313,7 +1313,8 @@ void MetricsDashboard::renderOandaMainView() {
     
     if (ImGui::BeginChild("MainChart", chart_size, true)) {
         if (historical_data_loaded_ && !historical_data_.empty()) {
-            ImGui::Text("24hr Historical Chart for %s", selected_instrument_.c_str());
+            // Display the time range of the cached candles (48 hours)
+            ImGui::Text("Historical Chart (48hr) for %s", selected_instrument_.c_str());
             ImGui::Text("Candles: %zu", historical_data_.size());
             
             // Chart info header
@@ -1342,7 +1343,8 @@ void MetricsDashboard::renderOandaMainView() {
     
     // SEP Metrics panel below chart
     if (ImGui::BeginChild("SEPMetrics", ImVec2(ImGui::GetContentRegionAvail().x, 200), true)) {
-        ImGui::Text("24hr Market Snapshot Metrics");
+        // Metrics calculated from the cached 48hr window
+        ImGui::Text("48hr Market Snapshot Metrics");
         ImGui::Separator();
         
         // Show cached snapshot metrics
@@ -1381,7 +1383,7 @@ void MetricsDashboard::renderOandaMainView() {
             ImGui::Text("Data Points: %zu | Calculated: %ld min ago", 
                        cache.minute_data.size(), time_since_calc);
         } else {
-            ImGui::Text("Loading 24hr snapshot metrics...");
+            ImGui::Text("Loading 48hr snapshot metrics...");
         }
         
         ImGui::Separator();
@@ -1551,8 +1553,9 @@ void MetricsDashboard::renderHistoricalChart() {
     // Time axis (simple for now)
     if (!historical_data_.empty()) {
         // First candle time
-        draw_list->AddText(ImVec2(chart_pos.x, chart_pos.y + chart_size.y + 5), 
-                          IM_COL32(180, 180, 190, 255), "24hr ago");
+        // Indicate the start of the cached window (48 hours ago)
+        draw_list->AddText(ImVec2(chart_pos.x, chart_pos.y + chart_size.y + 5),
+                          IM_COL32(180, 180, 190, 255), "48hr ago");
         
         // Last candle time  
         draw_list->AddText(ImVec2(chart_pos.x + chart_size.x - 30, chart_pos.y + chart_size.y + 5), 

--- a/src/workbench/core/metrics_dashboard.h
+++ b/src/workbench/core/metrics_dashboard.h
@@ -64,14 +64,16 @@ struct MarketDepth {
  */
 class MetricsDashboard {
 public:
-    // 24-hour sliding window cache
+    // 48-hour sliding window cache
     struct Chart24HrCache {
-        std::vector<sep::connectors::OandaCandle> minute_data;  // 1440 minutes = 24 hours
+        // Minute-by-minute data for two full days (used for a
+        // 24-hour sliding window view and short-term analysis)
+        std::vector<sep::connectors::OandaCandle> minute_data;  // 2880 minutes = 48 hours
         std::string instrument;
         std::chrono::system_clock::time_point last_update;
         bool is_valid{false};
         
-        // Coherence metrics for this 24hr snapshot
+        // Coherence metrics for this 48hr snapshot
         double coherence_metric{0.0};
         double stability_metric{0.0};
         double entropy_metric{0.0};


### PR DESCRIPTION
## Summary
- fix paths for concept JSON lookup in `main.js`
- update `parse_docs.py` to write `concepts.json` in repo root
- clarify caching period in metrics dashboard headers
- show `48hr` window text in dashboard chart

## Testing
- `./build.sh` *(fails: docker not found)*
- `timeout 60s ./run_workbench.sh` *(fails: waiting for build output)*

------
https://chatgpt.com/codex/tasks/task_e_68808007c4fc832ab64fcc72ed388235