### PR TITLE
Implement runtime signal threshold config

### DIFF
--- a/src/apps/workbench/config.cpp
+++ b/src/apps/workbench/config.cpp
@@ -33,6 +33,15 @@ namespace sep
                            engine.value("metrics_enabled", false),
                            engine.value("log_level", std::string{"info"}),
                            engine.value("patterns_file", std::string{"forex/final_symmetry.json"})};
+                if (engine.contains("signal_thresholds"))
+                {
+                    auto& th = engine["signal_thresholds"];
+                    signal_thresholds_.buy_min_coherence = th.value("buy_min_coherence", 0.7f);
+                    signal_thresholds_.buy_min_stability = th.value("buy_min_stability", 0.6f);
+                    signal_thresholds_.buy_max_entropy = th.value("buy_max_entropy", 0.3f);
+                    signal_thresholds_.sell_max_stability = th.value("sell_max_stability", 0.3f);
+                    signal_thresholds_.sell_min_entropy = th.value("sell_min_entropy", 0.7f);
+                }
 
                 auto& genesis = json["demos"]["genesis_pattern"];
                 auto& initial = genesis["initial_pattern"];
@@ -259,7 +268,13 @@ namespace sep
                 json["engine"] = {{"cuda_enabled", engine_.cuda_enabled},
                                   {"metrics_enabled", engine_.metrics_enabled},
                                   {"log_level", engine_.log_level},
-                                  {"patterns_file", engine_.patterns_file}};
+                                  {"patterns_file", engine_.patterns_file},
+                                  {"signal_thresholds",
+                                   {{"buy_min_coherence", signal_thresholds_.buy_min_coherence},
+                                    {"buy_min_stability", signal_thresholds_.buy_min_stability},
+                                    {"buy_max_entropy", signal_thresholds_.buy_max_entropy},
+                                    {"sell_max_stability", signal_thresholds_.sell_max_stability},
+                                    {"sell_min_entropy", signal_thresholds_.sell_min_entropy}}}};
 
                 json["demos"]["genesis_pattern"] = {
                     {"initial_pattern",

--- a/src/apps/workbench/config.hpp
+++ b/src/apps/workbench/config.hpp
@@ -26,6 +26,14 @@ namespace sep
             bool metrics_enabled;
             std::string log_level;
             std::string patterns_file;
+            struct SignalThresholds
+            {
+                float buy_min_coherence{0.7f};
+                float buy_min_stability{0.6f};
+                float buy_max_entropy{0.3f};
+                float sell_max_stability{0.3f};
+                float sell_min_entropy{0.7f};
+            } signal_thresholds;
         };
 
         struct GenesisPatternConfig
@@ -210,6 +218,8 @@ namespace sep
             const DigitalPhysicsConfig& digital_physics() const { return digital_physics_; }
             const CosmoConfig& cosmo() const { return cosmo_; }
             const OandaConfig& oanda() const { return oanda_; }
+            const EngineConfig::SignalThresholds& signal_thresholds() const { return signal_thresholds_; }
+            void set_signal_thresholds(const EngineConfig::SignalThresholds& th) { signal_thresholds_ = th; }
 
         private:
             Config() = default;
@@ -229,6 +239,7 @@ namespace sep
             DigitalPhysicsConfig digital_physics_{};
             CosmoConfig cosmo_{};
             OandaConfig oanda_{};
+            EngineConfig::SignalThresholds signal_thresholds_{};
         };
 
     }  // namespace workbench

--- a/src/apps/workbench/config.json
+++ b/src/apps/workbench/config.json
@@ -10,7 +10,14 @@
     "cuda_enabled": true,
     "metrics_enabled": true,
     "log_level": "info",
