### PR TITLE
Add offline candle loader and validation

### DIFF
--- a/src/apps/workbench/core/service_connector.cpp
+++ b/src/apps/workbench/core/service_connector.cpp
@@ -49,19 +49,17 @@ ServiceConnector::ServiceConnector(const ConnectionConfig& config)
         std::cout << "[ServiceConnector] API Key length: " << strlen(api_key) << std::endl;
         std::cout << "[ServiceConnector] Account ID: " << account_id << std::endl;
         if (oanda_connector_->initialize()) {
-            oanda_connector_->fetchHistoricalData("EUR_USD", "eur_usd_m1_48h.json");
-            sep::DataParser parser;
-            auto candles = parser.parseQuantJSON("eur_usd_m1_48h.json");
-            for (const auto& c : candles) {
-                std::tm tm = {};
-                std::istringstream ss(c.time);
-                ss >> std::get_time(&tm, "%Y-%m-%dT%H:%M:%S");
-                auto ts = std::chrono::system_clock::from_time_t(std::mktime(&tm));
-                initial_data_.emplace_back(c.open, c.high, c.low, c.close, (int)c.volume, ts);
+            if (oanda_connector_->fetchHistoricalData("EUR_USD", "eur_usd_m1_48h.json")) {
+                loadInitialData("eur_usd_m1_48h.json");
+            } else {
+                loadInitialData("eur_usd_m1_48h.json");
             }
+        } else {
+            loadInitialData("eur_usd_m1_48h.json");
         }
     } else {
         std::cout << "[ServiceConnector] ERROR: OANDA credentials not provided" << std::endl;
+        loadInitialData("eur_usd_m1_48h.json");
     }
 
     std::cout << "[ServiceConnector] Initialized with config: "
@@ -852,6 +850,25 @@ sep::core::Engine* ServiceConnector::createHttpEngineProxy(int socket_fd)
         std::cerr << "[ServiceConnector] Exception creating HTTP proxy engine: " << e.what() << std::endl;
         // Fallback to local engine
         return createLocalEngine();
+    }
+}
+
+void ServiceConnector::loadInitialData(const std::string& path)
+{
+    sep::DataParser parser;
+    auto candles = parser.parseQuantJSON(path);
+    initial_data_.clear();
+    for (const auto& c : candles)
+    {
+        std::tm tm = {};
+        std::istringstream ss(c.time);
+        ss >> std::get_time(&tm, "%Y-%m-%dT%H:%M:%S");
+        auto ts = std::chrono::system_clock::from_time_t(std::mktime(&tm));
+        initial_data_.emplace_back(c.open, c.high, c.low, c.close, static_cast<int>(c.volume), ts);
+    }
+    if (signals_tab_ && !initial_data_.empty())
+    {
+        signals_tab_->setCandleData(initial_data_);
     }
 }
 

--- a/src/apps/workbench/core/service_connector.hpp
+++ b/src/apps/workbench/core/service_connector.hpp
@@ -127,6 +127,8 @@ private:
 
     SignalsTabController* signals_tab_{nullptr};
     std::deque<CandleData> initial_data_;
+
+    void loadInitialData(const std::string& path);
 };
 
 } // namespace sep::workbench

