### PR TITLE
Implement simple backtesting workflow

### DIFF
--- a/src/apps/workbench/backtester/CMakeLists.txt
+++ b/src/apps/workbench/backtester/CMakeLists.txt
@@ -4,6 +4,9 @@ add_library(sep_backtester STATIC
     backtester.cpp
     data/data_loader.cpp
     data/json_data_parser.cpp
+    core/backtester_engine.cpp
+    core/performance_metrics.cpp
+    strategies/sep_signal_strategy.cpp
 )
 
 add_executable(data_loader_test data/data_loader_test.cpp)

--- a/src/apps/workbench/backtester/core/backtester_engine.cpp
+++ b/src/apps/workbench/backtester/core/backtester_engine.cpp
@@ -5,6 +5,8 @@
 #include <numeric>
 #include <vector>
 
+#include "apps/workbench/backtester/strategies/sep_signal_strategy.h"
+
 BacktesterEngine::BacktesterEngine() {
 }
 
@@ -13,6 +15,10 @@ BacktesterEngine::~BacktesterEngine() {
 
 sep::workbench::backtester::BacktestResult BacktesterEngine::run(const std::string& dataset_path) {
     sep::quantum::PatternMetricEngine engine;
+    if (engine.init(nullptr) != sep::SEPResult::SUCCESS) {
+        std::cerr << "Failed to initialize PatternMetricEngine" << std::endl;
+        return {};
+    }
     return run(dataset_path, &engine);
 }
 
@@ -23,10 +29,10 @@ sep::workbench::backtester::BacktestResult BacktesterEngine::run(
     if (dataset_path == "EURUSD_48H") {
         loader.load_48h_sample();
     } else {
-        loader.loadData(dataset_path);
+        loader.load_data(dataset_path);
     }
 
-    const auto& candles = loader.getCandleData();
+    const auto& candles = loader.get_data();
     sep::workbench::backtester::BacktestResult result{};
     if (candles.empty()) {
         return result;
@@ -35,19 +41,9 @@ sep::workbench::backtester::BacktestResult BacktesterEngine::run(
     if (!engine) {
         return result;
     }
-    sep::quantum::PatternMetricEngine& engine_ref = *engine;
-    std::vector<uint8_t> byte_stream;
-    byte_stream.reserve(candles.size() * sizeof(sep::workbench::CandleData));
-    for (const auto& candle : candles) {
-        const uint8_t* bytes = reinterpret_cast<const uint8_t*>(&candle);
-        byte_stream.insert(byte_stream.end(), bytes, bytes + sizeof(sep::workbench::CandleData));
-    }
 
-    engine_ref.ingestData(byte_stream.data(), byte_stream.size());
-    engine_ref.evolvePatterns();
-    engine_ref.computeMetrics();
-
-    const auto& signals = engine_ref.getSignals();
+    SEPSignalStrategy strategy;
+    auto signals = strategy.execute(candles);
     std::vector<float> prices;
     prices.reserve(candles.size());
     for (const auto& candle : candles) {

--- a/src/apps/workbench/backtester/strategies/base_strategy.h
+++ b/src/apps/workbench/backtester/strategies/base_strategy.h
@@ -1,7 +1,20 @@
 #pragma once
 
+#include <vector>
+
+#include "quantum/pattern_metric_engine.h"
+#include "common/financial_data_types.h"
+
 class BaseStrategy {
 public:
     virtual ~BaseStrategy() = default;
-    virtual void execute() = 0;
+
+    /**
+     * Execute the strategy on a sequence of candle data.
+     *
+     * @param candles Historical candle data to process.
+     * @return Generated buy/sell/hold signals for each candle.
+     */
+    virtual std::vector<sep::quantum::Signal>
+    execute(const std::vector<sep::common::CandleData>& candles) = 0;
 };

--- a/src/apps/workbench/backtester/strategies/sep_signal_strategy.cpp
+++ b/src/apps/workbench/backtester/strategies/sep_signal_strategy.cpp
@@ -3,11 +3,31 @@
 #include <iostream>
 
 SEPSignalStrategy::SEPSignalStrategy() {
+    if (engine_.init(nullptr) != sep::SEPResult::SUCCESS) {
+        std::cerr << "Failed to initialize PatternMetricEngine" << std::endl;
+    }
 }
 
-SEPSignalStrategy::~SEPSignalStrategy() {
-}
+SEPSignalStrategy::~SEPSignalStrategy() = default;
 
-void SEPSignalStrategy::execute() {
-    std::cout << "Executing SEP signal strategy..." << std::endl;
+std::vector<sep::quantum::Signal>
+SEPSignalStrategy::execute(const std::vector<sep::common::CandleData>& candles) {
+    std::vector<sep::quantum::Signal> signals;
+    if (candles.empty()) {
+        return signals;
+    }
+
+    std::vector<uint8_t> byte_stream;
+    byte_stream.reserve(candles.size() * sizeof(sep::common::CandleData));
+    for (const auto& c : candles) {
+        const uint8_t* ptr = reinterpret_cast<const uint8_t*>(&c);
+        byte_stream.insert(byte_stream.end(), ptr,
+                           ptr + sizeof(sep::common::CandleData));
+    }
+
+    engine_.ingestData(byte_stream.data(), byte_stream.size());
+    engine_.evolvePatterns();
+    engine_.computeMetrics();
+    signals = engine_.getSignals();
+    return signals;
 }

--- a/src/apps/workbench/backtester/strategies/sep_signal_strategy.h
+++ b/src/apps/workbench/backtester/strategies/sep_signal_strategy.h
@@ -1,11 +1,17 @@
 #pragma once
 
 #include "base_strategy.h"
+#include "quantum/pattern_metric_engine.h"
 
+// Strategy that generates trading signals using the PatternMetricEngine.
 class SEPSignalStrategy : public BaseStrategy {
 public:
     SEPSignalStrategy();
     ~SEPSignalStrategy();
 
-    void execute() override;
+    std::vector<sep::quantum::Signal>
+    execute(const std::vector<sep::common::CandleData>& candles) override;
+
+private:
+    sep::quantum::PatternMetricEngine engine_;
 };

--- a/src/apps/workbench/backtester/ui/backtester_tab_controller.cpp
+++ b/src/apps/workbench/backtester/ui/backtester_tab_controller.cpp
@@ -1,6 +1,7 @@
 #include "backtester_tab_controller.h"
 
 #include "imgui.h"
+#include "implot.h"
 #include <iostream>
 
 BacktesterTabController::BacktesterTabController()
@@ -12,13 +13,72 @@ BacktesterTabController::~BacktesterTabController() {
 void BacktesterTabController::render() {
     ImGui::Begin("Backtester");
     ImGui::InputText("Dataset", dataset_path_, sizeof(dataset_path_));
-    if (ImGui::Button("Run")) {
-        result_ = engine_->run(dataset_path_);
+
+    if (!running_) {
+        if (ImGui::Button("Start")) {
+            running_ = true;
+            result_ = engine_->run(dataset_path_);
+            running_ = false;
+        }
+    } else {
+        if (ImGui::Button("Stop")) {
+            running_ = false;
+        }
     }
+
+    ImGui::Separator();
     ImGui::Text("Total Trades: %d", result_.total_trades);
     ImGui::Text("Win Rate: %.2f", result_.win_rate);
     ImGui::Text("Total PnL: %.2f", result_.total_pnl);
     ImGui::Text("Sharpe Ratio: %.2f", result_.sharpe_ratio);
     ImGui::Text("Max Drawdown: %.2f", result_.max_drawdown);
+
+    if (!result_.trades.empty()) {
+        std::vector<double> xs(result_.trades.size());
+        std::vector<double> curve(result_.trades.size());
+        double cumulative = 0.0;
+        for (size_t i = 0; i < result_.trades.size(); ++i) {
+            const auto& t = result_.trades[i];
+            double pnl = (t.type == sep::quantum::SignalType::BUY)
+                            ? t.exit_price - t.entry_price
+                            : t.entry_price - t.exit_price;
+            cumulative += pnl;
+            xs[i] = static_cast<double>(i);
+            curve[i] = cumulative;
+        }
+
+        if (ImPlot::BeginPlot("Profit Curve", ImVec2(-1,150))) {
+            ImPlot::PlotLine("PnL", xs.data(), curve.data(), static_cast<int>(curve.size()));
+            ImPlot::EndPlot();
+        }
+
+        if (ImGui::BeginTable("Trades", 5, ImGuiTableFlags_Borders)) {
+            ImGui::TableSetupColumn("#");
+            ImGui::TableSetupColumn("Type");
+            ImGui::TableSetupColumn("Entry");
+            ImGui::TableSetupColumn("Exit");
+            ImGui::TableSetupColumn("PnL");
+            ImGui::TableHeadersRow();
+            for (size_t i = 0; i < result_.trades.size(); ++i) {
+                const auto& t = result_.trades[i];
+                double pnl = (t.type == sep::quantum::SignalType::BUY)
+                                ? t.exit_price - t.entry_price
+                                : t.entry_price - t.exit_price;
+                ImGui::TableNextRow();
+                ImGui::TableSetColumnIndex(0);
+                ImGui::Text("%zu", i);
+                ImGui::TableSetColumnIndex(1);
+                ImGui::Text("%s", t.type == sep::quantum::SignalType::BUY ? "BUY" : "SELL");
+                ImGui::TableSetColumnIndex(2);
+                ImGui::Text("%.4f", t.entry_price);
+                ImGui::TableSetColumnIndex(3);
+                ImGui::Text("%.4f", t.exit_price);
+                ImGui::TableSetColumnIndex(4);
+                ImGui::Text("%.4f", pnl);
+            }
+            ImGui::EndTable();
+        }
+    }
+
     ImGui::End();
 }

--- a/src/apps/workbench/backtester/ui/backtester_tab_controller.h
+++ b/src/apps/workbench/backtester/ui/backtester_tab_controller.h
@@ -13,5 +13,6 @@ public:
 private:
     std::unique_ptr<BacktesterEngine> engine_;
     sep::workbench::backtester::BacktestResult result_{};
+    bool running_ = false;
     char dataset_path_[512] = "eur_usd_m1_48h.json";
 };

--- a/src/apps/workbench/core/workbench_core.cpp
+++ b/src/apps/workbench/core/workbench_core.cpp
@@ -115,6 +115,7 @@ bool WorkbenchEngine::initialize()
         signals_tab_ = std::make_unique<workbench::SignalsTabController>();
         engine_tab_ = std::make_unique<workbench::EngineTabController>();
         backend_tab_ = std::make_unique<workbench::BackendTabController>();
+        backtester_tab_ = std::make_unique<workbench::BacktesterTabController>();
 
         signals_tab_->initialize();
         engine_tab_->initialize();
@@ -688,6 +689,11 @@ void WorkbenchEngine::renderTabs()
             if (ImGui::BeginTabItem("Backend"))
             {
                 backend_tab_->render();
+                ImGui::EndTabItem();
+            }
+            if (ImGui::BeginTabItem("Backtester"))
+            {
+                backtester_tab_->render();
                 ImGui::EndTabItem();
             }
             ImGui::EndTabBar();

--- a/src/apps/workbench/core/workbench_core.hpp
+++ b/src/apps/workbench/core/workbench_core.hpp
@@ -4,6 +4,7 @@
 #include "tabs/signals_tab_controller.h"
 #include "tabs/engine_tab_controller.h"
 #include "tabs/backend_tab_controller.h"
+#include "backtester/ui/backtester_tab_controller.h"
 #include "ui_layout_manager.h"
 #include "multi_timeframe_analyzer.h"
 
@@ -110,6 +111,7 @@ private:
     std::unique_ptr<SignalsTabController> signals_tab_;
     std::unique_ptr<EngineTabController> engine_tab_;
     std::unique_ptr<BackendTabController> backend_tab_;
+    std::unique_ptr<BacktesterTabController> backtester_tab_;
     std::unique_ptr<QuantumSignalGenerator> signal_generator_;
     std::shared_ptr<MetricsMonitor> metrics_monitor_;
     std::unique_ptr<MultiTimeframeAnalyzer> multi_timeframe_analyzer_;


### PR DESCRIPTION
## Summary
- implement a BacktesterEngine using SEPSignalStrategy
- generate signals in SEPSignalStrategy via PatternMetricEngine
- show backtesting results in BacktesterTabController with profit curve and table
- register the backtester tab in WorkbenchEngine
- include core/strategy sources in CMake

## Testing
- `./build.sh` *(fails: cd: /sep: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6884882c633c832aacf91b66b7f675fc