### PR TITLE
Fix headers for core data types

### DIFF
--- a/src/apps/workbench/backtester/data/data_loader.h
+++ b/src/apps/workbench/backtester/data/data_loader.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "apps/workbench/core/common_structs.h"
+#include "common/financial_data_types.h"
 
 #include <string>
 #include <vector>

--- a/src/apps/workbench/backtester/data/json_data_parser.h
+++ b/src/apps/workbench/backtester/data/json_data_parser.h
@@ -2,7 +2,7 @@
 
 #include <string>
 
-#include "apps/workbench/core/common_structs.h"
+#include "common/financial_data_types.h"
 
 #include <vector>
 

--- a/src/apps/workbench/backtester/data_loader.h
+++ b/src/apps/workbench/backtester/data_loader.h
@@ -2,7 +2,7 @@
 
 #include <vector>
 
-#include "core/common_structs.h"
+#include "common/financial_data_types.h"
 
 namespace sep {
 namespace workbench {

--- a/src/apps/workbench/core/common_structs.h
+++ b/src/apps/workbench/core/common_structs.h
@@ -5,76 +5,12 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include "common/financial_data_types.h"
 
 #include "imgui.h"
 
 namespace sep::workbench {
 
-// Enhanced real-time data structures
-struct TickData {
-    double bid, ask, spread;
-    std::chrono::system_clock::time_point timestamp;
-    int volume_tick = 0;
-    
-    TickData(double b, double a, std::chrono::system_clock::time_point t)
-        : bid(b), ask(a), spread(a - b), timestamp(t) {}
-};
-
-struct OrderBookLevel {
-    double price;
-    double size;
-    int order_count;
-    
-    OrderBookLevel(double p, double s, int c = 1) : price(p), size(s), order_count(c) {}
-};
-
-struct OrderBook {
-    std::vector<OrderBookLevel> bids;
-    std::vector<OrderBookLevel> asks;
-    std::chrono::system_clock::time_point timestamp;
-    
-    void clear() { bids.clear(); asks.clear(); }
-};
-
-struct PendingOrder {
-    enum Type { MARKET, LIMIT, STOP, STOP_LIMIT };
-    enum Side { BUY, SELL };
-    
-    std::string id;
-    Type type;
-    Side side;
-    double size;
-    double price;
-    double stop_loss = 0.0;
-    double take_profit = 0.0;
-    std::chrono::system_clock::time_point created_time;
-    std::string status = "PENDING";
-    
-    PendingOrder(Type t, Side s, double sz, double p) 
-        : type(t), side(s), size(sz), price(p), 
-          created_time(std::chrono::system_clock::now()) {}
-};
-
-
-struct TradeHistory {
-    std::string id;
-    std::string instrument;
-    PendingOrder::Side side;
-    double size;
-    double entry_price;
-    double exit_price;
-    double pl;
-    std::chrono::system_clock::time_point entry_time;
-    std::chrono::system_clock::time_point exit_time;
-    std::string strategy = "Manual";
-    
-    TradeHistory(const std::string& inst, PendingOrder::Side s, double sz, 
-                 double entry, double exit, std::chrono::system_clock::time_point et,
-                 std::chrono::system_clock::time_point ext)
-        : instrument(inst), side(s), size(sz), entry_price(entry), exit_price(exit),
-          pl((s == PendingOrder::BUY ? (exit - entry) : (entry - exit)) * sz),
-          entry_time(et), exit_time(ext) {}
-};
 
 struct ChartZoom {
     double price_min = 0, price_max = 0;
@@ -159,15 +95,6 @@ struct SEPSignalData {
                       spread(0), signal_type(NEUTRAL) {}
 };
 
-struct CandleData {
-    double open, high, low, close;
-    int volume;
-    std::chrono::system_clock::time_point timestamp;
-    
-    CandleData(double o, double h, double l, double c, int v, 
-               std::chrono::system_clock::time_point t)
-        : open(o), high(h), low(l), close(c), volume(v), timestamp(t) {}
-};
 
 struct EnhancedHoverInfo {
     bool active = false;

--- a/src/apps/workbench/core/multi_timeframe_analyzer.cpp
+++ b/src/apps/workbench/core/multi_timeframe_analyzer.cpp
@@ -1,6 +1,6 @@
 #include "multi_timeframe_analyzer.h"
 #include "engine/data_parser.h"
-#include "common_structs.h"
+#include "common/financial_data_types.h"
 #include "connectors/market_data_converter.h"
 
 #include <algorithm>

--- a/src/apps/workbench/core/multi_timeframe_analyzer.h
+++ b/src/apps/workbench/core/multi_timeframe_analyzer.h
@@ -12,7 +12,7 @@
 #include "quantum/coherence_manager.h"
 #include "engine/metrics_collector.h"
 #include "connectors/oanda_connector.h"
-#include "apps/workbench/core/common_structs.h"
+#include "common/financial_data_types.h"
 
 namespace sep::workbench {
 

--- a/src/apps/workbench/core/service_connector.cpp
+++ b/src/apps/workbench/core/service_connector.cpp
@@ -2,6 +2,7 @@
 
 // Include engine headers - they should be found via CMake include paths
 #include "engine.h"
+#include "engine/manager.h"
 #include "service_proxy_engine.h"
 #include "config.h"
 #include "ui_layout_manager.h"
@@ -33,7 +34,7 @@ ServiceConnector::ServiceConnector() : ServiceConnector(ConnectionConfig{}) {}
 
 ServiceConnector::ServiceConnector(const ConnectionConfig& config)
     : config_(config) {
-    auto& cfg = workbench::Config::getInstance().oanda();
+    auto& cfg = sep::config::ConfigManager::getInstance().oanda();
     std::string api_key = cfg.demo_api_key.empty() ? cfg.api_key : cfg.demo_api_key;
     std::string account_id = cfg.demo_account_id.empty() ? cfg.account_id : cfg.demo_account_id;
     if (api_key.empty() || account_id.empty()) {

--- a/src/apps/workbench/core/service_connector.hpp
+++ b/src/apps/workbench/core/service_connector.hpp
@@ -11,7 +11,7 @@
 #include "service_proxy_engine.h"
 #include "trade_manager.h"
 #include "tabs/signals_tab_controller.h"
-#include "core/common_structs.h"
+#include "common/financial_data_types.h"
 
 namespace sep {
 namespace core {

--- a/src/apps/workbench/core/workbench_main.cpp
+++ b/src/apps/workbench/core/workbench_main.cpp
@@ -1,6 +1,9 @@
 #include "std_includes.h"
 #include "workbench_core.hpp"
 #include "engine/logging.h"
+#include "apps/workbench/core/service_proxy_engine.h"
+#include "apps/workbench/backtester/backtester.h"
+#include "apps/workbench/backtester/data/data_loader.h"
 
 // Global workbench instance for signal handling
 static sep::workbench::WorkbenchEngine* g_workbench = nullptr;

--- a/src/apps/workbench/tabs/engine_tab_controller.h
+++ b/src/apps/workbench/tabs/engine_tab_controller.h
@@ -5,14 +5,14 @@
 #include <string>
 #include <vector>
 
-#include "core/common_structs.h"
+#include "common/financial_data_types.h"
 #include "core/metrics_monitor.h"
 #include "engine/engine.h"
 #include "quantum/coherence_manager.h"
 #include "quantum/pattern_metric_engine.h"
-#include "core/service_proxy_engine.h"
-#include "../backtester/backtester.h"
-#include "../backtester/data/data_loader.h"
+#include "apps/workbench/core/service_proxy_engine.h"
+#include "apps/workbench/backtester/backtester.h"
+#include "apps/workbench/backtester/data/data_loader.h"
 
 namespace sep::workbench {
 

--- a/src/apps/workbench/tabs/signals_tab_controller.h
+++ b/src/apps/workbench/tabs/signals_tab_controller.h
@@ -6,7 +6,7 @@
 #include <unordered_map>
 #include <vector>
 
-#include "core/common_structs.h"
+#include "common/financial_data_types.h"
 #include "imgui.h"
 #include "connectors/oanda_connector.h"
 #include "signal_generator/quantum_signal_generator.h"

--- a/src/common/financial_data_types.h
+++ b/src/common/financial_data_types.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <chrono>
+#include <string>
+#include <vector>
+
+namespace sep {
+namespace workbench {
+
+struct TickData {
+    double bid, ask, spread;
+    std::chrono::system_clock::time_point timestamp;
+    int volume_tick = 0;
+
+    TickData(double b, double a, std::chrono::system_clock::time_point t)
+        : bid(b), ask(a), spread(a - b), timestamp(t) {}
+};
+
+struct OrderBookLevel {
+    double price;
+    double size;
+    int order_count;
+
+    OrderBookLevel(double p, double s, int c = 1) : price(p), size(s), order_count(c) {}
+};
+
+struct OrderBook {
+    std::vector<OrderBookLevel> bids;
+    std::vector<OrderBookLevel> asks;
+    std::chrono::system_clock::time_point timestamp;
+
+    void clear() { bids.clear(); asks.clear(); }
+};
+
+struct PendingOrder {
+    enum Type { MARKET, LIMIT, STOP, STOP_LIMIT };
+    enum Side { BUY, SELL };
+
+    std::string id;
+    Type type;
+    Side side;
+    double size;
+    double price;
+    double stop_loss = 0.0;
+    double take_profit = 0.0;
+    std::chrono::system_clock::time_point created_time;
+    std::string status = "PENDING";
+
+    PendingOrder(Type t, Side s, double sz, double p)
+        : type(t), side(s), size(sz), price(p),
+          created_time(std::chrono::system_clock::now()) {}
+};
+
+struct TradeHistory {
+    std::string id;
+    std::string instrument;
+    PendingOrder::Side side;
+    double size;
+    double entry_price;
+    double exit_price;
+    double pl;
+    std::chrono::system_clock::time_point entry_time;
+    std::chrono::system_clock::time_point exit_time;
+    std::string strategy = "Manual";
+
+    TradeHistory(const std::string& inst, PendingOrder::Side s, double sz,
+                 double entry, double exit, std::chrono::system_clock::time_point et,
+                 std::chrono::system_clock::time_point ext)
+        : instrument(inst), side(s), size(sz), entry_price(entry), exit_price(exit),
+          pl((s == PendingOrder::BUY ? (exit - entry) : (entry - exit)) * sz),
+          entry_time(et), exit_time(ext) {}
+};
+
+struct CandleData {
+    double open, high, low, close;
+    int volume;
+    std::chrono::system_clock::time_point timestamp;
+
+    CandleData(double o, double h, double l, double c, int v,
+               std::chrono::system_clock::time_point t)
+        : open(o), high(h), low(l), close(c), volume(v), timestamp(t) {}
+};
+
+} // namespace workbench
+} // namespace sep


### PR DESCRIPTION
## Summary
- move common financial structs to `src/common/financial_data_types.h`
- update headers to use the new file
- wire `ConfigManager` in `service_connector`
- add missing workbench includes for engine tab and main

## Testing
- `./build.sh` *(fails: cd /sep: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688464036c8c832a82750056a6792e2b