### PR TITLE
Enhance backtesting and validation

### DIFF
--- a/src/apps/workbench/backtester/core/backtester_engine.cpp
+++ b/src/apps/workbench/backtester/core/backtester_engine.cpp
@@ -51,6 +51,7 @@ sep::workbench::backtester::BacktestResult BacktesterEngine::run(
     }
 
     std::vector<float> pnl;
+    std::vector<sep::workbench::backtester::Trade> trades;
     int wins = 0;
     int losses = 0;
     size_t count = std::min(signals.size(), prices.size() - 1);
@@ -59,18 +60,21 @@ sep::workbench::backtester::BacktestResult BacktesterEngine::run(
             float entry = prices[i];
             float exit = prices[i + 1];
             pnl.push_back(exit - entry);
+            trades.push_back({sep::quantum::SignalType::BUY, entry, exit, 1});
             wins += exit > entry;
             losses += exit <= entry;
         } else if (signals[i].type == sep::quantum::SignalType::SELL) {
             float entry = prices[i];
             float exit = prices[i + 1];
             pnl.push_back(entry - exit);
+            trades.push_back({sep::quantum::SignalType::SELL, entry, exit, 1});
             wins += entry > exit;
             losses += entry <= exit;
         }
     }
 
     result.total_trades = static_cast<int>(pnl.size());
