### PR TITLE
Add health check for proxy engine

### DIFF
--- a/src/apps/workbench/core/service_connector.cpp
+++ b/src/apps/workbench/core/service_connector.cpp
@@ -840,15 +840,20 @@ sep::core::Engine* ServiceConnector::createHttpEngineProxy(int socket_fd)
     try {
         std::cout << "[ServiceConnector] Creating HTTP proxy engine for remote service..." << std::endl;
         
-        // Create a proxy engine that forwards commands to the remote service via HTTP
-        http_proxy_engine_ = std::make_unique<sep::core::ServiceProxyEngine>(config_.service_address, config_.service_port);
-        
-        // Test the connection
-        if (!http_proxy_engine_->isConnected()) {
-            std::cerr << "[ServiceConnector] HTTP proxy engine connection failed" << std::endl;
-            // Fallback to local engine
-            return createLocalEngine();
-        }
+    // Create a proxy engine that forwards commands to the remote service via HTTP
+    http_proxy_engine_ = std::make_unique<sep::core::ServiceProxyEngine>(config_.service_address, config_.service_port);
+
+    sep::config::CudaConfig cfg{};
+    if (!http_proxy_engine_->init(cfg) || !http_proxy_engine_->isConnected()) {
+        std::string err = "HTTP proxy engine connection failed: " + http_proxy_engine_->getLastError();
+        std::cerr << "[ServiceConnector] " << err << std::endl;
+        health_metrics_.last_error = err;
+        health_metrics_.is_responsive = false;
+        // Fallback to local engine
+        return createLocalEngine();
+    }
+
+    health_metrics_.last_error.clear();
         
         std::cout << "[ServiceConnector] HTTP proxy engine created successfully" << std::endl;
         health_metrics_.is_responsive = true;

--- a/src/apps/workbench/core/service_connector.hpp
+++ b/src/apps/workbench/core/service_connector.hpp
@@ -37,6 +37,7 @@ struct ServiceHealth {
     float coherence_average{0.0f};
     std::string version_info;
     std::chrono::steady_clock::time_point last_heartbeat;
+    std::string last_error;
 };
 
 // Connection configuration

--- a/src/apps/workbench/core/service_proxy_engine.cpp
+++ b/src/apps/workbench/core/service_proxy_engine.cpp
@@ -23,8 +23,57 @@ ServiceProxyEngine::~ServiceProxyEngine() {
 
 bool ServiceProxyEngine::init(const sep::config::CudaConfig& config) {
     std::cout << "[ServiceProxyEngine] Initializing proxy engine..." << std::endl;
-    is_connected_ = true;
-    return true;
+    is_connected_ = false;
+    last_error_.clear();
+
+    int sock = socket(AF_INET, SOCK_STREAM, 0);
+    if (sock == -1) {
+        last_error_ = "socket creation failed";
+        return false;
+    }
+
+    struct sockaddr_in server_addr;
+    server_addr.sin_family = AF_INET;
+    server_addr.sin_port = htons(service_port_);
+    inet_pton(AF_INET, service_address_.c_str(), &server_addr.sin_addr);
+
+    if (connect(sock, (struct sockaddr*)&server_addr, sizeof(server_addr)) == -1) {
+        last_error_ = "connection failed";
+        close(sock);
+        return false;
+    }
+
+    std::string request = "GET " + buildRequestPath("health") + " HTTP/1.1\r\n" +
+                          "Host: " + service_address_ + "\r\n" +
+                          "Connection: close\r\n\r\n";
+
+    if (send(sock, request.c_str(), request.length(), 0) == -1) {
+        last_error_ = "send failed";
+        close(sock);
+        return false;
+    }
+
+    char buffer[256];
+    ssize_t bytes = recv(sock, buffer, sizeof(buffer) - 1, 0);
+    if (bytes <= 0) {
+        last_error_ = "no response";
+        close(sock);
+        return false;
+    }
+
+    buffer[bytes] = '\0';
+    std::istringstream iss(buffer);
+    std::string http_version;
+    int status = 0;
+    iss >> http_version >> status;
+    if (status == 200) {
+        is_connected_ = true;
+    } else {
+        last_error_ = "HTTP " + std::to_string(status);
+    }
+
+    close(sock);
+    return is_connected_;
 }
 
 void ServiceProxyEngine::run() {

--- a/src/apps/workbench/core/service_proxy_engine.h
+++ b/src/apps/workbench/core/service_proxy_engine.h
@@ -41,6 +41,7 @@ public:
                       sep::cuda::QSHResult& qsh_result);
 
     bool isConnected() const { return is_connected_; }
+    const std::string& getLastError() const { return last_error_; }
 
     sep::workbench::SignalValidator::ValidationResult validate_signal(
         const std::vector<sep::quantum::Signal>& signals, const std::vector<float>& prices);
@@ -67,6 +68,8 @@ private:
     // Helper methods for HTTP communication
     bool sendRequest(const std::string& endpoint, const std::string& payload, std::string& response);
     std::string buildRequestPath(const std::string& endpoint) const;
+
+    std::string last_error_;
 };
 
 } // namespace core


### PR DESCRIPTION
## Summary
- perform handshake on proxy engine init and set connection state based on HTTP 200
- surface handshake errors through ServiceConnector health metrics
- log and fallback when proxy engine cannot connect
- expose last error retrieval from proxy engine

## Testing
- `./simple_test_runner`

------
https://chatgpt.com/codex/tasks/task_e_68844c46d7b0832abd9eaaabb91a649c