### PR TITLE
Add offline candle dataset support

### DIFF
--- a/src/apps/data_downloader.cpp
+++ b/src/apps/data_downloader.cpp
@@ -16,7 +16,7 @@ int main() {
     std::cout << "OandaConnector initialized successfully." << std::endl;
 
     // Setup 48-hour sample data for EUR_USD
-    connector.setupSampleData("EUR_USD", "M1", "Testing/OANDA/eurusd_48h.json");
+    connector.setupSampleData("EUR_USD", "M1", "eur_usd_m1_48h.json");
 
     if (connector.hasError()) {
         std::cerr << "Error setting up sample data: " << connector.getLastError() << std::endl;

--- a/src/apps/workbench/backtester/data/data_loader.cpp
+++ b/src/apps/workbench/backtester/data/data_loader.cpp
@@ -12,28 +12,12 @@ DataLoader::DataLoader() {}
 DataLoader::~DataLoader() {}
 
 void DataLoader::loadData(const std::string& filepath) {
-    m_candleData = JsonDataParser::parse(filepath);
+    load_data(filepath);
 }
 
-const std::vector<sep::workbench::CandleData>& DataLoader::getCandleData() const {
-    return m_candleData;
-}
-
-void DataLoader::load_48h_sample() {
-    namespace fs = std::filesystem;
-    const std::string output = "Testing/OANDA/eurusd_48h.json";
-
-    sep::connectors::OandaConnector connector("", "", true);
-    if (!connector.initialize()) {
-        return;
-    }
-
-    auto candles = connector.getHistoricalData("EUR_USD", "M1", "", "", 48 * 60);
-    connector.shutdown();
-
-    std::vector<sep::CandleData> export_candles;
-    export_candles.reserve(candles.size());
-
+void DataLoader::load_data(const std::string& filepath) {
+    sep::DataParser parser;
+    auto candles = parser.parseQuantJSON(filepath);
     m_candleData.clear();
     m_candleData.reserve(candles.size());
 
@@ -44,18 +28,24 @@ void DataLoader::load_48h_sample() {
         auto tp = std::chrono::system_clock::from_time_t(std::mktime(&tm));
         m_candleData.emplace_back(c.open, c.high, c.low, c.close,
                                   static_cast<int>(c.volume), tp);
+    }
+}
 
-        sep::CandleData cd;
-        cd.time = c.time;
-        cd.volume = static_cast<uint64_t>(c.volume);
-        cd.open = static_cast<float>(c.open);
-        cd.high = static_cast<float>(c.high);
-        cd.low = static_cast<float>(c.low);
-        cd.close = static_cast<float>(c.close);
-        export_candles.push_back(cd);
+const std::vector<sep::workbench::CandleData>& DataLoader::getCandleData() const {
+    return m_candleData;
+}
+
+void DataLoader::load_48h_sample() {
+    namespace fs = std::filesystem;
+    const std::string output = "eur_usd_m1_48h.json";
+
+    if (!fs::exists(output)) {
+        sep::connectors::OandaConnector connector("", "", true);
+        if (connector.initialize()) {
+            connector.saveEURUSDM1_48h(output);
+            connector.shutdown();
+        }
     }
 
-    fs::create_directories("Testing/OANDA");
-    sep::DataParser parser;
-    parser.saveValidatedCandlesJSON(export_candles, output);
+    load_data(output);
 }

--- a/src/apps/workbench/backtester/data/data_loader.h
+++ b/src/apps/workbench/backtester/data/data_loader.h
@@ -11,6 +11,7 @@ public:
     ~DataLoader();
 
     void loadData(const std::string& filepath);
+    void load_data(const std::string& filepath);
     void load_48h_sample();
 
     const std::vector<sep::workbench::CandleData>& getCandleData() const;

--- a/src/apps/workbench/backtester/data/data_loader_test.cpp
+++ b/src/apps/workbench/backtester/data/data_loader_test.cpp
@@ -3,7 +3,7 @@
 
 int main() {
     DataLoader dataLoader;
-    dataLoader.loadData("Testing/OANDA/eurusd_48h.json");
+    dataLoader.loadData("eur_usd_m1_48h.json");
 
     const auto& candleData = dataLoader.getCandleData();
 

--- a/src/apps/workbench/backtester/ui/backtester_tab_controller.h
+++ b/src/apps/workbench/backtester/ui/backtester_tab_controller.h
@@ -13,5 +13,5 @@ public:
 private:
     std::unique_ptr<BacktesterEngine> engine_;
     sep::workbench::backtester::BacktestResult result_{};
-    char dataset_path_[512] = "Testing/OANDA/eurusd_48h.json";
+    char dataset_path_[512] = "eur_usd_m1_48h.json";
 };

--- a/src/apps/workbench/core/service_connector.cpp
+++ b/src/apps/workbench/core/service_connector.cpp
@@ -60,24 +60,25 @@ ServiceConnector::ServiceConnector(const ConnectionConfig& config)
         std::cout << "[ServiceConnector] OANDA connector configured for PRACTICE server" << std::endl;
         std::cout << "[ServiceConnector] API Key length: " << api_key.length() << std::endl;
         std::cout << "[ServiceConnector] Account ID: " << account_id << std::endl;
+        const std::string dataset = "eur_usd_m1_48h.json";
         if (oanda_connector_->initialize()) {
-            if (oanda_connector_->fetchHistoricalData("EUR_USD", "Testing/OANDA/eurusd_48h.json")) {
-                loadInitialData("Testing/OANDA/eurusd_48h.json");
+            if (oanda_connector_->saveEURUSDM1_48h(dataset)) {
+                loadInitialData(dataset);
             } else {
                 DataLoader loader;
                 loader.load_48h_sample();
-                loadInitialData("Testing/OANDA/eurusd_48h.json");
+                loadInitialData(dataset);
             }
         } else {
             DataLoader loader;
             loader.load_48h_sample();
-            loadInitialData("Testing/OANDA/eurusd_48h.json");
+            loadInitialData(dataset);
         }
     } else {
         std::cout << "[ServiceConnector] ERROR: OANDA credentials not provided" << std::endl;
         DataLoader loader;
         loader.load_48h_sample();
-        loadInitialData("Testing/OANDA/eurusd_48h.json");
+        loadInitialData("eur_usd_m1_48h.json");
     }
 
     std::cout << "[ServiceConnector] Initialized with config: "

--- a/src/apps/workbench/tabs/backend_tab_controller.cpp
+++ b/src/apps/workbench/tabs/backend_tab_controller.cpp
@@ -219,7 +219,7 @@ void BackendTabController::renderBacktesterPanel() {
     }
     ImGui::SameLine();
     if (ImGui::Button("Run 48h Sample")) {
-        strncpy(backtest_file_buffer_, "Testing/OANDA/eurusd_48h.json", sizeof(backtest_file_buffer_) - 1);
+        strncpy(backtest_file_buffer_, "eur_usd_m1_48h.json", sizeof(backtest_file_buffer_) - 1);
         backtest_file_buffer_[sizeof(backtest_file_buffer_) - 1] = '\0';
         data_loader_->load_data(backtest_file_buffer_);
         backtester_->run(pattern_engine_.get(), data_loader_.get());

--- a/src/apps/workbench/tabs/backend_tab_controller.h
+++ b/src/apps/workbench/tabs/backend_tab_controller.h
@@ -52,8 +52,8 @@ private:
     FileDialog file_dialog_;
 
     // UI State
-    char file_path_buffer_[512] = "Testing/OANDA/eurusd_48h.json";
-    char backtest_file_buffer_[512] = "Testing/OANDA/eurusd_48h.json";
+    char file_path_buffer_[512] = "eur_usd_m1_48h.json";
+    char backtest_file_buffer_[512] = "eur_usd_m1_48h.json";
     int data_source_type_{0};  // 0=File, 1=Live Stream, 2=Generated
     char export_path_buffer_[512] = "metrics_export.json";
     float risk_percentage_ = 2.0f;

--- a/src/connectors/oanda_connector.cpp
+++ b/src/connectors/oanda_connector.cpp
@@ -758,6 +758,11 @@ bool OandaConnector::fetchHistoricalData(const std::string& instrument, const st
     return true;
 }
 
+bool OandaConnector::saveEURUSDM1_48h(const std::string& output_file)
+{
+    return fetchHistoricalData("EUR_USD", output_file);
+}
+
 // --- Data Validation Implementations ---
 
 int64_t OandaConnector::parseTimestamp(const std::string& time_str)

--- a/src/connectors/oanda_connector.h
+++ b/src/connectors/oanda_connector.h
@@ -101,6 +101,7 @@ public:
     // Sample Data
     void setupSampleData(const std::string& instrument, const std::string& granularity, const std::string& output_file);
     bool fetchHistoricalData(const std::string& instrument, const std::string& output_file);
+    bool saveEURUSDM1_48h(const std::string& output_file = "eur_usd_m1_48h.json");
 
     // Error handling
     std::string getLastError() const { return last_error_; }

--- a/src/engine/data_parser.cpp
+++ b/src/engine/data_parser.cpp
@@ -402,13 +402,67 @@ std::vector<CandleData> DataParser::parseQuantJSON(const std::string& path)
         nlohmann::json j;
         file >> j;
         
-        if (!j.contains("candles") || !j["candles"].is_array()) {
-            std::cerr << "Error: JSON file does not contain 'candles' array" << std::endl;
-            return candles;
-        }
-        
-        int index = 0;
-        for (const auto& candle_json : j["candles"]) {
+        if (j.is_array()) {
+            int index = 0;
+            for (const auto& candle_json : j) {
+                CandleData candle;
+
+                bool valid = true;
+
+                if (candle_json.contains("time") && candle_json["time"].is_string()) {
+                    candle.time = candle_json["time"].get<std::string>();
+                } else {
+                    std::cerr << "[DataParser] Missing time at index " << index << "\n";
+                    valid = false;
+                }
+
+                if (candle_json.contains("volume") && candle_json["volume"].is_number()) {
+                    candle.volume = candle_json["volume"].get<uint64_t>();
+                } else {
+                    candle.volume = 0;
+                }
+
+                if (candle_json.contains("open") && candle_json["open"].is_number())
+                    candle.open = candle_json["open"].get<float>();
+                else
+                    valid = false;
+                if (candle_json.contains("high") && candle_json["high"].is_number())
+                    candle.high = candle_json["high"].get<float>();
+                else
+                    valid = false;
+                if (candle_json.contains("low") && candle_json["low"].is_number())
+                    candle.low = candle_json["low"].get<float>();
+                else
+                    valid = false;
+                if (candle_json.contains("close") && candle_json["close"].is_number())
+                    candle.close = candle_json["close"].get<float>();
+                else
+                    valid = false;
+
+                if (!candles.empty()) {
+                    auto prev_ts = parseTimestamp(candles.back().time);
+                    auto cur_ts = parseTimestamp(candle.time);
+                    if (cur_ts <= prev_ts) {
+                        std::cerr << "[DataParser] Non-increasing timestamp at index " << index << "\n";
+                        valid = false;
+                    } else if (cur_ts - prev_ts != 60000) {
+                        std::cerr << "[DataParser] Missing candle between " << candles.back().time
+                                  << " and " << candle.time << "\n";
+                    }
+                }
+
+                if (valid)
+                    candles.push_back(candle);
+                index++;
+            }
+        } else {
+            if (!j.contains("candles") || !j["candles"].is_array()) {
+                std::cerr << "Error: JSON file does not contain 'candles' array" << std::endl;
+                return candles;
+            }
+
+            int index = 0;
+            for (const auto& candle_json : j["candles"]) {
             CandleData candle;
             
             // Parse time
@@ -457,9 +511,10 @@ std::vector<CandleData> DataParser::parseQuantJSON(const std::string& path)
                 }
             }
 
-            if (valid_prices)
-                candles.push_back(candle);
-            index++;
+                if (valid_prices)
+                    candles.push_back(candle);
+                index++;
+            }
         }
         
     } catch (const std::exception& e) {


### PR DESCRIPTION
## Summary
- extend OandaConnector with helper to fetch EUR/USD M1 sample
- enhance DataParser to read raw array-form candle JSON
- implement `DataLoader::load_data` and update sample logic
- hook dataset into ServiceConnector fallback path
- update various UI/default paths to `eur_usd_m1_48h.json`

## Testing
- `./build.sh` *(fails: /sep directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_6884668c9e1c832a8942758db9155119