### PR TITLE
Convert candle timestamp to ISO string

### DIFF
--- a/src/apps/workbench/core/multi_timeframe_analyzer.cpp
+++ b/src/apps/workbench/core/multi_timeframe_analyzer.cpp
@@ -7,6 +7,9 @@
 #include <iostream>
 #include <numeric>
 #include <sstream>
+#include <chrono>
+#include <iomanip>
+#include <ctime>
 
 // Temporary logging macros until we fix the logging system
 #define SEP_LOG_ERROR(msg) std::cerr << "[ERROR] " << msg << std::endl
@@ -227,7 +230,13 @@ TimeframeMetrics MultiTimeframeAnalyzer::analyzeTimeframe(
             oanda_candle.low = candle.low;
             oanda_candle.close = candle.close;
             oanda_candle.volume = candle.volume;
-            oanda_candle.time = ""; // TODO: Convert timestamp properly
+            {
+                std::time_t tt = std::chrono::system_clock::to_time_t(candle.timestamp);
+                std::tm tm = *std::gmtime(&tt);
+                std::ostringstream oss;
+                oss << std::put_time(&tm, "%Y-%m-%dT%H:%M:%SZ");
+                oanda_candle.time = oss.str();
+            }
             oanda_candles.push_back(oanda_candle);
         }
         auto byte_stream = sep::connectors::MarketDataConverter::candlesToByteStream(oanda_candles);


### PR DESCRIPTION
## Summary
- convert `CandleData.timestamp` to ISO-8601 when creating `OandaCandle`
- add required chrono/format headers

## Testing
- `g++ -std=c++20 -fsyntax-only -Isrc src/apps/workbench/core/multi_timeframe_analyzer.cpp` *(fails: glm/glm.hpp: No such file or directory)*
- `./build.sh` *(fails: cd: /sep: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68844c698188832a95aa8e5b559ebfdd