### PR TITLE
Fix signal generation and update OANDA config

### DIFF
--- a/src/apps/workbench/core/service_connector.cpp
+++ b/src/apps/workbench/core/service_connector.cpp
@@ -7,6 +7,7 @@
 #include "config.h"
 #include "quantum/pattern_metric_engine.h"
 #include "ui_layout_manager.h"
+#include "apps/workbench/backtester/data/data_loader.h"
 
 #include <iostream>
 #include <thread>
@@ -35,7 +36,7 @@ ServiceConnector::ServiceConnector() : ServiceConnector(ConnectionConfig{}) {}
 
 ServiceConnector::ServiceConnector(const ConnectionConfig& config)
     : config_(config) {
-    auto& cfg = sep::config::ConfigManager::getInstance().oanda();
+    auto& cfg = sep::workbench::Config::getInstance().oanda();
     std::string api_key = cfg.demo_api_key.empty() ? cfg.api_key : cfg.demo_api_key;
     std::string account_id = cfg.demo_account_id.empty() ? cfg.account_id : cfg.demo_account_id;
     if (api_key.empty() || account_id.empty()) {
@@ -65,18 +66,18 @@ ServiceConnector::ServiceConnector(const ConnectionConfig& config)
             if (oanda_connector_->saveEURUSDM1_48h(dataset)) {
                 loadInitialData(dataset);
             } else {
-                DataLoader loader;
+                backtester::DataLoader loader;
                 loader.load_48h_sample();
                 loadInitialData(dataset);
             }
         } else {
-            DataLoader loader;
+            backtester::DataLoader loader;
             loader.load_48h_sample();
             loadInitialData(dataset);
         }
     } else {
         std::cout << "[ServiceConnector] ERROR: OANDA credentials not provided" << std::endl;
-        DataLoader loader;
+        backtester::DataLoader loader;
         loader.load_48h_sample();
         loadInitialData("eur_usd_m1_48h.json");
     }

--- a/src/quantum/pattern_metric_engine.cpp
+++ b/src/quantum/pattern_metric_engine.cpp
@@ -413,24 +413,21 @@ void PatternMetricEngine::generateSignals() {
     current_signals_.clear();
     for (const auto& m : current_metrics_) {
         SignalType type = evaluateSignal(m);
+        Signal s;
+        s.type = type;
+        s.pattern_id = m.pattern_id;
 
         if (type != SignalType::HOLD) {
-            Signal s;
-            s.type = type;
             if (type == SignalType::BUY) {
                 s.confidence = m.coherence * m.stability;
             } else {
                 s.confidence = (1.0f - m.stability) * m.entropy;
             }
-            s.pattern_id = m.pattern_id;
             current_signals_.push_back(s);
             auto now = std::chrono::system_clock::now();
             sep::logging::logPatternDetected(s.pattern_id, now);
             sep::logging::logSignalDetected(s.pattern_id, s.type, now);
         }
-        s.pattern_id = m.pattern_id;
-        current_signals_.push_back(s);
-        sep::logging::logSignalDetected(s.pattern_id, s.type, std::chrono::system_clock::now());
     }
 }
 


### PR DESCRIPTION
## Summary
- fix logic in PatternMetricEngine::generateSignals to avoid duplicate pushes
- include backtester data loader and use workbench Config in service connector

## Testing
- `./build.sh` *(fails: cd: /sep: No such file or directory)*
- `cmake ..` *(fails: CUDA_HOME environment variable not set)*

------
https://chatgpt.com/codex/tasks/task_e_68846bd6c338832ab433c26fdede76d3