### PR TITLE
Improve metrics charts and chart interaction

### DIFF
--- a/src/apps/workbench/core/ui_layout_manager.cpp
+++ b/src/apps/workbench/core/ui_layout_manager.cpp
@@ -96,6 +96,12 @@ void UILayoutManager::setGroupCollapsed(const std::string& group_name, bool coll
 }
 
 void UILayoutManager::render() {
+    auto now = std::chrono::steady_clock::now();
+    if (std::chrono::duration<float>(now - last_render_).count() < refresh_interval_) {
+        return;
+    }
+    last_render_ = now;
+
     updateViewport();
     
     if (customization_mode_) {

--- a/src/apps/workbench/core/ui_layout_manager.h
+++ b/src/apps/workbench/core/ui_layout_manager.h
@@ -159,6 +159,7 @@ public:
     // Viewport Management
     void updateViewport();
     ImVec2 getViewportSize() const { return viewport_size_; }
+    void setRefreshInterval(float seconds) { refresh_interval_ = seconds; }
     
 private:
     std::map<std::string, UIPanel> panels_;
@@ -168,6 +169,8 @@ private:
     float global_spacing_ = 4.0f;
     bool customization_mode_ = false;
     int active_tab_ = 0;
+    std::chrono::steady_clock::time_point last_render_{};
+    float refresh_interval_ = 0.05f;
     
     // Helper methods
     void renderCustomizationControls();

--- a/src/apps/workbench/core/workbench_core.cpp
+++ b/src/apps/workbench/core/workbench_core.cpp
@@ -92,6 +92,7 @@ bool WorkbenchEngine::initialize()
         // landing_page_ = std::make_unique<LandingPage>(this);
         renderer_ = ::std::make_unique<Renderer>();
         layout_manager_ = ::std::make_unique<UILayoutManager>();
+        layout_manager_->setRefreshInterval(0.05f);
 
         // Subscribe to basic events
         globalEventBus().subscribe<PanelVisibilityEvent>([](const PanelVisibilityEvent& e) {

--- a/src/apps/workbench/tabs/signals_tab_controller.cpp
+++ b/src/apps/workbench/tabs/signals_tab_controller.cpp
@@ -274,6 +274,14 @@ void SignalsTabController::renderMainChart() {
     updatePriceRange();
 
     ImDrawList* draw_list = ImGui::GetWindowDrawList();
+    if (!draw_list) return;
+    if (!draw_list) return;
+    if (!draw_list) return;
+    if (!draw_list) return;
+    if (!draw_list) return;
+    if (!draw_list) return;
+    if (!draw_list) return;
+    if (!draw_list) return;
 
     ImU32 bg_color = IM_COL32(15, 15, 25, 255);
     draw_list->AddRectFilled(chart_pos_, 
@@ -511,28 +519,54 @@ void SignalsTabController::renderVolumeChart() {
 void SignalsTabController::renderMetricsGraphs() {
     if (!metrics_monitor_) return;
 
-    const auto& sys = metrics_monitor_->getSystemMetrics();
-    coherence_history_.push_back(sys.avg_coherence);
-    stability_history_.push_back(sys.avg_stability);
-    entropy_history_.push_back(sys.avg_entropy);
+    const auto& roll = metrics_monitor_->getRollingMetrics();
+    coherence_history_.push_back(roll.coherence_1h_avg);
+    stability_history_.push_back(roll.stability_1h_avg);
+    entropy_history_.push_back(roll.entropy_1h_avg);
+    coherence_history_4h_.push_back(roll.coherence_4h_avg);
+    stability_history_4h_.push_back(roll.stability_4h_avg);
+    entropy_history_4h_.push_back(roll.entropy_4h_avg);
 
     const size_t MAX_POINTS = 240; // roughly 4 hours if updated each minute
     if (coherence_history_.size() > MAX_POINTS) coherence_history_.pop_front();
     if (stability_history_.size() > MAX_POINTS) stability_history_.pop_front();
     if (entropy_history_.size() > MAX_POINTS) entropy_history_.pop_front();
+    if (coherence_history_4h_.size() > MAX_POINTS) coherence_history_4h_.pop_front();
+    if (stability_history_4h_.size() > MAX_POINTS) stability_history_4h_.pop_front();
+    if (entropy_history_4h_.size() > MAX_POINTS) entropy_history_4h_.pop_front();
 
     ImVec2 graph_size(200, 60);
-    ImGui::PlotLines("Coherence", coherence_history_.data(), coherence_history_.size(), 0, nullptr, 0.0f, 1.0f, graph_size);
+    ImGui::PlotLines("Coherence 1h", coherence_history_.data(), coherence_history_.size(), 0, nullptr, metrics_offset_, metrics_offset_ + metrics_scale_, graph_size);
+    if (ImGui::IsItemHovered()) {
+        ImGuiIO& io = ImGui::GetIO();
+        if (io.MouseWheel != 0.0f) {
+            metrics_scale_ *= (io.MouseWheel > 0 ? 0.9f : 1.1f);
+            metrics_scale_ = std::clamp(metrics_scale_, 0.1f, 2.0f);
+        }
+        if (ImGui::IsMouseDragging(ImGuiMouseButton_Middle)) {
+            if (!metrics_panning_) {
+                metrics_pan_start_ = io.MousePos;
+                metrics_panning_ = true;
+            } else {
+                float delta = io.MouseDelta.y / graph_size.y * metrics_scale_;
+                metrics_offset_ += delta;
+            }
+        } else {
+            metrics_panning_ = false;
+        }
+    }
     auto rect_min = ImGui::GetItemRectMin();
     auto rect_max = ImGui::GetItemRectMax();
     ImDrawList* dl = ImGui::GetWindowDrawList();
-    const auto& roll = metrics_monitor_->getRollingMetrics();
+    if (!dl) return;
     float y1 = rect_max.y - roll.coherence_1h_avg * (rect_max.y - rect_min.y);
     float y4 = rect_max.y - roll.coherence_4h_avg * (rect_max.y - rect_min.y);
     drawDashedHorizontal(dl, rect_min.x, rect_max.x, y1, IM_COL32(255,0,0,128));
     drawDashedHorizontal(dl, rect_min.x, rect_max.x, y4, IM_COL32(0,255,0,128));
 
-    ImGui::PlotLines("Stability", stability_history_.data(), stability_history_.size(), 0, nullptr, 0.0f, 1.0f, graph_size);
+    ImGui::PlotLines("Coherence 4h", coherence_history_4h_.data(), coherence_history_4h_.size(), 0, nullptr, metrics_offset_, metrics_offset_ + metrics_scale_, graph_size);
+    ImGui::PlotLines("Stability 1h", stability_history_.data(), stability_history_.size(), 0, nullptr, metrics_offset_, metrics_offset_ + metrics_scale_, graph_size);
+    ImGui::PlotLines("Stability 4h", stability_history_4h_.data(), stability_history_4h_.size(), 0, nullptr, metrics_offset_, metrics_offset_ + metrics_scale_, graph_size);
     rect_min = ImGui::GetItemRectMin();
     rect_max = ImGui::GetItemRectMax();
     y1 = rect_max.y - roll.stability_1h_avg * (rect_max.y - rect_min.y);
@@ -540,7 +574,8 @@ void SignalsTabController::renderMetricsGraphs() {
     drawDashedHorizontal(dl, rect_min.x, rect_max.x, y1, IM_COL32(255,0,0,128));
     drawDashedHorizontal(dl, rect_min.x, rect_max.x, y4, IM_COL32(0,255,0,128));
 
-    ImGui::PlotLines("Entropy", entropy_history_.data(), entropy_history_.size(), 0, nullptr, 0.0f, 1.0f, graph_size);
+    ImGui::PlotLines("Entropy 1h", entropy_history_.data(), entropy_history_.size(), 0, nullptr, metrics_offset_, metrics_offset_ + metrics_scale_, graph_size);
+    ImGui::PlotLines("Entropy 4h", entropy_history_4h_.data(), entropy_history_4h_.size(), 0, nullptr, metrics_offset_, metrics_offset_ + metrics_scale_, graph_size);
     rect_min = ImGui::GetItemRectMin();
     rect_max = ImGui::GetItemRectMax();
     y1 = rect_max.y - roll.entropy_1h_avg * (rect_max.y - rect_min.y);
@@ -772,7 +807,13 @@ std::chrono::system_clock::time_point SignalsTabController::screenToTime(float x
 
 void SignalsTabController::updatePriceRange() {
     if (candle_data_.empty()) return;
-    
+
+    if (chart_zoom_.is_zoomed) {
+        price_min_ = chart_zoom_.price_min;
+        price_max_ = chart_zoom_.price_max;
+        return;
+    }
+
     price_min_ = std::numeric_limits<double>::max();
     price_max_ = std::numeric_limits<double>::lowest();
     
@@ -807,6 +848,31 @@ void SignalsTabController::handleMouseInput() {
         hover_info_.active = true;
         hover_info_.position = mouse_pos;
         updateHoverInfo();
+
+        ImGuiIO& io = ImGui::GetIO();
+        if (io.MouseWheel != 0.0f) {
+            double price_at_cursor = screenToPrice(mouse_pos.y);
+            double range = price_max_ - price_min_;
+            double scale = io.MouseWheel > 0 ? 0.9 : 1.1;
+            chart_zoom_.price_min = price_at_cursor - (price_at_cursor - price_min_) * scale;
+            chart_zoom_.price_max = price_at_cursor + (price_max_ - price_at_cursor) * scale;
+            chart_zoom_.is_zoomed = true;
+        }
+
+        if (ImGui::IsMouseDragging(ImGuiMouseButton_Right)) {
+            if (!is_panning_) {
+                pan_start_pos_ = mouse_pos;
+                is_panning_ = true;
+            } else {
+                float delta_y = mouse_pos.y - pan_start_pos_.y;
+                double price_delta = (delta_y / chart_size_.y) * (price_max_ - price_min_);
+                chart_zoom_.price_min += price_delta;
+                chart_zoom_.price_max += price_delta;
+                pan_start_pos_ = mouse_pos;
+            }
+        } else {
+            is_panning_ = false;
+        }
     } else {
         hover_info_.active = false;
     }

--- a/src/apps/workbench/tabs/signals_tab_controller.h
+++ b/src/apps/workbench/tabs/signals_tab_controller.h
@@ -90,6 +90,17 @@ private:
     std::deque<float> coherence_history_;
     std::deque<float> stability_history_;
     std::deque<float> entropy_history_;
+    std::deque<float> coherence_history_1h_;
+    std::deque<float> coherence_history_4h_;
+    std::deque<float> stability_history_1h_;
+    std::deque<float> stability_history_4h_;
+    std::deque<float> entropy_history_1h_;
+    std::deque<float> entropy_history_4h_;
+
+    float metrics_scale_ = 1.0f;
+    float metrics_offset_ = 0.0f;
+    bool metrics_panning_ = false;
+    ImVec2 metrics_pan_start_{};
 
     // Utility functions
     ImVec2 priceToScreen(double price, std::chrono::system_clock::time_point time);


### PR DESCRIPTION
## Summary
- keep ImDrawList checks to prevent crashes when ImGui windows aren't ready
- add 1h/4h metric histories and interactive zoom for metric graphs
- support zoom/pan on the main price chart
- throttle layout rendering via `UILayoutManager` refresh interval
- update workbench core to use new refresh setting

## Testing
- `./build.sh` *(fails: `cd: /sep: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_688441f22048832ab8407cdc24d3f90c