+    result.trades = std::move(trades);
     if (result.total_trades > 0) {
         result.win_rate = static_cast<float>(wins) / result.total_trades;
         result.total_pnl = std::accumulate(pnl.begin(), pnl.end(), 0.0f);

--- a/src/apps/workbench/backtester/core/performance_metrics.cpp
+++ b/src/apps/workbench/backtester/core/performance_metrics.cpp
@@ -1,6 +1,7 @@
 #include "performance_metrics.h"
 
 #include <cmath>
+#include <numeric>
 #include <vector>
 
 PerformanceMetrics::PerformanceMetrics() {
@@ -14,11 +15,7 @@ float PerformanceMetrics::computeSharpeRatio(const std::vector<float>& pnl_serie
         return 0.0f;
     }
 
-    float sum = 0.0f;
-    for (float p : pnl_series) {
-        sum += p;
-    }
-
+    float sum = std::accumulate(pnl_series.begin(), pnl_series.end(), 0.0f);
     float mean = sum / static_cast<float>(pnl_series.size());
 
     float variance = 0.0f;
@@ -26,7 +23,6 @@ float PerformanceMetrics::computeSharpeRatio(const std::vector<float>& pnl_serie
         float diff = p - mean;
         variance += diff * diff;
     }
-
     if (pnl_series.size() > 1) {
         variance /= static_cast<float>(pnl_series.size() - 1);
     }
@@ -49,18 +45,15 @@ float PerformanceMetrics::computeMaxDrawdown(const std::vector<float>& pnl_serie
     float equity = 0.0f;
     float peak = 0.0f;
     float max_dd = 0.0f;
-
     for (float p : pnl_series) {
         equity += p;
         if (equity > peak) {
             peak = equity;
         }
-
         float drawdown = peak - equity;
         if (drawdown > max_dd) {
             max_dd = drawdown;
         }
     }
-
     return max_dd;
 }

--- a/src/apps/workbench/core/service_proxy_engine.cpp
+++ b/src/apps/workbench/core/service_proxy_engine.cpp
@@ -201,7 +201,38 @@ sep::workbench::SignalValidator::ValidationResult ServiceProxyEngine::validateSi
 sep::workbench::SignalValidator::ValidationResult ServiceProxyEngine::validateSignalsAgainstHistory(
     const std::vector<sep::quantum::Signal>& signals,
     const std::vector<float>& prices) {
-    return validateSignals(signals, prices);
+    if (signals.empty() || prices.size() < 2) {
+        return {0.0, 1.0};
+    }
+
+    size_t limit = std::min(signals.size(), prices.size() - 1);
+    size_t correct = 0;
+    size_t total = 0;
+    size_t false_pos = 0;
+    for (size_t i = 0; i < limit; ++i) {
+        const auto& s = signals[i];
+        float cur = prices[i];
+        float next = prices[i + 1];
+        float change = (next - cur) / cur;
+        bool up = change > 0.0001f;
+        bool down = change < -0.0001f;
+        if (s.confidence > 0.7f) {
+            bool buy = s.type == sep::quantum::SignalType::BUY;
+            bool sell = s.type == sep::quantum::SignalType::SELL;
+            if (buy || sell) {
+                ++total;
+                if ((buy && up) || (sell && down)) {
+                    ++correct;
+                } else if ((buy && down) || (sell && up)) {
+                    ++false_pos;
+                }
+            }
+        }
+    }
+
+    double accuracy = total > 0 ? static_cast<double>(correct) / total : 0.0;
+    double false_rate = total > 0 ? static_cast<double>(false_pos) / total : 0.0;
+    return {accuracy, false_rate};
 }
 
 } // namespace core

--- a/src/apps/workbench/tabs/backend_tab_controller.cpp
+++ b/src/apps/workbench/tabs/backend_tab_controller.cpp
@@ -203,6 +203,17 @@ void BackendTabController::renderBacktesterPanel() {
     if (ImGui::Button("Run Backtest")) {
         data_loader_->load_data(backtest_file_buffer_);
         backtester_->run(pattern_engine_.get(), data_loader_.get());
+        equity_curve_.clear();
+        const auto& trades = backtester_->getResult().trades;
+        float equity = 0.0f;
+        equity_curve_.push_back(equity);
+        for (const auto& t : trades) {
+            float diff = (t.type == sep::quantum::SignalType::BUY)
+                             ? t.exit_price - t.entry_price
+                             : t.entry_price - t.exit_price;
+            equity += diff;
+            equity_curve_.push_back(equity);
+        }
     }
     ImGui::SameLine();
     if (ImGui::Button("Run 48h Sample")) {
@@ -210,6 +221,17 @@ void BackendTabController::renderBacktesterPanel() {
         backtest_file_buffer_[sizeof(backtest_file_buffer_) - 1] = '\0';
         data_loader_->load_data(backtest_file_buffer_);
         backtester_->run(pattern_engine_.get(), data_loader_.get());
+        equity_curve_.clear();
+        const auto& trades = backtester_->getResult().trades;
+        float equity = 0.0f;
+        equity_curve_.push_back(equity);
+        for (const auto& t : trades) {
+            float diff = (t.type == sep::quantum::SignalType::BUY)
+                             ? t.exit_price - t.entry_price
+                             : t.entry_price - t.exit_price;
+            equity += diff;
+            equity_curve_.push_back(equity);
+        }
     }
 
     const auto& result = backtester_->getResult();
@@ -218,6 +240,10 @@ void BackendTabController::renderBacktesterPanel() {
     ImGui::Text("Total PnL: %.2f", result.total_pnl);
     ImGui::Text("Sharpe Ratio: %.2f", result.sharpe_ratio);
     ImGui::Text("Max Drawdown: %.2f", result.max_drawdown);
+    if (!equity_curve_.empty()) {
+        ImGui::PlotLines("Equity Curve", equity_curve_.data(),
+                         static_cast<int>(equity_curve_.size()));
+    }
 
     ImGui::End();
 }

--- a/src/apps/workbench/tabs/backend_tab_controller.h
+++ b/src/apps/workbench/tabs/backend_tab_controller.h
@@ -63,6 +63,7 @@ private:
     nlohmann::json orders_;
     std::vector<sep::connectors::OrderInfo> order_cache_;
     bool paper_trading_ = false;
+    std::vector<float> equity_curve_;
 };
 
 } // namespace sep::workbench


### PR DESCRIPTION
## Summary
- record trades from PatternMetricEngine signals
- add equity curve plotting in backtester UI
- compute Sharpe ratio & max drawdown in PerformanceMetrics
- add signal accuracy validator in ServiceProxyEngine

## Testing
- `./build.sh` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_688442043698832abce94c318545e135