### PR TITLE
Implement signal thresholds and correlation plotting

### DIFF
--- a/src/apps/workbench/core/multi_timeframe_analyzer.cpp
+++ b/src/apps/workbench/core/multi_timeframe_analyzer.cpp
@@ -145,6 +145,13 @@ void MultiTimeframeAnalyzer::updateAllTimeframes(const std::string& instrument) 
         if (metrics_history_[tf].size() > max_metrics_history_) {
             metrics_history_[tf].pop_front();
         }
+
+        // Update correlation history using latest metrics and price moves
+        auto corr = calculateCorrelationMetrics(tf);
+        correlation_history_[tf].push_back(corr);
+        if (correlation_history_[tf].size() > max_correlation_history_) {
+            correlation_history_[tf].pop_front();
+        }
     }
 }
 
@@ -691,6 +698,13 @@ CorrelationMetrics MultiTimeframeAnalyzer::calculateCorrelationMetrics(const std
     correlation_metrics.entropy_spearman = spearman(entropy_values, price_moves);
 
     return correlation_metrics;
+}
+
+std::deque<CorrelationMetrics> MultiTimeframeAnalyzer::getCorrelationHistory(const std::string& timeframe) const {
+    if (correlation_history_.count(timeframe)) {
+        return correlation_history_.at(timeframe);
+    }
+    return {};
 }
 
 // TimeframeUtils implementation

--- a/src/apps/workbench/core/multi_timeframe_analyzer.h
+++ b/src/apps/workbench/core/multi_timeframe_analyzer.h
@@ -127,6 +127,10 @@ private:
     // Rolling history of analyzed metrics per timeframe
     std::map<std::string, std::deque<TimeframeMetrics>> metrics_history_;
     size_t max_metrics_history_ = 1000;
+
+    // Correlation history per timeframe
+    std::map<std::string, std::deque<CorrelationMetrics>> correlation_history_;
+    size_t max_correlation_history_ = 1000;
     
     // Internal methods
     std::vector<CandleData> resampleCandles(
@@ -188,6 +192,7 @@ public:
     std::string getStatusReport() const;
 
     CorrelationMetrics calculateCorrelationMetrics(const std::string& timeframe);
+    std::deque<CorrelationMetrics> getCorrelationHistory(const std::string& timeframe) const;
 };
 
 // Helper functions for timeframe conversions

