### PR TITLE
Add metric map storage

### DIFF
--- a/src/apps/workbench/core/metrics_monitor.cpp
+++ b/src/apps/workbench/core/metrics_monitor.cpp
@@ -144,6 +144,17 @@ const MetricsMonitor::RollingMetrics& MetricsMonitor::getRollingMetrics() const 
     return rolling_metrics_;
 }
 
+std::unordered_map<std::string, double> MetricsMonitor::getMetrics() const {
+    std::lock_guard<std::mutex> lock(metrics_mutex_);
+    return metrics_;
+}
+
+void MetricsMonitor::set(const std::string& key, double value) {
+    std::lock_guard<std::mutex> lock(metrics_mutex_);
+    metrics_[key] = value;
+    metrics_history_dirty_ = true;
+}
+
 const MetricsMonitor::ThresholdSignal& MetricsMonitor::getLatestSignal() const {
     return latest_signal_;
 }

--- a/src/apps/workbench/core/metrics_monitor.h
+++ b/src/apps/workbench/core/metrics_monitor.h
@@ -111,15 +111,8 @@ public:
     sep::connectors::MarketData getLatestMarketData() const;
     void setLatestMarketData(const sep::connectors::MarketData& data);
     
-    // Added for debugging and testing
-    std::unordered_map<std::string, double> getMetrics() {
-        std::lock_guard<std::mutex> lock(metrics_mutex_);
-        return {};
-    }
-
-    void set(const std::string& key, double value) {
-        std::lock_guard<std::mutex> lock(metrics_mutex_);
-    }
+    std::unordered_map<std::string, double> getMetrics() const;
+    void set(const std::string& key, double value);
     
     // Simple threshold detection as specified in TODO.md
     struct SimpleSignals {
@@ -163,6 +156,8 @@ private:
         std::chrono::steady_clock::time_point timestamp;
     };
     std::vector<MetricsSnapshot> metrics_history_;
+    std::unordered_map<std::string, double> metrics_;
+    bool metrics_history_dirty_{false};
     
     std::atomic<bool> processing_{false};
     std::atomic<bool> shutdown_requested_{false};


### PR DESCRIPTION
## Summary
- manage metrics with internal `unordered_map`
- update `set()` and `getMetrics()` implementations
- expose metrics retrieval and flag history dirty
- remove leftover debug comment

## Testing
- `cmake -S simple_test -B build_simple`
- `cmake --build build_simple`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68844c5e3aa4832a9b130c979b196654