### PR TITLE
Add safe directory creation for correlation export

### DIFF
--- a/src/apps/workbench/tabs/engine_tab_controller.cpp
+++ b/src/apps/workbench/tabs/engine_tab_controller.cpp
@@ -4,6 +4,7 @@
 #include <map>
 
 #include <iostream>
+#include <filesystem>
 
 #include "imgui.h"
 
@@ -280,10 +281,35 @@ void EngineTabController::renderCorrelationPanel() {
 
     ImGui::InputText("Export Path", correlation_export_path_, sizeof(correlation_export_path_));
     if (ImGui::Button("Export")) {
-        sep::DataParser parser;
-        std::map<std::string, workbench::CorrelationMetrics> data{{selected_timeframe, correlation_metrics}};
-        parser.exportCorrelationCSV(correlation_export_path_, data);
-        parser.exportCorrelationJSON(std::string(correlation_export_path_) + ".json", data);
+        correlation_export_status_.clear();
+        std::string path_str(correlation_export_path_);
+        std::filesystem::path csv_path(path_str);
+        std::filesystem::path dir = csv_path.parent_path();
+        bool ok = true;
+        if (!dir.empty() && !std::filesystem::exists(dir)) {
+            try {
+                std::filesystem::create_directories(dir);
+            } catch (const std::exception& e) {
+                std::cerr << "[EngineTabController] Failed to create directory: " << e.what() << std::endl;
+                correlation_export_status_ = "Failed to create directory";
+                ok = false;
+            }
+        }
+        if (ok) {
+            sep::DataParser parser;
+            std::map<std::string, workbench::CorrelationMetrics> data{{selected_timeframe, correlation_metrics}};
+            bool csv_ok = parser.exportCorrelationCSV(path_str, data);
+            bool json_ok = parser.exportCorrelationJSON(path_str + ".json", data);
+            if (!csv_ok || !json_ok) {
+                std::cerr << "[EngineTabController] Failed to export correlation metrics" << std::endl;
+                correlation_export_status_ = "Export failed";
+            } else {
+                correlation_export_status_ = "Export successful";
+            }
+        }
+    }
+    if (!correlation_export_status_.empty()) {
+        ImGui::Text("%s", correlation_export_status_.c_str());
     }
 
     ImGui::End();

--- a/src/apps/workbench/tabs/engine_tab_controller.h
+++ b/src/apps/workbench/tabs/engine_tab_controller.h
@@ -55,6 +55,7 @@ private:
     // Export path buffer
     char correlation_export_path_[512] = "correlation.csv";
     char metrics_export_path_[512] = "metrics.json";
+    std::string correlation_export_status_{};
 
     // Strategy optimization
     std::unique_ptr<backtester::Backtester> backtester_;


### PR DESCRIPTION
## Summary
- ensure export directory exists in `renderCorrelationPanel`
- show status string after export

## Testing
- `./build.sh` *(fails: cd: /sep: No such file or directory)*
- `./run_clang_tidy.sh` *(fails: compile_commands.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68844c9bd73c832a877dbc329b13678a