### PR TITLE
Implement 48h sample data utilities

### DIFF
--- a/src/apps/data_downloader.cpp
+++ b/src/apps/data_downloader.cpp
@@ -16,7 +16,7 @@ int main() {
     std::cout << "OandaConnector initialized successfully." << std::endl;
 
     // Setup 48-hour sample data for EUR_USD
-    connector.setupSampleData("EUR_USD", "M1", "eur_usd_m1_48h.json");
+    connector.setupSampleData("EUR_USD", "M1", "Testing/OANDA/eurusd_48h.json");
 
     if (connector.hasError()) {
         std::cerr << "Error setting up sample data: " << connector.getLastError() << std::endl;

--- a/src/apps/workbench/backtester/data/data_loader.cpp
+++ b/src/apps/workbench/backtester/data/data_loader.cpp
@@ -21,19 +21,22 @@ const std::vector<sep::workbench::CandleData>& DataLoader::getCandleData() const
 
 void DataLoader::load_48h_sample() {
     namespace fs = std::filesystem;
+    const std::string output = "Testing/OANDA/eurusd_48h.json";
+
     sep::connectors::OandaConnector connector("", "", true);
     if (!connector.initialize()) {
         return;
     }
 
-    auto candles = connector.getHistoricalData("EUR_USD", "M1", "", "", 2880);
+    auto candles = connector.getHistoricalData("EUR_USD", "M1", "", "", 48 * 60);
     connector.shutdown();
 
-        std::vector<sep::CandleData> export_candles;
+    std::vector<sep::CandleData> export_candles;
     export_candles.reserve(candles.size());
 
     m_candleData.clear();
     m_candleData.reserve(candles.size());
+
     for (const auto& c : candles) {
         std::tm tm{};
         std::stringstream ss(c.time);
@@ -42,17 +45,17 @@ void DataLoader::load_48h_sample() {
         m_candleData.emplace_back(c.open, c.high, c.low, c.close,
                                   static_cast<int>(c.volume), tp);
 
-                sep::CandleData ec;
-        ec.time = c.time;
-        ec.volume = static_cast<uint64_t>(c.volume);
-        ec.open = static_cast<float>(c.open);
-        ec.high = static_cast<float>(c.high);
-        ec.low = static_cast<float>(c.low);
-        ec.close = static_cast<float>(c.close);
-        export_candles.push_back(ec);
+        sep::CandleData cd;
+        cd.time = c.time;
+        cd.volume = static_cast<uint64_t>(c.volume);
+        cd.open = static_cast<float>(c.open);
+        cd.high = static_cast<float>(c.high);
+        cd.low = static_cast<float>(c.low);
+        cd.close = static_cast<float>(c.close);
+        export_candles.push_back(cd);
     }
 
-        fs::create_directories("Testing/OANDA");
-        sep::DataParser parser;
-    parser.writeQuantJSON(export_candles, "Testing/OANDA/eurusd_48h.json");
+    fs::create_directories("Testing/OANDA");
+    sep::DataParser parser;
+    parser.saveValidatedCandlesJSON(export_candles, output);
 }

--- a/src/apps/workbench/backtester/data/data_loader_test.cpp
+++ b/src/apps/workbench/backtester/data/data_loader_test.cpp
@@ -3,7 +3,7 @@
 
 int main() {
     DataLoader dataLoader;
-    dataLoader.loadData("eur_usd_m1_48h.json");
+    dataLoader.loadData("Testing/OANDA/eurusd_48h.json");
 
     const auto& candleData = dataLoader.getCandleData();
 

--- a/src/apps/workbench/backtester/ui/backtester_tab_controller.h
+++ b/src/apps/workbench/backtester/ui/backtester_tab_controller.h
@@ -13,5 +13,5 @@ public:
 private:
     std::unique_ptr<BacktesterEngine> engine_;
     sep::workbench::backtester::BacktestResult result_{};
-    char dataset_path_[512] = "eur_usd_m1_48h.json";
+    char dataset_path_[512] = "Testing/OANDA/eurusd_48h.json";
 };

--- a/src/apps/workbench/core/service_connector.cpp
+++ b/src/apps/workbench/core/service_connector.cpp
@@ -59,17 +59,23 @@ ServiceConnector::ServiceConnector(const ConnectionConfig& config)
         std::cout << "[ServiceConnector] API Key length: " << api_key.length() << std::endl;
         std::cout << "[ServiceConnector] Account ID: " << account_id << std::endl;
         if (oanda_connector_->initialize()) {
-            if (oanda_connector_->fetchHistoricalData("EUR_USD", "eur_usd_m1_48h.json")) {
-                loadInitialData("eur_usd_m1_48h.json");
+            if (oanda_connector_->fetchHistoricalData("EUR_USD", "Testing/OANDA/eurusd_48h.json")) {
+                loadInitialData("Testing/OANDA/eurusd_48h.json");
             } else {
-                loadInitialData("eur_usd_m1_48h.json");
+                DataLoader loader;
+                loader.load_48h_sample();
+                loadInitialData("Testing/OANDA/eurusd_48h.json");
             }
         } else {
-            loadInitialData("eur_usd_m1_48h.json");
+            DataLoader loader;
+            loader.load_48h_sample();
+            loadInitialData("Testing/OANDA/eurusd_48h.json");
         }
     } else {
         std::cout << "[ServiceConnector] ERROR: OANDA credentials not provided" << std::endl;
-        loadInitialData("eur_usd_m1_48h.json");
+        DataLoader loader;
+        loader.load_48h_sample();
+        loadInitialData("Testing/OANDA/eurusd_48h.json");
     }
 
     std::cout << "[ServiceConnector] Initialized with config: "

--- a/src/apps/workbench/tabs/backend_tab_controller.cpp
+++ b/src/apps/workbench/tabs/backend_tab_controller.cpp
@@ -219,7 +219,7 @@ void BackendTabController::renderBacktesterPanel() {
     }
     ImGui::SameLine();
     if (ImGui::Button("Run 48h Sample")) {
-        strncpy(backtest_file_buffer_, "eur_usd_m1_48h.json", sizeof(backtest_file_buffer_) - 1);
+        strncpy(backtest_file_buffer_, "Testing/OANDA/eurusd_48h.json", sizeof(backtest_file_buffer_) - 1);
         backtest_file_buffer_[sizeof(backtest_file_buffer_) - 1] = '\0';
         data_loader_->load_data(backtest_file_buffer_);
         backtester_->run(pattern_engine_.get(), data_loader_.get());

--- a/src/apps/workbench/tabs/backend_tab_controller.h
+++ b/src/apps/workbench/tabs/backend_tab_controller.h
@@ -52,8 +52,8 @@ private:
     FileDialog file_dialog_;
 
     // UI State
-    char file_path_buffer_[512] = "eur_usd_m1_48h.json";
-    char backtest_file_buffer_[512] = "eur_usd_m1_48h.json";
+    char file_path_buffer_[512] = "Testing/OANDA/eurusd_48h.json";
+    char backtest_file_buffer_[512] = "Testing/OANDA/eurusd_48h.json";
     int data_source_type_{0};  // 0=File, 1=Live Stream, 2=Generated
     char export_path_buffer_[512] = "metrics_export.json";
     float risk_percentage_ = 2.0f;

--- a/src/connectors/oanda_connector.cpp
+++ b/src/connectors/oanda_connector.cpp
@@ -754,7 +754,7 @@ bool OandaConnector::fetchHistoricalData(const std::string& instrument, const st
     }
 
     DataParser parser;
-    parser.writeQuantJSON(out, output_file);
+    parser.saveValidatedCandlesJSON(out, output_file);
     return true;
 }
 

--- a/src/engine/data_parser.cpp
+++ b/src/engine/data_parser.cpp
@@ -544,6 +544,36 @@ void DataParser::writeQuantJSON(const std::vector<CandleData>& candles, const st
     }
 }
 
+bool DataParser::saveValidatedCandlesJSON(const std::vector<CandleData>& candles,
+                                          const std::string& path) const
+{
+    if (candles.empty()) {
+        return false;
+    }
+
+    // Basic integrity checks and chronological ordering
+    for (size_t i = 0; i < candles.size(); ++i) {
+        const auto& c = candles[i];
+        if (!std::isfinite(c.open) || !std::isfinite(c.high) || !std::isfinite(c.low) ||
+            !std::isfinite(c.close) || c.high < c.low || c.volume < 0 ||
+            c.open > c.high || c.open < c.low || c.close > c.high || c.close < c.low) {
+            std::cerr << "[DataParser] Invalid candle at index " << i << "\n";
+            return false;
+        }
+        if (i > 0) {
+            auto prev_ts = parseTimestamp(candles[i - 1].time);
+            auto cur_ts = parseTimestamp(c.time);
+            if (cur_ts <= prev_ts) {
+                std::cerr << "[DataParser] Non-increasing timestamp at index " << i << "\n";
+                return false;
+            }
+        }
+    }
+
+    writeQuantJSON(candles, path);
+    return true;
+}
+
 uint64_t DataParser::parseTimestamp(const std::string& timestamp) const
 {
     // Parse ISO 8601 format with nanoseconds: "2021-04-07T00:00:00.000000000Z"

--- a/src/engine/data_parser.h
+++ b/src/engine/data_parser.h
@@ -64,6 +64,10 @@ public:
     // Utility: write candle data to OANDA-style JSON
     void writeQuantJSON(const std::vector<CandleData>& candles, const std::string& path) const;
 
+    // Save candle data with validation checks (time ordering, field ranges)
+    bool saveValidatedCandlesJSON(const std::vector<CandleData>& candles,
+                                  const std::string& path) const;
+
     // Convert patterns to PinStates for engine compatibility
         std::vector<PinState> toPinStates(const std::vector<quantum::Pattern>& patterns);
 


### PR DESCRIPTION
## Summary
- add `saveValidatedCandlesJSON` to `DataParser` for integrity checks when persisting candles
- update OandaConnector to use the validated writer
- finish DataLoader `load_48h_sample` to fetch and persist recent EUR/USD candles
- ensure ServiceConnector fetches sample data in offline mode
- switch default sample paths to `Testing/OANDA/eurusd_48h.json`

## Testing
- `g++ -std=c++17 -c src/engine/data_parser.cpp -I src -I extern` *(fails: glm/glm.hpp not found)*
- `g++ -std=c++17 -c src/apps/workbench/backtester/data/data_loader.cpp -I src -I extern` *(fails: imgui.h not found)*


------
https://chatgpt.com/codex/tasks/task_e_68846409b214832ab3fed85dbd9a9ce1