### PR TITLE
Add demo trading structures

### DIFF
--- a/src/apps/workbench/config.cpp
+++ b/src/apps/workbench/config.cpp
@@ -3,6 +3,7 @@
 #include <spdlog/spdlog.h>
 
 #include <fstream>
+#include <algorithm>
 
 namespace sep
 {
@@ -153,6 +154,47 @@ namespace sep
                 {
                     auto& oanda = json["oanda"];
                     oanda_ = {oanda.value("api_key", ""), oanda.value("account_id", ""), oanda.value("sandbox", true)};
+                }
+                else
+                {
+                    const char* env_key = std::getenv("OANDA_API_KEY");
+                    const char* env_id = std::getenv("OANDA_ACCOUNT_ID");
+                    if (env_key && env_id)
+                    {
+                        oanda_ = {env_key, env_id, true};
+                    }
+                    else
+                    {
+                        std::ifstream kfile("keys.txt");
+                        if (kfile.is_open())
+                        {
+                            std::string line;
+                            while (std::getline(kfile, line))
+                            {
+                                if (line.find("OANDA_API_KEY") != std::string::npos)
+                                {
+                                    auto pos = line.find('=');
+                                    if (pos != std::string::npos)
+                                    {
+                                        std::string val = line.substr(pos + 1);
+                                        val.erase(std::remove(val.begin(), val.end(), '"'), val.end());
+                                        oanda_.api_key = val;
+                                    }
+                                }
+                                else if (line.find("OANDA_ACCOUNT_ID") != std::string::npos)
+                                {
+                                    auto pos = line.find('=');
+                                    if (pos != std::string::npos)
+                                    {
+                                        std::string val = line.substr(pos + 1);
+                                        val.erase(std::remove(val.begin(), val.end(), '"'), val.end());
+                                        oanda_.account_id = val;
+                                    }
+                                }
+                            }
+                            oanda_.sandbox = true;
+                        }
+                    }
                 }
 
                 return true;

--- a/src/apps/workbench/core/service_connector.cpp
+++ b/src/apps/workbench/core/service_connector.cpp
@@ -4,6 +4,7 @@
 #include "engine.h"
 #include "service_proxy_engine.h"
 #include "config.h"
+#include "../config.hpp"
 
 #include <iostream>
 #include <thread>
@@ -31,19 +32,24 @@ ServiceConnector::ServiceConnector() : ServiceConnector(ConnectionConfig{}) {}
 
 ServiceConnector::ServiceConnector(const ConnectionConfig& config)
     : config_(config) {
-    const char* api_key = std::getenv("OANDA_API_KEY");
-    const char* account_id = std::getenv("OANDA_ACCOUNT_ID");
-    if (api_key && account_id) {
-        // Use practice server (sandbox=true) for safe testing
-        oanda_connector_ = std::make_unique<sep::connectors::OandaConnector>(api_key, account_id, true);
-        std::cout << "[ServiceConnector] OANDA connector configured for PRACTICE server" << std::endl;
-        std::cout << "[ServiceConnector] API Key length: " << strlen(api_key) << std::endl;
-        std::cout << "[ServiceConnector] Account ID: " << account_id << std::endl;
-    } else {
-        std::cout << "[ServiceConnector] ERROR: OANDA credentials not found in environment" << std::endl;
-        std::cout << "[ServiceConnector] API Key: " << (api_key ? "FOUND" : "NOT FOUND") << std::endl;
-        std::cout << "[ServiceConnector] Account ID: " << (account_id ? "FOUND" : "NOT FOUND") << std::endl;
+    auto& cfg = sep::workbench::Config::getInstance().oanda();
+    std::string api_key = cfg.api_key;
+    std::string account_id = cfg.account_id;
+    if (api_key.empty() || account_id.empty()) {
+        const char* env_key = std::getenv("OANDA_API_KEY");
+        const char* env_id = std::getenv("OANDA_ACCOUNT_ID");
+        if (env_key) api_key = env_key;
+        if (env_id) account_id = env_id;
     }
+
+    if (!api_key.empty() && !account_id.empty()) {
+        oanda_connector_ = std::make_unique<sep::connectors::OandaConnector>(api_key, account_id, true);
+        trade_manager_ = std::make_unique<workbench::TradeManager>(oanda_connector_.get());
+        std::cout << "[ServiceConnector] OANDA connector configured" << std::endl;
+    } else {
+        std::cout << "[ServiceConnector] ERROR: OANDA credentials not provided" << std::endl;
+    }
+
     std::cout << "[ServiceConnector] Initialized with config: "
                << config.service_address << ":" << config.service_port << std::endl;
 }
@@ -51,6 +57,7 @@ ServiceConnector::ServiceConnector(const ConnectionConfig& config)
 ServiceConnector::~ServiceConnector() {
     disconnect();
     stopHealthMonitoring();
+    trade_manager_.reset();
 }
 
 bool ServiceConnector::connect() {

--- a/src/apps/workbench/core/service_connector.hpp
+++ b/src/apps/workbench/core/service_connector.hpp
@@ -9,6 +9,7 @@
 
 #include "connectors/oanda_connector.h"
 #include "service_proxy_engine.h"
+#include "trade_manager.h"
 
 namespace sep {
 namespace core {
@@ -64,6 +65,7 @@ public:
     // Service interaction
     sep::core::Engine* getEngine() const { return service_engine_; }
     sep::connectors::OandaConnector* getOandaConnector() const { return oanda_connector_.get(); }
+    workbench::TradeManager* getTradeManager() const { return trade_manager_.get(); }
     ServiceHealth getServiceHealth() const;
     
     // Health monitoring
@@ -88,6 +90,7 @@ private:
     // Service connection
     sep::core::Engine* service_engine_{nullptr};
     std::unique_ptr<sep::connectors::OandaConnector> oanda_connector_;
+    std::unique_ptr<workbench::TradeManager> trade_manager_;
     void* service_handle_{nullptr}; // Platform-specific handle
     
     // Health monitoring

--- a/src/apps/workbench/core/trade_manager.cpp
+++ b/src/apps/workbench/core/trade_manager.cpp
@@ -97,11 +97,19 @@ void TradeManager::updatePositions(const Order& order) {
                            [&](const Position& p) { return p.instrument == order.instrument; });
 
     if (it != positions_.end()) {
-        double existing_units = it->size;
-        double existing_value = existing_units * it->average_price;
-        double new_value = order.units * order.price;
-
+        double prev_units = it->size;
+        double prev_avg = it->average_price;
         it->size += order.units;
+        if ((prev_units > 0 && it->size < prev_units) || (prev_units < 0 && it->size > prev_units)) {
+            // closing part of position
+            double close_units = order.units;
+            double pnl = (order.price - prev_avg) * close_units;
+            if (prev_units < 0) pnl = -pnl;
+            realized_pnl_ += pnl;
+            account_balance_ += pnl;
+        }
+        double existing_value = prev_units * prev_avg;
+        double new_value = order.units * order.price;
         if (it->size == 0) {
             it->average_price = 0;
         } else {
@@ -110,6 +118,7 @@ void TradeManager::updatePositions(const Order& order) {
     } else {
         Position new_position(order.instrument, order.units, order.price);
         positions_.push_back(new_position);
+        account_balance_ -= order.units * order.price;
     }
 }
 

--- a/src/apps/workbench/core/trade_manager.h
+++ b/src/apps/workbench/core/trade_manager.h
@@ -51,6 +51,9 @@ public:
     const std::vector<Order>& getOrders() const;
     const std::vector<Position>& getPositions() const;
 
+    double getAccountBalance() const { return account_balance_; }
+    double getRealizedPnL() const { return realized_pnl_; }
+
     void setPaperTrading(bool paper_trading);
 
 private:
@@ -61,6 +64,7 @@ private:
     std::vector<Position> positions_;
     std::mutex mutex_;
     double account_balance_ = 100000.0;
+    double realized_pnl_ = 0.0;
     double risk_percentage_ = 0.02;
     bool paper_trading_ = false;
 };

--- a/src/apps/workbench/core/workbench_core.cpp
+++ b/src/apps/workbench/core/workbench_core.cpp
@@ -117,6 +117,7 @@ bool WorkbenchEngine::initialize()
         engine_tab_->setSEPEngine(active_engine_);
         engine_tab_->setMultiTimeframeAnalyzer(multi_timeframe_analyzer_.get());
         backend_tab_->setServiceConnector(service_connector_.get());
+        backend_tab_->setTradeManager(service_connector_->getTradeManager());
 
         // Create offline engine as fallback
         ::std::cout << "[WorkbenchEngine] Creating offline engine..." << ::std::endl;

--- a/src/apps/workbench/tabs/backend_tab_controller.cpp
+++ b/src/apps/workbench/tabs/backend_tab_controller.cpp
@@ -79,9 +79,13 @@ void BackendTabController::renderDataSourceSelector() {
 void BackendTabController::renderOrderManagementPanel() {
     ImGui::Begin("Paper Trading");
     if (ImGui::Checkbox("Enable Paper Trading", &paper_trading_)) {
-        if (service_connector_) {
-            // service_connector_->getTradeManager()->setPaperTrading(paper_trading_);
+        if (trade_manager_) {
+            trade_manager_->setPaperTrading(paper_trading_);
         }
+    }
+    if (trade_manager_) {
+        ImGui::Text("Balance: %.2f", trade_manager_->getAccountBalance());
+        ImGui::Text("Realized PnL: %.2f", trade_manager_->getRealizedPnL());
     }
     ImGui::End();
 
@@ -91,28 +95,16 @@ void BackendTabController::renderOrderManagementPanel() {
     ImGui::InputInt("Units", &units_);
 
     if (ImGui::Button("Place Buy Order")) {
-        if (service_connector_) {
-            nlohmann::json order_details;
-            order_details["order"]["instrument"] = instrument_buffer_;
-            order_details["order"]["units"] = std::to_string(units_);
-            order_details["order"]["type"] = "MARKET";
-            order_details["order"]["timeInForce"] = "FOK";
-            order_details["order"]["positionFill"] = "DEFAULT";
-            service_connector_->getOandaConnector()->placeOrder(order_details);
+        if (trade_manager_) {
+            trade_manager_->placeOrder(instrument_buffer_, units_, 0.0f, stop_loss_pips_, take_profit_pips_);
         }
     }
 
     ImGui::SameLine();
 
     if (ImGui::Button("Place Sell Order")) {
-        if (service_connector_) {
-            nlohmann::json order_details;
-            order_details["order"]["instrument"] = instrument_buffer_;
-            order_details["order"]["units"] = std::to_string(-units_);
-            order_details["order"]["type"] = "MARKET";
-            order_details["order"]["timeInForce"] = "FOK";
-            order_details["order"]["positionFill"] = "DEFAULT";
-            service_connector_->getOandaConnector()->placeOrder(order_details);
+        if (trade_manager_) {
+            trade_manager_->placeOrder(instrument_buffer_, -units_, 0.0f, stop_loss_pips_, take_profit_pips_);
         }
     }
 

--- a/src/apps/workbench/tabs/backend_tab_controller.h
+++ b/src/apps/workbench/tabs/backend_tab_controller.h
@@ -23,9 +23,11 @@ public:
 
     void setMetricsMonitor(std::shared_ptr<MetricsMonitor> monitor);
     void setServiceConnector(ServiceConnector* connector);
+    void setTradeManager(TradeManager* manager) { trade_manager_ = manager; }
 
 private:
     ServiceConnector* service_connector_ = nullptr;
+    TradeManager* trade_manager_ = nullptr;
     void renderDataSourceSelector();
     void renderBacktesterPanel();
     void renderOrderManagementPanel();

--- a/src/connectors/oanda_connector.cpp
+++ b/src/connectors/oanda_connector.cpp
@@ -491,7 +491,27 @@ nlohmann::json OandaConnector::placeOrder(const nlohmann::json& order_details) {
 
     if (response.response_code == 201) {
         try {
-            return nlohmann::json::parse(response.data);
+            auto json_resp = nlohmann::json::parse(response.data);
+            OrderInfo info;
+            if (json_resp.contains("orderCreateTransaction")) {
+                const auto& tx = json_resp["orderCreateTransaction"];
+                info.id = tx.value("id", "");
+                info.instrument = tx.value("instrument", "");
+                info.units = std::stod(tx.value("units", "0"));
+                info.price = tx.contains("price") ? std::stod(tx["price"].get<std::string>()) : 0.0;
+                info.status = OrderStatus::PENDING;
+                pending_orders_.push_back(info);
+            }
+            if (json_resp.contains("orderFillTransaction")) {
+                const auto& tx = json_resp["orderFillTransaction"];
+                info.id = tx.value("id", "");
+                info.instrument = tx.value("instrument", "");
+                info.units = std::stod(tx.value("units", "0"));
+                info.price = std::stod(tx.value("price", "0"));
+                info.status = OrderStatus::FILLED;
+                filled_orders_.push_back(info);
+            }
+            return json_resp;
         } catch (const std::exception& e) {
             last_error_ = "Failed to parse placeOrder response: " + std::string(e.what());
             return nlohmann::json{{"error", last_error_}};
@@ -526,6 +546,60 @@ nlohmann::json OandaConnector::getOrders() {
     
     last_error_ = "Failed to get orders: " + response.data;
     return nlohmann::json{ {"error", last_error_} };
+}
+
+void OandaConnector::refreshOrders() {
+    auto fetch_state = [this](const std::string& state) -> nlohmann::json {
+        std::string endpoint = "/v3/accounts/" + account_id_ + "/orders?state=" + state;
+        CurlResponse res = makeRequest(endpoint, "GET");
+        if (res.response_code == 200) {
+            return nlohmann::json::parse(res.data);
+        }
+        return {};
+    };
+
+    pending_orders_.clear();
+    filled_orders_.clear();
+    canceled_orders_.clear();
+
+    auto pending_json = fetch_state("PENDING");
+    if (pending_json.contains("orders")) {
+        for (const auto& o : pending_json["orders"]) {
+            OrderInfo info;
+            info.id = o.value("id", "");
+            info.instrument = o.value("instrument", "");
+            info.units = std::stod(o.value("units", "0"));
+            info.price = o.contains("price") ? std::stod(o["price"].get<std::string>()) : 0.0;
+            info.status = OrderStatus::PENDING;
+            pending_orders_.push_back(info);
+        }
+    }
+
+    auto filled_json = fetch_state("FILLED");
+    if (filled_json.contains("orders")) {
+        for (const auto& o : filled_json["orders"]) {
+            OrderInfo info;
+            info.id = o.value("id", "");
+            info.instrument = o.value("instrument", "");
+            info.units = std::stod(o.value("units", "0"));
+            info.price = o.contains("price") ? std::stod(o["price"].get<std::string>()) : 0.0;
+            info.status = OrderStatus::FILLED;
+            filled_orders_.push_back(info);
+        }
+    }
+
+    auto canceled_json = fetch_state("CANCELLED");
+    if (canceled_json.contains("orders")) {
+        for (const auto& o : canceled_json["orders"]) {
+            OrderInfo info;
+            info.id = o.value("id", "");
+            info.instrument = o.value("instrument", "");
+            info.units = std::stod(o.value("units", "0"));
+            info.price = o.contains("price") ? std::stod(o["price"].get<std::string>()) : 0.0;
+            info.status = OrderStatus::CANCELED;
+            canceled_orders_.push_back(info);
+        }
+    }
 }
 
 void OandaConnector::setupSampleData(const std::string& instrument, const std::string& granularity, const std::string& output_file) {

--- a/src/connectors/oanda_connector.h
+++ b/src/connectors/oanda_connector.h
@@ -49,6 +49,16 @@ struct DataValidationResult
     std::vector<std::string> warnings;
 };
 
+enum class OrderStatus { PENDING, FILLED, CANCELED };
+
+struct OrderInfo {
+    std::string id;
+    std::string instrument;
+    double units{0};
+    double price{0};
+    OrderStatus status{OrderStatus::PENDING};
+};
+
 class OandaConnector {
 public:
     OandaConnector(const std::string& api_key, const std::string& account_id, bool sandbox = true);
@@ -93,6 +103,12 @@ public:
     std::string getLastError() const { return last_error_; }
     bool hasError() const { return !last_error_.empty(); }
 
+    // Order tracking
+    void refreshOrders();
+    const std::vector<OrderInfo>& pendingOrders() const { return pending_orders_; }
+    const std::vector<OrderInfo>& filledOrders() const { return filled_orders_; }
+    const std::vector<OrderInfo>& canceledOrders() const { return canceled_orders_; }
+
 private:
     std::string api_key_;
     std::string account_id_;
@@ -134,7 +150,12 @@ private:
     std::thread stream_thread_;
     std::string stream_buffer_;
     void streamPriceData(const std::string& instruments);
-};
+
+    // Order caches
+    std::vector<OrderInfo> pending_orders_;
+    std::vector<OrderInfo> filled_orders_;
+    std::vector<OrderInfo> canceled_orders_;
+}; 
 
 } // namespace connectors
 }  // namespace sep


### PR DESCRIPTION
## Summary
- add OrderInfo tracking in OandaConnector
- parse and refresh order states
- load demo credentials from environment or keys.txt
- create TradeManager through ServiceConnector and expose it to the backend
- show paper trading balance and PnL in backend tab

## Testing
- `./build.sh` *(fails: cd /sep: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68842ce83210832aae337ef1640ca12f