### PR TITLE
Refactor CandleData references

### DIFF
--- a/src/connectors/CMakeLists.txt
+++ b/src/connectors/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(sep_connectors STATIC
 target_include_directories(sep_connectors PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/src/common
 PRIVATE
     ${CURL_INCLUDE_DIRS}
 )

--- a/src/connectors/oanda_connector.cpp
+++ b/src/connectors/oanda_connector.cpp
@@ -8,7 +8,10 @@
 #include <sstream>
 #include <thread>
 #include "engine/data_parser.h"
+#include "common/financial_data_types.h"
+#ifdef SEP_ENABLE_WORKBENCH
 #include "apps/workbench/core/ui_layout_manager.h"
+#endif
 #include <mutex>
 
 namespace sep {
@@ -560,7 +563,10 @@ nlohmann::json OandaConnector::placeOrder(const nlohmann::json& order_details) {
                 info.status = OrderStatus::PENDING;
                 pending_orders_.push_back(info);
                 if (order_callback_) order_callback_(info);
+                // publish order update to UI if available
+#ifdef SEP_ENABLE_WORKBENCH
                 sep::workbench::globalEventBus().publish(sep::workbench::OrderUpdateEvent{info});
+#endif
             }
             if (json_resp.contains("orderFillTransaction")) {
                 const auto& tx = json_resp["orderFillTransaction"];
@@ -571,7 +577,10 @@ nlohmann::json OandaConnector::placeOrder(const nlohmann::json& order_details) {
                 info.status = OrderStatus::FILLED;
                 filled_orders_.push_back(info);
                 if (order_callback_) order_callback_(info);
+                // publish order update to UI if available
+#ifdef SEP_ENABLE_WORKBENCH
                 sep::workbench::globalEventBus().publish(sep::workbench::OrderUpdateEvent{info});
+#endif
             }
             refreshOrders();
             return json_resp;
@@ -636,7 +645,10 @@ void OandaConnector::refreshOrders() {
             info.status = OrderStatus::PENDING;
             pending_orders_.push_back(info);
             if (order_callback_) order_callback_(info);
+            // publish order update to UI if available
+#ifdef SEP_ENABLE_WORKBENCH
             sep::workbench::globalEventBus().publish(sep::workbench::OrderUpdateEvent{info});
+#endif
         }
     }
 
@@ -651,7 +663,10 @@ void OandaConnector::refreshOrders() {
             info.status = OrderStatus::FILLED;
             filled_orders_.push_back(info);
             if (order_callback_) order_callback_(info);
+            // publish order update to UI if available
+#ifdef SEP_ENABLE_WORKBENCH
             sep::workbench::globalEventBus().publish(sep::workbench::OrderUpdateEvent{info});
+#endif
         }
     }
 
@@ -666,7 +681,10 @@ void OandaConnector::refreshOrders() {
             info.status = OrderStatus::CANCELED;
             canceled_orders_.push_back(info);
             if (order_callback_) order_callback_(info);
+            // publish order update to UI if available
+#ifdef SEP_ENABLE_WORKBENCH
             sep::workbench::globalEventBus().publish(sep::workbench::OrderUpdateEvent{info});
+#endif
         }
     }
 }
@@ -740,11 +758,11 @@ bool OandaConnector::fetchHistoricalData(const std::string& instrument, const st
         return false;
     }
 
