### PR TITLE
Implement event bus and request caching

### DIFF
--- a/src/apps/workbench/core/service_connector.cpp
+++ b/src/apps/workbench/core/service_connector.cpp
@@ -4,6 +4,7 @@
 #include "engine.h"
 #include "service_proxy_engine.h"
 #include "config.h"
+#include "ui_layout_manager.h"
 
 #include <iostream>
 #include <thread>
@@ -93,7 +94,8 @@ bool ServiceConnector::connect() {
         // Start health monitoring
         startHealthMonitoring();
         
-        // Notify callback
+        // Notify via EventBus
+        globalEventBus().publish(ConnectionStateEvent{ConnectionState::CONNECTED});
         if (connection_callback_) {
             connection_callback_(ConnectionState::CONNECTED);
         }
@@ -151,7 +153,8 @@ void ServiceConnector::disconnect() {
     service_engine_ = nullptr;
     connection_state_ = ConnectionState::DISCONNECTED;
     
-    // Notify callback
+    // Notify via EventBus
+    globalEventBus().publish(ConnectionStateEvent{ConnectionState::DISCONNECTED});
     if (connection_callback_) {
         connection_callback_(ConnectionState::DISCONNECTED);
     }
@@ -220,7 +223,8 @@ void ServiceConnector::monitoringLoop() {
                             connection_state_ = ConnectionState::DISCONNECTED;
                         }
                         
-                        // Notify callback of state change
+                        // Notify via EventBus
+                        globalEventBus().publish(ConnectionStateEvent{connection_state_});
                         if (connection_callback_) {
                             connection_callback_(connection_state_);
                         }

--- a/src/apps/workbench/core/ui_layout_manager.cpp
+++ b/src/apps/workbench/core/ui_layout_manager.cpp
@@ -4,7 +4,13 @@
 #include <iostream>
 #include <nlohmann/json.hpp>
 
+
 #include "imgui.h"
+
+EventBus& globalEventBus() {
+    static EventBus bus;
+    return bus;
+}
 
 namespace sep::workbench {
 
@@ -24,6 +30,7 @@ void UILayoutManager::unregisterPanel(const std::string& panel_id) {
 void UILayoutManager::setPanelVisible(const std::string& panel_id, bool visible) {
     if (panels_.find(panel_id) != panels_.end()) {
         panels_[panel_id].visible = visible;
+        globalEventBus().publish(PanelVisibilityEvent{panel_id, visible});
     }
 }
 
@@ -72,6 +79,7 @@ void UILayoutManager::createLayoutGroup(const std::string& group_name, PanelGrou
     }
     
     layout_groups_[group_name] = group;
+    globalEventBus().publish(GroupCollapsedEvent{group_name, group.collapsed});
 }
 
 void UILayoutManager::addPanelToGroup(const std::string& group_name, const std::string& panel_id) {
@@ -83,6 +91,7 @@ void UILayoutManager::addPanelToGroup(const std::string& group_name, const std::
 void UILayoutManager::setGroupCollapsed(const std::string& group_name, bool collapsed) {
     if (layout_groups_.find(group_name) != layout_groups_.end()) {
         layout_groups_[group_name].collapsed = collapsed;
+        globalEventBus().publish(GroupCollapsedEvent{group_name, collapsed});
     }
 }
 

--- a/src/apps/workbench/core/ui_layout_manager.h
+++ b/src/apps/workbench/core/ui_layout_manager.h
@@ -4,6 +4,8 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <unordered_map>
+#include <typeindex>
 
 #include "imgui.h"
 
@@ -65,6 +67,50 @@ struct LayoutGroup {
     bool collapsed = false;
     std::vector<std::string> panel_ids;
 };
+
+// Simple event structures
+struct PanelVisibilityEvent {
+    std::string panel_id;
+    bool visible{false};
+};
+
+struct GroupCollapsedEvent {
+    std::string group_name;
+    bool collapsed{false};
+};
+
+struct ConnectionStateEvent {
+    ConnectionState state;
+};
+
+class EventBus {
+public:
+    template<typename EventType>
+    void subscribe(std::function<void(const EventType&)> handler) {
+        auto key = std::type_index(typeid(EventType));
+        handlers_[key].push_back([handler](const void* e) {
+            handler(*static_cast<const EventType*>(e));
+        });
+    }
+
+    template<typename EventType>
+    void publish(const EventType& event) {
+        auto key = std::type_index(typeid(EventType));
+        auto it = handlers_.find(key);
+        if (it != handlers_.end()) {
+            for (auto& cb : it->second) {
+                cb(&event);
+            }
+        }
+    }
+
+private:
+    std::unordered_map<std::type_index,
+                       std::vector<std::function<void(const void*)>>> handlers_;
+};
+
+// Global event bus accessor
+EventBus& globalEventBus();
 
 class UILayoutManager {
 public:

--- a/src/apps/workbench/core/workbench_core.cpp
+++ b/src/apps/workbench/core/workbench_core.cpp
@@ -92,6 +92,15 @@ bool WorkbenchEngine::initialize()
         // landing_page_ = std::make_unique<LandingPage>(this);
         renderer_ = ::std::make_unique<Renderer>();
         layout_manager_ = ::std::make_unique<UILayoutManager>();
+
+        // Subscribe to basic events
+        globalEventBus().subscribe<PanelVisibilityEvent>([](const PanelVisibilityEvent& e) {
+            std::cout << "[EventBus] Panel " << e.panel_id
+                      << (e.visible ? " shown" : " hidden") << std::endl;
+        });
+        globalEventBus().subscribe<ConnectionStateEvent>([this](const ConnectionStateEvent& e) {
+            metrics_.service_connected = (e.state == ConnectionState::CONNECTED);
+        });
         signal_generator_ = ::std::make_unique<QuantumSignalGenerator>();
         metrics_monitor_ = ::std::make_unique<MetricsMonitor>();
         multi_timeframe_analyzer_ = ::std::make_unique<MultiTimeframeAnalyzer>();

--- a/src/connectors/oanda_connector.cpp
+++ b/src/connectors/oanda_connector.cpp
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <sstream>
 #include <thread>
+#include <mutex>
 
 namespace sep {
 namespace connectors {
@@ -221,7 +222,18 @@ size_t OandaConnector::StreamCallback(void* contents, size_t size, size_t nmemb,
 }
 
 OandaConnector::CurlResponse OandaConnector::makeRequest(const std::string& endpoint, const std::string& method, const std::string& data) {
-    enforceRateLimit();
+    {
+        std::lock_guard<std::mutex> lock(request_mutex_);
+        auto it = response_cache_.find(endpoint);
+        if (it != response_cache_.end()) {
+            auto age = std::chrono::steady_clock::now() - it->second.timestamp;
+            if (age < std::chrono::seconds(2)) {
+                return it->second.response;
+            }
+        }
+    }
+
+    enforceRateLimit(endpoint);
     
     CurlResponse response;
     
@@ -265,6 +277,11 @@ OandaConnector::CurlResponse OandaConnector::makeRequest(const std::string& endp
     {
         std::cerr << "OANDA API Error: " << response.response_code << " - " << response.data
                   << std::endl;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(request_mutex_);
+        response_cache_[endpoint] = {response, std::chrono::steady_clock::now()};
     }
 
     return response;
@@ -436,17 +453,26 @@ OandaCandle OandaConnector::parseCandle(const nlohmann::json& candle_data) {
     return candle;
 }
 
-void OandaConnector::enforceRateLimit()
+void OandaConnector::enforceRateLimit(const std::string& endpoint)
 {
+    std::unique_lock<std::mutex> lock(request_mutex_);
     auto now = std::chrono::steady_clock::now();
     auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - last_request_time_);
-
     if (elapsed.count() < 50)
-    {  // OANDA allows 100 req/sec, 10ms, but being conservative
+    {
         std::this_thread::sleep_for(std::chrono::milliseconds(50 - elapsed.count()));
     }
 
+    auto it = endpoint_last_request_.find(endpoint);
+    if (it != endpoint_last_request_.end()) {
+        auto diff = std::chrono::duration_cast<std::chrono::milliseconds>(now - it->second);
+        if (diff.count() < 250) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(250 - diff.count()));
+        }
+    }
+
     last_request_time_ = std::chrono::steady_clock::now();
+    endpoint_last_request_[endpoint] = last_request_time_;
 }
 
 void OandaConnector::streamPriceData(const std::string& instruments)

--- a/src/connectors/oanda_connector.h
+++ b/src/connectors/oanda_connector.h
@@ -10,6 +10,8 @@
 #include <iterator>
 #include <numeric>
 #include <thread>
+#include <unordered_map>
+#include <mutex>
 #include <curl/curl.h>
 #include <nlohmann/json.hpp>
 
@@ -126,8 +128,15 @@ private:
     std::vector<double> calculateHistoricalATRs(const std::vector<OandaCandle>& candles);
 
     // Rate limiting
-    void enforceRateLimit();
+    void enforceRateLimit(const std::string& endpoint);
     std::chrono::steady_clock::time_point last_request_time_;
+    std::unordered_map<std::string, std::chrono::steady_clock::time_point> endpoint_last_request_;
+    struct CachedResponse {
+        CurlResponse response;
+        std::chrono::steady_clock::time_point timestamp;
+    };
+    std::unordered_map<std::string, CachedResponse> response_cache_;
+    std::mutex request_mutex_;
     
     // Streaming support
     std::atomic<bool> streaming_active_{false};


### PR DESCRIPTION
## Summary
- add EventBus implementation and global accessor
- publish layout events when panels or groups change
- broadcast connection status updates via EventBus
- batch OANDA requests using caching and per-endpoint rate limits
- subscribe to events from `WorkbenchEngine`

## Testing
- `./build.sh` *(fails: cd /sep: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68842cf8f230832a8642b3a70cf7f6ea