### PR TITLE
Implement pattern detection logging

### DIFF
--- a/src/apps/workbench/core/multi_timeframe_analyzer.cpp
+++ b/src/apps/workbench/core/multi_timeframe_analyzer.cpp
@@ -711,6 +711,7 @@ CorrelationMetrics MultiTimeframeAnalyzer::calculateCorrelationMetrics(const std
     correlation_metrics.stability_spearman = spearman(stability_values, price_moves);
     correlation_metrics.entropy_pearson = pearson(entropy_values, price_moves);
     correlation_metrics.entropy_spearman = spearman(entropy_values, price_moves);
+    correlation_metrics.sample_count = static_cast<int>(n);
 
     return correlation_metrics;
 }

--- a/src/apps/workbench/core/multi_timeframe_analyzer.h
+++ b/src/apps/workbench/core/multi_timeframe_analyzer.h
@@ -64,6 +64,7 @@ struct CorrelationMetrics {
     double stability_spearman = 0.0;
     double entropy_pearson = 0.0;
     double entropy_spearman = 0.0;
+    int sample_count = 0;
 };
 
 struct MultiTimeframeSignal {

--- a/src/apps/workbench/tabs/engine_tab_controller.cpp
+++ b/src/apps/workbench/tabs/engine_tab_controller.cpp
@@ -259,6 +259,7 @@ void EngineTabController::renderCorrelationPanel() {
     ImGui::Text("%.3f", correlation_metrics.entropy_pearson); ImGui::NextColumn();
     ImGui::Text("%.3f", correlation_metrics.entropy_spearman); ImGui::NextColumn();
     ImGui::Columns(1);
+    ImGui::Text("Samples: %d", correlation_metrics.sample_count);
 
     // Plot correlation history
     auto history = multi_timeframe_analyzer_->getCorrelationHistory(selected_timeframe);

--- a/src/apps/workbench/tabs/signals_tab_controller.cpp
+++ b/src/apps/workbench/tabs/signals_tab_controller.cpp
@@ -34,8 +34,8 @@ bool SignalsTabController::initialize() {
     return true;
 }
 
-void SignalsTabController::renderThresholdPanel() {
-    ImGui::Begin("Signal Thresholds");
+void SignalsTabController::renderThresholdControlPanel() {
+    ImGui::Begin("Signal Controls");
     ImGui::Text("BUY thresholds");
     ImGui::SliderFloat("Buy Coherence", &buy_min_coherence_, 0.0f, 1.0f);
     ImGui::SliderFloat("Buy Stability", &buy_min_stability_, 0.0f, 1.0f);
@@ -63,7 +63,7 @@ void SignalsTabController::renderThresholdPanel() {
 
 void SignalsTabController::render() {
     ImGui::Columns(2, "SignalsColumns", true);
-    renderThresholdPanel();
+    renderThresholdControlPanel();
     ImGui::NextColumn();
 
     if (metrics_monitor_) {

--- a/src/apps/workbench/tabs/signals_tab_controller.h
+++ b/src/apps/workbench/tabs/signals_tab_controller.h
@@ -24,7 +24,7 @@ public:
 
     bool initialize();
     void render();
-    void renderThresholdPanel();
+    void renderThresholdControlPanel();
     void shutdown();
 
     void setOandaConnector(sep::connectors::OandaConnector* connector);

--- a/src/engine/data_parser.cpp
+++ b/src/engine/data_parser.cpp
@@ -575,7 +575,7 @@ bool DataParser::exportCorrelationCSV(const std::string& path,
     if (!file.is_open()) {
         return false;
     }
-    file << "timeframe,coh_pearson,coh_spearman,stab_pearson,stab_spearman,entropy_pearson,entropy_spearman\n";
+    file << "timeframe,coh_pearson,coh_spearman,stab_pearson,stab_spearman,entropy_pearson,entropy_spearman,samples\n";
     for (const auto& [tf, metrics] : data) {
         file << tf << ','
              << metrics.coherence_pearson << ','
@@ -583,7 +583,8 @@ bool DataParser::exportCorrelationCSV(const std::string& path,
              << metrics.stability_pearson << ','
              << metrics.stability_spearman << ','
              << metrics.entropy_pearson << ','
-             << metrics.entropy_spearman << "\n";
+             << metrics.entropy_spearman << ','
+             << metrics.sample_count << "\n";
     }
     return true;
 }
@@ -598,7 +599,8 @@ bool DataParser::exportCorrelationJSON(const std::string& path,
             {"stab_pearson", metrics.stability_pearson},
             {"stab_spearman", metrics.stability_spearman},
             {"entropy_pearson", metrics.entropy_pearson},
-            {"entropy_spearman", metrics.entropy_spearman}
+            {"entropy_spearman", metrics.entropy_spearman},
+            {"samples", metrics.sample_count}
         };
     }
     std::ofstream file(path);

--- a/src/quantum/pattern_metric_engine.cpp
+++ b/src/quantum/pattern_metric_engine.cpp
@@ -422,7 +422,9 @@ void PatternMetricEngine::generateSignals() {
             }
             s.pattern_id = m.pattern_id;
             current_signals_.push_back(s);
-            sep::logging::logSignalDetected(s.pattern_id, s.type, std::chrono::system_clock::now());
+            auto now = std::chrono::system_clock::now();
+            sep::logging::logPatternDetected(s.pattern_id, now);
+            sep::logging::logSignalDetected(s.pattern_id, s.type, now);
         }
     }
 }


### PR DESCRIPTION
## Summary
- log pattern detections when signals fire in PatternMetricEngine
- rename SignalsTabController panel method to renderThresholdControlPanel
- add sample count to correlation metrics and export helpers
- show sample count on EngineTabController correlation panel

## Testing
- `./build.sh` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6884641eeb88832a97d5e52a691696fb