### PR TITLE
Enhance signal thresholds and correlation export

### DIFF
--- a/src/apps/workbench/tabs/signals_tab_controller.cpp
+++ b/src/apps/workbench/tabs/signals_tab_controller.cpp
@@ -37,14 +37,15 @@ bool SignalsTabController::initialize() {
 void SignalsTabController::renderThresholdPanel() {
     ImGui::Begin("Signal Thresholds");
     ImGui::Text("BUY thresholds");
-    ImGui::SliderFloat("Buy Coherence", &buy_min_coherence_, 0.0f, 1.0f);
-    ImGui::SliderFloat("Buy Stability", &buy_min_stability_, 0.0f, 1.0f);
-    ImGui::SliderFloat("Buy Max Entropy", &buy_max_entropy_, 0.0f, 1.0f);
+    bool changed = false;
+    changed |= ImGui::SliderFloat("Buy Coherence", &buy_min_coherence_, 0.0f, 1.0f);
+    changed |= ImGui::SliderFloat("Buy Stability", &buy_min_stability_, 0.0f, 1.0f);
+    changed |= ImGui::SliderFloat("Buy Max Entropy", &buy_max_entropy_, 0.0f, 1.0f);
     ImGui::Separator();
     ImGui::Text("SELL thresholds");
-    ImGui::SliderFloat("Sell Max Stability", &sell_max_stability_, 0.0f, 1.0f);
-    ImGui::SliderFloat("Sell Min Entropy", &sell_min_entropy_, 0.0f, 1.0f);
-    if (ImGui::Button("Apply")) {
+    changed |= ImGui::SliderFloat("Sell Max Stability", &sell_max_stability_, 0.0f, 1.0f);
+    changed |= ImGui::SliderFloat("Sell Min Entropy", &sell_min_entropy_, 0.0f, 1.0f);
+    if (changed || ImGui::Button("Apply")) {
         if (workbench_engine_) {
             auto* pme = workbench_engine_->getPatternMetricEngine();
             if (pme) {

--- a/src/engine/data_parser.cpp
+++ b/src/engine/data_parser.cpp
@@ -609,4 +609,28 @@ bool DataParser::exportCorrelationJSON(const std::string& path,
     return true;
 }
 
+bool DataParser::exportCorrelationHistoryCSV(const std::string& path,
+                                             const std::map<std::string, std::deque<workbench::CorrelationMetrics>>& history) const {
+    std::ofstream file(path);
+    if (!file.is_open()) {
+        return false;
+    }
+
+    file << "timeframe,index,coh_pearson,coh_spearman,stab_pearson,stab_spearman,entropy_pearson,entropy_spearman\n";
+    for (const auto& [tf, metrics_queue] : history) {
+        size_t idx = 0;
+        for (const auto& m : metrics_queue) {
+            file << tf << ',' << idx++ << ','
+                 << m.coherence_pearson << ','
+                 << m.coherence_spearman << ','
+                 << m.stability_pearson << ','
+                 << m.stability_spearman << ','
+                 << m.entropy_pearson << ','
+                 << m.entropy_spearman << "\n";
+        }
+    }
+
+    return true;
+}
+
 } // namespace sep

--- a/src/engine/data_parser.h
+++ b/src/engine/data_parser.h
@@ -2,6 +2,7 @@
 
 #include "engine/standard_includes.h"
 #include <map>
+#include <deque>
 #include "apps/workbench/core/multi_timeframe_analyzer.h"
 
 namespace sep {
@@ -72,6 +73,8 @@ public:
                               const std::map<std::string, workbench::CorrelationMetrics>& data) const;
     bool exportCorrelationJSON(const std::string& path,
                                const std::map<std::string, workbench::CorrelationMetrics>& data) const;
+    bool exportCorrelationHistoryCSV(const std::string& path,
+                                     const std::map<std::string, std::deque<workbench::CorrelationMetrics>>& history) const;
 
 private:
     // Format detection

--- a/src/quantum/pattern_metric_engine.cpp
+++ b/src/quantum/pattern_metric_engine.cpp
@@ -157,6 +157,7 @@ void PatternMetricEngine::addPattern(const sep::compat::PatternData& pattern) {
     if (current_patterns_.size() > max_history_size_) {
         current_patterns_.pop_front();
     }
+    sep::logging::logPatternDetected(pattern.id, std::chrono::system_clock::now());
     cache_dirty_ = true;
 }
 
@@ -412,33 +413,32 @@ void PatternMetricEngine::generateSignals() {
     current_signals_.clear();
     for (const auto& m : current_metrics_) {
         SignalType type = evaluateSignal(m);
-        if (type != SignalType::HOLD) {
-            Signal s;
-            s.type = type;
-            if (type == SignalType::BUY) {
-                s.confidence = m.coherence * m.stability;
-            } else {
-                s.confidence = (1.0f - m.stability) * m.entropy;
-            }
-            s.pattern_id = m.pattern_id;
-            current_signals_.push_back(s);
-            sep::logging::logSignalDetected(s.pattern_id, s.type, std::chrono::system_clock::now());
+        if (type == SignalType::HOLD) continue;
+
+        Signal s;
+        s.type = type;
+        if (type == SignalType::BUY) {
+            s.confidence = m.coherence * m.stability;
+        } else {
+            s.confidence = (1.0f - m.stability) * m.entropy;
         }
+        s.pattern_id = m.pattern_id;
+        current_signals_.push_back(s);
+        sep::logging::logSignalDetected(s.pattern_id, s.type, std::chrono::system_clock::now());
     }
 }
 
 // Evaluate signal based on threshold rules defined in docs/TODO.md
 SignalType PatternMetricEngine::evaluateSignal(const PatternMetrics& m) const {
-    // Example rule: stability < 0.3 && entropy > 0.7 triggers SELL
-    if (m.stability < signal_thresholds_.sell_max_stability &&
-        m.entropy > signal_thresholds_.sell_min_entropy) {
+    const auto& th = signal_thresholds_;
+
+    if (m.stability < th.sell_max_stability && m.entropy > th.sell_min_entropy) {
         return SignalType::SELL;
     }
 
-    // Example rule: coherence/stability high with low entropy triggers BUY
-    if (m.coherence > signal_thresholds_.buy_min_coherence &&
-        m.stability > signal_thresholds_.buy_min_stability &&
-        m.entropy < signal_thresholds_.buy_max_entropy) {
+    if (m.coherence > th.buy_min_coherence &&
+        m.stability > th.buy_min_stability &&
+        m.entropy < th.buy_max_entropy) {
         return SignalType::BUY;
     }
 
@@ -460,6 +460,7 @@ void PatternMetricEngine::processBuffer([[maybe_unused]] bool is_final_chunk) {
         // Add extracted patterns to our current pattern set with history limit
         for (const auto& pattern : extracted_patterns) {
             current_patterns_.push_back(pattern);
+            sep::logging::logPatternDetected(pattern.id, std::chrono::system_clock::now());
             if (current_patterns_.size() > max_history_size_) {
                 current_patterns_.pop_front();
             }


### PR DESCRIPTION
## Summary
- log detected patterns in `PatternMetricEngine`
- refine signal generation logic to apply configured thresholds
- allow live tuning of thresholds in `SignalsTabController`
- add CSV export helper for correlation history

## Testing
- `./build.sh` *(fails: cd: /sep: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6884641eeb88832a97d5e52a691696fb