### PR TITLE
Implement runtime signal thresholds

### DIFF
--- a/src/apps/workbench/tabs/signals_tab_controller.cpp
+++ b/src/apps/workbench/tabs/signals_tab_controller.cpp
@@ -27,17 +27,24 @@ bool SignalsTabController::initialize() {
 void SignalsTabController::render() {
     ImGui::Columns(2, "SignalsColumns", true);
     ImGui::Begin("Signal Thresholds");
-    ImGui::SliderFloat("Min Coherence", &min_coherence_, 0.0f, 1.0f);
-    ImGui::SliderFloat("Min Stability", &min_stability_, 0.0f, 1.0f);
-    ImGui::SliderFloat("Max Entropy", &max_entropy_, 0.0f, 1.0f);
+    ImGui::Text("BUY thresholds");
+    ImGui::SliderFloat("Buy Coherence", &buy_min_coherence_, 0.0f, 1.0f);
+    ImGui::SliderFloat("Buy Stability", &buy_min_stability_, 0.0f, 1.0f);
+    ImGui::SliderFloat("Buy Max Entropy", &buy_max_entropy_, 0.0f, 1.0f);
+    ImGui::Separator();
+    ImGui::Text("SELL thresholds");
+    ImGui::SliderFloat("Sell Max Stability", &sell_max_stability_, 0.0f, 1.0f);
+    ImGui::SliderFloat("Sell Min Entropy", &sell_min_entropy_, 0.0f, 1.0f);
     if (ImGui::Button("Apply")) {
         if (workbench_engine_) {
             auto* pme = workbench_engine_->getPatternMetricEngine();
             if (pme) {
                 sep::quantum::SignalThresholds thresholds;
-                thresholds.min_coherence = min_coherence_;
-                thresholds.min_stability = min_stability_;
-                thresholds.max_entropy = max_entropy_;
+                thresholds.buy_min_coherence = buy_min_coherence_;
+                thresholds.buy_min_stability = buy_min_stability_;
+                thresholds.buy_max_entropy = buy_max_entropy_;
+                thresholds.sell_max_stability = sell_max_stability_;
+                thresholds.sell_min_entropy = sell_min_entropy_;
                 pme->setSignalThresholds(thresholds);
             }
         }

--- a/src/apps/workbench/tabs/signals_tab_controller.h
+++ b/src/apps/workbench/tabs/signals_tab_controller.h
@@ -63,9 +63,11 @@ private:
     bool auto_detect_trends_ = true;
 
     // Threshold settings for signal generation
-    float min_coherence_ = 0.7f;
-    float min_stability_ = 0.6f;
-    float max_entropy_ = 0.3f;
+    float buy_min_coherence_ = 0.7f;
+    float buy_min_stability_ = 0.6f;
+    float buy_max_entropy_ = 0.3f;
+    float sell_max_stability_ = 0.4f;
+    float sell_min_entropy_ = 0.7f;
 
     // Chart dimensions and state
     ImVec2 chart_size_;

--- a/src/engine/logging.cpp
+++ b/src/engine/logging.cpp
@@ -11,6 +11,7 @@
 #include <cstring> // For std::strlen
 #include <spdlog/spdlog.h>
 #include <cstring>
+#include "quantum/pattern_metric_engine.h"
 
 namespace sep::logging {
 
@@ -137,6 +138,24 @@ void logPatternDetected(const std::string &pattern_id,
     char buf[32];
     std::strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", std::localtime(&tt));
     logger->info("Pattern detected {} at {}", pattern_id, buf);
+}
+
+void logSignalDetected(const std::string &pattern_id,
+                       sep::quantum::SignalType type,
+                       std::chrono::system_clock::time_point timestamp)
+{
+    auto logger = spdlog::get("pattern_engine");
+    if (!logger) return;
+
+    std::time_t tt = std::chrono::system_clock::to_time_t(timestamp);
+    char buf[32];
+    std::strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", std::localtime(&tt));
+
+    const char* type_str = (type == sep::quantum::SignalType::BUY)
+                               ? "BUY"
+                               : (type == sep::quantum::SignalType::SELL ? "SELL" : "HOLD");
+
+    logger->info("Signal {} for pattern {} at {}", type_str, pattern_id, buf);
 }
 
 }  // namespace sep::logging

--- a/src/engine/logging.h
+++ b/src/engine/logging.h
@@ -11,6 +11,10 @@
 #include "memory/types.h"
 #include "tracing.h"
 
+namespace sep::quantum {
+    enum class SignalType;
+}
+
 namespace sep::logging {
 
 #ifndef SEP_HAS_OPENTELEMETRY
@@ -61,6 +65,11 @@ class Manager {
 // Log a detected pattern with timestamp to the pattern_engine logger
 void logPatternDetected(const std::string &pattern_id,
                         std::chrono::system_clock::time_point timestamp);
+
+// Log a detected signal with pattern id and type
+void logSignalDetected(const std::string &pattern_id,
+                       sep::quantum::SignalType type,
+                       std::chrono::system_clock::time_point timestamp);
 
 // Global functions
 inline void initializeLogging() { Manager::initialize(); }

--- a/src/quantum/pattern_metric_engine.cpp
+++ b/src/quantum/pattern_metric_engine.cpp
@@ -177,11 +177,27 @@ void PatternMetricEngine::setSignalThresholds(const SignalThresholds& thresholds
     std::lock_guard<std::mutex> lock(engine_mutex_);
     signal_thresholds_ = thresholds;
     if (auto logger = sep::logging::Manager::getInstance().getLogger("pattern_engine")) {
-        logger->info("Signal thresholds updated: coherence={} stability={} entropy={}",
-                     signal_thresholds_.min_coherence,
-                     signal_thresholds_.min_stability,
-                     signal_thresholds_.max_entropy);
+        logger->info(
+            "Signal thresholds updated: buy_coh={} buy_stab={} buy_entropy={} sell_stab={} sell_entropy={}",
+            signal_thresholds_.buy_min_coherence,
+            signal_thresholds_.buy_min_stability,
+            signal_thresholds_.buy_max_entropy,
+            signal_thresholds_.sell_max_stability,
+            signal_thresholds_.sell_min_entropy);
     }
+}
+
+void PatternMetricEngine::setBuyThresholds(float min_coherence, float min_stability, float max_entropy) {
+    std::lock_guard<std::mutex> lock(engine_mutex_);
+    signal_thresholds_.buy_min_coherence = min_coherence;
+    signal_thresholds_.buy_min_stability = min_stability;
+    signal_thresholds_.buy_max_entropy = max_entropy;
+}
+
+void PatternMetricEngine::setSellThresholds(float max_stability, float min_entropy) {
+    std::lock_guard<std::mutex> lock(engine_mutex_);
+    signal_thresholds_.sell_max_stability = max_stability;
+    signal_thresholds_.sell_min_entropy = min_entropy;
 }
 
 const std::vector<Signal>& PatternMetricEngine::getSignals() const {
@@ -395,22 +411,33 @@ std::vector<sep::compat::PatternData> PatternMetricEngine::extractPatternsFromBy
 void PatternMetricEngine::generateSignals() {
     current_signals_.clear();
     for (const auto& m : current_metrics_) {
-        if (m.stability < signal_thresholds_.min_stability && m.entropy > signal_thresholds_.max_entropy) {
+        SignalType type = evaluateSignal(m);
+        if (type != SignalType::HOLD) {
             Signal s;
-            s.type = SignalType::SELL;
-            s.confidence = (1.0f - m.stability) * m.entropy;
+            s.type = type;
+            if (type == SignalType::BUY) {
+                s.confidence = m.coherence * m.stability;
+            } else {
+                s.confidence = (1.0f - m.stability) * m.entropy;
+            }
             s.pattern_id = m.pattern_id;
             current_signals_.push_back(s);
-            sep::logging::logPatternDetected(s.pattern_id, std::chrono::system_clock::now());
-        } else if (m.coherence > signal_thresholds_.min_coherence && m.stability > signal_thresholds_.min_stability) {
-            Signal s;
-            s.type = SignalType::BUY;
-            s.confidence = m.coherence * m.stability;
-            s.pattern_id = m.pattern_id;
-            current_signals_.push_back(s);
-            sep::logging::logPatternDetected(s.pattern_id, std::chrono::system_clock::now());
+            sep::logging::logSignalDetected(s.pattern_id, s.type, std::chrono::system_clock::now());
         }
     }
+}
+
+SignalType PatternMetricEngine::evaluateSignal(const PatternMetrics& m) const {
+    if (m.stability < signal_thresholds_.sell_max_stability &&
+        m.entropy > signal_thresholds_.sell_min_entropy) {
+        return SignalType::SELL;
+    }
+    if (m.coherence > signal_thresholds_.buy_min_coherence &&
+        m.stability > signal_thresholds_.buy_min_stability &&
+        m.entropy < signal_thresholds_.buy_max_entropy) {
+        return SignalType::BUY;
+    }
+    return SignalType::HOLD;
 }
 
 void PatternMetricEngine::processBuffer([[maybe_unused]] bool is_final_chunk) {

--- a/src/quantum/pattern_metric_engine.h
+++ b/src/quantum/pattern_metric_engine.h
@@ -22,9 +22,11 @@ namespace sep::quantum {
 
     struct SignalThresholds
     {
-        float min_coherence{0.7f};
-        float min_stability{0.6f};
-        float max_entropy{0.3f};
+        float buy_min_coherence{0.7f};
+        float buy_min_stability{0.6f};
+        float buy_max_entropy{0.3f};
+        float sell_max_stability{0.4f};
+        float sell_min_entropy{0.7f};
     };
 
     enum class SignalType
@@ -142,6 +144,12 @@ public:
     /// @brief Sets the thresholds for signal generation.
     void setSignalThresholds(const SignalThresholds& thresholds);
 
+    /// @brief Set BUY signal thresholds individually
+    void setBuyThresholds(float min_coherence, float min_stability, float max_entropy);
+
+    /// @brief Set SELL signal thresholds individually
+    void setSellThresholds(float max_stability, float min_entropy);
+
     /// @brief Returns the current thresholds for signal generation.
     SignalThresholds getSignalThresholds() const {
         return signal_thresholds_;
@@ -172,6 +180,7 @@ private:
     std::vector<compat::PatternData> extractPatternsFromBytes(const uint8_t* data, size_t size);
     void processBuffer(bool is_final_chunk = false);
     void generateSignals();
+    SignalType evaluateSignal(const PatternMetrics& metrics) const;
     
     // Quantum processing components
     std::unique_ptr<QuantumProcessorQFH> qfh_processor_;


### PR DESCRIPTION
## Summary
- extend pattern signal thresholds to separate BUY and SELL values
- expose adjustment setters in `PatternMetricEngine`
- add ImGui controls for thresholds in `SignalsTabController`
- log detected signal type and pattern IDs

## Testing
- `./build.sh` *(fails: cd: /sep: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688438a02520832a89de0bd624527959