### PR TITLE
Enable demo trading and order tracking

### DIFF
--- a/src/apps/workbench/config.cpp
+++ b/src/apps/workbench/config.cpp
@@ -153,17 +153,30 @@ namespace sep
                 if (json.contains("oanda"))
                 {
                     auto& oanda = json["oanda"];
-                    oanda_ = {oanda.value("api_key", ""), oanda.value("account_id", ""), oanda.value("sandbox", true)};
+                    oanda_.api_key = oanda.value("api_key", "");
+                    oanda_.account_id = oanda.value("account_id", "");
+                    oanda_.demo_api_key = oanda.value("demo_api_key", "");
+                    oanda_.demo_account_id = oanda.value("demo_account_id", "");
+                    oanda_.sandbox = oanda.value("sandbox", true);
                 }
                 else
                 {
                     const char* env_key = std::getenv("OANDA_API_KEY");
                     const char* env_id = std::getenv("OANDA_ACCOUNT_ID");
+                    const char* env_demo_key = std::getenv("OANDA_DEMO_API_KEY");
+                    const char* env_demo_id = std::getenv("OANDA_DEMO_ACCOUNT_ID");
                     if (env_key && env_id)
                     {
-                        oanda_ = {env_key, env_id, true};
+                        oanda_.api_key = env_key;
+                        oanda_.account_id = env_id;
+                        oanda_.sandbox = true;
                     }
-                    else
+                    if (env_demo_key && env_demo_id)
+                    {
+                        oanda_.demo_api_key = env_demo_key;
+                        oanda_.demo_account_id = env_demo_id;
+                    }
+                    if (!(env_key && env_id) && !(env_demo_key && env_demo_id))
                     {
                         std::ifstream kfile("keys.txt");
                         if (kfile.is_open())
@@ -189,6 +202,26 @@ namespace sep
                                         std::string val = line.substr(pos + 1);
                                         val.erase(std::remove(val.begin(), val.end(), '"'), val.end());
                                         oanda_.account_id = val;
+                                    }
+                                }
+                                else if (line.find("OANDA_DEMO_API_KEY") != std::string::npos)
+                                {
+                                    auto pos = line.find('=');
+                                    if (pos != std::string::npos)
+                                    {
+                                        std::string val = line.substr(pos + 1);
+                                        val.erase(std::remove(val.begin(), val.end(), '"'), val.end());
+                                        oanda_.demo_api_key = val;
+                                    }
+                                }
+                                else if (line.find("OANDA_DEMO_ACCOUNT_ID") != std::string::npos)
+                                {
+                                    auto pos = line.find('=');
+                                    if (pos != std::string::npos)
+                                    {
+                                        std::string val = line.substr(pos + 1);
+                                        val.erase(std::remove(val.begin(), val.end(), '"'), val.end());
+                                        oanda_.demo_account_id = val;
                                     }
                                 }
                             }
@@ -315,7 +348,11 @@ namespace sep
 
                 json["cosmo"] = {{"box_size", cosmo_.box_size}, {"time_step", cosmo_.time_step}};
 
-                json["oanda"] = {{"api_key", oanda_.api_key}, {"account_id", oanda_.account_id}, {"sandbox", oanda_.sandbox}};
+                json["oanda"] = {{"api_key", oanda_.api_key},
+                                   {"account_id", oanda_.account_id},
+                                   {"demo_api_key", oanda_.demo_api_key},
+                                   {"demo_account_id", oanda_.demo_account_id},
+                                   {"sandbox", oanda_.sandbox}};
 
                 std::ofstream file(path);
                 if (!file.is_open())

--- a/src/apps/workbench/config.hpp
+++ b/src/apps/workbench/config.hpp
@@ -176,6 +176,8 @@ namespace sep
         {
             std::string api_key;
             std::string account_id;
+            std::string demo_api_key;
+            std::string demo_account_id;
             bool sandbox;
         };
 

