### PR TITLE
Add automatic 48h OANDA sample loading

### DIFF
--- a/src/apps/workbench/backtester/data/data_loader.cpp
+++ b/src/apps/workbench/backtester/data/data_loader.cpp
@@ -1,9 +1,25 @@
 #include "data_loader.h"
 #include "data/json_data_parser.h"
+#include <filesystem>
+
 
 namespace sep {
 namespace workbench {
 namespace backtester {
+
+std::string DataLoader::load_48h_sample()
+{
+    const std::string sample_path = "Testing/OANDA/sample_48h.json";
+    if (std::filesystem::exists(sample_path))
+    {
+        load_data(sample_path);
+        return sample_path;
+    }
+
+    const std::string fallback = "eur_usd_m1_48h.json";
+    load_data(fallback);
+    return fallback;
+}
 
 void DataLoader::load_data(const std::string& file_path)
 {

--- a/src/apps/workbench/backtester/data/data_loader.h
+++ b/src/apps/workbench/backtester/data/data_loader.h
@@ -14,6 +14,16 @@ namespace sep
             class DataLoader
             {
             public:
+                /**
+                 * @brief Load the default 48h EUR/USD sample if available.
+                 *
+                 * This checks for Testing/OANDA/sample_48h.json and falls back
+                 * to eur_usd_m1_48h.json when the file is missing.
+                 *
+                 * @return The path of the dataset that was loaded.
+                 */
+                std::string load_48h_sample();
+
                 void load_data(const std::string& file_path);
                 const std::vector<common::CandleData>& get_data() const { return data_; }
 

--- a/src/apps/workbench/core/service_connector.cpp
+++ b/src/apps/workbench/core/service_connector.cpp
@@ -8,6 +8,7 @@
 #include "quantum/pattern_metric_engine.h"
 #include "ui_layout_manager.h"
 #include "apps/workbench/backtester/data/data_loader.h"
+#include <filesystem>
 #include "apps/workbench/backtester/backtester.h"
 
 #include <iostream>
@@ -62,25 +63,36 @@ ServiceConnector::ServiceConnector(const ConnectionConfig& config)
         std::cout << "[ServiceConnector] OANDA connector configured for PRACTICE server" << std::endl;
         std::cout << "[ServiceConnector] API Key length: " << api_key.length() << std::endl;
         std::cout << "[ServiceConnector] Account ID: " << account_id << std::endl;
-        const std::string dataset = "eur_usd_m1_48h.json";
+        const std::string dataset = "Testing/OANDA/sample_48h.json";
+        bool dataset_exists = std::filesystem::exists(dataset);
+        const char* skip_env = std::getenv("SEP_SKIP_FETCH");
+        bool skip_fetch = skip_env && dataset_exists;
+
         if (oanda_connector_->initialize()) {
-            if (oanda_connector_->saveEURUSDM1_48h(dataset)) {
+            if (!skip_fetch) {
+                std::filesystem::create_directories("Testing/OANDA");
+                if (oanda_connector_->saveEURUSDM1_48h(dataset)) {
+                    dataset_exists = true;
+                }
+            }
+
+            if (dataset_exists) {
                 loadInitialData(dataset);
             } else {
                 backtester::DataLoader loader;
-                loader.load_48h_sample();
-                loadInitialData(dataset);
+                const std::string loaded = loader.load_48h_sample();
+                loadInitialData(loaded);
             }
         } else {
             backtester::DataLoader loader;
-            loader.load_48h_sample();
-            loadInitialData(dataset);
+            const std::string loaded = loader.load_48h_sample();
+            loadInitialData(loaded);
         }
     } else {
         std::cout << "[ServiceConnector] ERROR: OANDA credentials not provided" << std::endl;
         backtester::DataLoader loader;
-        loader.load_48h_sample();
-        loadInitialData("eur_usd_m1_48h.json");
+        const std::string loaded = loader.load_48h_sample();
+        loadInitialData(loaded);
     }
 
     std::cout << "[ServiceConnector] Initialized with config: "

--- a/src/apps/workbench/core/workbench_main.cpp
+++ b/src/apps/workbench/core/workbench_main.cpp
@@ -29,6 +29,7 @@ int main(int argc, char* argv[]) {
     
     // Parse command line arguments for OANDA credentials
     std::string api_key, account_id;
+    bool skip_fetch = false;
     for (int i = 1; i < argc; i++) {
         if (std::string(argv[i]) == "--api-key" && i + 1 < argc) {
             api_key = argv[i + 1];
@@ -36,6 +37,8 @@ int main(int argc, char* argv[]) {
         } else if (std::string(argv[i]) == "--account-id" && i + 1 < argc) {
             account_id = argv[i + 1];
             i++; // Skip the next argument
+        } else if (std::string(argv[i]) == "--skip-fetch") {
+            skip_fetch = true;
         }
     }
     
@@ -47,6 +50,9 @@ int main(int argc, char* argv[]) {
     if (!account_id.empty()) {
         setenv("OANDA_ACCOUNT_ID", account_id.c_str(), 1);
         std::cout << "[Main] OANDA Account ID set: " << account_id << std::endl;
+    }
+    if (skip_fetch) {
+        setenv("SEP_SKIP_FETCH", "1", 1);
     }
 
     // Verify SEP engine availability before launching


### PR DESCRIPTION
## Summary
- auto-save EURUSD 48h dataset to `Testing/OANDA/sample_48h.json`
- check for sample dataset before fetching again using env/CLI flag
- expose `DataLoader::load_48h_sample` helper
- allow `--skip-fetch` option in workbench

## Testing
- `./build.sh` *(fails: cd /sep: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68847e82db58832a9d2961fe6e0733c5