### PR TITLE
Add OANDA 48h sample loader

### DIFF
--- a/src/apps/workbench/backtester/core/backtester_engine.cpp
+++ b/src/apps/workbench/backtester/core/backtester_engine.cpp
@@ -20,7 +20,11 @@ sep::workbench::backtester::BacktestResult BacktesterEngine::run(
     const std::string& dataset_path,
     sep::quantum::PatternMetricEngine* engine) {
     sep::workbench::backtester::DataLoader loader;
-    loader.loadData(dataset_path);
+    if (dataset_path == "EURUSD_48H") {
+        loader.load_48h_sample();
+    } else {
+        loader.loadData(dataset_path);
+    }
 
     const auto& candles = loader.getCandleData();
     sep::workbench::backtester::BacktestResult result{};

--- a/src/apps/workbench/backtester/data/data_loader.cpp
+++ b/src/apps/workbench/backtester/data/data_loader.cpp
@@ -1,5 +1,11 @@
 #include "apps/workbench/backtester/data/data_loader.h"
 #include "apps/workbench/backtester/data/json_data_parser.h"
+#include "connectors/oanda_connector.h"
+#include "engine/data_parser.h"
+#include <chrono>
+#include <filesystem>
+#include <iomanip>
+#include <sstream>
 
 DataLoader::DataLoader() {}
 
@@ -11,4 +17,41 @@ void DataLoader::loadData(const std::string& filepath) {
 
 const std::vector<sep::workbench::CandleData>& DataLoader::getCandleData() const {
     return m_candleData;
+}
+
+void DataLoader::load_48h_sample() {
+    sep::connectors::OandaConnector connector("", "", true);
+    if (!connector.initialize()) {
+        return;
+    }
+
+    auto candles = connector.getHistoricalData("EUR_USD", "M1", "", "", 2880);
+    connector.shutdown();
+
+    std::vector<sep::CandleData> export_candles;
+    export_candles.reserve(candles.size());
+
+    m_candleData.clear();
+    m_candleData.reserve(candles.size());
+    for (const auto& c : candles) {
+        std::tm tm{};
+        std::stringstream ss(c.time);
+        ss >> std::get_time(&tm, "%Y-%m-%dT%H:%M:%S");
+        auto tp = std::chrono::system_clock::from_time_t(std::mktime(&tm));
+        m_candleData.emplace_back(c.open, c.high, c.low, c.close,
+                                  static_cast<int>(c.volume), tp);
+
+        sep::CandleData ec;
+        ec.time = c.time;
+        ec.volume = static_cast<uint64_t>(c.volume);
+        ec.open = static_cast<float>(c.open);
+        ec.high = static_cast<float>(c.high);
+        ec.low = static_cast<float>(c.low);
+        ec.close = static_cast<float>(c.close);
+        export_candles.push_back(ec);
+    }
+
+    std::filesystem::create_directories("Testing/OANDA");
+    sep::DataParser parser;
+    parser.writeQuantJSON(export_candles, "Testing/OANDA/eurusd_48h.json");
 }

--- a/src/apps/workbench/backtester/data/data_loader.h
+++ b/src/apps/workbench/backtester/data/data_loader.h
@@ -11,6 +11,7 @@ public:
     ~DataLoader();
 
     void loadData(const std::string& filepath);
+    void load_48h_sample();
 
     const std::vector<sep::workbench::CandleData>& getCandleData() const;
 


### PR DESCRIPTION
## Summary
- add `load_48h_sample()` to backtester DataLoader
- write OANDA data to `Testing/OANDA/eurusd_48h.json`
- allow `BacktesterEngine` to use the special `EURUSD_48H` dataset

## Testing
- `./build.sh` *(fails: cd /sep: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68844c8137e0832a815a77a315e883b3