### PR TITLE
Add OANDA paper trading support

### DIFF
--- a/src/apps/workbench/config.cpp
+++ b/src/apps/workbench/config.cpp
@@ -158,6 +158,7 @@ namespace sep
                     oanda_.demo_api_key = oanda.value("demo_api_key", "");
                     oanda_.demo_account_id = oanda.value("demo_account_id", "");
                     oanda_.sandbox = oanda.value("sandbox", true);
+                    oanda_.paper_trading = oanda.value("paper_trading", false);
                 }
                 else
                 {
@@ -175,6 +176,7 @@ namespace sep
                     {
                         oanda_.demo_api_key = env_demo_key;
                         oanda_.demo_account_id = env_demo_id;
+                        oanda_.paper_trading = true;
                     }
                     if (!(env_key && env_id) && !(env_demo_key && env_demo_id))
                     {
@@ -212,6 +214,7 @@ namespace sep
                                         std::string val = line.substr(pos + 1);
                                         val.erase(std::remove(val.begin(), val.end(), '"'), val.end());
                                         oanda_.demo_api_key = val;
+                                        oanda_.paper_trading = true;
                                     }
                                 }
                                 else if (line.find("OANDA_DEMO_ACCOUNT_ID") != std::string::npos)
@@ -222,6 +225,7 @@ namespace sep
                                         std::string val = line.substr(pos + 1);
                                         val.erase(std::remove(val.begin(), val.end(), '"'), val.end());
                                         oanda_.demo_account_id = val;
+                                        oanda_.paper_trading = true;
                                     }
                                 }
                             }
@@ -352,7 +356,8 @@ namespace sep
                                    {"account_id", oanda_.account_id},
                                    {"demo_api_key", oanda_.demo_api_key},
                                    {"demo_account_id", oanda_.demo_account_id},
-                                   {"sandbox", oanda_.sandbox}};
+                                   {"sandbox", oanda_.sandbox},
+                                   {"paper_trading", oanda_.paper_trading}};
 
                 std::ofstream file(path);
                 if (!file.is_open())

--- a/src/apps/workbench/config.hpp
+++ b/src/apps/workbench/config.hpp
@@ -179,6 +179,7 @@ namespace sep
             std::string demo_api_key;
             std::string demo_account_id;
             bool sandbox;
+            bool paper_trading{false};
         };
 
         class Config

--- a/src/apps/workbench/config.json
+++ b/src/apps/workbench/config.json
@@ -114,5 +114,13 @@
     "particle_count": 1000,
     "simulation_speed": 1.0,
     "gravity_constant": 6.67430e-11
+  },
+  "oanda": {
+    "api_key": "",
+    "account_id": "",
+    "demo_api_key": "",
+    "demo_account_id": "",
+    "sandbox": true,
+    "paper_trading": true
   }
 }

