### PR TITLE
Add rolling metrics graphs and shared monitor

### DIFF
--- a/src/apps/workbench/core/metrics_monitor.cpp
+++ b/src/apps/workbench/core/metrics_monitor.cpp
@@ -59,6 +59,7 @@ void MetricsMonitor::shutdown() {
 void MetricsMonitor::clear() {
     std::lock_guard<std::mutex> lock(metrics_mutex_);
     pattern_stats_.clear();
+    pattern_stats_map_.clear();
     system_metrics_ = SystemMetrics{};
     system_metrics_.last_update = std::chrono::steady_clock::now();
     rolling_metrics_ = RollingMetrics{};
@@ -224,25 +225,39 @@ void MetricsMonitor::updateMetrics() {
     auto metrics = engine->computeMetrics();
 
     std::lock_guard<std::mutex> lock(metrics_mutex_);
-    pattern_stats_.clear();
 
     auto now = std::chrono::steady_clock::now();
 
-    // Convert quantum engine metrics to our format
     for (const auto& metric : metrics)
     {
-        PatternStats stats;
-        stats.pattern_id = std::string(metric.pattern_id);
-        stats.coherence = metric.coherence;
-        stats.stability = metric.stability;
-        stats.entropy = metric.entropy;
-        stats.first_seen = now;  // We don't track this in the engine yet
-        stats.last_seen = now;
-        stats.frequency = 1;                       // TODO: Track frequency in engine
-        stats.length = strlen(metric.pattern_id);  // Approximate
-        stats.persistence = 0.0f;
+        std::string id(metric.pattern_id);
+        auto it = pattern_stats_map_.find(id);
+        if (it == pattern_stats_map_.end()) {
+            PatternStats stats;
+            stats.pattern_id = id;
+            stats.coherence = metric.coherence;
+            stats.stability = metric.stability;
+            stats.entropy = metric.entropy;
+            stats.first_seen = now;
+            stats.last_seen = now;
+            stats.frequency = 1;
+            stats.length = strlen(metric.pattern_id);
+            stats.persistence = 0.0f;
+            pattern_stats_map_[id] = stats;
+        } else {
+            auto& s = it->second;
+            s.coherence = metric.coherence;
+            s.stability = metric.stability;
+            s.entropy = metric.entropy;
+            s.last_seen = now;
+            s.frequency += 1;
+        }
+    }
 
-        pattern_stats_.push_back(stats);
+    pattern_stats_.clear();
+    pattern_stats_.reserve(pattern_stats_map_.size());
+    for (const auto& kv : pattern_stats_map_) {
+        pattern_stats_.push_back(kv.second);
     }
 
     calculateSystemMetrics();

--- a/src/apps/workbench/core/metrics_monitor.h
+++ b/src/apps/workbench/core/metrics_monitor.h
@@ -151,6 +151,7 @@ private:
     // The actual engine will be created in the implementation
     void* engine_; // Using void* to avoid including the header here
     std::vector<PatternStats> pattern_stats_;
+    std::unordered_map<std::string, PatternStats> pattern_stats_map_;
     SystemMetrics system_metrics_;
     RollingMetrics rolling_metrics_;
     ThresholdSignal latest_signal_;

--- a/src/apps/workbench/core/workbench_core.cpp
+++ b/src/apps/workbench/core/workbench_core.cpp
@@ -102,7 +102,7 @@ bool WorkbenchEngine::initialize()
             metrics_.service_connected = (e.state == ConnectionState::CONNECTED);
         });
         signal_generator_ = ::std::make_unique<QuantumSignalGenerator>();
-        metrics_monitor_ = ::std::make_unique<MetricsMonitor>();
+        metrics_monitor_ = ::std::make_shared<MetricsMonitor>();
         multi_timeframe_analyzer_ = ::std::make_unique<MultiTimeframeAnalyzer>();
         
         // Initialize renderer and metrics dashboard
@@ -121,10 +121,11 @@ bool WorkbenchEngine::initialize()
         // Set up data flow
         signals_tab_->setOandaConnector(service_connector_->getOandaConnector());
         signals_tab_->setQuantumSignalGenerator(signal_generator_.get());
-        signals_tab_->setMetricsMonitor(metrics_monitor_.get());
+        signals_tab_->setMetricsMonitor(metrics_monitor_);
         signals_tab_->setWorkbenchEngine(this);
         service_connector_->setSignalsTab(signals_tab_.get());
         engine_tab_->setSEPEngine(active_engine_);
+        engine_tab_->setMetricsMonitor(metrics_monitor_);
         engine_tab_->setMultiTimeframeAnalyzer(multi_timeframe_analyzer_.get());
         backend_tab_->setServiceConnector(service_connector_.get());
         backend_tab_->setTradeManager(service_connector_->getTradeManager());

--- a/src/apps/workbench/core/workbench_core.hpp
+++ b/src/apps/workbench/core/workbench_core.hpp
@@ -111,7 +111,7 @@ private:
     std::unique_ptr<EngineTabController> engine_tab_;
     std::unique_ptr<BackendTabController> backend_tab_;
     std::unique_ptr<QuantumSignalGenerator> signal_generator_;
-    std::unique_ptr<MetricsMonitor> metrics_monitor_;
+    std::shared_ptr<MetricsMonitor> metrics_monitor_;
     std::unique_ptr<MultiTimeframeAnalyzer> multi_timeframe_analyzer_;
     
     // Engine components (may be null if service not connected)

--- a/src/apps/workbench/tabs/engine_tab_controller.cpp
+++ b/src/apps/workbench/tabs/engine_tab_controller.cpp
@@ -63,6 +63,7 @@ void EngineTabController::renderSEPMetricsPanel() {
     }
 
     const auto& system_metrics = metrics_monitor_->getSystemMetrics();
+    const auto& rolling = metrics_monitor_->getRollingMetrics();
 
     ImGui::Text("Coherence: %.3f", system_metrics.avg_coherence);
     ImGui::ProgressBar(system_metrics.avg_coherence, ImVec2(-1, 0));
@@ -72,6 +73,14 @@ void EngineTabController::renderSEPMetricsPanel() {
 
     ImGui::Text("Entropy:   %.3f", system_metrics.avg_entropy);
     ImGui::ProgressBar(1.0f - system_metrics.avg_entropy, ImVec2(-1, 0));
+
+    ImGui::Text("1h Avg Coherence: %.3f", rolling.coherence_1h_avg);
+    ImGui::Text("1h Avg Stability: %.3f", rolling.stability_1h_avg);
+    ImGui::Text("1h Avg Entropy: %.3f", rolling.entropy_1h_avg);
+
+    ImGui::Text("4h Avg Coherence: %.3f", rolling.coherence_4h_avg);
+    ImGui::Text("4h Avg Stability: %.3f", rolling.stability_4h_avg);
+    ImGui::Text("4h Avg Entropy: %.3f", rolling.entropy_4h_avg);
 
     ImGui::Spacing();
     ImGui::Separator();
@@ -109,9 +118,14 @@ void EngineTabController::renderSEPMetricsPanel() {
 
         ImGui::Text("Memory Tiers:");
         for (int i = 0; i < 3; i++) {
-            ImGui::Text("  Tier %d: %.3f coherence, %.3f fragmentation", 
+            ImGui::Text("  Tier %d: %.3f coherence, %.3f fragmentation",
                        i, coherence_metrics.tier_coherence[i], coherence_metrics.tier_fragmentation[i]);
         }
+    }
+
+    ImGui::InputText("Metrics JSON Path", metrics_export_path_, sizeof(metrics_export_path_));
+    if (ImGui::Button("Export Metrics")) {
+        metrics_monitor_->saveMetricsToFile(metrics_export_path_);
     }
 }
 

--- a/src/apps/workbench/tabs/engine_tab_controller.h
+++ b/src/apps/workbench/tabs/engine_tab_controller.h
@@ -50,6 +50,7 @@ private:
 
     // Export path buffer
     char correlation_export_path_[512] = "correlation.csv";
+    char metrics_export_path_[512] = "metrics.json";
 };
 
 } // namespace sep::workbench

