### PR TITLE
Add backtesting integration and metrics

### DIFF
--- a/src/apps/workbench/backtester/core/backtester_engine.cpp
+++ b/src/apps/workbench/backtester/core/backtester_engine.cpp
@@ -12,6 +12,13 @@ BacktesterEngine::~BacktesterEngine() {
 }
 
 sep::workbench::backtester::BacktestResult BacktesterEngine::run(const std::string& dataset_path) {
+    sep::quantum::PatternMetricEngine engine;
+    return run(dataset_path, &engine);
+}
+
+sep::workbench::backtester::BacktestResult BacktesterEngine::run(
+    const std::string& dataset_path,
+    sep::quantum::PatternMetricEngine* engine) {
     sep::workbench::backtester::DataLoader loader;
     loader.loadData(dataset_path);
 
@@ -21,7 +28,10 @@ sep::workbench::backtester::BacktestResult BacktesterEngine::run(const std::stri
         return result;
     }
 
-    sep::quantum::PatternMetricEngine engine;
+    if (!engine) {
+        return result;
+    }
+    sep::quantum::PatternMetricEngine& engine_ref = *engine;
     std::vector<uint8_t> byte_stream;
     byte_stream.reserve(candles.size() * sizeof(sep::workbench::CandleData));
     for (const auto& candle : candles) {
@@ -29,11 +39,11 @@ sep::workbench::backtester::BacktestResult BacktesterEngine::run(const std::stri
         byte_stream.insert(byte_stream.end(), bytes, bytes + sizeof(sep::workbench::CandleData));
     }
 
-    engine.ingestData(byte_stream.data(), byte_stream.size());
-    engine.evolvePatterns();
-    engine.computeMetrics();
+    engine_ref.ingestData(byte_stream.data(), byte_stream.size());
+    engine_ref.evolvePatterns();
+    engine_ref.computeMetrics();
 
-    const auto& signals = engine.getSignals();
+    const auto& signals = engine_ref.getSignals();
     std::vector<float> prices;
     prices.reserve(candles.size());
     for (const auto& candle : candles) {

--- a/src/apps/workbench/backtester/core/backtester_engine.h
+++ b/src/apps/workbench/backtester/core/backtester_engine.h
@@ -13,4 +13,6 @@ public:
     ~BacktesterEngine();
 
     sep::workbench::backtester::BacktestResult run(const std::string& dataset_path);
+    sep::workbench::backtester::BacktestResult run(const std::string& dataset_path,
+                                                   sep::quantum::PatternMetricEngine* engine);
 };

--- a/src/apps/workbench/backtester/core/performance_metrics.cpp
+++ b/src/apps/workbench/backtester/core/performance_metrics.cpp
@@ -18,33 +18,49 @@ float PerformanceMetrics::computeSharpeRatio(const std::vector<float>& pnl_serie
     for (float p : pnl_series) {
         sum += p;
     }
-    float avg = sum / pnl_series.size();
 
-    float var = 0.0f;
+    float mean = sum / static_cast<float>(pnl_series.size());
+
+    float variance = 0.0f;
     for (float p : pnl_series) {
-        var += (p - avg) * (p - avg);
+        float diff = p - mean;
+        variance += diff * diff;
     }
-    float std_dev = std::sqrt(var / pnl_series.size());
+
+    if (pnl_series.size() > 1) {
+        variance /= static_cast<float>(pnl_series.size() - 1);
+    }
+
+    float std_dev = std::sqrt(variance);
     if (std_dev == 0.0f) {
         return 0.0f;
     }
-    return avg / std_dev;
+
+    float sharpe = mean / std_dev;
+    sharpe *= std::sqrt(static_cast<float>(pnl_series.size()));
+    return sharpe;
 }
 
 float PerformanceMetrics::computeMaxDrawdown(const std::vector<float>& pnl_series) {
-    float running_total = 0.0f;
+    if (pnl_series.empty()) {
+        return 0.0f;
+    }
+
+    float equity = 0.0f;
     float peak = 0.0f;
-    float max_drawdown = 0.0f;
+    float max_dd = 0.0f;
 
     for (float p : pnl_series) {
-        running_total += p;
-        if (running_total > peak) {
-            peak = running_total;
+        equity += p;
+        if (equity > peak) {
+            peak = equity;
         }
-        float drawdown = peak - running_total;
-        if (drawdown > max_drawdown) {
-            max_drawdown = drawdown;
+
+        float drawdown = peak - equity;
+        if (drawdown > max_dd) {
+            max_dd = drawdown;
         }
     }
-    return max_drawdown;
+
+    return max_dd;
 }

--- a/src/apps/workbench/backtester/core/performance_metrics.h
+++ b/src/apps/workbench/backtester/core/performance_metrics.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <vector>
+
 class PerformanceMetrics {
 public:
     PerformanceMetrics();

--- a/src/apps/workbench/core/service_proxy_engine.cpp
+++ b/src/apps/workbench/core/service_proxy_engine.cpp
@@ -198,5 +198,11 @@ sep::workbench::SignalValidator::ValidationResult ServiceProxyEngine::validateSi
     return {accuracy, false_rate};
 }
 
+sep::workbench::SignalValidator::ValidationResult ServiceProxyEngine::validateSignalsAgainstHistory(
+    const std::vector<sep::quantum::Signal>& signals,
+    const std::vector<float>& prices) {
+    return validateSignals(signals, prices);
+}
+
 } // namespace core
 } // namespace sep

--- a/src/apps/workbench/core/service_proxy_engine.h
+++ b/src/apps/workbench/core/service_proxy_engine.h
@@ -48,6 +48,10 @@ public:
         const std::vector<sep::quantum::Signal>& signals,
         const std::vector<float>& prices);
 
+    sep::workbench::SignalValidator::ValidationResult validateSignalsAgainstHistory(
+        const std::vector<sep::quantum::Signal>& signals,
+        const std::vector<float>& prices);
+
 private:
     std::string service_address_;
     int service_port_;

--- a/src/apps/workbench/tabs/backend_tab_controller.cpp
+++ b/src/apps/workbench/tabs/backend_tab_controller.cpp
@@ -2,6 +2,7 @@
 
 #include <filesystem>
 #include <iostream>
+#include <cstring>
 
 #include "imgui.h"
 
@@ -176,7 +177,7 @@ void BackendTabController::renderBacktesterPanel() {
             }
 
             sep::core::ServiceProxyEngine proxy("localhost", 8080);
-            validation_result_ = proxy.validateSignals(signals, prices);
+            validation_result_ = proxy.validateSignalsAgainstHistory(signals, prices);
         }
     }
 
