### PR TITLE
Implement backtesting panel

### DIFF
--- a/scripts/financial_backtest.py
+++ b/scripts/financial_backtest.py
@@ -7,11 +7,16 @@ def calculate_gauge(metrics_df):
     """
     Calculates the predictive gauge from the primary metrics.
     """
-    # Normalize metrics (example: using a rolling Z-score)
-    # This is a placeholder; a more robust normalization will be implemented.
-    metrics_df['coherence_norm'] = (metrics_df['coherence'] - metrics_df['coherence'].rolling(20).mean()) / metrics_df['coherence'].rolling(20).std()
-    metrics_df['stability_norm'] = (metrics_df['stability'] - metrics_df['stability'].rolling(20).mean()) / metrics_df['stability'].rolling(20).std()
-    metrics_df['entropy_norm'] = (metrics_df['entropy'] - metrics_df['entropy'].rolling(20).mean()) / metrics_df['entropy'].rolling(20).std()
+    # Normalize metrics using standard Z-score
+    metrics_df['coherence_norm'] = (
+        metrics_df['coherence'] - metrics_df['coherence'].mean()
+    ) / metrics_df['coherence'].std(ddof=0)
+    metrics_df['stability_norm'] = (
+        metrics_df['stability'] - metrics_df['stability'].mean()
+    ) / metrics_df['stability'].std(ddof=0)
+    metrics_df['entropy_norm'] = (
+        metrics_df['entropy'] - metrics_df['entropy'].mean()
+    ) / metrics_df['entropy'].std(ddof=0)
 
     # Fill NaNs that result from rolling calculations
     metrics_df.fillna(0, inplace=True)
@@ -186,9 +191,16 @@ def main():
         return
 
     metrics_df = pd.DataFrame(metrics_data)
-    # This will need to be aligned with the actual output of the engine
-    # For now, creating a placeholder date range
-    metrics_df['date'] = pd.to_datetime(pd.date_range(start='2021-01-01', periods=len(metrics_df), freq='D'))
+
+    # Use actual timestamps if provided, fall back to synthetic range
+    if 'timestamp' in metrics_df.columns:
+        metrics_df['date'] = pd.to_datetime(metrics_df['timestamp'])
+    elif 'time' in metrics_df.columns:
+        metrics_df['date'] = pd.to_datetime(metrics_df['time'])
+    else:
+        metrics_df['date'] = pd.to_datetime(
+            pd.date_range(start='2021-01-01', periods=len(metrics_df), freq='D')
+        )
 
     # --- Synthetic Market Data Generation ---
     # Create a synthetic price series based on the metrics

--- a/src/apps/workbench/tabs/backend_tab_controller.cpp
+++ b/src/apps/workbench/tabs/backend_tab_controller.cpp
@@ -32,6 +32,7 @@ void BackendTabController::render() {
     renderDataSourceSelector();
     ImGui::Separator();
     renderBacktesterPanel();
+    renderBacktestingSuite();
     renderOrderManagementPanel();
     renderTradeHistoryPanel();
 
@@ -198,9 +199,11 @@ void BackendTabController::renderBacktesterPanel() {
     ImGui::Text("False Positive Rate: %.2f", validation_result_.false_positive_rate);
     ImGui::PopID();
     ImGui::End();
+}
 
-    ImGui::Begin("Backtester");
-    ImGui::PushID("Backtester");
+void BackendTabController::renderBacktestingSuite() {
+    ImGui::Begin("BacktestingSuite");
+    ImGui::PushID("BacktestingSuite");
     ImGui::InputText("Dataset", backtest_file_buffer_, sizeof(backtest_file_buffer_));
     if (ImGui::Button("Run Backtest")) {
         data_loader_->load_data(backtest_file_buffer_);
@@ -247,6 +250,7 @@ void BackendTabController::renderBacktesterPanel() {
                          static_cast<int>(equity_curve_.size()));
     }
 
+    ImGui::PopID();
     ImGui::End();
 }
 

--- a/src/apps/workbench/tabs/backend_tab_controller.h
+++ b/src/apps/workbench/tabs/backend_tab_controller.h
@@ -37,6 +37,7 @@ private:
     void renderBacktesterPanel();
     void renderOrderManagementPanel();
     void renderTradeHistoryPanel();
+    void renderBacktestingSuite();
     void updateTradeHistory();
 
     void handleDataLoad();


### PR DESCRIPTION
## Summary
- add BacktestingSuite UI panel for running backtests
- normalize metrics with real Z-score and use timestamps when available

## Testing
- `./build.sh` *(fails: docker command not found)*
- `pytest -q` *(fails: FileNotFoundError and missing fixtures)*

------
https://chatgpt.com/codex/tasks/task_e_68846699c938832aaf2f58200947bcf9