### PR TITLE
Add paper trading and strategy optimization

### DIFF
--- a/src/apps/workbench/core/trade_manager.cpp
+++ b/src/apps/workbench/core/trade_manager.cpp
@@ -1,14 +1,34 @@
 #include "apps/workbench/core/trade_manager.h"
 #include <algorithm>
+#include <chrono>
+#include <thread>
 
 namespace sep {
 namespace workbench {
 
 TradeManager::TradeManager(sep::connectors::OandaConnector* connector)
-    : oanda_connector_(connector) {}
+    : oanda_connector_(connector)
+{
+    starting_balance_ = account_balance_;
+    sep::logging::LoggerConfig config;
+    config.file.path = "trades.log";
+    logger_ = sep::logging::Manager::getInstance().createLogger("trade_manager", config);
+}
+
+TradeManager::~TradeManager()
+{
+    stopPaperTrading();
+}
 
 void TradeManager::setPaperTrading(bool paper_trading) {
     paper_trading_ = paper_trading;
+    if (paper_trading_) {
+        if (!paper_instrument_.empty()) {
+            startPaperTrading(paper_instrument_);
+        }
+    } else {
+        stopPaperTrading();
+    }
 }
 
 nlohmann::json TradeManager::placeOrder(const std::string& instrument,
@@ -33,6 +53,11 @@ nlohmann::json TradeManager::placeOrder(const std::string& instrument,
         order.state = OrderState::FILLED;
         orders_.push_back(order);
         updatePositions(order);
+        sep::logging::logTrade(instrument, units, current_price, 0.0);
+        paper_instrument_ = instrument;
+        if (paper_trading_ && !paper_thread_active_) {
+            startPaperTrading(instrument);
+        }
         return {{"paper_trade", "success"}};
     }
 
@@ -73,6 +98,7 @@ nlohmann::json TradeManager::placeOrder(const std::string& instrument,
         order.state = OrderState::FILLED;
         orders_.push_back(order);
         updatePositions(order);
+        sep::logging::logTrade(instrument, units, order.price, 0.0);
     }
 
     return result;
@@ -110,6 +136,14 @@ void TradeManager::updatePositions(const Order& order) {
             if (prev_units < 0) pnl = -pnl;
             realized_pnl_ += pnl;
             account_balance_ += pnl;
+            if (pnl > 0)
+                win_count_++;
+            else if (pnl < 0)
+                loss_count_++;
+            sep::logging::logTrade(order.instrument, order.units, order.price, pnl);
+            double roi = getROI();
+            if (roi < -0.05)
+                sep::logging::logAnomaly("ROI below -5%");
         }
         double existing_value = prev_units * prev_avg;
         double new_value = order.units * order.price;
@@ -123,6 +157,46 @@ void TradeManager::updatePositions(const Order& order) {
         positions_.push_back(new_position);
         account_balance_ -= order.units * order.price;
     }
+}
+
+void TradeManager::startPaperTrading(const std::string& instrument)
+{
+    paper_instrument_ = instrument;
+    if (paper_thread_active_) return;
+    paper_thread_active_ = true;
+    paper_thread_ = std::thread([this]() {
+        while (paper_thread_active_) {
+            if (oanda_connector_) {
+                auto md = oanda_connector_->getMarketData(paper_instrument_);
+                std::lock_guard<std::mutex> lock(mutex_);
+                for (auto& pos : positions_) {
+                    pos.current_price = (pos.size > 0) ? md.bid : md.ask;
+                    pos.unrealized_pl = (pos.current_price - pos.average_price) * pos.size;
+                }
+            }
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+        }
+    });
+}
+
+void TradeManager::stopPaperTrading()
+{
+    paper_thread_active_ = false;
+    if (paper_thread_.joinable())
+        paper_thread_.join();
+}
+
+double TradeManager::getWinLossRatio() const
+{
+    int total = win_count_ + loss_count_;
+    if (total == 0) return 0.0;
+    return static_cast<double>(win_count_) / total;
+}
+
+double TradeManager::getROI() const
+{
+    if (starting_balance_ == 0.0) return 0.0;
+    return realized_pnl_ / starting_balance_;
 }
 
 } // namespace workbench

--- a/src/apps/workbench/core/trade_manager.h
+++ b/src/apps/workbench/core/trade_manager.h
@@ -7,6 +7,10 @@
 #include <vector>
 #include <mutex>
 #include <chrono>
+#include <thread>
+#include <atomic>
+#include <memory>
+#include "engine/logging.h"
 
 namespace sep {
 namespace workbench {
@@ -39,7 +43,7 @@ struct Position {
 class TradeManager {
 public:
     TradeManager(sep::connectors::OandaConnector* connector);
-    ~TradeManager() = default;
+    ~TradeManager();
 
     nlohmann::json placeOrder(const std::string& instrument,
                               double units,
@@ -61,16 +65,31 @@ public:
 
     void setPaperTrading(bool paper_trading);
 
+    // Continuous paper trading controls
+    void startPaperTrading(const std::string& instrument);
+    void stopPaperTrading();
+
+    // Performance metrics
+    double getWinLossRatio() const;
+    double getROI() const;
+
 private:
     void updatePositions(const Order& order);
 
     sep::connectors::OandaConnector* oanda_connector_;
     std::vector<Order> orders_;
     std::vector<Position> positions_;
+    std::shared_ptr<spdlog::logger> logger_;
+    std::thread paper_thread_;
+    std::atomic<bool> paper_thread_active_{false};
+    std::string paper_instrument_;
     std::mutex mutex_;
     double account_balance_ = 100000.0;
+    double starting_balance_ = 100000.0;
     double realized_pnl_ = 0.0;
     double risk_percentage_ = 0.02;
+    int win_count_ = 0;
+    int loss_count_ = 0;
     bool paper_trading_ = false;
 };
 

--- a/src/apps/workbench/tabs/engine_tab_controller.cpp
+++ b/src/apps/workbench/tabs/engine_tab_controller.cpp
@@ -9,7 +9,9 @@
 
 namespace sep::workbench {
 
-EngineTabController::EngineTabController() {}
+EngineTabController::EngineTabController()
+    : backtester_(std::make_unique<backtester::Backtester>()),
+      data_loader_(std::make_unique<backtester::DataLoader>()) {}
 
 EngineTabController::~EngineTabController() { shutdown(); }
 bool EngineTabController::initialize() {
@@ -27,6 +29,7 @@ void EngineTabController::render() {
 
         renderEngineControls();
         renderCorrelationPanel();
+        renderStrategyOptimization();
         ImGui::EndTabItem();
     }
 }
@@ -245,6 +248,34 @@ void EngineTabController::renderCorrelationPanel() {
         parser.exportCorrelationCSV(correlation_export_path_, data);
     }
 
+    ImGui::End();
+}
+
+void EngineTabController::renderStrategyOptimization()
+{
+    ImGui::Begin("Strategy Optimization");
+    ImGui::InputText("Dataset", dataset_path_, sizeof(dataset_path_));
+    if (ImGui::Button("Run Backtest")) {
+        if (pattern_engine_ && dataset_path_[0] != '\0') {
+            data_loader_->load_data(dataset_path_);
+            backtester_->run(pattern_engine_, data_loader_.get());
+            last_result_ = backtester_->getResult();
+            opt_coherence_ = 0.5f + last_result_.win_rate * 0.5f;
+        }
+    }
+    ImGui::Text("Win Rate: %.2f", last_result_.win_rate);
+    ImGui::SliderFloat("Coherence", &opt_coherence_, 0.0f, 1.0f);
+    ImGui::SliderFloat("Stability", &opt_stability_, 0.0f, 1.0f);
+    ImGui::SliderFloat("Entropy", &opt_entropy_, 0.0f, 1.0f);
+    if (ImGui::Button("Apply Thresholds")) {
+        if (pattern_engine_) {
+            sep::quantum::SignalThresholds th;
+            th.min_coherence = opt_coherence_;
+            th.min_stability = opt_stability_;
+            th.max_entropy = opt_entropy_;
+            pattern_engine_->setSignalThresholds(th);
+        }
+    }
     ImGui::End();
 }
 

--- a/src/apps/workbench/tabs/engine_tab_controller.h
+++ b/src/apps/workbench/tabs/engine_tab_controller.h
@@ -10,6 +10,8 @@
 #include "engine/engine.h"
 #include "quantum/coherence_manager.h"
 #include "quantum/pattern_metric_engine.h"
+#include "../backtester/backtester.h"
+#include "../backtester/data_loader.h"
 
 namespace sep::workbench {
 
@@ -50,6 +52,17 @@ private:
 
     // Export path buffer
     char correlation_export_path_[512] = "correlation.csv";
+
+    // Strategy optimization
+    std::unique_ptr<backtester::Backtester> backtester_;
+    std::unique_ptr<backtester::DataLoader> data_loader_;
+    char dataset_path_[512] = "";
+    float opt_coherence_{0.7f};
+    float opt_stability_{0.6f};
+    float opt_entropy_{0.3f};
+    backtester::BacktestResult last_result_{};
+
+    void renderStrategyOptimization();
 };
 
 } // namespace sep::workbench

--- a/src/engine/logging.cpp
+++ b/src/engine/logging.cpp
@@ -139,5 +139,26 @@ void logPatternDetected(const std::string &pattern_id,
     logger->info("Pattern detected {} at {}", pattern_id, buf);
 }
 
+void logTrade(const std::string &instrument,
+              double units,
+              double price,
+              double pnl)
+{
+    auto logger = spdlog::get("trade_manager");
+    if (!logger) return;
+    logger->info("Trade {} {:.0f} @ {:.5f} pnl {:.5f}",
+                 instrument,
+                 units,
+                 price,
+                 pnl);
+}
+
+void logAnomaly(const std::string &message)
+{
+    auto logger = spdlog::get("trade_manager");
+    if (!logger) return;
+    logger->warn("Anomaly detected: {}", message);
+}
+
 }  // namespace sep::logging
 

--- a/src/engine/logging.h
+++ b/src/engine/logging.h
@@ -62,6 +62,15 @@ class Manager {
 void logPatternDetected(const std::string &pattern_id,
                         std::chrono::system_clock::time_point timestamp);
 
+// Log executed trade details to the trade_manager logger
+void logTrade(const std::string &instrument,
+              double units,
+              double price,
+              double pnl);
+
+// Log anomaly events such as abnormal ROI drawdown
+void logAnomaly(const std::string &message);
+
 // Global functions
 inline void initializeLogging() { Manager::initialize(); }
 inline Level levelFromString(const std::string &level)


### PR DESCRIPTION
## Summary
- implement trade logging helpers
- support continuous paper trading with performance metrics
- add strategy optimization panel in EngineTabController

## Testing
- `./build.sh` *(fails: cd: /sep: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688438b43880832a8c4e82c4578b747d