--- a/src/apps/workbench/tabs/engine_tab_controller.cpp
+++ b/src/apps/workbench/tabs/engine_tab_controller.cpp
@@ -255,11 +255,31 @@ void EngineTabController::renderCorrelationPanel() {
     ImGui::Text("%.3f", correlation_metrics.entropy_spearman); ImGui::NextColumn();
     ImGui::Columns(1);
 
+    // Plot correlation history
+    auto history = multi_timeframe_analyzer_->getCorrelationHistory(selected_timeframe);
+    std::vector<float> coh_p, coh_s, stab_p, stab_s, ent_p, ent_s;
+    for (const auto& h : history) {
+        coh_p.push_back(static_cast<float>(h.coherence_pearson));
+        coh_s.push_back(static_cast<float>(h.coherence_spearman));
+        stab_p.push_back(static_cast<float>(h.stability_pearson));
+        stab_s.push_back(static_cast<float>(h.stability_spearman));
+        ent_p.push_back(static_cast<float>(h.entropy_pearson));
+        ent_s.push_back(static_cast<float>(h.entropy_spearman));
+    }
+    const ImVec2 graph_size(200, 60);
+    ImGui::PlotLines("Coh Pearson", coh_p.data(), coh_p.size(), 0, nullptr, -1.0f, 1.0f, graph_size);
+    ImGui::PlotLines("Coh Spearman", coh_s.data(), coh_s.size(), 0, nullptr, -1.0f, 1.0f, graph_size);
+    ImGui::PlotLines("Stab Pearson", stab_p.data(), stab_p.size(), 0, nullptr, -1.0f, 1.0f, graph_size);
+    ImGui::PlotLines("Stab Spearman", stab_s.data(), stab_s.size(), 0, nullptr, -1.0f, 1.0f, graph_size);
+    ImGui::PlotLines("Ent Pearson", ent_p.data(), ent_p.size(), 0, nullptr, -1.0f, 1.0f, graph_size);
+    ImGui::PlotLines("Ent Spearman", ent_s.data(), ent_s.size(), 0, nullptr, -1.0f, 1.0f, graph_size);
+
     ImGui::InputText("Export Path", correlation_export_path_, sizeof(correlation_export_path_));
     if (ImGui::Button("Export")) {
         sep::DataParser parser;
         std::map<std::string, workbench::CorrelationMetrics> data{{selected_timeframe, correlation_metrics}};
         parser.exportCorrelationCSV(correlation_export_path_, data);
+        parser.exportCorrelationJSON(std::string(correlation_export_path_) + ".json", data);
     }
 
     ImGui::End();

--- a/src/apps/workbench/tabs/signals_tab_controller.cpp
+++ b/src/apps/workbench/tabs/signals_tab_controller.cpp
@@ -34,8 +34,7 @@ bool SignalsTabController::initialize() {
     return true;
 }
 
-void SignalsTabController::render() {
-    ImGui::Columns(2, "SignalsColumns", true);
+void SignalsTabController::renderThresholdPanel() {
     ImGui::Begin("Signal Thresholds");
     ImGui::Text("BUY thresholds");
     ImGui::SliderFloat("Buy Coherence", &buy_min_coherence_, 0.0f, 1.0f);
@@ -60,7 +59,11 @@ void SignalsTabController::render() {
         }
     }
     ImGui::End();
+}
 
+void SignalsTabController::render() {
+    ImGui::Columns(2, "SignalsColumns", true);
+    renderThresholdPanel();
     ImGui::NextColumn();
 
     if (metrics_monitor_) {

--- a/src/apps/workbench/tabs/signals_tab_controller.h
+++ b/src/apps/workbench/tabs/signals_tab_controller.h
@@ -24,6 +24,7 @@ public:
 
     bool initialize();
     void render();
+    void renderThresholdPanel();
     void shutdown();
 
     void setOandaConnector(sep::connectors::OandaConnector* connector);
@@ -66,7 +67,7 @@ private:
     float buy_min_coherence_ = 0.7f;
     float buy_min_stability_ = 0.6f;
     float buy_max_entropy_ = 0.3f;
-    float sell_max_stability_ = 0.4f;
+    float sell_max_stability_ = 0.3f;
     float sell_min_entropy_ = 0.7f;
 
     // Chart dimensions and state

--- a/src/engine/data_parser.cpp
+++ b/src/engine/data_parser.cpp
@@ -588,4 +588,25 @@ bool DataParser::exportCorrelationCSV(const std::string& path,
     return true;
 }
 
+bool DataParser::exportCorrelationJSON(const std::string& path,
+                                       const std::map<std::string, workbench::CorrelationMetrics>& data) const {
+    nlohmann::json j;
+    for (const auto& [tf, metrics] : data) {
+        j[tf] = {
+            {"coh_pearson", metrics.coherence_pearson},
+            {"coh_spearman", metrics.coherence_spearman},
+            {"stab_pearson", metrics.stability_pearson},
+            {"stab_spearman", metrics.stability_spearman},
+            {"entropy_pearson", metrics.entropy_pearson},
+            {"entropy_spearman", metrics.entropy_spearman}
+        };
+    }
+    std::ofstream file(path);
+    if (!file.is_open()) {
+        return false;
+    }
+    file << j.dump(2);
+    return true;
+}
+
 } // namespace sep

--- a/src/engine/data_parser.h
+++ b/src/engine/data_parser.h
@@ -66,6 +66,8 @@ public:
     // Export correlation metrics to CSV
     bool exportCorrelationCSV(const std::string& path,
                               const std::map<std::string, workbench::CorrelationMetrics>& data) const;
+    bool exportCorrelationJSON(const std::string& path,
+                               const std::map<std::string, workbench::CorrelationMetrics>& data) const;
 
 private:
     // Format detection

--- a/src/quantum/pattern_metric_engine.cpp
+++ b/src/quantum/pattern_metric_engine.cpp
@@ -427,16 +427,21 @@ void PatternMetricEngine::generateSignals() {
     }
 }
 
+// Evaluate signal based on threshold rules defined in docs/TODO.md
 SignalType PatternMetricEngine::evaluateSignal(const PatternMetrics& m) const {
+    // Example rule: stability < 0.3 && entropy > 0.7 triggers SELL
     if (m.stability < signal_thresholds_.sell_max_stability &&
         m.entropy > signal_thresholds_.sell_min_entropy) {
         return SignalType::SELL;
     }
+
+    // Example rule: coherence/stability high with low entropy triggers BUY
     if (m.coherence > signal_thresholds_.buy_min_coherence &&
         m.stability > signal_thresholds_.buy_min_stability &&
         m.entropy < signal_thresholds_.buy_max_entropy) {
         return SignalType::BUY;
     }
+
     return SignalType::HOLD;
 }
 

--- a/src/quantum/pattern_metric_engine.h
+++ b/src/quantum/pattern_metric_engine.h
@@ -25,7 +25,7 @@ namespace sep::quantum {
         float buy_min_coherence{0.7f};
         float buy_min_stability{0.6f};
         float buy_max_entropy{0.3f};
-        float sell_max_stability{0.4f};
+        float sell_max_stability{0.3f};
         float sell_min_entropy{0.7f};
     };
 


### PR DESCRIPTION
## Summary
- implement threshold-based evaluation using stability/entropy rules
- expose threshold panel through a dedicated method
- track and plot correlation metrics across timeframes
- support CSV and JSON export of correlation data

## Testing
- `./build.sh` *(failed: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688441fb0114832ab05a73a94c5b8eba