### PR TITLE
Add memory-mapped ingestion and internal demo scoring

### DIFF
--- a/src/apps/workbench/demos/drug_optimizer.cpp
+++ b/src/apps/workbench/demos/drug_optimizer.cpp
@@ -1,6 +1,7 @@
 #include "drug_optimizer.hpp"
 
 #include <cstdlib>
+#include <algorithm>
 
 #include "../simple_renderer.h"
 // Include glm_config.h before any GLM headers to ensure GLM_ENABLE_EXPERIMENTAL is defined
@@ -32,8 +33,11 @@ namespace workbench {
 
 float DrugOptimizerDemo::computeBindingScore(const MoleculePose& pose) {
 #ifdef SEP_EXT_CHEM
-    // Placeholder for external chemistry library integration
-    return external_chemistry_score(pose.position.x, pose.position.y, pose.position.z);
+    // Approximate binding affinity when external chemistry extensions are enabled
+    float distance = glm::length(pose.position);
+    float orientation_factor = 1.0f - glm::length(pose.orientation) / 3.0f;
+    orientation_factor = std::max(0.0f, orientation_factor);
+    return orientation_factor / (1.0f + distance);
 #else
     return 1.0f / (1.0f + glm::length2(pose.position));
 #endif

--- a/src/quantum/pattern_metric_engine.cpp
+++ b/src/quantum/pattern_metric_engine.cpp
@@ -1,5 +1,13 @@
 #include "quantum/pattern_metric_engine.h"
 #include "engine/logging.h"
+#ifdef _WIN32
+#    include <windows.h>
+#else
+#    include <sys/mman.h>
+#    include <sys/stat.h>
+#    include <fcntl.h>
+#    include <unistd.h>
+#endif
 
 char sep::quantum::pattern_id[sep::compat::PatternData::MAX_ID_LENGTH];
 float sep::quantum::coherence = 0.0f;
@@ -48,9 +56,58 @@ void PatternMetricEngine::ingestFile(const std::string& filepath)
     }
 }
 
-void PatternMetricEngine::ingestMappedFile([[maybe_unused]] const std::string& filepath)
+void PatternMetricEngine::ingestMappedFile(const std::string& filepath)
 {
-    // Implementation for memory-mapped file ingestion would go here.
+#ifdef _WIN32
+    HANDLE file = CreateFileA(filepath.c_str(), GENERIC_READ, FILE_SHARE_READ,
+                              nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (file == INVALID_HANDLE_VALUE) {
+        return;
+    }
+
+    LARGE_INTEGER size{};
+    if (!GetFileSizeEx(file, &size)) {
+        CloseHandle(file);
+        return;
+    }
+
+    HANDLE mapping = CreateFileMappingA(file, nullptr, PAGE_READONLY, 0, 0, nullptr);
+    if (!mapping) {
+        CloseHandle(file);
+        return;
+    }
+
+    void* data = MapViewOfFile(mapping, FILE_MAP_READ, 0, 0, 0);
+    if (data) {
+        ingestData(static_cast<uint8_t*>(data), static_cast<size_t>(size.QuadPart));
+        UnmapViewOfFile(data);
+    }
+
+    CloseHandle(mapping);
+    CloseHandle(file);
+#else
+    int fd = open(filepath.c_str(), O_RDONLY);
+    if (fd == -1) {
+        return;
+    }
+
+    struct stat sb {};
+    if (fstat(fd, &sb) == -1) {
+        close(fd);
+        return;
+    }
+
+    void* map = mmap(nullptr, sb.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
+    if (map == MAP_FAILED) {
+        close(fd);
+        return;
+    }
+
+    ingestData(static_cast<uint8_t*>(map), static_cast<size_t>(sb.st_size));
+
+    munmap(map, sb.st_size);
+    close(fd);
+#endif
 }
 
 void PatternMetricEngine::evolvePatterns() {


### PR DESCRIPTION
## Summary
- support memory mapped files in PatternMetricEngine
- add internal stub for DrugOptimizerDemo when SEP_EXT_CHEM is enabled

## Testing
- `./build.sh` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68842cf23b60832abb291fc34c176bb8