### PR TITLE
Integrate ImPlot library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,13 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(imgui)
 
+FetchContent_Declare(
+  implot
+  GIT_REPOSITORY https://github.com/epezent/implot.git
+  GIT_TAG v0.16
+)
+FetchContent_MakeAvailable(implot)
+
 # Create imgui library manually since imgui doesn't provide CMakeLists.txt
 set(IMGUI_SOURCES
     ${imgui_SOURCE_DIR}/imgui.cpp
@@ -97,6 +104,20 @@ target_include_directories(imgui PUBLIC
     ${imgui_SOURCE_DIR}
     ${imgui_SOURCE_DIR}/backends
 )
+
+set(IMPLOT_SOURCES
+    ${implot_SOURCE_DIR}/implot.cpp
+    ${implot_SOURCE_DIR}/implot_items.cpp
+    ${implot_SOURCE_DIR}/implot_demo.cpp
+)
+
+add_library(implot STATIC ${IMPLOT_SOURCES})
+
+target_include_directories(implot PUBLIC
+    ${implot_SOURCE_DIR}
+)
+
+target_link_libraries(implot PUBLIC imgui)
 
 # Find and link required dependencies
 find_package(PkgConfig REQUIRED)

--- a/src/apps/workbench/CMakeLists.txt
+++ b/src/apps/workbench/CMakeLists.txt
@@ -24,6 +24,7 @@ target_include_directories(sep_workbench_lib PUBLIC
     ${CMAKE_SOURCE_DIR}/src/connectors
     ${CMAKE_SOURCE_DIR}/src/glad
     ${imgui_SOURCE_DIR}
+    ${implot_SOURCE_DIR}
     ${imgui_SOURCE_DIR}/backends
 )
 
@@ -34,6 +35,7 @@ target_link_libraries(sep_workbench_lib PUBLIC
     sep_memory
     sep_connectors
     imgui
+    implot
     glad
     OpenGL::GL
     glfw
@@ -49,6 +51,7 @@ target_link_libraries(sep_workbench PRIVATE
     sep_workbench_lib
     sep_backtester
     imgui
+    implot
     sep_audio
     sep_quantum
     sep_memory  

--- a/src/apps/workbench/tabs/signals_tab_controller.cpp
+++ b/src/apps/workbench/tabs/signals_tab_controller.cpp
@@ -3,6 +3,7 @@
 #include "quantum/pattern_metric_engine.h"
 #include "apps/workbench/config.hpp"
 #include "core/metrics_monitor.h"
+
 #include <implot.h>
 #include <algorithm>
 #include <numeric>


### PR DESCRIPTION
## Summary
- include `implot.h` in `signals_tab_controller.cpp`
- fetch and build ImPlot in the root CMake build
- link the new ImPlot library in workbench builds

## Testing
- `cmake -B _build -S .` *(fails: CUDA_HOME environment variable not set)*

------
https://chatgpt.com/codex/tasks/task_e_68846be2db28832a80a8ea4c0b8a123c