--- a/src/apps/workbench/core/service_connector.cpp
+++ b/src/apps/workbench/core/service_connector.cpp
@@ -34,13 +34,20 @@ ServiceConnector::ServiceConnector() : ServiceConnector(ConnectionConfig{}) {}
 ServiceConnector::ServiceConnector(const ConnectionConfig& config)
     : config_(config) {
     auto& cfg = sep::workbench::Config::getInstance().oanda();
-    std::string api_key = cfg.api_key;
-    std::string account_id = cfg.account_id;
+    std::string api_key = cfg.demo_api_key.empty() ? cfg.api_key : cfg.demo_api_key;
+    std::string account_id = cfg.demo_account_id.empty() ? cfg.account_id : cfg.demo_account_id;
     if (api_key.empty() || account_id.empty()) {
         const char* env_key = std::getenv("OANDA_API_KEY");
         const char* env_id = std::getenv("OANDA_ACCOUNT_ID");
-        if (env_key) api_key = env_key;
-        if (env_id) account_id = env_id;
+        const char* env_demo_key = std::getenv("OANDA_DEMO_API_KEY");
+        const char* env_demo_id = std::getenv("OANDA_DEMO_ACCOUNT_ID");
+        if (env_demo_key && env_demo_id) {
+            api_key = env_demo_key;
+            account_id = env_demo_id;
+        } else {
+            if (env_key) api_key = env_key;
+            if (env_id) account_id = env_id;
+        }
     }
 
     if (!api_key.empty() && !account_id.empty()) {

--- a/src/apps/workbench/core/trade_manager.cpp
+++ b/src/apps/workbench/core/trade_manager.cpp
@@ -23,6 +23,15 @@ nlohmann::json TradeManager::placeOrder(const std::string& instrument,
     if (units == 0) {
         units = position_size;
     }
+
+    double current_exposure = 0.0;
+    for (const auto& pos : positions_) {
+        current_exposure += std::abs(pos.size) * pos.current_price;
+    }
+    double new_exposure = current_exposure + std::abs(units) * current_price;
+    if (new_exposure > account_balance_ * max_exposure_pct_) {
+        return {{"error", "Exposure limit exceeded"}};
+    }
     if (paper_trading_) {
         std::lock_guard<std::mutex> lock(mutex_);
         Order order;

--- a/src/apps/workbench/core/trade_manager.h
+++ b/src/apps/workbench/core/trade_manager.h
@@ -51,6 +51,8 @@ public:
     double getAccountBalance() const { return account_balance_; }
     void setRiskPercentage(double pct) { risk_percentage_ = pct; }
     double getRiskPercentage() const { return risk_percentage_; }
+    void setMaxExposurePct(double pct) { max_exposure_pct_ = pct; }
+    double getMaxExposurePct() const { return max_exposure_pct_; }
 
     void updateOrderStatus(const std::string& order_id, OrderState state);
     const std::vector<Order>& getOrders() const;
@@ -71,6 +73,7 @@ private:
     double account_balance_ = 100000.0;
     double realized_pnl_ = 0.0;
     double risk_percentage_ = 0.02;
+    double max_exposure_pct_ = 0.02;
     bool paper_trading_ = false;
 };
 

--- a/src/apps/workbench/core/ui_layout_manager.h
+++ b/src/apps/workbench/core/ui_layout_manager.h
@@ -8,6 +8,7 @@
 #include <typeindex>
 
 #include "imgui.h"
+#include "connectors/oanda_connector.h"
 
 namespace sep::workbench {
 
@@ -81,6 +82,10 @@ struct GroupCollapsedEvent {
 
 struct ConnectionStateEvent {
     ConnectionState state;
+};
+
+struct OrderUpdateEvent {
+    sep::connectors::OrderInfo info;
 };
 
 class EventBus {

--- a/src/apps/workbench/tabs/backend_tab_controller.cpp
+++ b/src/apps/workbench/tabs/backend_tab_controller.cpp
@@ -15,6 +15,14 @@ BackendTabController::BackendTabController()
 BackendTabController::~BackendTabController() { shutdown(); }
 bool BackendTabController::initialize() {
     std::cout << "[BackendTabController] Initializing..." << std::endl;
+    globalEventBus().subscribe<OrderUpdateEvent>([this](const OrderUpdateEvent& e) {
+        auto it = std::find_if(order_cache_.begin(), order_cache_.end(), [&](const sep::connectors::OrderInfo& o) { return o.id == e.info.id; });
+        if (it == order_cache_.end()) {
+            order_cache_.push_back(e.info);
+        } else {
+            *it = e.info;
+        }
+    });
     return true;
 }
 
@@ -135,8 +143,11 @@ void BackendTabController::renderOrderManagementPanel() {
     }
 
     ImGui::Text("Orders:");
-    if (!orders_.is_null()) {
-        ImGui::TextUnformatted(orders_.dump(4).c_str());
+    for (const auto& o : order_cache_) {
+        const char* status_str = "PENDING";
+        if (o.status == sep::connectors::OrderStatus::FILLED) status_str = "FILLED";
+        else if (o.status == sep::connectors::OrderStatus::CANCELED) status_str = "CANCELED";
+        ImGui::Text("%s %s %.0f @ %.5f [%s]", o.id.c_str(), o.instrument.c_str(), o.units, o.price, status_str);
     }
 
     ImGui::End();

--- a/src/apps/workbench/tabs/backend_tab_controller.h
+++ b/src/apps/workbench/tabs/backend_tab_controller.h
@@ -7,6 +7,8 @@
 #include "../core/file_dialog.hpp"
 #include "../core/service_connector.hpp"
 #include "../core/trade_manager.h"
+#include "../core/ui_layout_manager.h"
+#include "connectors/oanda_connector.h"
 #include "../backtester/data_loader.h"
 #include "quantum/pattern_metric_engine.h"
 #include "../core/service_proxy_engine.h"
@@ -58,6 +60,7 @@ private:
     int units_ = 1000;
     nlohmann::json open_positions_;
     nlohmann::json orders_;
+    std::vector<sep::connectors::OrderInfo> order_cache_;
     bool paper_trading_ = false;
 };
 

--- a/src/connectors/oanda_connector.cpp
+++ b/src/connectors/oanda_connector.cpp
@@ -528,6 +528,8 @@ nlohmann::json OandaConnector::placeOrder(const nlohmann::json& order_details) {
                 info.price = tx.contains("price") ? std::stod(tx["price"].get<std::string>()) : 0.0;
                 info.status = OrderStatus::PENDING;
                 pending_orders_.push_back(info);
+                if (order_callback_) order_callback_(info);
+                sep::workbench::globalEventBus().publish(sep::workbench::OrderUpdateEvent{info});
             }
             if (json_resp.contains("orderFillTransaction")) {
                 const auto& tx = json_resp["orderFillTransaction"];
@@ -537,6 +539,8 @@ nlohmann::json OandaConnector::placeOrder(const nlohmann::json& order_details) {
                 info.price = std::stod(tx.value("price", "0"));
                 info.status = OrderStatus::FILLED;
                 filled_orders_.push_back(info);
+                if (order_callback_) order_callback_(info);
+                sep::workbench::globalEventBus().publish(sep::workbench::OrderUpdateEvent{info});
             }
             return json_resp;
         } catch (const std::exception& e) {
@@ -599,6 +603,8 @@ void OandaConnector::refreshOrders() {
             info.price = o.contains("price") ? std::stod(o["price"].get<std::string>()) : 0.0;
             info.status = OrderStatus::PENDING;
             pending_orders_.push_back(info);
+            if (order_callback_) order_callback_(info);
+            sep::workbench::globalEventBus().publish(sep::workbench::OrderUpdateEvent{info});
         }
     }
 
@@ -612,6 +618,8 @@ void OandaConnector::refreshOrders() {
             info.price = o.contains("price") ? std::stod(o["price"].get<std::string>()) : 0.0;
             info.status = OrderStatus::FILLED;
             filled_orders_.push_back(info);
+            if (order_callback_) order_callback_(info);
+            sep::workbench::globalEventBus().publish(sep::workbench::OrderUpdateEvent{info});
         }
     }
 
@@ -625,6 +633,8 @@ void OandaConnector::refreshOrders() {
             info.price = o.contains("price") ? std::stod(o["price"].get<std::string>()) : 0.0;
             info.status = OrderStatus::CANCELED;
             canceled_orders_.push_back(info);
+            if (order_callback_) order_callback_(info);
+            sep::workbench::globalEventBus().publish(sep::workbench::OrderUpdateEvent{info});
         }
     }
 }

--- a/src/connectors/oanda_connector.h
+++ b/src/connectors/oanda_connector.h
@@ -111,6 +111,7 @@ public:
     const std::vector<OrderInfo>& pendingOrders() const { return pending_orders_; }
     const std::vector<OrderInfo>& filledOrders() const { return filled_orders_; }
     const std::vector<OrderInfo>& canceledOrders() const { return canceled_orders_; }
+    void setOrderCallback(std::function<void(const OrderInfo&)> cb) { order_callback_ = std::move(cb); }
 
 private:
     std::string api_key_;
@@ -165,7 +166,8 @@ private:
     std::vector<OrderInfo> pending_orders_;
     std::vector<OrderInfo> filled_orders_;
     std::vector<OrderInfo> canceled_orders_;
-}; 
+    std::function<void(const OrderInfo&)> order_callback_;
+};
 
 } // namespace connectors
 }  // namespace sep


### PR DESCRIPTION
## Summary
- add exposure control in `TradeManager`
- track order states in `OandaConnector` and publish events
- load demo API credentials from config and environment
- display latest order status in Backend tab

## Testing
- `bash -x build.sh`
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_688438ae6454832aaaf1729604195606