--- a/src/apps/workbench/tabs/signals_tab_controller.cpp
+++ b/src/apps/workbench/tabs/signals_tab_controller.cpp
@@ -10,6 +10,16 @@
 #include <sstream>
 #include <limits>
 
+static void drawDashedHorizontal(ImDrawList* dl, float x1, float x2, float y,
+                                 ImU32 col, float dash = 4.0f, float gap = 4.0f) {
+    float x = x1;
+    while (x < x2) {
+        float x_end = std::min(x + dash, x2);
+        dl->AddLine(ImVec2(x, y), ImVec2(x_end, y), col);
+        x += dash + gap;
+    }
+}
+
 namespace sep::workbench {
 
 SignalsTabController::SignalsTabController()
@@ -232,8 +242,8 @@ void SignalsTabController::setQuantumSignalGenerator(QuantumSignalGenerator* gen
     signal_generator_ = generator;
 }
 
-void SignalsTabController::setMetricsMonitor(MetricsMonitor* monitor) {
-    metrics_monitor_ = monitor;
+void SignalsTabController::setMetricsMonitor(std::shared_ptr<MetricsMonitor> monitor) {
+    metrics_monitor_ = std::move(monitor);
 }
 
 void SignalsTabController::setWorkbenchEngine(WorkbenchEngine* engine) {
@@ -512,24 +522,24 @@ void SignalsTabController::renderMetricsGraphs() {
     const auto& roll = metrics_monitor_->getRollingMetrics();
     float y1 = rect_max.y - roll.coherence_1h_avg * (rect_max.y - rect_min.y);
     float y4 = rect_max.y - roll.coherence_4h_avg * (rect_max.y - rect_min.y);
-    dl->AddLine(ImVec2(rect_min.x, y1), ImVec2(rect_max.x, y1), IM_COL32(255,0,0,128));
-    dl->AddLine(ImVec2(rect_min.x, y4), ImVec2(rect_max.x, y4), IM_COL32(0,255,0,128));
+    drawDashedHorizontal(dl, rect_min.x, rect_max.x, y1, IM_COL32(255,0,0,128));
+    drawDashedHorizontal(dl, rect_min.x, rect_max.x, y4, IM_COL32(0,255,0,128));
 
     ImGui::PlotLines("Stability", stability_history_.data(), stability_history_.size(), 0, nullptr, 0.0f, 1.0f, graph_size);
     rect_min = ImGui::GetItemRectMin();
     rect_max = ImGui::GetItemRectMax();
     y1 = rect_max.y - roll.stability_1h_avg * (rect_max.y - rect_min.y);
     y4 = rect_max.y - roll.stability_4h_avg * (rect_max.y - rect_min.y);
-    dl->AddLine(ImVec2(rect_min.x, y1), ImVec2(rect_max.x, y1), IM_COL32(255,0,0,128));
-    dl->AddLine(ImVec2(rect_min.x, y4), ImVec2(rect_max.x, y4), IM_COL32(0,255,0,128));
+    drawDashedHorizontal(dl, rect_min.x, rect_max.x, y1, IM_COL32(255,0,0,128));
+    drawDashedHorizontal(dl, rect_min.x, rect_max.x, y4, IM_COL32(0,255,0,128));
 
     ImGui::PlotLines("Entropy", entropy_history_.data(), entropy_history_.size(), 0, nullptr, 0.0f, 1.0f, graph_size);
     rect_min = ImGui::GetItemRectMin();
     rect_max = ImGui::GetItemRectMax();
     y1 = rect_max.y - roll.entropy_1h_avg * (rect_max.y - rect_min.y);
     y4 = rect_max.y - roll.entropy_4h_avg * (rect_max.y - rect_min.y);
-    dl->AddLine(ImVec2(rect_min.x, y1), ImVec2(rect_max.x, y1), IM_COL32(255,0,0,128));
-    dl->AddLine(ImVec2(rect_min.x, y4), ImVec2(rect_max.x, y4), IM_COL32(0,255,0,128));
+    drawDashedHorizontal(dl, rect_min.x, rect_max.x, y1, IM_COL32(255,0,0,128));
+    drawDashedHorizontal(dl, rect_min.x, rect_max.x, y4, IM_COL32(0,255,0,128));
 }
 
 void SignalsTabController::renderTrendLines() {

--- a/src/apps/workbench/tabs/signals_tab_controller.h
+++ b/src/apps/workbench/tabs/signals_tab_controller.h
@@ -28,7 +28,7 @@ public:
 
     void setOandaConnector(sep::connectors::OandaConnector* connector);
     void setQuantumSignalGenerator(QuantumSignalGenerator* generator);
-    void setMetricsMonitor(MetricsMonitor* monitor);
+    void setMetricsMonitor(std::shared_ptr<MetricsMonitor> monitor);
     void setWorkbenchEngine(WorkbenchEngine* engine);
 
     void setCandleData(const std::deque<CandleData>& data);
@@ -38,7 +38,7 @@ public:
 private:
     sep::connectors::OandaConnector* oanda_connector_ = nullptr;
     QuantumSignalGenerator* signal_generator_ = nullptr;
-    MetricsMonitor* metrics_monitor_ = nullptr;
+    std::shared_ptr<MetricsMonitor> metrics_monitor_;
     WorkbenchEngine* workbench_engine_ = nullptr;
     // Chart data
     std::deque<CandleData> candle_data_;


### PR DESCRIPTION
## Summary
- compute rolling averages with 1h and 4h windows
- track pattern frequency in MetricsMonitor
- render ImGui graphs with dashed threshold lines
- expose system metrics and export JSON in Engine tab
- share MetricsMonitor across controllers

## Testing
- `cmake -S simple_test -B build-test`
- `cmake --build build-test`
- `./build-test/simple_test_runner`

------
https://chatgpt.com/codex/tasks/task_e_6884389bc198832a847ce722981cdfcb