### PR TITLE
Add correlation metrics and export

### DIFF
--- a/src/apps/workbench/core/multi_timeframe_analyzer.cpp
+++ b/src/apps/workbench/core/multi_timeframe_analyzer.cpp
@@ -607,6 +607,12 @@ CorrelationMetrics MultiTimeframeAnalyzer::calculateCorrelationMetrics(const std
         prices.push_back(candle.close);
     }
 
+    // Price movements (delta close)
+    std::vector<double> price_moves;
+    for (size_t i = 1; i < prices.size(); ++i) {
+        price_moves.push_back(prices[i] - prices[i - 1]);
+    }
+
     std::vector<double> coherence_values;
     std::vector<double> stability_values;
     std::vector<double> entropy_values;
@@ -617,31 +623,62 @@ CorrelationMetrics MultiTimeframeAnalyzer::calculateCorrelationMetrics(const std
         entropy_values.push_back(pattern.entropy);
     }
 
-    auto calculate_correlation = [](const std::vector<double>& v1, const std::vector<double>& v2) {
-        if (v1.size() != v2.size() || v1.empty()) {
+    auto pearson = [](const std::vector<double>& a, const std::vector<double>& b) {
+        if (a.size() != b.size() || a.empty()) {
             return 0.0;
         }
 
-        double sum_v1 = 0.0, sum_v2 = 0.0, sum_v1_sq = 0.0, sum_v2_sq = 0.0, sum_products = 0.0;
-        int n = v1.size();
+        double sum_a = 0.0, sum_b = 0.0, sum_a_sq = 0.0, sum_b_sq = 0.0, sum_prod = 0.0;
+        int n = static_cast<int>(a.size());
 
         for (int i = 0; i < n; ++i) {
-            sum_v1 += v1[i];
-            sum_v2 += v2[i];
-            sum_v1_sq += v1[i] * v1[i];
-            sum_v2_sq += v2[i] * v2[i];
-            sum_products += v1[i] * v2[i];
+            sum_a += a[i];
+            sum_b += b[i];
+            sum_a_sq += a[i] * a[i];
+            sum_b_sq += b[i] * b[i];
+            sum_prod += a[i] * b[i];
         }
 
-        double numerator = n * sum_products - sum_v1 * sum_v2;
-        double denominator = std::sqrt((n * sum_v1_sq - sum_v1 * sum_v1) * (n * sum_v2_sq - sum_v2 * sum_v2));
+        double numerator = n * sum_prod - sum_a * sum_b;
+        double denominator = std::sqrt((n * sum_a_sq - sum_a * sum_a) * (n * sum_b_sq - sum_b * sum_b));
 
         return (denominator == 0) ? 0.0 : numerator / denominator;
     };
 
-    correlation_metrics.coherence_price_correlation = calculate_correlation(coherence_values, prices);
-    correlation_metrics.stability_price_correlation = calculate_correlation(stability_values, prices);
-    correlation_metrics.entropy_price_correlation = calculate_correlation(entropy_values, prices);
+    auto spearman = [&pearson](const std::vector<double>& a, const std::vector<double>& b) {
+        if (a.size() != b.size() || a.empty()) {
+            return 0.0;
+        }
+
+        int n = static_cast<int>(a.size());
+        std::vector<std::pair<double, int>> ar(n), br(n);
+        for (int i = 0; i < n; ++i) {
+            ar[i] = {a[i], i};
+            br[i] = {b[i], i};
+        }
+        std::sort(ar.begin(), ar.end(), [](auto& x, auto& y){ return x.first < y.first; });
+        std::sort(br.begin(), br.end(), [](auto& x, auto& y){ return x.first < y.first; });
+        std::vector<double> rank_a(n), rank_b(n);
+        for (int i = 0; i < n; ++i) {
+            rank_a[ar[i].second] = i + 1;
+            rank_b[br[i].second] = i + 1;
+        }
+        return pearson(rank_a, rank_b);
+    };
+
+    // Ensure vectors are same length
+    size_t n = std::min({coherence_values.size(), stability_values.size(), entropy_values.size(), price_moves.size()});
+    coherence_values.resize(n);
+    stability_values.resize(n);
+    entropy_values.resize(n);
+    price_moves.resize(n);
+
+    correlation_metrics.coherence_pearson = pearson(coherence_values, price_moves);
+    correlation_metrics.coherence_spearman = spearman(coherence_values, price_moves);
+    correlation_metrics.stability_pearson = pearson(stability_values, price_moves);
+    correlation_metrics.stability_spearman = spearman(stability_values, price_moves);
+    correlation_metrics.entropy_pearson = pearson(entropy_values, price_moves);
+    correlation_metrics.entropy_spearman = spearman(entropy_values, price_moves);
 
     return correlation_metrics;
 }

--- a/src/apps/workbench/core/multi_timeframe_analyzer.h
+++ b/src/apps/workbench/core/multi_timeframe_analyzer.h
@@ -58,9 +58,12 @@ struct TimeframeMetrics {
 };
 
 struct CorrelationMetrics {
-    double coherence_price_correlation = 0.0;
-    double stability_price_correlation = 0.0;
-    double entropy_price_correlation = 0.0;
+    double coherence_pearson = 0.0;
+    double coherence_spearman = 0.0;
+    double stability_pearson = 0.0;
+    double stability_spearman = 0.0;
+    double entropy_pearson = 0.0;
+    double entropy_spearman = 0.0;
 };
 
 struct MultiTimeframeSignal {

--- a/src/apps/workbench/tabs/engine_tab_controller.cpp
+++ b/src/apps/workbench/tabs/engine_tab_controller.cpp
@@ -1,5 +1,7 @@
 #include "engine_tab_controller.h"
 #include "core/multi_timeframe_analyzer.h"
+#include "engine/data_parser.h"
+#include <map>
 
 #include <iostream>
 
@@ -216,9 +218,32 @@ void EngineTabController::renderCorrelationPanel() {
 
     auto correlation_metrics = multi_timeframe_analyzer_->calculateCorrelationMetrics(selected_timeframe);
 
-    ImGui::Text("Coherence-Price Correlation: %.3f", correlation_metrics.coherence_price_correlation);
-    ImGui::Text("Stability-Price Correlation: %.3f", correlation_metrics.stability_price_correlation);
-    ImGui::Text("Entropy-Price Correlation: %.3f", correlation_metrics.entropy_price_correlation);
+    ImGui::Text("Correlation Coefficients");
+    ImGui::Columns(3);
+    ImGui::Text("Metric"); ImGui::NextColumn();
+    ImGui::Text("Pearson"); ImGui::NextColumn();
+    ImGui::Text("Spearman"); ImGui::NextColumn();
+    ImGui::Separator();
+
+    ImGui::Text("Coherence"); ImGui::NextColumn();
+    ImGui::Text("%.3f", correlation_metrics.coherence_pearson); ImGui::NextColumn();
+    ImGui::Text("%.3f", correlation_metrics.coherence_spearman); ImGui::NextColumn();
+
+    ImGui::Text("Stability"); ImGui::NextColumn();
+    ImGui::Text("%.3f", correlation_metrics.stability_pearson); ImGui::NextColumn();
+    ImGui::Text("%.3f", correlation_metrics.stability_spearman); ImGui::NextColumn();
+
+    ImGui::Text("Entropy"); ImGui::NextColumn();
+    ImGui::Text("%.3f", correlation_metrics.entropy_pearson); ImGui::NextColumn();
+    ImGui::Text("%.3f", correlation_metrics.entropy_spearman); ImGui::NextColumn();
+    ImGui::Columns(1);
+
+    ImGui::InputText("Export Path", correlation_export_path_, sizeof(correlation_export_path_));
+    if (ImGui::Button("Export")) {
+        sep::DataParser parser;
+        std::map<std::string, workbench::CorrelationMetrics> data{{selected_timeframe, correlation_metrics}};
+        parser.exportCorrelationCSV(correlation_export_path_, data);
+    }
 
     ImGui::End();
 }

--- a/src/apps/workbench/tabs/engine_tab_controller.h
+++ b/src/apps/workbench/tabs/engine_tab_controller.h
@@ -47,6 +47,9 @@ private:
     std::vector<sep::quantum::PatternMetrics> getCurrentPatternMetrics();
     sep::quantum::CoherenceManager::CoherenceMetrics getCoherenceMetrics();
     void resetEngineState();
+
+    // Export path buffer
+    char correlation_export_path_[512] = "correlation.csv";
 };
 
 } // namespace sep::workbench

