### PR TITLE
Add signal validation and trade management

### DIFF
--- a/src/apps/workbench/core/service_proxy_engine.cpp
+++ b/src/apps/workbench/core/service_proxy_engine.cpp
@@ -153,5 +153,50 @@ sep::workbench::SignalValidator::ValidationResult ServiceProxyEngine::validate_s
     return validator.validate_signal(signals, prices);
 }
 
+sep::workbench::SignalValidator::ValidationResult ServiceProxyEngine::validateSignals(
+    const std::vector<sep::quantum::Signal>& signals,
+    const std::vector<float>& prices) {
+    if (signals.empty() || prices.size() < 2) {
+        return {0.0, 1.0};
+    }
+
+    size_t correct_predictions = 0;
+    size_t total_predictions = 0;
+    size_t false_positives = 0;
+
+    for (size_t i = 0; i < signals.size() - 1 && i < prices.size() - 1; ++i) {
+        const auto& sig = signals[i];
+        float current = prices[i];
+        float next = prices[i + 1];
+
+        float change = (next - current) / current;
+        bool up = change > 0.0001f;
+        bool down = change < -0.0001f;
+
+        if (sig.confidence > 0.7f) {
+            bool buy = sig.type == sep::quantum::SignalType::BUY;
+            bool sell = sig.type == sep::quantum::SignalType::SELL;
+
+            if (buy || sell) {
+                ++total_predictions;
+                if ((buy && up) || (sell && down)) {
+                    ++correct_predictions;
+                } else if ((buy && down) || (sell && up)) {
+                    ++false_positives;
+                }
+            }
+        }
+    }
+
+    double accuracy = total_predictions > 0 ?
+                          static_cast<double>(correct_predictions) / total_predictions :
+                          0.0;
+    double false_rate = total_predictions > 0 ?
+                           static_cast<double>(false_positives) / total_predictions :
+                           0.0;
+
+    return {accuracy, false_rate};
+}
+
 } // namespace core
 } // namespace sep

--- a/src/apps/workbench/core/service_proxy_engine.h
+++ b/src/apps/workbench/core/service_proxy_engine.h
@@ -44,6 +44,10 @@ public:
     sep::workbench::SignalValidator::ValidationResult validate_signal(
         const std::vector<sep::quantum::Signal>& signals, const std::vector<float>& prices);
 
+    sep::workbench::SignalValidator::ValidationResult validateSignals(
+        const std::vector<sep::quantum::Signal>& signals,
+        const std::vector<float>& prices);
+
 private:
     std::string service_address_;
     int service_port_;

