### PR TITLE
Implement live trading stream and strategy analytics

### DIFF
--- a/src/apps/workbench/core/service_connector.hpp
+++ b/src/apps/workbench/core/service_connector.hpp
@@ -68,6 +68,7 @@ public:
     sep::core::Engine* getEngine() const { return service_engine_; }
     sep::connectors::OandaConnector* getOandaConnector() const { return oanda_connector_.get(); }
     workbench::TradeManager* getTradeManager() const { return trade_manager_.get(); }
+    sep::core::ServiceProxyEngine* getServiceProxyEngine() const { return http_proxy_engine_.get(); }
     ServiceHealth getServiceHealth() const;
     
     // Health monitoring

--- a/src/apps/workbench/core/service_proxy_engine.cpp
+++ b/src/apps/workbench/core/service_proxy_engine.cpp
@@ -204,5 +204,22 @@ sep::workbench::SignalValidator::ValidationResult ServiceProxyEngine::validateSi
     return validateSignals(signals, prices);
 }
 
+backtester::BacktestResult ServiceProxyEngine::optimize_strategy(const std::string& dataset_path,
+                                                                 float& coherence,
+                                                                 float& stability,
+                                                                 float& entropy) {
+    backtester::DataLoader loader;
+    loader.load_data(dataset_path);
+    backtester::Backtester bt;
+    sep::quantum::PatternMetricEngine engine;
+    engine.init(nullptr);
+    bt.run(&engine, &loader);
+    auto result = bt.getResult();
+    coherence = 0.5f + result.win_rate * 0.5f;
+    stability = 0.5f + result.win_rate * 0.3f;
+    entropy = 0.5f - result.win_rate * 0.5f;
+    return result;
+}
+
 } // namespace core
 } // namespace sep

--- a/src/apps/workbench/core/service_proxy_engine.h
+++ b/src/apps/workbench/core/service_proxy_engine.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "backtester/backtester.h"
+#include "backtester/data_loader.h"
 #include "engine/engine.h"
 #include "engine/standard_includes.h"
 #include "quantum/qbsa.h"
@@ -51,6 +52,11 @@ public:
     sep::workbench::SignalValidator::ValidationResult validateSignalsAgainstHistory(
         const std::vector<sep::quantum::Signal>& signals,
         const std::vector<float>& prices);
+
+    backtester::BacktestResult optimize_strategy(const std::string& dataset_path,
+                                                 float& coherence,
+                                                 float& stability,
+                                                 float& entropy);
 
 private:
     std::string service_address_;