--- a/src/apps/workbench/core/service_connector.cpp
+++ b/src/apps/workbench/core/service_connector.cpp
@@ -52,6 +52,9 @@ ServiceConnector::ServiceConnector(const ConnectionConfig& config)
 
     if (!api_key.empty() && !account_id.empty()) {
         oanda_connector_ = std::make_unique<sep::connectors::OandaConnector>(api_key, account_id, true);
+        trade_manager_ = std::make_unique<sep::workbench::TradeManager>(oanda_connector_.get());
+        trade_manager_->setRiskPercentage(0.02);
+        trade_manager_->setPaperTrading(cfg.paper_trading);
         std::cout << "[ServiceConnector] OANDA connector configured for PRACTICE server" << std::endl;
         std::cout << "[ServiceConnector] API Key length: " << strlen(api_key) << std::endl;
         std::cout << "[ServiceConnector] Account ID: " << account_id << std::endl;

--- a/src/apps/workbench/core/trade_manager.cpp
+++ b/src/apps/workbench/core/trade_manager.cpp
@@ -10,6 +10,7 @@ TradeManager::TradeManager(sep::connectors::OandaConnector* connector)
     : oanda_connector_(connector)
 {
     starting_balance_ = account_balance_;
+    balance_history_.push_back(account_balance_);
     sep::logging::LoggerConfig config;
     config.file.path = "trades.log";
     logger_ = sep::logging::Manager::getInstance().createLogger("trade_manager", config);
@@ -36,7 +37,8 @@ nlohmann::json TradeManager::placeOrder(const std::string& instrument,
                                         double current_price,
                                         double stop_loss_pips,
                                         double take_profit_pips) {
-    double risk_amount = account_balance_ * risk_percentage_;
+    double applied_risk = std::min(risk_percentage_, 0.02);
+    double risk_amount = account_balance_ * applied_risk;
     double pips_to_risk = stop_loss_pips;
     double pip_value = 0.0001;
     double position_size = risk_amount / (pips_to_risk * pip_value);
@@ -49,7 +51,7 @@ nlohmann::json TradeManager::placeOrder(const std::string& instrument,
         current_exposure += std::abs(pos.size) * pos.current_price;
     }
     double new_exposure = current_exposure + std::abs(units) * current_price;
-    if (new_exposure > account_balance_ * max_exposure_pct_) {
+    if (new_exposure > account_balance_ * 0.02) {
         return {{"error", "Exposure limit exceeded"}};
     }
     if (paper_trading_) {
@@ -166,6 +168,7 @@ void TradeManager::updatePositions(const Order& order) {
         positions_.push_back(new_position);
         account_balance_ -= order.units * order.price;
     }
+    balance_history_.push_back(account_balance_);
 }
 
 void TradeManager::startPaperTrading(const std::string& instrument)

--- a/src/apps/workbench/core/trade_manager.h
+++ b/src/apps/workbench/core/trade_manager.h
@@ -75,6 +75,8 @@ public:
     double getWinLossRatio() const;
     double getROI() const;
 
+    const std::vector<double>& getBalanceHistory() const { return balance_history_; }
+
 private:
     void updatePositions(const Order& order);
 
@@ -94,6 +96,7 @@ private:
     int win_count_ = 0;
     int loss_count_ = 0;
     bool paper_trading_ = false;
+    std::vector<double> balance_history_;
 };
 
 } // namespace workbench

--- a/src/apps/workbench/tabs/backend_tab_controller.cpp
+++ b/src/apps/workbench/tabs/backend_tab_controller.cpp
@@ -53,9 +53,8 @@ void BackendTabController::setMetricsMonitor(std::shared_ptr<MetricsMonitor> mon
 
 void BackendTabController::setServiceConnector(ServiceConnector* connector) {
     service_connector_ = connector;
-    if (service_connector_ && service_connector_->getOandaConnector()) {
-        trade_manager_ = std::make_unique<sep::workbench::TradeManager>(
-            service_connector_->getOandaConnector());
+    if (service_connector_) {
+        trade_manager_ = service_connector_->getTradeManager();
     }
 }
 
@@ -99,6 +98,10 @@ void BackendTabController::renderOrderManagementPanel() {
     if (trade_manager_) {
         ImGui::Text("Balance: %.2f", trade_manager_->getAccountBalance());
         ImGui::Text("Realized PnL: %.2f", trade_manager_->getRealizedPnL());
+        const auto& hist = trade_manager_->getBalanceHistory();
+        if (!hist.empty()) {
+            ImGui::PlotLines("Balance History", hist.data(), hist.size());
+        }
     }
     ImGui::End();
 
@@ -124,10 +127,8 @@ void BackendTabController::renderOrderManagementPanel() {
     }
 
     if (ImGui::Button("Refresh Orders and Positions")) {
-        if (trade_manager_) {
-            // no-op: local orders already stored
-        }
-        if (service_connector_) {
+        if (service_connector_ && service_connector_->getOandaConnector()) {
+            service_connector_->getOandaConnector()->refreshOrders();
             open_positions_ = service_connector_->getOandaConnector()->getOpenPositions();
             orders_ = service_connector_->getOandaConnector()->getOrders();
         }

--- a/src/apps/workbench/tabs/backend_tab_controller.h
+++ b/src/apps/workbench/tabs/backend_tab_controller.h
@@ -45,7 +45,6 @@ private:
     std::unique_ptr<backtester::Backtester> backtester_;
     std::unique_ptr<sep::workbench::backtester::DataLoader> data_loader_;
     std::unique_ptr<sep::quantum::PatternMetricEngine> pattern_engine_;
-    std::unique_ptr<sep::workbench::TradeManager> trade_manager_;
     FileDialog file_dialog_;
 
     // UI State

--- a/src/connectors/oanda_connector.cpp
+++ b/src/connectors/oanda_connector.cpp
@@ -572,6 +572,7 @@ nlohmann::json OandaConnector::placeOrder(const nlohmann::json& order_details) {
                 if (order_callback_) order_callback_(info);
                 sep::workbench::globalEventBus().publish(sep::workbench::OrderUpdateEvent{info});
             }
+            refreshOrders();
             return json_resp;
         } catch (const std::exception& e) {
             last_error_ = "Failed to parse placeOrder response: " + std::string(e.what());


### PR DESCRIPTION
## Summary
- implement risk-based sizing with 2% max exposure
- keep account balance history for plotting
- call OANDA API for order status updates
- show balance graph and order refresh in BackendTabController
- store demo credentials and paper trading flag in config
- create TradeManager from ServiceConnector

## Testing
- `g++ -std=c++17 -c src/apps/workbench/core/trade_manager.cpp -I src -I extern -I .` *(fails: nlohmann/json.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6884421c05b8832a91e6f8816cd78bd4