-    "patterns_file": "forex/final_symmetry.json"
+    "patterns_file": "forex/final_symmetry.json",
+    "signal_thresholds": {
+      "buy_min_coherence": 0.7,
+      "buy_min_stability": 0.6,
+      "buy_max_entropy": 0.3,
+      "sell_max_stability": 0.3,
+      "sell_min_entropy": 0.7
+    }
   },
   "demos": {
     "genesis_pattern": {

--- a/src/apps/workbench/tabs/engine_tab_controller.cpp
+++ b/src/apps/workbench/tabs/engine_tab_controller.cpp
@@ -301,6 +301,8 @@ void EngineTabController::renderCorrelationPanel() {
             std::map<std::string, workbench::CorrelationMetrics> data{{selected_timeframe, correlation_metrics}};
             bool csv_ok = parser.exportCorrelationCSV(path_str, data);
             bool json_ok = parser.exportCorrelationJSON(path_str + ".json", data);
+            auto history = multi_timeframe_analyzer_->getCorrelationHistory(selected_timeframe);
+            parser.exportCorrelationForBacktester(path_str + ".bt.csv", history);
             if (!csv_ok || !json_ok) {
                 std::cerr << "[EngineTabController] Failed to export correlation metrics" << std::endl;
                 correlation_export_status_ = "Export failed";

--- a/src/apps/workbench/tabs/signals_tab_controller.cpp
+++ b/src/apps/workbench/tabs/signals_tab_controller.cpp
@@ -1,6 +1,7 @@
 #include "signals_tab_controller.h"
 #include "apps/workbench/core/workbench_core.hpp"
 #include "quantum/pattern_metric_engine.h"
+#include "apps/workbench/config.hpp"
 #include "core/metrics_monitor.h"
 #include <algorithm>
 #include <numeric>
@@ -31,6 +32,12 @@ SignalsTabController::~SignalsTabController() {
 
 bool SignalsTabController::initialize() {
     std::cout << "[SignalsTabController] Initializing..." << std::endl;
+    const auto& th = Config::getInstance().signal_thresholds();
+    buy_min_coherence_ = th.buy_min_coherence;
+    buy_min_stability_ = th.buy_min_stability;
+    buy_max_entropy_ = th.buy_max_entropy;
+    sell_max_stability_ = th.sell_max_stability;
+    sell_min_entropy_ = th.sell_min_entropy;
     return true;
 }
 
@@ -56,6 +63,8 @@ void SignalsTabController::renderThresholdControlPanel() {
                 thresholds.sell_max_stability = sell_max_stability_;
                 thresholds.sell_min_entropy = sell_min_entropy_;
                 pme->setSignalThresholds(thresholds);
+                Config::getInstance().set_signal_thresholds(thresholds);
+                Config::getInstance().save("src/apps/workbench/config.json");
             }
         }
     }

--- a/src/apps/workbench/tabs/signals_tab_controller.h
+++ b/src/apps/workbench/tabs/signals_tab_controller.h
@@ -10,6 +10,7 @@
 #include "imgui.h"
 #include "connectors/oanda_connector.h"
 #include "signal_generator/quantum_signal_generator.h"
+#include "apps/workbench/config.hpp"
 
 namespace sep::workbench {
 

--- a/src/engine/data_parser.cpp
+++ b/src/engine/data_parser.cpp
@@ -665,4 +665,24 @@ bool DataParser::exportCorrelationHistoryCSV(const std::string& path,
     return true;
 }
 
+bool DataParser::exportCorrelationForBacktester(const std::string& path,
+                                                const std::deque<workbench::CorrelationMetrics>& metrics) const {
+    std::ofstream file(path);
+    if (!file.is_open()) {
+        return false;
+    }
+    file << "index,coh_pearson,coh_spearman,stab_pearson,stab_spearman,entropy_pearson,entropy_spearman\n";
+    size_t idx = 0;
+    for (const auto& m : metrics) {
+        file << idx++ << ','
+             << m.coherence_pearson << ','
+             << m.coherence_spearman << ','
+             << m.stability_pearson << ','
+             << m.stability_spearman << ','
+             << m.entropy_pearson << ','
+             << m.entropy_spearman << "\n";
+    }
+    return true;
+}
+
 } // namespace sep

--- a/src/engine/data_parser.h
+++ b/src/engine/data_parser.h
@@ -79,6 +79,8 @@ public:
                                const std::map<std::string, workbench::CorrelationMetrics>& data) const;
     bool exportCorrelationHistoryCSV(const std::string& path,
                                      const std::map<std::string, std::deque<workbench::CorrelationMetrics>>& history) const;
+    bool exportCorrelationForBacktester(const std::string& path,
+                                        const std::deque<workbench::CorrelationMetrics>& metrics) const;
 
 private:
     // Format detection


### PR DESCRIPTION
## Summary
- allow configuring signal thresholds in workbench config
- load/save thresholds from `SignalsTabController`
- expose correlation export for backtester

## Testing
- `./build.sh` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688466944ccc832a8e487df5a7059032