### PR TITLE
Update Oanda connector namespaces

### DIFF
--- a/src/apps/workbench/tabs/signals_tab_controller.h
+++ b/src/apps/workbench/tabs/signals_tab_controller.h
@@ -11,6 +11,7 @@
 #include "connectors/oanda_connector.h"
 #include "signal_generator/quantum_signal_generator.h"
 #include "apps/workbench/config.hpp"
+#include "apps/workbench/core/common_structs.h"
 
 namespace sep::workbench {
 

--- a/src/connectors/oanda_connector.cpp
+++ b/src/connectors/oanda_connector.cpp
@@ -8,6 +8,7 @@
 #include <sstream>
 #include <thread>
 #include "engine/data_parser.h"
+#include "apps/workbench/core/ui_layout_manager.h"
 #include <mutex>
 
 namespace sep {
@@ -559,7 +560,7 @@ nlohmann::json OandaConnector::placeOrder(const nlohmann::json& order_details) {
                 info.status = OrderStatus::PENDING;
                 pending_orders_.push_back(info);
                 if (order_callback_) order_callback_(info);
-                workbench::globalEventBus().publish(workbench::OrderUpdateEvent{info});
+                sep::workbench::globalEventBus().publish(sep::workbench::OrderUpdateEvent{info});
             }
             if (json_resp.contains("orderFillTransaction")) {
                 const auto& tx = json_resp["orderFillTransaction"];


### PR DESCRIPTION
## Summary
- include UI layout manager in Oanda connector
- switch event bus calls to fully-qualified `sep::workbench` namespace
- include workbench common structures header for signals tab controller

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68846bc5b904832abd4c817a6211af02