### PR TITLE
Integrate backtester components

### DIFF
--- a/src/apps/workbench/backtester/core/backtester_engine.cpp
+++ b/src/apps/workbench/backtester/core/backtester_engine.cpp
@@ -1,6 +1,9 @@
 #include "backtester_engine.h"
 
+#include <algorithm>
 #include <iostream>
+#include <numeric>
+#include <vector>
 
 BacktesterEngine::BacktesterEngine() {
 }
@@ -8,6 +11,62 @@ BacktesterEngine::BacktesterEngine() {
 BacktesterEngine::~BacktesterEngine() {
 }
 
-void BacktesterEngine::run() {
-    std::cout << "BacktesterEngine running..." << std::endl;
+sep::workbench::backtester::BacktestResult BacktesterEngine::run(const std::string& dataset_path) {
+    sep::workbench::backtester::DataLoader loader;
+    loader.loadData(dataset_path);
+
+    const auto& candles = loader.getCandleData();
+    sep::workbench::backtester::BacktestResult result{};
+    if (candles.empty()) {
+        return result;
+    }
+
+    sep::quantum::PatternMetricEngine engine;
+    std::vector<uint8_t> byte_stream;
+    byte_stream.reserve(candles.size() * sizeof(sep::workbench::CandleData));
+    for (const auto& candle : candles) {
+        const uint8_t* bytes = reinterpret_cast<const uint8_t*>(&candle);
+        byte_stream.insert(byte_stream.end(), bytes, bytes + sizeof(sep::workbench::CandleData));
+    }
+
+    engine.ingestData(byte_stream.data(), byte_stream.size());
+    engine.evolvePatterns();
+    engine.computeMetrics();
+
+    const auto& signals = engine.getSignals();
+    std::vector<float> prices;
+    prices.reserve(candles.size());
+    for (const auto& candle : candles) {
+        prices.push_back(static_cast<float>(candle.close));
+    }
+
+    std::vector<float> pnl;
+    int wins = 0;
+    int losses = 0;
+    size_t count = std::min(signals.size(), prices.size() - 1);
+    for (size_t i = 0; i < count; ++i) {
+        if (signals[i].type == sep::quantum::SignalType::BUY) {
+            float entry = prices[i];
+            float exit = prices[i + 1];
+            pnl.push_back(exit - entry);
+            wins += exit > entry;
+            losses += exit <= entry;
+        } else if (signals[i].type == sep::quantum::SignalType::SELL) {
+            float entry = prices[i];
+            float exit = prices[i + 1];
+            pnl.push_back(entry - exit);
+            wins += entry > exit;
+            losses += entry <= exit;
+        }
+    }
+
+    result.total_trades = static_cast<int>(pnl.size());
+    if (result.total_trades > 0) {
+        result.win_rate = static_cast<float>(wins) / result.total_trades;
+        result.total_pnl = std::accumulate(pnl.begin(), pnl.end(), 0.0f);
+        result.sharpe_ratio = PerformanceMetrics::computeSharpeRatio(pnl);
+        result.max_drawdown = PerformanceMetrics::computeMaxDrawdown(pnl);
+    }
+
+    return result;
 }

--- a/src/apps/workbench/backtester/core/backtester_engine.h
+++ b/src/apps/workbench/backtester/core/backtester_engine.h
@@ -1,9 +1,16 @@
 #pragma once
 
+#include "apps/workbench/backtester/data/data_loader.h"
+#include "apps/workbench/backtester/backtester.h"
+#include "apps/workbench/backtester/core/performance_metrics.h"
+#include "quantum/pattern_metric_engine.h"
+#include <string>
+#include <vector>
+
 class BacktesterEngine {
 public:
     BacktesterEngine();
     ~BacktesterEngine();
 
-    void run();
+    sep::workbench::backtester::BacktestResult run(const std::string& dataset_path);
 };

--- a/src/apps/workbench/backtester/core/performance_metrics.cpp
+++ b/src/apps/workbench/backtester/core/performance_metrics.cpp
@@ -1,6 +1,7 @@
 #include "performance_metrics.h"
 
-#include <iostream>
+#include <cmath>
+#include <vector>
 
 PerformanceMetrics::PerformanceMetrics() {
 }
@@ -8,6 +9,42 @@ PerformanceMetrics::PerformanceMetrics() {
 PerformanceMetrics::~PerformanceMetrics() {
 }
 
-void PerformanceMetrics::calculate() {
-    std::cout << "Calculating performance metrics..." << std::endl;
+float PerformanceMetrics::computeSharpeRatio(const std::vector<float>& pnl_series) {
+    if (pnl_series.empty()) {
+        return 0.0f;
+    }
+
+    float sum = 0.0f;
+    for (float p : pnl_series) {
+        sum += p;
+    }
+    float avg = sum / pnl_series.size();
+
+    float var = 0.0f;
+    for (float p : pnl_series) {
+        var += (p - avg) * (p - avg);
+    }
+    float std_dev = std::sqrt(var / pnl_series.size());
+    if (std_dev == 0.0f) {
+        return 0.0f;
+    }
+    return avg / std_dev;
+}
+
+float PerformanceMetrics::computeMaxDrawdown(const std::vector<float>& pnl_series) {
+    float running_total = 0.0f;
+    float peak = 0.0f;
+    float max_drawdown = 0.0f;
+
+    for (float p : pnl_series) {
+        running_total += p;
+        if (running_total > peak) {
+            peak = running_total;
+        }
+        float drawdown = peak - running_total;
+        if (drawdown > max_drawdown) {
+            max_drawdown = drawdown;
+        }
+    }
+    return max_drawdown;
 }

--- a/src/apps/workbench/backtester/core/performance_metrics.h
+++ b/src/apps/workbench/backtester/core/performance_metrics.h
@@ -5,5 +5,6 @@ public:
     PerformanceMetrics();
     ~PerformanceMetrics();
 
-    void calculate();
+    static float computeSharpeRatio(const std::vector<float>& pnl_series);
+    static float computeMaxDrawdown(const std::vector<float>& pnl_series);
 };

--- a/src/apps/workbench/backtester/ui/backtester_tab_controller.cpp
+++ b/src/apps/workbench/backtester/ui/backtester_tab_controller.cpp
@@ -1,13 +1,24 @@
 #include "backtester_tab_controller.h"
 
+#include "imgui.h"
 #include <iostream>
 
-BacktesterTabController::BacktesterTabController() {
-}
+BacktesterTabController::BacktesterTabController()
+    : engine_(std::make_unique<BacktesterEngine>()) {}
 
 BacktesterTabController::~BacktesterTabController() {
 }
 
 void BacktesterTabController::render() {
-    std::cout << "Rendering backtester tab..." << std::endl;
+    ImGui::Begin("Backtester");
+    ImGui::InputText("Dataset", dataset_path_, sizeof(dataset_path_));
+    if (ImGui::Button("Run")) {
+        result_ = engine_->run(dataset_path_);
+    }
+    ImGui::Text("Total Trades: %d", result_.total_trades);
+    ImGui::Text("Win Rate: %.2f", result_.win_rate);
+    ImGui::Text("Total PnL: %.2f", result_.total_pnl);
+    ImGui::Text("Sharpe Ratio: %.2f", result_.sharpe_ratio);
+    ImGui::Text("Max Drawdown: %.2f", result_.max_drawdown);
+    ImGui::End();
 }

--- a/src/apps/workbench/backtester/ui/backtester_tab_controller.h
+++ b/src/apps/workbench/backtester/ui/backtester_tab_controller.h
@@ -1,9 +1,17 @@
 #pragma once
 
+#include "apps/workbench/backtester/core/backtester_engine.h"
+#include <memory>
+
 class BacktesterTabController {
 public:
     BacktesterTabController();
     ~BacktesterTabController();
 
     void render();
+
+private:
+    std::unique_ptr<BacktesterEngine> engine_;
+    sep::workbench::backtester::BacktestResult result_{};
+    char dataset_path_[512] = "eur_usd_m1_48h.json";
 };


### PR DESCRIPTION
## Summary
- wire PatternMetricEngine into BacktesterEngine to generate trades
- provide Sharpe ratio and drawdown helpers
- add dataset controls to Backtester tab UI

## Testing
- `g++ -std=c++17 src/apps/workbench/backtester/data/data_loader_test.cpp src/apps/workbench/backtester/data/data_loader.cpp src/apps/workbench/backtester/data/json_data_parser.cpp -I src -I src/apps/workbench/stubs -I third_party/nlohmann_json/include -o /tmp/dl_test && /tmp/dl_test | head` *(fails: imgui related errors)*

------
https://chatgpt.com/codex/tasks/task_e_68842cd18d4c832a97b827c3606aba96