-    std::vector<CandleData> out;
+    std::vector<sep::common::CandleData> out;
     out.reserve(candles.size());
     for (const auto& c : candles)
     {
-        CandleData cd;
+        sep::common::CandleData cd;
         cd.time = c.time;
         cd.open = static_cast<float>(c.open);
         cd.high = static_cast<float>(c.high);

--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -32,6 +32,7 @@ target_sources(sep_engine PRIVATE
 target_include_directories(sep_engine PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/src/common
 )
 
 if(MSVC)

--- a/src/engine/data_parser.cpp
+++ b/src/engine/data_parser.cpp
@@ -6,6 +6,7 @@
 #include "engine/standard_includes.h"
 #include "quantum/types.h"
 #include "types.h"
+#include "common/financial_data_types.h"
 
 namespace sep {
 
@@ -63,11 +64,11 @@ std::vector<quantum::Pattern> DataParser::parseBuffer(const uint8_t* data, size_
             std::string json_str(reinterpret_cast<const char*>(data), size);
             try {
                 nlohmann::json j = nlohmann::json::parse(json_str.c_str());
-                std::vector<CandleData> candles;
+                std::vector<sep::common::CandleData> candles;
 
                 if (j.contains("candles") && j["candles"].is_array()) {
                     for (const auto& candle_json : j["candles"]) {
-                        CandleData candle;
+                        sep::common::CandleData candle;
                         
                         if (candle_json.contains("time") && candle_json["time"].is_string()) {
                             candle.time = candle_json["time"].get<std::string>().c_str();
@@ -388,9 +389,9 @@ DataFormat DataParser::detectFileFormat(const std::string& path) const
     return DataFormat::BINARY;
 }
 
-std::vector<CandleData> DataParser::parseQuantJSON(const std::string& path)
+std::vector<sep::common::CandleData> DataParser::parseQuantJSON(const std::string& path)
 {
-    std::vector<CandleData> candles;
+    std::vector<sep::common::CandleData> candles;
     std::ifstream file(path.c_str());
 
     if (!file.is_open()) {
@@ -405,7 +406,7 @@ std::vector<CandleData> DataParser::parseQuantJSON(const std::string& path)
         if (j.is_array()) {
             int index = 0;
             for (const auto& candle_json : j) {
-                CandleData candle;
+                sep::common::CandleData candle;
 
                 bool valid = true;
 
@@ -463,7 +464,7 @@ std::vector<CandleData> DataParser::parseQuantJSON(const std::string& path)
 
             int index = 0;
             for (const auto& candle_json : j["candles"]) {
-            CandleData candle;
+            sep::common::CandleData candle;
             
             // Parse time
             if (candle_json.contains("time") && candle_json["time"].is_string()) {
@@ -526,7 +527,7 @@ std::vector<CandleData> DataParser::parseQuantJSON(const std::string& path)
 }
 
 std::vector<quantum::Pattern> DataParser::candlesToPatterns(
-    const std::vector<CandleData>& candles)
+    const std::vector<sep::common::CandleData>& candles)
 {
     std::vector<sep::quantum::Pattern> patterns;
 
@@ -567,7 +568,7 @@ std::vector<quantum::Pattern> DataParser::candlesToPatterns(
     return patterns;
 }
 
-void DataParser::writeQuantJSON(const std::vector<CandleData>& candles, const std::string& path) const
+void DataParser::writeQuantJSON(const std::vector<sep::common::CandleData>& candles, const std::string& path) const
 {
     nlohmann::json j;
     j["candles"] = nlohmann::json::array();
@@ -599,7 +600,7 @@ void DataParser::writeQuantJSON(const std::vector<CandleData>& candles, const st
     }
 }
 
-bool DataParser::saveValidatedCandlesJSON(const std::vector<CandleData>& candles,
+bool DataParser::saveValidatedCandlesJSON(const std::vector<sep::common::CandleData>& candles,
                                           const std::string& path) const
 {
     if (candles.empty()) {

--- a/src/engine/data_parser.h
+++ b/src/engine/data_parser.h
@@ -3,6 +3,7 @@
 #include "engine/standard_includes.h"
 #include <map>
 #include <deque>
+#include "common/financial_data_types.h"
 
 
 namespace sep {
@@ -26,16 +27,6 @@ namespace sep {
         struct CorrelationMetrics;
     }
 
-struct CandleData
-    {
-        std::string time;
-        uint64_t volume;
-        float open;
-        float high;
-        float low;
-        float close;
-    };
-
 // Universal data parser for all input sources
 class DataParser {
 public:
@@ -55,18 +46,18 @@ public:
                                                    DataFormat format = DataFormat::AUTO);
 
     // Specific format parsers
-    std::vector<CandleData> parseQuantJSON(const std::string& path);
+    std::vector<sep::common::CandleData> parseQuantJSON(const std::string& path);
         std::vector<quantum::Pattern> parseCSV(const std::string& path);
         std::vector<quantum::Pattern> parseBinary(const uint8_t* data, size_t size);
 
     // Convert raw candle data to SEP patterns
-        std::vector<quantum::Pattern> candlesToPatterns(const std::vector<CandleData>& candles);
+        std::vector<quantum::Pattern> candlesToPatterns(const std::vector<sep::common::CandleData>& candles);
 
     // Utility: write candle data to OANDA-style JSON
-    void writeQuantJSON(const std::vector<CandleData>& candles, const std::string& path) const;
+    void writeQuantJSON(const std::vector<sep::common::CandleData>& candles, const std::string& path) const;
 
     // Save candle data with validation checks (time ordering, field ranges)
-    bool saveValidatedCandlesJSON(const std::vector<CandleData>& candles,
+    bool saveValidatedCandlesJSON(const std::vector<sep::common::CandleData>& candles,
                                   const std::string& path) const;
 
     // Convert patterns to PinStates for engine compatibility


### PR DESCRIPTION
## Summary
- switch DataParser over to sep::common::CandleData
- wrap UI event bus calls in connector with `SEP_ENABLE_WORKBENCH`
- drop GUI header from connector
- include `src/common` in engine and connector builds

## Testing
- `./build.sh` *(fails: "cd: /sep: No such file or directory")*

------
https://chatgpt.com/codex/tasks/task_e_68847e4dc8cc832abce87d522258c4e4