### PR TITLE
Add checks in imgui stub and cleanup SignalsTabController

### DIFF
--- a/src/apps/workbench/stubs/imgui.cpp
+++ b/src/apps/workbench/stubs/imgui.cpp
@@ -4,6 +4,7 @@
 
 namespace ImGui {
     bool Begin(const char* name) {
+        if (!name) return false;
         printf("[ImGui] Begin: %s\n", name);
         return true;
     }
@@ -13,6 +14,7 @@ namespace ImGui {
     }
 
     void Text(const char* fmt, ...) {
+        if (!fmt) return;
         va_list args;
         va_start(args, fmt);
         printf("[ImGui] ");
@@ -26,16 +28,19 @@ namespace ImGui {
     }
 
     bool Checkbox(const char* label, bool* v) {
+        if (!label || !v) return false;
         printf("[ImGui] Checkbox: %s = %s\n", label, *v ? "true" : "false");
         return false;
     }
 
     bool SliderFloat(const char* label, float* v, float v_min, float v_max) {
+        if (!label || !v) return false;
         printf("[ImGui] SliderFloat: %s = %.3f (%.3f - %.3f)\n", label, *v, v_min, v_max);
         return false;
     }
 
     bool Button(const char* label) {
+        if (!label) return false;
         printf("[ImGui] Button: %s\n", label);
         return false;
     }

--- a/src/apps/workbench/tabs/signals_tab_controller.cpp
+++ b/src/apps/workbench/tabs/signals_tab_controller.cpp
@@ -26,7 +26,7 @@ bool SignalsTabController::initialize() {
 
 void SignalsTabController::render() {
     ImGui::Columns(2, "SignalsColumns", true);
-    ImGui::Begin("Signal Thresholds");
+    (void)ImGui::Begin("Signal Thresholds");
     static float min_coherence = 0.7f;
     static float min_stability = 0.6f;
     static float max_entropy = 0.3f;
@@ -50,7 +50,7 @@ void SignalsTabController::render() {
     ImGui::NextColumn();
 
     if (metrics_monitor_) {
-        ImGui::Begin("SEP Engine Metrics");
+        (void)ImGui::Begin("SEP Engine Metrics");
         const auto& system_metrics = metrics_monitor_->getSystemMetrics();
         const auto& rolling_metrics = metrics_monitor_->getRollingMetrics();
 
@@ -653,7 +653,7 @@ void SignalsTabController::renderChartGrid() {
         
         double price = price_max_ - ((price_max_ - price_min_) * i / num_price_lines);
         char price_text[32];
-        sprintf(price_text, "%.5f", price);
+        (void)sprintf(price_text, "%.5f", price);
         draw_list->AddText(ImVec2(chart_pos_.x - 70, y - 8), 
                            IM_COL32(150, 150, 160, 255), price_text);
     }
@@ -666,7 +666,7 @@ void SignalsTabController::renderChartGrid() {
                            grid_color);
         
         char time_text[16];
-        sprintf(time_text, "%02d:00", (24 - (i * 4)) % 24);
+        (void)sprintf(time_text, "%02d:00", (24 - (i * 4)) % 24);
         draw_list->AddText(ImVec2(x - 15, chart_pos_.y + chart_size_.y + 5), 
                            IM_COL32(150, 150, 160, 255), time_text);
     }


### PR DESCRIPTION
## Summary
- guard against null pointers in `imgui` stub implementations
- silence warnings by casting ignored `ImGui::Begin` and `sprintf` results to `void`

## Testing
- `cmake --build simple_test/build`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68842cff0130832ab5e87d409b9cf7fd