--- a/src/apps/workbench/core/trade_manager.cpp
+++ b/src/apps/workbench/core/trade_manager.cpp
@@ -20,6 +20,9 @@ nlohmann::json TradeManager::placeOrder(const std::string& instrument,
     double pips_to_risk = stop_loss_pips;
     double pip_value = 0.0001;
     double position_size = risk_amount / (pips_to_risk * pip_value);
+    if (units == 0) {
+        units = position_size;
+    }
     if (paper_trading_) {
         std::lock_guard<std::mutex> lock(mutex_);
         Order order;

--- a/src/apps/workbench/core/trade_manager.h
+++ b/src/apps/workbench/core/trade_manager.h
@@ -47,6 +47,11 @@ public:
                               double stop_loss_pips,
                               double take_profit_pips);
 
+    void setAccountBalance(double balance) { account_balance_ = balance; }
+    double getAccountBalance() const { return account_balance_; }
+    void setRiskPercentage(double pct) { risk_percentage_ = pct; }
+    double getRiskPercentage() const { return risk_percentage_; }
+
     void updateOrderStatus(const std::string& order_id, OrderState state);
     const std::vector<Order>& getOrders() const;
     const std::vector<Position>& getPositions() const;

--- a/src/apps/workbench/tabs/backend_tab_controller.cpp
+++ b/src/apps/workbench/tabs/backend_tab_controller.cpp
@@ -44,6 +44,10 @@ void BackendTabController::setMetricsMonitor(std::shared_ptr<MetricsMonitor> mon
 
 void BackendTabController::setServiceConnector(ServiceConnector* connector) {
     service_connector_ = connector;
+    if (service_connector_ && service_connector_->getOandaConnector()) {
+        trade_manager_ = std::make_unique<sep::workbench::TradeManager>(
+            service_connector_->getOandaConnector());
+    }
 }
 
 void BackendTabController::renderDataSourceSelector() {
@@ -79,8 +83,8 @@ void BackendTabController::renderDataSourceSelector() {
 void BackendTabController::renderOrderManagementPanel() {
     ImGui::Begin("Paper Trading");
     if (ImGui::Checkbox("Enable Paper Trading", &paper_trading_)) {
-        if (service_connector_) {
-            // service_connector_->getTradeManager()->setPaperTrading(paper_trading_);
+        if (trade_manager_) {
+            trade_manager_->setPaperTrading(paper_trading_);
         }
     }
     ImGui::End();
@@ -91,32 +95,25 @@ void BackendTabController::renderOrderManagementPanel() {
     ImGui::InputInt("Units", &units_);
 
     if (ImGui::Button("Place Buy Order")) {
-        if (service_connector_) {
-            nlohmann::json order_details;
-            order_details["order"]["instrument"] = instrument_buffer_;
-            order_details["order"]["units"] = std::to_string(units_);
-            order_details["order"]["type"] = "MARKET";
-            order_details["order"]["timeInForce"] = "FOK";
-            order_details["order"]["positionFill"] = "DEFAULT";
-            service_connector_->getOandaConnector()->placeOrder(order_details);
+        if (trade_manager_ && service_connector_) {
+            auto md = service_connector_->getOandaConnector()->getMarketData(instrument_buffer_);
+            trade_manager_->placeOrder(instrument_buffer_, units_, md.ask, stop_loss_pips_, take_profit_pips_);
         }
     }
 
     ImGui::SameLine();
 
     if (ImGui::Button("Place Sell Order")) {
-        if (service_connector_) {
-            nlohmann::json order_details;
-            order_details["order"]["instrument"] = instrument_buffer_;
-            order_details["order"]["units"] = std::to_string(-units_);
-            order_details["order"]["type"] = "MARKET";
-            order_details["order"]["timeInForce"] = "FOK";
-            order_details["order"]["positionFill"] = "DEFAULT";
-            service_connector_->getOandaConnector()->placeOrder(order_details);
+        if (trade_manager_ && service_connector_) {
+            auto md = service_connector_->getOandaConnector()->getMarketData(instrument_buffer_);
+            trade_manager_->placeOrder(instrument_buffer_, -units_, md.bid, stop_loss_pips_, take_profit_pips_);
         }
     }
 
     if (ImGui::Button("Refresh Orders and Positions")) {
+        if (trade_manager_) {
+            // no-op: local orders already stored
+        }
         if (service_connector_) {
             open_positions_ = service_connector_->getOandaConnector()->getOpenPositions();
             orders_ = service_connector_->getOandaConnector()->getOrders();
@@ -126,6 +123,11 @@ void BackendTabController::renderOrderManagementPanel() {
     ImGui::Text("Open Positions:");
     if (!open_positions_.is_null()) {
         ImGui::TextUnformatted(open_positions_.dump(4).c_str());
+    }
+
+    if (trade_manager_) {
+        ImGui::Text("Local Positions: %zu", trade_manager_->getPositions().size());
+        ImGui::Text("Local Orders: %zu", trade_manager_->getOrders().size());
     }
 
     ImGui::Text("Orders:");
@@ -138,7 +140,12 @@ void BackendTabController::renderOrderManagementPanel() {
 
 void BackendTabController::renderBacktesterPanel() {
     ImGui::Begin("Risk Management");
-    ImGui::SliderFloat("Risk Percentage", &risk_percentage_, 0.1f, 5.0f, "%.2f%%");
+    if (ImGui::SliderFloat("Risk Percentage", &risk_percentage_, 0.1f, 5.0f, "%.2f%%")) {
+        if (trade_manager_) trade_manager_->setRiskPercentage(risk_percentage_ / 100.0);
+    }
+    if (trade_manager_) {
+        ImGui::Text("Account Balance: %.2f", trade_manager_->getAccountBalance());
+    }
     ImGui::InputFloat("Stop Loss (pips)", &stop_loss_pips_);
     ImGui::InputFloat("Take Profit (pips)", &take_profit_pips_);
     ImGui::End();
@@ -165,7 +172,7 @@ void BackendTabController::renderBacktesterPanel() {
             }
 
             sep::core::ServiceProxyEngine proxy("localhost", 8080);
-            validation_result_ = proxy.validate_signal(signals, prices);
+            validation_result_ = proxy.validateSignals(signals, prices);
         }
     }
 

--- a/src/apps/workbench/tabs/backend_tab_controller.h
+++ b/src/apps/workbench/tabs/backend_tab_controller.h
@@ -6,6 +6,7 @@
 #include "../backtester/backtester.h"
 #include "../core/file_dialog.hpp"
 #include "../core/service_connector.hpp"
+#include "../core/trade_manager.h"
 #include "../backtester/data_loader.h"
 #include "quantum/pattern_metric_engine.h"
 #include "../core/service_proxy_engine.h"
@@ -40,6 +41,7 @@ private:
     std::unique_ptr<backtester::Backtester> backtester_;
     std::unique_ptr<sep::workbench::backtester::DataLoader> data_loader_;
     std::unique_ptr<sep::quantum::PatternMetricEngine> pattern_engine_;
+    std::unique_ptr<sep::workbench::TradeManager> trade_manager_;
     FileDialog file_dialog_;
 
     // UI State


### PR DESCRIPTION
## Summary
- implement new `validateSignals` method in ServiceProxyEngine
- use position sizing in TradeManager for 2% risk per trade
- surface trade management details and signal validation in BackendTabController

## Testing
- `./build.sh` *(failed: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68842cdbc4b8832ab6eeca0fffbbb7d5