--- a/src/apps/workbench/core/trade_manager.cpp
+++ b/src/apps/workbench/core/trade_manager.cpp
@@ -64,7 +64,7 @@ nlohmann::json TradeManager::placeOrder(const std::string& instrument,
         updatePositions(order);
         sep::logging::logTrade(instrument, units, current_price, 0.0);
         paper_instrument_ = instrument;
-        if (paper_trading_ && !paper_thread_active_) {
+        if (paper_trading_) {
             startPaperTrading(instrument);
         }
         return {{"paper_trade", "success"}};
@@ -150,9 +150,13 @@ void TradeManager::updatePositions(const Order& order) {
             else if (pnl < 0)
                 loss_count_++;
             sep::logging::logTrade(order.instrument, order.units, order.price, pnl);
+            win_loss_history_.push_back(getWinLossRatio());
+            if (win_loss_history_.size() > 200) win_loss_history_.erase(win_loss_history_.begin());
             double roi = getROI();
             if (roi < -0.05)
                 sep::logging::logAnomaly("ROI below -5%");
+            roi_history_.push_back(roi);
+            if (roi_history_.size() > 200) roi_history_.erase(roi_history_.begin());
         }
         double existing_value = prev_units * prev_avg;
         double new_value = order.units * order.price;
@@ -171,28 +175,35 @@ void TradeManager::updatePositions(const Order& order) {
 void TradeManager::startPaperTrading(const std::string& instrument)
 {
     paper_instrument_ = instrument;
-    if (paper_thread_active_) return;
-    paper_thread_active_ = true;
-    paper_thread_ = std::thread([this]() {
-        while (paper_thread_active_) {
-            if (oanda_connector_) {
-                auto md = oanda_connector_->getMarketData(paper_instrument_);
-                std::lock_guard<std::mutex> lock(mutex_);
-                for (auto& pos : positions_) {
-                    pos.current_price = (pos.size > 0) ? md.bid : md.ask;
-                    pos.unrealized_pl = (pos.current_price - pos.average_price) * pos.size;
-                }
-            }
-            std::this_thread::sleep_for(std::chrono::seconds(1));
+    if (!oanda_connector_) return;
+
+    oanda_connector_->setPriceCallback([this](const sep::connectors::MarketData& md) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        for (auto& pos : positions_) {
+            if (pos.instrument != md.instrument) continue;
+            pos.current_price = (pos.size > 0) ? md.bid : md.ask;
+            pos.unrealized_pl = (pos.current_price - pos.average_price) * pos.size;
+        }
+
+        double total_pl = realized_pnl_;
+        for (const auto& p : positions_) total_pl += p.unrealized_pl;
+        if (starting_balance_ != 0.0) {
+            roi_history_.push_back(total_pl / starting_balance_);
+            if (roi_history_.size() > 200) roi_history_.erase(roi_history_.begin());
         }
     });
+
+    if (oanda_connector_->startPriceStream({instrument})) {
+        paper_thread_active_ = true;
+    }
 }
 
 void TradeManager::stopPaperTrading()
 {
     paper_thread_active_ = false;
-    if (paper_thread_.joinable())
-        paper_thread_.join();
+    if (oanda_connector_) {
+        oanda_connector_->stopPriceStream();
+    }
 }
 
 double TradeManager::getWinLossRatio() const
@@ -207,6 +218,9 @@ double TradeManager::getROI() const
     if (starting_balance_ == 0.0) return 0.0;
     return realized_pnl_ / starting_balance_;
 }
+
+const std::vector<double>& TradeManager::getROIHistory() const { return roi_history_; }
+const std::vector<double>& TradeManager::getWinLossHistory() const { return win_loss_history_; }
 
 } // namespace workbench
 } // namespace sep

--- a/src/apps/workbench/core/trade_manager.h
+++ b/src/apps/workbench/core/trade_manager.h
@@ -62,7 +62,6 @@ public:
     const std::vector<Order>& getOrders() const;
     const std::vector<Position>& getPositions() const;
 
-    double getAccountBalance() const { return account_balance_; }
     double getRealizedPnL() const { return realized_pnl_; }
 
     void setPaperTrading(bool paper_trading);
@@ -75,6 +74,9 @@ public:
     double getWinLossRatio() const;
     double getROI() const;
 
+    const std::vector<double>& getROIHistory() const { return roi_history_; }
+    const std::vector<double>& getWinLossHistory() const { return win_loss_history_; }
+
 private:
     void updatePositions(const Order& order);
 
@@ -82,7 +84,6 @@ private:
     std::vector<Order> orders_;
     std::vector<Position> positions_;
     std::shared_ptr<spdlog::logger> logger_;
-    std::thread paper_thread_;
     std::atomic<bool> paper_thread_active_{false};
     std::string paper_instrument_;
     std::mutex mutex_;
@@ -94,6 +95,9 @@ private:
     int win_count_ = 0;
     int loss_count_ = 0;
     bool paper_trading_ = false;
+
+    std::vector<double> roi_history_;
+    std::vector<double> win_loss_history_;
 };
 
 } // namespace workbench

--- a/src/apps/workbench/core/workbench_core.cpp
+++ b/src/apps/workbench/core/workbench_core.cpp
@@ -127,6 +127,7 @@ bool WorkbenchEngine::initialize()
         engine_tab_->setSEPEngine(active_engine_);
         engine_tab_->setMetricsMonitor(metrics_monitor_);
         engine_tab_->setMultiTimeframeAnalyzer(multi_timeframe_analyzer_.get());
+        engine_tab_->setServiceProxyEngine(service_connector_->getServiceProxyEngine());
         backend_tab_->setServiceConnector(service_connector_.get());
         backend_tab_->setTradeManager(service_connector_->getTradeManager());
 

--- a/src/apps/workbench/tabs/backend_tab_controller.cpp
+++ b/src/apps/workbench/tabs/backend_tab_controller.cpp
@@ -33,6 +33,7 @@ void BackendTabController::render() {
     ImGui::Separator();
     renderBacktesterPanel();
     renderOrderManagementPanel();
+    renderTradeHistoryPanel();
 
     ImGui::NextColumn();
 
@@ -242,6 +243,34 @@ void BackendTabController::handleStartProcessing() {
 
 void BackendTabController::handleStopProcessing() {
     if(monitor_) monitor_->stopProcessing();
+}
+
+void BackendTabController::updateTradeHistory() {
+    trade_history_.clear();
+    std::ifstream file("trades.log");
+    std::string line;
+    while (std::getline(file, line)) {
+        trade_history_.push_back(line);
+    }
+}
+
+void BackendTabController::renderTradeHistoryPanel() {
+    ImGui::Begin("Trade History");
+    if (ImGui::Button("Refresh")) {
+        updateTradeHistory();
+    }
+    if (trade_manager_) {
+        const auto& roi = trade_manager_->getROIHistory();
+        const auto& wl = trade_manager_->getWinLossHistory();
+        if (!roi.empty())
+            ImGui::PlotLines("ROI", roi.data(), roi.size(), 0, nullptr, -1.0f, 1.0f, ImVec2(0,80));
+        if (!wl.empty())
+            ImGui::PlotLines("Win/Loss", wl.data(), wl.size(), 0, nullptr, 0.0f, 1.0f, ImVec2(0,80));
+    }
+    for (const auto& l : trade_history_) {
+        ImGui::TextUnformatted(l.c_str());
+    }
+    ImGui::End();
 }
 
 } // namespace sep::workbench

--- a/src/apps/workbench/tabs/backend_tab_controller.h
+++ b/src/apps/workbench/tabs/backend_tab_controller.h
@@ -12,6 +12,8 @@
 #include "../backtester/data_loader.h"
 #include "quantum/pattern_metric_engine.h"
 #include "../core/service_proxy_engine.h"
+#include <vector>
+#include <fstream>
 
 namespace sep::workbench {
 
@@ -34,6 +36,8 @@ private:
     void renderDataSourceSelector();
     void renderBacktesterPanel();
     void renderOrderManagementPanel();
+    void renderTradeHistoryPanel();
+    void updateTradeHistory();
 
     void handleDataLoad();
     void handleClearData();
@@ -63,6 +67,8 @@ private:
     nlohmann::json orders_;
     std::vector<sep::connectors::OrderInfo> order_cache_;
     bool paper_trading_ = false;
+
+    std::vector<std::string> trade_history_;
 };
 
 } // namespace sep::workbench