@@ -187,8 +188,16 @@ void BackendTabController::renderBacktesterPanel() {
 
     ImGui::Begin("Backtester");
     ImGui::PushID("Backtester");
+    ImGui::InputText("Dataset", backtest_file_buffer_, sizeof(backtest_file_buffer_));
     if (ImGui::Button("Run Backtest")) {
-        data_loader_->load_data(file_path_buffer_);
+        data_loader_->load_data(backtest_file_buffer_);
+        backtester_->run(pattern_engine_.get(), data_loader_.get());
+    }
+    ImGui::SameLine();
+    if (ImGui::Button("Run 48h Sample")) {
+        strncpy(backtest_file_buffer_, "eur_usd_m1_48h.json", sizeof(backtest_file_buffer_) - 1);
+        backtest_file_buffer_[sizeof(backtest_file_buffer_) - 1] = '\0';
+        data_loader_->load_data(backtest_file_buffer_);
         backtester_->run(pattern_engine_.get(), data_loader_.get());
     }
 

--- a/src/apps/workbench/tabs/backend_tab_controller.h
+++ b/src/apps/workbench/tabs/backend_tab_controller.h
@@ -47,7 +47,8 @@ private:
     FileDialog file_dialog_;
 
     // UI State
-    char file_path_buffer_[512] = "";
+    char file_path_buffer_[512] = "eur_usd_m1_48h.json";
+    char backtest_file_buffer_[512] = "eur_usd_m1_48h.json";
     int data_source_type_{0};  // 0=File, 1=Live Stream, 2=Generated
     char export_path_buffer_[512] = "metrics_export.json";
     float risk_percentage_ = 2.0f;


### PR DESCRIPTION
## Summary
- wire BacktesterEngine to accept an external PatternMetricEngine
- improve Sharpe ratio and max drawdown calculations
- add dataset controls and sample backtest option to BackendTabController
- expose signal history validation in ServiceProxyEngine

## Testing
- `cmake ../simple_test`
- `cmake --build .`
- `./simple_test_runner`
- `./run_clang_tidy.sh` *(fails: compile_commands.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_688438aaa84c832a8d8d7a2396952514