--- a/src/apps/workbench/core/workbench_core.cpp
+++ b/src/apps/workbench/core/workbench_core.cpp
@@ -694,46 +694,53 @@ void WorkbenchEngine::renderTabs()
 void WorkbenchEngine::updateData()
 {
     // Real implementation of data fetching pipeline (DATA.md integration)
+    std::deque<CandleData> candle_data;
+    bool fetched = false;
     if (service_connector_ && service_connector_->getOandaConnector()) {
         auto oanda_connector = service_connector_->getOandaConnector();
         try {
-            // Fetch 48-hour sample data (TODO.md Phase 1.1)
             auto now = std::chrono::system_clock::now();
-            auto hours_48_ago = now - std::chrono::hours(48);
-            
+            auto start = now - std::chrono::hours(48);
+
             auto now_t = std::chrono::system_clock::to_time_t(now);
-            auto hours_48_ago_t = std::chrono::system_clock::to_time_t(hours_48_ago);
-            
-            std::string from_time = std::to_string(hours_48_ago_t);
-            std::string to_time = std::to_string(now_t);
-            
-            // Fetch historical EUR/USD M1 data
-            auto historical_candles = oanda_connector->getHistoricalData("EUR_USD", "M1", from_time, to_time, 2880);
-            
-            std::deque<CandleData> candle_data;
-            for (const auto& oanda_candle : historical_candles) {
-                // Parse OANDA timestamp (RFC 3339 format: "2021-04-07T00:00:00.000000000Z")
+            auto start_t = std::chrono::system_clock::to_time_t(start);
+
+            auto historical_candles = oanda_connector->getHistoricalData(
+                "EUR_USD", "M1", std::to_string(start_t), std::to_string(now_t), 2880);
+
+            for (const auto& oc : historical_candles) {
                 std::tm tm = {};
-                std::istringstream ss(oanda_candle.time);
+                std::istringstream ss(oc.time);
                 ss >> std::get_time(&tm, "%Y-%m-%dT%H:%M:%S");
-                auto timestamp = std::chrono::system_clock::from_time_t(std::mktime(&tm));
-                
-                CandleData candle(oanda_candle.open, oanda_candle.high, 
-                                oanda_candle.low, oanda_candle.close, 
-                                static_cast<int>(oanda_candle.volume), timestamp);
-                candle_data.push_back(candle);
+                auto ts = std::chrono::system_clock::from_time_t(std::mktime(&tm));
+                candle_data.emplace_back(oc.open, oc.high, oc.low, oc.close,
+                                        static_cast<int>(oc.volume), ts);
             }
-            
-            // Update signals tab with fetched data
-            if (signals_tab_) {
+
+            fetched = !candle_data.empty();
+            if (fetched && signals_tab_) {
                 signals_tab_->setCandleData(candle_data);
             }
-            
-            std::cout << "[WorkbenchEngine] Fetched " << candle_data.size() 
-                      << " candles from OANDA" << std::endl;
-                      
+
+            if (fetched) {
+                std::cout << "[WorkbenchEngine] Fetched " << candle_data.size()
+                          << " candles from OANDA" << std::endl;
+            }
+
         } catch (const std::exception& e) {
             std::cerr << "[WorkbenchEngine] OANDA data fetch error: " << e.what() << std::endl;
+        }
+    }
+
+    if (!fetched && service_connector_) {
+        candle_data = std::deque<CandleData>(service_connector_->getInitialData().begin(),
+                                             service_connector_->getInitialData().end());
+        if (signals_tab_ && !candle_data.empty()) {
+            signals_tab_->setCandleData(candle_data);
+        }
+        if (!candle_data.empty()) {
+            std::cout << "[WorkbenchEngine] Loaded " << candle_data.size()
+                      << " candles from local cache" << std::endl;
         }
     }
 

--- a/src/connectors/oanda_connector.cpp
+++ b/src/connectors/oanda_connector.cpp
@@ -85,19 +85,35 @@ std::vector<OandaCandle> OandaConnector::getHistoricalData(
     int count) {
     
     std::vector<OandaCandle> candles;
-    
+
+    std::string use_from = from;
+    std::string use_to = to;
+
+    // Convenience: if requesting exactly 48 hours of M1 data without explicit
+    // range, compute timestamps automatically.
+    if (granularity == "M1" && count == 48 * 60 && from.empty() && to.empty())
+    {
+        auto now = std::chrono::system_clock::now();
+        auto start = now - std::chrono::hours(48);
+        use_from = std::to_string(std::chrono::system_clock::to_time_t(start));
+        use_to = std::to_string(std::chrono::system_clock::to_time_t(now));
+    }
+
     std::string endpoint = "/v3/instruments/" + instrument + "/candles";
     endpoint += "?granularity=" + granularity;
-    
-    if (count > 0) {
+
+    if (count > 0)
+    {
         endpoint += "&count=" + std::to_string(count);
     }
-    
-    if (!from.empty()) {
-        endpoint += "&from=" + from;
+
+    if (!use_from.empty())
+    {
+        endpoint += "&from=" + use_from;
     }
-    if (!to.empty()) {
-        endpoint += "&to=" + to;
+    if (!use_to.empty())
+    {
+        endpoint += "&to=" + use_to;
     }
 
     auto response = makeRequest(endpoint);
@@ -118,6 +134,20 @@ std::vector<OandaCandle> OandaConnector::getHistoricalData(
 
         for (const auto& candle_json : json_response["candles"]) {
             candles.push_back(parseCandle(candle_json));
+        }
+
+        // Perform integrity validation for 48h M1 datasets
+        if (granularity == "M1" && count == 48 * 60) {
+            auto validation = validateCandleSequence(candles, granularity);
+            if (!validation.valid || candles.size() != static_cast<size_t>(48 * 60)) {
+                last_error_ = "Missing or invalid candles detected";
+                for (const auto& err : validation.errors) {
+                    last_error_ += " - " + err;
+                }
+                if (candles.size() != static_cast<size_t>(48 * 60)) {
+                    last_error_ += " - expected 2880 got " + std::to_string(candles.size());
+                }
+            }
         }
         
     } catch (const std::exception& e) {

--- a/src/engine/data_parser.cpp
+++ b/src/engine/data_parser.cpp
@@ -1,6 +1,7 @@
 #include "data_parser.h"
 
 #include <nlohmann/json.hpp>
+#include <cmath>
 
 #include "engine/standard_includes.h"
 #include "quantum/types.h"
@@ -517,6 +518,13 @@ void DataParser::writeQuantJSON(const std::vector<CandleData>& candles, const st
     j["candles"] = nlohmann::json::array();
     for (const auto& c : candles)
     {
+        if (!std::isfinite(c.open) || !std::isfinite(c.high) || !std::isfinite(c.low) ||
+            !std::isfinite(c.close) || c.high < c.low)
+        {
+            std::cerr << "[DataParser] Invalid candle data at " << c.time << std::endl;
+            continue;
+        }
+
         nlohmann::json cj;
         cj["time"] = c.time;
         cj["volume"] = c.volume;


### PR DESCRIPTION
## Summary
- extend `OandaConnector::getHistoricalData` with auto 48h range and candle sequence check
- validate OHLC values before writing JSON in `DataParser`
- load cached candle JSON during `ServiceConnector` construction and expose through `getInitialData`
- use cached candles in `WorkbenchEngine::updateData` when live fetch fails

## Testing
- `cmake .. && make` in `simple_test`
- `ctest --output-on-failure`
- `g++ -std=c++17 -c src/engine/data_parser.cpp` *(fails: glm/glm.hpp: No such file or directory)*
- `./run_clang_tidy.sh` *(fails: compile_commands.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68843895eb74832a8694f97b31f50cad