### PR TITLE
Add runtime signal threshold configuration

### DIFF
--- a/src/apps/workbench/tabs/signals_tab_controller.cpp
+++ b/src/apps/workbench/tabs/signals_tab_controller.cpp
@@ -27,20 +27,17 @@ bool SignalsTabController::initialize() {
 void SignalsTabController::render() {
     ImGui::Columns(2, "SignalsColumns", true);
     ImGui::Begin("Signal Thresholds");
-    static float min_coherence = 0.7f;
-    static float min_stability = 0.6f;
-    static float max_entropy = 0.3f;
-    ImGui::SliderFloat("Min Coherence", &min_coherence, 0.0f, 1.0f);
-    ImGui::SliderFloat("Min Stability", &min_stability, 0.0f, 1.0f);
-    ImGui::SliderFloat("Max Entropy", &max_entropy, 0.0f, 1.0f);
+    ImGui::SliderFloat("Min Coherence", &min_coherence_, 0.0f, 1.0f);
+    ImGui::SliderFloat("Min Stability", &min_stability_, 0.0f, 1.0f);
+    ImGui::SliderFloat("Max Entropy", &max_entropy_, 0.0f, 1.0f);
     if (ImGui::Button("Apply")) {
         if (workbench_engine_) {
             auto* pme = workbench_engine_->getPatternMetricEngine();
             if (pme) {
                 sep::quantum::SignalThresholds thresholds;
-                thresholds.min_coherence = min_coherence;
-                thresholds.min_stability = min_stability;
-                thresholds.max_entropy = max_entropy;
+                thresholds.min_coherence = min_coherence_;
+                thresholds.min_stability = min_stability_;
+                thresholds.max_entropy = max_entropy_;
                 pme->setSignalThresholds(thresholds);
             }
         }

--- a/src/apps/workbench/tabs/signals_tab_controller.h
+++ b/src/apps/workbench/tabs/signals_tab_controller.h
@@ -62,6 +62,11 @@ private:
     bool show_trend_lines_ = true;
     bool auto_detect_trends_ = true;
 
+    // Threshold settings for signal generation
+    float min_coherence_ = 0.7f;
+    float min_stability_ = 0.6f;
+    float max_entropy_ = 0.3f;
+
     // Chart dimensions and state
     ImVec2 chart_size_;
     ImVec2 chart_pos_;

--- a/src/engine/logging.cpp
+++ b/src/engine/logging.cpp
@@ -127,5 +127,17 @@ std::string Manager::levelToString(Level level)
     }
 }
 
+void logPatternDetected(const std::string &pattern_id,
+                        std::chrono::system_clock::time_point timestamp)
+{
+    auto logger = spdlog::get("pattern_engine");
+    if (!logger) return;
+
+    std::time_t tt = std::chrono::system_clock::to_time_t(timestamp);
+    char buf[32];
+    std::strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", std::localtime(&tt));
+    logger->info("Pattern detected {} at {}", pattern_id, buf);
+}
+
 }  // namespace sep::logging
 

--- a/src/engine/logging.h
+++ b/src/engine/logging.h
@@ -58,6 +58,10 @@ class Manager {
   ::spdlog::level::level_enum toSpdLogLevel(Level level);
 };
 
+// Log a detected pattern with timestamp to the pattern_engine logger
+void logPatternDetected(const std::string &pattern_id,
+                        std::chrono::system_clock::time_point timestamp);
+
 // Global functions
 inline void initializeLogging() { Manager::initialize(); }
 inline Level levelFromString(const std::string &level)

--- a/src/quantum/pattern_metric_engine.cpp
+++ b/src/quantum/pattern_metric_engine.cpp
@@ -104,6 +104,12 @@ sep::compat::PatternData PatternMetricEngine::mutatePattern(const sep::compat::P
 void PatternMetricEngine::setSignalThresholds(const SignalThresholds& thresholds) {
     std::lock_guard<std::mutex> lock(engine_mutex_);
     signal_thresholds_ = thresholds;
+    if (auto logger = sep::logging::Manager::getInstance().getLogger("pattern_engine")) {
+        logger->info("Signal thresholds updated: coherence={} stability={} entropy={}",
+                     signal_thresholds_.min_coherence,
+                     signal_thresholds_.min_stability,
+                     signal_thresholds_.max_entropy);
+    }
 }
 
 const std::vector<Signal>& PatternMetricEngine::getSignals() const {
@@ -316,12 +322,14 @@ void PatternMetricEngine::generateSignals() {
             s.confidence = (1.0f - m.stability) * m.entropy;
             s.pattern_id = m.pattern_id;
             current_signals_.push_back(s);
+            sep::logging::logPatternDetected(s.pattern_id, std::chrono::system_clock::now());
         } else if (m.coherence > signal_thresholds_.min_coherence && m.stability > signal_thresholds_.min_stability) {
             Signal s;
             s.type = SignalType::BUY;
             s.confidence = m.coherence * m.stability;
             s.pattern_id = m.pattern_id;
             current_signals_.push_back(s);
+            sep::logging::logPatternDetected(s.pattern_id, std::chrono::system_clock::now());
         }
     }
 }

--- a/src/quantum/pattern_metric_engine.h
+++ b/src/quantum/pattern_metric_engine.h
@@ -141,6 +141,11 @@ public:
     /// @brief Sets the thresholds for signal generation.
     void setSignalThresholds(const SignalThresholds& thresholds);
 
+    /// @brief Returns the current thresholds for signal generation.
+    SignalThresholds getSignalThresholds() const {
+        return signal_thresholds_;
+    }
+
     /// @brief Gets the latest generated signals.
     const std::vector<Signal>& getSignals() const;
 


### PR DESCRIPTION
## Summary
- allow updating signal thresholds at runtime in `PatternMetricEngine`
- provide getter for current thresholds
- log pattern detections and threshold updates
- expose threshold sliders in `SignalsTabController`

## Testing
- `./build.sh` *(fails: `cd: /sep: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_68842cb2ad74832a886be792e96880f4