--- a/src/engine/data_parser.cpp
+++ b/src/engine/data_parser.cpp
@@ -515,4 +515,23 @@ uint64_t DataParser::parseTimestamp(const std::string& timestamp) const
         now.time_since_epoch()).count();
 }
 
+bool DataParser::exportCorrelationCSV(const std::string& path,
+                                      const std::map<std::string, workbench::CorrelationMetrics>& data) const {
+    std::ofstream file(path);
+    if (!file.is_open()) {
+        return false;
+    }
+    file << "timeframe,coh_pearson,coh_spearman,stab_pearson,stab_spearman,entropy_pearson,entropy_spearman\n";
+    for (const auto& [tf, metrics] : data) {
+        file << tf << ','
+             << metrics.coherence_pearson << ','
+             << metrics.coherence_spearman << ','
+             << metrics.stability_pearson << ','
+             << metrics.stability_spearman << ','
+             << metrics.entropy_pearson << ','
+             << metrics.entropy_spearman << "\n";
+    }
+    return true;
+}
+
 } // namespace sep

--- a/src/engine/data_parser.h
+++ b/src/engine/data_parser.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "engine/standard_includes.h"
+#include <map>
+#include "apps/workbench/core/multi_timeframe_analyzer.h"
 
 namespace sep {
     namespace quantum
@@ -57,6 +59,10 @@ public:
 
     // Convert patterns to PinStates for engine compatibility
     std::vector<sep::PinState> toPinStates(const std::vector<sep::quantum::Pattern>& patterns);
+
+    // Export correlation metrics to CSV
+    bool exportCorrelationCSV(const std::string& path,
+                              const std::map<std::string, workbench::CorrelationMetrics>& data) const;
 
 private:
     // Format detection


### PR DESCRIPTION
## Summary
- compute Pearson and Spearman coefficients on multi-timeframe metrics
- export correlation results via `DataParser`
- show correlation tables in workbench engine tab with export option

## Testing
- `g++ -std=c++17 -I./src -c src/apps/workbench/core/multi_timeframe_analyzer.cpp -o /tmp/test.o` *(fails: glm/glm.hpp not found)*
- `./build.sh` *(fails: cd: /sep: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68842cc3efcc832aa3df216aa31efc32