### PR TITLE
Persist forex patterns via JSON

### DIFF
--- a/config.json
+++ b/config.json
@@ -9,7 +9,8 @@
   "engine": {
     "cuda_enabled": true,
     "metrics_enabled": true,
-    "log_level": "info"
+    "log_level": "info",
+    "patterns_file": "forex/final_symmetry.json"
   },
   "demos": {
     "genesis_pattern": {

--- a/src/apps/workbench/config.cpp
+++ b/src/apps/workbench/config.cpp
@@ -31,7 +31,8 @@ namespace sep
                 auto& engine = json["engine"];
                 engine_ = {engine.value("cuda_enabled", false),
                            engine.value("metrics_enabled", false),
-                           engine.value("log_level", std::string{"info"})};
+                           engine.value("log_level", std::string{"info"}),
+                           engine.value("patterns_file", std::string{"forex/final_symmetry.json"})};
 
                 auto& genesis = json["demos"]["genesis_pattern"];
                 auto& initial = genesis["initial_pattern"];
@@ -257,7 +258,8 @@ namespace sep
 
                 json["engine"] = {{"cuda_enabled", engine_.cuda_enabled},
                                   {"metrics_enabled", engine_.metrics_enabled},
-                                  {"log_level", engine_.log_level}};
+                                  {"log_level", engine_.log_level},
+                                  {"patterns_file", engine_.patterns_file}};
 
                 json["demos"]["genesis_pattern"] = {
                     {"initial_pattern",

--- a/src/apps/workbench/config.hpp
+++ b/src/apps/workbench/config.hpp
@@ -25,6 +25,7 @@ namespace sep
             bool cuda_enabled;
             bool metrics_enabled;
             std::string log_level;
+            std::string patterns_file;
         };
 
         struct GenesisPatternConfig

--- a/src/apps/workbench/config.json
+++ b/src/apps/workbench/config.json
@@ -9,7 +9,8 @@
   "engine": {
     "cuda_enabled": true,
     "metrics_enabled": true,
-    "log_level": "info"
+    "log_level": "info",
+    "patterns_file": "forex/final_symmetry.json"
   },
   "demos": {
     "genesis_pattern": {

--- a/src/apps/workbench/core/forex_pattern_generator.cpp
+++ b/src/apps/workbench/core/forex_pattern_generator.cpp
@@ -1,13 +1,19 @@
 #include "forex_pattern_generator.h"
+#include "../config.hpp"
 #include <iostream>
 #include <algorithm>
 #include <fstream>
+#include <filesystem>
 #include <nlohmann/json.hpp>
 
 namespace sep::workbench {
 
 ForexPatternGenerator::ForexPatternGenerator() {
-    initializeDefaultPatterns();
+    loadPatterns();
+}
+
+ForexPatternGenerator::~ForexPatternGenerator() {
+    savePatterns();
 }
 
 void ForexPatternGenerator::initializeDefaultPatterns() {
@@ -224,18 +230,79 @@ void ForexPatternGenerator::applyFeedback(const std::string& pattern_id, bool wa
             if (pattern.resonance > 0.75f && pattern.consciousness_level < 4) {
                 pattern.consciousness_level = std::min(4, pattern.consciousness_level + 1);
             }
-            
+
+            savePatterns();
+
             break;
         }
     }
 }
 
 void ForexPatternGenerator::loadPatterns() {
-    // TODO: Load from JSON file if needed
+    const auto& cfg = Config::getInstance().engine();
+    std::filesystem::path path = cfg.patterns_file;
+    if (path.empty()) {
+        initializeDefaultPatterns();
+        return;
+    }
+
+    try {
+        std::ifstream file(path);
+        if (!file.is_open()) {
+            initializeDefaultPatterns();
+            return;
+        }
+
+        nlohmann::json j;
+        file >> j;
+
+        if (!j.contains("patterns")) {
+            initializeDefaultPatterns();
+            return;
+        }
+
+        patterns_.clear();
+        for (const auto& p : j["patterns"]) {
+            patterns_.emplace_back(
+                p.value("patternId", ""),
+                p.value("note", ""),
+                p.value("resonance", 0.0f),
+                p.value("consciousnessLevel", 1));
+        }
+    } catch (const std::exception& e) {
+        std::cerr << "Failed to load patterns: " << e.what() << std::endl;
+        initializeDefaultPatterns();
+    }
 }
 
 void ForexPatternGenerator::savePatterns() {
-    // TODO: Save to JSON file if needed
+    const auto& cfg = Config::getInstance().engine();
+    std::filesystem::path path = cfg.patterns_file;
+    if (path.empty()) {
+        return;
+    }
+
+    nlohmann::json j;
+    j["patterns"] = nlohmann::json::array();
+    for (const auto& p : patterns_) {
+        j["patterns"].push_back({
+            {"patternId", p.pattern_id},
+            {"note", p.note},
+            {"resonance", p.resonance},
+            {"consciousnessLevel", p.consciousness_level}
+        });
+    }
+    try {
+        std::ofstream file(path);
+        if (!file.is_open()) {
+            std::cerr << "Failed to open patterns file for writing: "
+                      << path << std::endl;
+            return;
+        }
+        file << j.dump(2);
+    } catch (const std::exception& e) {
+        std::cerr << "Failed to save patterns: " << e.what() << std::endl;
+    }
 }
 
 } // namespace sep::workbench

--- a/src/apps/workbench/core/forex_pattern_generator.h
+++ b/src/apps/workbench/core/forex_pattern_generator.h
@@ -43,7 +43,7 @@ struct ForexSignal {
 class ForexPatternGenerator {
 public:
     ForexPatternGenerator();
-    ~ForexPatternGenerator() = default;
+    ~ForexPatternGenerator();
     
     // Pattern management
     void loadPatterns();


### PR DESCRIPTION
## Summary
- extend `EngineConfig` with `patterns_file`
- read/write patterns path in workbench config
- implement JSON load and save in `ForexPatternGenerator`
- save updated patterns after feedback and on destruction
- update config defaults with `patterns_file`

## Testing
- `./build.sh` *(fails: cd /sep no such file)*
- `./run_clang_tidy.sh` *(fails: compile_commands.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68844c75d934832aaf54615de4105736