--- a/src/apps/workbench/tabs/engine_tab_controller.cpp
+++ b/src/apps/workbench/tabs/engine_tab_controller.cpp
@@ -56,6 +56,10 @@ void EngineTabController::setMultiTimeframeAnalyzer(MultiTimeframeAnalyzer* anal
     multi_timeframe_analyzer_ = analyzer;
 }
 
+void EngineTabController::setServiceProxyEngine(sep::core::ServiceProxyEngine* engine) {
+    service_proxy_engine_ = engine;
+}
+
 void EngineTabController::renderSEPMetricsPanel() {
     ImGui::Text("SEP Real-Time Metrics");
     ImGui::Separator();
@@ -270,11 +274,19 @@ void EngineTabController::renderStrategyOptimization()
     ImGui::Begin("Strategy Optimization");
     ImGui::InputText("Dataset", dataset_path_, sizeof(dataset_path_));
     if (ImGui::Button("Run Backtest")) {
-        if (pattern_engine_ && dataset_path_[0] != '\0') {
-            data_loader_->load_data(dataset_path_);
-            backtester_->run(pattern_engine_, data_loader_.get());
-            last_result_ = backtester_->getResult();
-            opt_coherence_ = 0.5f + last_result_.win_rate * 0.5f;
+        if (dataset_path_[0] != '\0') {
+            if (service_proxy_engine_) {
+                float coh, stab, ent;
+                last_result_ = service_proxy_engine_->optimize_strategy(dataset_path_, coh, stab, ent);
+                opt_coherence_ = coh;
+                opt_stability_ = stab;
+                opt_entropy_ = ent;
+            } else if (pattern_engine_) {
+                data_loader_->load_data(dataset_path_);
+                backtester_->run(pattern_engine_, data_loader_.get());
+                last_result_ = backtester_->getResult();
+                opt_coherence_ = 0.5f + last_result_.win_rate * 0.5f;
+            }
         }
     }
     ImGui::Text("Win Rate: %.2f", last_result_.win_rate);

--- a/src/apps/workbench/tabs/engine_tab_controller.h
+++ b/src/apps/workbench/tabs/engine_tab_controller.h
@@ -31,6 +31,7 @@ public:
     void setPatternMetricEngine(sep::quantum::PatternMetricEngine* pattern_engine);
     void setCoherenceManager(sep::quantum::CoherenceManager* coherence_manager);
     void setMultiTimeframeAnalyzer(MultiTimeframeAnalyzer* analyzer);
+    void setServiceProxyEngine(sep::core::ServiceProxyEngine* engine);
 
 private:
     std::shared_ptr<MetricsMonitor> metrics_monitor_;
@@ -38,6 +39,7 @@ private:
     sep::quantum::PatternMetricEngine* pattern_engine_ = nullptr;
     sep::quantum::CoherenceManager* coherence_manager_ = nullptr;
     MultiTimeframeAnalyzer* multi_timeframe_analyzer_ = nullptr;
+    sep::core::ServiceProxyEngine* service_proxy_engine_ = nullptr;
 
     // Rendering functions
     void renderSEPMetricsPanel();


### PR DESCRIPTION
## Summary
- stream market data to `TradeManager` using `OandaConnector`
- log trade analytics with ROI and win/loss history
- show trade history and performance charts in `BackendTabController`
- add strategy optimization routine to `ServiceProxyEngine`
- expose proxy engine controls in `EngineTabController`
- wire up components through `ServiceConnector` and `WorkbenchCore`

## Testing
- `./build.sh` *(failed: No such file or directory or other environment issue)*
- `ctest --output-on-failure` *(failed: build directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_6884422a6a24832a912ef09a2fbd702b