### PR TITLE
Add OANDA historical fetch and metrics plotting

### DIFF
--- a/src/apps/workbench/core/metrics_monitor.cpp
+++ b/src/apps/workbench/core/metrics_monitor.cpp
@@ -328,11 +328,13 @@ void MetricsMonitor::calculateRollingMetrics() {
 
     // Calculate 24h averages
     auto cutoff_24h = now - std::chrono::hours(24);
+    auto cutoff_4h = now - std::chrono::hours(4);
     auto cutoff_1h = now - std::chrono::hours(1);
     
     float sum_coherence_24h = 0, sum_stability_24h = 0, sum_entropy_24h = 0;
+    float sum_coherence_4h = 0, sum_stability_4h = 0, sum_entropy_4h = 0;
     float sum_coherence_1h = 0, sum_stability_1h = 0, sum_entropy_1h = 0;
-    int count_24h = 0, count_1h = 0;
+    int count_24h = 0, count_4h = 0, count_1h = 0;
     
     // Collect oldest and newest values for trend calculation
     float oldest_coherence = 0, oldest_stability = 0, oldest_entropy = 0;
@@ -356,6 +358,13 @@ void MetricsMonitor::calculateRollingMetrics() {
             newest_coherence = snap.coherence;
             newest_stability = snap.stability;
             newest_entropy = snap.entropy;
+        }
+
+        if (snap.timestamp >= cutoff_4h) {
+            sum_coherence_4h += snap.coherence;
+            sum_stability_4h += snap.stability;
+            sum_entropy_4h += snap.entropy;
+            count_4h++;
         }
         
         if (snap.timestamp >= cutoff_1h) {
@@ -388,6 +397,12 @@ void MetricsMonitor::calculateRollingMetrics() {
         rolling_metrics_.coherence_1h_avg = sum_coherence_1h / count_1h;
         rolling_metrics_.stability_1h_avg = sum_stability_1h / count_1h;
         rolling_metrics_.entropy_1h_avg = sum_entropy_1h / count_1h;
+    }
+
+    if (count_4h > 0) {
+        rolling_metrics_.coherence_4h_avg = sum_coherence_4h / count_4h;
+        rolling_metrics_.stability_4h_avg = sum_stability_4h / count_4h;
+        rolling_metrics_.entropy_4h_avg = sum_entropy_4h / count_4h;
     }
 
     rolling_metrics_.last_calculation = now;

--- a/src/apps/workbench/core/metrics_monitor.h
+++ b/src/apps/workbench/core/metrics_monitor.h
@@ -53,6 +53,9 @@ public:
         float coherence_24h_avg{0.0f};
         float stability_24h_avg{0.0f};
         float entropy_24h_avg{0.0f};
+        float coherence_4h_avg{0.0f};
+        float stability_4h_avg{0.0f};
+        float entropy_4h_avg{0.0f};
         float coherence_1h_avg{0.0f};
         float stability_1h_avg{0.0f};
         float entropy_1h_avg{0.0f};

--- a/src/apps/workbench/core/service_connector.cpp
+++ b/src/apps/workbench/core/service_connector.cpp
@@ -8,6 +8,7 @@
 #include <iostream>
 #include <thread>
 #include <cstring>
+#include "engine/data_parser.h"
 
 // Platform-specific includes
 #ifdef _WIN32
@@ -39,6 +40,18 @@ ServiceConnector::ServiceConnector(const ConnectionConfig& config)
         std::cout << "[ServiceConnector] OANDA connector configured for PRACTICE server" << std::endl;
         std::cout << "[ServiceConnector] API Key length: " << strlen(api_key) << std::endl;
         std::cout << "[ServiceConnector] Account ID: " << account_id << std::endl;
+        if (oanda_connector_->initialize()) {
+            oanda_connector_->fetchHistoricalData("EUR_USD", "eur_usd_m1_48h.json");
+            sep::DataParser parser;
+            auto candles = parser.parseQuantJSON("eur_usd_m1_48h.json");
+            for (const auto& c : candles) {
+                std::tm tm = {};
+                std::istringstream ss(c.time);
+                ss >> std::get_time(&tm, "%Y-%m-%dT%H:%M:%S");
+                auto ts = std::chrono::system_clock::from_time_t(std::mktime(&tm));
+                initial_data_.emplace_back(c.open, c.high, c.low, c.close, (int)c.volume, ts);
+            }
+        }
     } else {
         std::cout << "[ServiceConnector] ERROR: OANDA credentials not found in environment" << std::endl;
         std::cout << "[ServiceConnector] API Key: " << (api_key ? "FOUND" : "NOT FOUND") << std::endl;
@@ -163,6 +176,15 @@ bool ServiceConnector::reconnect() {
     disconnect();
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
     return connect();
+}
+
+void ServiceConnector::setSignalsTab(SignalsTabController* tab)
+{
+    signals_tab_ = tab;
+    if (signals_tab_ && !initial_data_.empty())
+    {
+        signals_tab_->setCandleData(initial_data_);
+    }
 }
 
 ServiceHealth ServiceConnector::getServiceHealth() const {

--- a/src/apps/workbench/core/service_connector.hpp
+++ b/src/apps/workbench/core/service_connector.hpp
@@ -9,6 +9,8 @@
 
 #include "connectors/oanda_connector.h"
 #include "service_proxy_engine.h"
+#include "tabs/signals_tab_controller.h"
+#include "core/common_structs.h"
 
 namespace sep {
 namespace core {
@@ -79,6 +81,9 @@ public:
     void setConfig(const ConnectionConfig& config) { config_ = config; }
     const ConnectionConfig& getConfig() const { return config_; }
 
+    void setSignalsTab(SignalsTabController* tab);
+    const std::deque<CandleData>& getInitialData() const { return initial_data_; }
+
 private:
     // Internal state
     std::atomic<ConnectionState> connection_state_{ConnectionState::DISCONNECTED};
@@ -116,6 +121,9 @@ private:
     // Engine instances
     std::unique_ptr<sep::core::Engine> local_engine_;
     std::unique_ptr<sep::core::ServiceProxyEngine> http_proxy_engine_;
+
+    SignalsTabController* signals_tab_{nullptr};
+    std::deque<CandleData> initial_data_;
 };
 
 } // namespace sep::workbench

--- a/src/apps/workbench/core/workbench_core.cpp
+++ b/src/apps/workbench/core/workbench_core.cpp
@@ -114,6 +114,7 @@ bool WorkbenchEngine::initialize()
         signals_tab_->setQuantumSignalGenerator(signal_generator_.get());
         signals_tab_->setMetricsMonitor(metrics_monitor_.get());
         signals_tab_->setWorkbenchEngine(this);
+        service_connector_->setSignalsTab(signals_tab_.get());
         engine_tab_->setSEPEngine(active_engine_);
         engine_tab_->setMultiTimeframeAnalyzer(multi_timeframe_analyzer_.get());
         backend_tab_->setServiceConnector(service_connector_.get());

--- a/src/apps/workbench/tabs/signals_tab_controller.cpp
+++ b/src/apps/workbench/tabs/signals_tab_controller.cpp
@@ -70,6 +70,7 @@ void SignalsTabController::render() {
         ImGui::Text("Stability: %.3f", rolling_metrics.stability_24h_avg);
         ImGui::Text("Entropy: %.3f", rolling_metrics.entropy_24h_avg);
 
+        renderMetricsGraphs();
         ImGui::End();
     }
 
@@ -491,6 +492,47 @@ void SignalsTabController::renderVolumeChart() {
         
         draw_list->AddRectFilled(bar_min, bar_max, vol_color);
     }
+}
+
+void SignalsTabController::renderMetricsGraphs() {
+    if (!metrics_monitor_) return;
+
+    const auto& sys = metrics_monitor_->getSystemMetrics();
+    coherence_history_.push_back(sys.avg_coherence);
+    stability_history_.push_back(sys.avg_stability);
+    entropy_history_.push_back(sys.avg_entropy);
+
+    const size_t MAX_POINTS = 240; // roughly 4 hours if updated each minute
+    if (coherence_history_.size() > MAX_POINTS) coherence_history_.pop_front();
+    if (stability_history_.size() > MAX_POINTS) stability_history_.pop_front();
+    if (entropy_history_.size() > MAX_POINTS) entropy_history_.pop_front();
+
+    ImVec2 graph_size(200, 60);
+    ImGui::PlotLines("Coherence", coherence_history_.data(), coherence_history_.size(), 0, nullptr, 0.0f, 1.0f, graph_size);
+    auto rect_min = ImGui::GetItemRectMin();
+    auto rect_max = ImGui::GetItemRectMax();
+    ImDrawList* dl = ImGui::GetWindowDrawList();
+    const auto& roll = metrics_monitor_->getRollingMetrics();
+    float y1 = rect_max.y - roll.coherence_1h_avg * (rect_max.y - rect_min.y);
+    float y4 = rect_max.y - roll.coherence_4h_avg * (rect_max.y - rect_min.y);
+    dl->AddLine(ImVec2(rect_min.x, y1), ImVec2(rect_max.x, y1), IM_COL32(255,0,0,128));
+    dl->AddLine(ImVec2(rect_min.x, y4), ImVec2(rect_max.x, y4), IM_COL32(0,255,0,128));
+
+    ImGui::PlotLines("Stability", stability_history_.data(), stability_history_.size(), 0, nullptr, 0.0f, 1.0f, graph_size);
+    rect_min = ImGui::GetItemRectMin();
+    rect_max = ImGui::GetItemRectMax();
+    y1 = rect_max.y - roll.stability_1h_avg * (rect_max.y - rect_min.y);
+    y4 = rect_max.y - roll.stability_4h_avg * (rect_max.y - rect_min.y);
+    dl->AddLine(ImVec2(rect_min.x, y1), ImVec2(rect_max.x, y1), IM_COL32(255,0,0,128));
+    dl->AddLine(ImVec2(rect_min.x, y4), ImVec2(rect_max.x, y4), IM_COL32(0,255,0,128));
+
+    ImGui::PlotLines("Entropy", entropy_history_.data(), entropy_history_.size(), 0, nullptr, 0.0f, 1.0f, graph_size);
+    rect_min = ImGui::GetItemRectMin();
+    rect_max = ImGui::GetItemRectMax();
+    y1 = rect_max.y - roll.entropy_1h_avg * (rect_max.y - rect_min.y);
+    y4 = rect_max.y - roll.entropy_4h_avg * (rect_max.y - rect_min.y);
+    dl->AddLine(ImVec2(rect_min.x, y1), ImVec2(rect_max.x, y1), IM_COL32(255,0,0,128));
+    dl->AddLine(ImVec2(rect_min.x, y4), ImVec2(rect_max.x, y4), IM_COL32(0,255,0,128));
 }
 
 void SignalsTabController::renderTrendLines() {

--- a/src/apps/workbench/tabs/signals_tab_controller.h
+++ b/src/apps/workbench/tabs/signals_tab_controller.h
@@ -78,6 +78,11 @@ private:
     void renderHoverInfo();
     void renderCrosshair();
     void renderChartGrid();
+    void renderMetricsGraphs();
+
+    std::deque<float> coherence_history_;
+    std::deque<float> stability_history_;
+    std::deque<float> entropy_history_;
 
     // Utility functions
     ImVec2 priceToScreen(double price, std::chrono::system_clock::time_point time);

--- a/src/connectors/oanda_connector.cpp
+++ b/src/connectors/oanda_connector.cpp
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <sstream>
 #include <thread>
+#include "engine/data_parser.h"
 
 namespace sep {
 namespace connectors {
@@ -573,6 +574,35 @@ void OandaConnector::setupSampleData(const std::string& instrument, const std::s
     out_stream.close();
 
     std::cout << "[OandaConnector] Successfully wrote " << candles.size() << " candles to " << output_file << std::endl;
+}
+
+bool OandaConnector::fetchHistoricalData(const std::string& instrument, const std::string& output_file)
+{
+    auto now = std::chrono::system_clock::now();
+    auto start = now - std::chrono::hours(48);
+    auto now_t = std::chrono::system_clock::to_time_t(now);
+    auto start_t = std::chrono::system_clock::to_time_t(start);
+
+    auto candles = getHistoricalData(instrument, "M1", std::to_string(start_t), std::to_string(now_t), 48 * 60);
+    if (candles.empty()) return false;
+
+    std::vector<sep::CandleData> out;
+    out.reserve(candles.size());
+    for (const auto& c : candles)
+    {
+        sep::CandleData cd;
+        cd.time = c.time;
+        cd.open = static_cast<float>(c.open);
+        cd.high = static_cast<float>(c.high);
+        cd.low = static_cast<float>(c.low);
+        cd.close = static_cast<float>(c.close);
+        cd.volume = c.volume;
+        out.push_back(cd);
+    }
+
+    sep::DataParser parser;
+    parser.writeQuantJSON(out, output_file);
+    return true;
 }
 
 // --- Data Validation Implementations ---

--- a/src/connectors/oanda_connector.h
+++ b/src/connectors/oanda_connector.h
@@ -88,6 +88,7 @@ public:
 
     // Sample Data
     void setupSampleData(const std::string& instrument, const std::string& granularity, const std::string& output_file);
+    bool fetchHistoricalData(const std::string& instrument, const std::string& output_file);
 
     // Error handling
     std::string getLastError() const { return last_error_; }

--- a/src/engine/data_parser.cpp
+++ b/src/engine/data_parser.cpp
@@ -406,6 +406,7 @@ std::vector<CandleData> DataParser::parseQuantJSON(const std::string& path)
             return candles;
         }
         
+        int index = 0;
         for (const auto& candle_json : j["candles"]) {
             CandleData candle;
             
@@ -437,7 +438,27 @@ std::vector<CandleData> DataParser::parseQuantJSON(const std::string& path)
                 }
             }
             
-            candles.push_back(candle);
+            bool valid_prices = true;
+            if (candle.high < candle.low ||
+                candle.open > candle.high || candle.open < candle.low ||
+                candle.close > candle.high || candle.close < candle.low)
+            {
+                std::cerr << "[DataParser] Invalid OHLC at index " << index << "\n";
+                valid_prices = false;
+            }
+
+            if (!candles.empty()) {
+                auto prev_ts = parseTimestamp(candles.back().time);
+                auto cur_ts = parseTimestamp(candle.time);
+                if (cur_ts - prev_ts != 60000) {
+                    std::cerr << "[DataParser] Missing candle between " << candles.back().time
+                              << " and " << candle.time << "\n";
+                }
+            }
+
+            if (valid_prices)
+                candles.push_back(candle);
+            index++;
         }
         
     } catch (const std::exception& e) {
@@ -488,6 +509,31 @@ std::vector<sep::quantum::Pattern> DataParser::candlesToPatterns(
     }
     
     return patterns;
+}
+
+void DataParser::writeQuantJSON(const std::vector<CandleData>& candles, const std::string& path) const
+{
+    nlohmann::json j;
+    j["candles"] = nlohmann::json::array();
+    for (const auto& c : candles)
+    {
+        nlohmann::json cj;
+        cj["time"] = c.time;
+        cj["volume"] = c.volume;
+        cj["mid"] = {
+            {"o", std::to_string(c.open)},
+            {"h", std::to_string(c.high)},
+            {"l", std::to_string(c.low)},
+            {"c", std::to_string(c.close)}
+        };
+        j["candles"].push_back(cj);
+    }
+
+    std::ofstream file(path);
+    if (file.is_open())
+    {
+        file << j.dump(4);
+    }
 }
 
 uint64_t DataParser::parseTimestamp(const std::string& timestamp) const

--- a/src/engine/data_parser.h
+++ b/src/engine/data_parser.h
@@ -55,6 +55,9 @@ public:
     // Convert raw candle data to SEP patterns
     std::vector<sep::quantum::Pattern> candlesToPatterns(const std::vector<CandleData>& candles);
 
+    // Utility: write candle data to OANDA-style JSON
+    void writeQuantJSON(const std::vector<CandleData>& candles, const std::string& path) const;
+
     // Convert patterns to PinStates for engine compatibility
     std::vector<sep::PinState> toPinStates(const std::vector<sep::quantum::Pattern>& patterns);
 


### PR DESCRIPTION
## Summary
- add fetchHistoricalData to OandaConnector and use DataParser to write JSON
- enforce integrity checks for candles in DataParser
- compute 4h averages in MetricsMonitor
- load initial candle dataset through ServiceConnector and forward to SignalsTab
- plot metrics history with rolling averages in SignalsTabController

## Testing
- `./build.sh` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_68842c9ca938832a9dae5a858368b912