### PR TITLE
Fix workbench includes and types

### DIFF
--- a/src/apps/workbench/CMakeLists.txt
+++ b/src/apps/workbench/CMakeLists.txt
@@ -21,6 +21,7 @@ target_include_directories(sep_workbench_lib PUBLIC
     ${CMAKE_SOURCE_DIR}/src/engine
     ${CMAKE_SOURCE_DIR}/src/api
     ${CMAKE_SOURCE_DIR}/src/apps/workbench
+    ${CMAKE_SOURCE_DIR}/src/apps/workbench/backtester
     ${CMAKE_SOURCE_DIR}/src/apps/workbench/backtester/data
     ${CMAKE_SOURCE_DIR}/src/apps/common
     ${CMAKE_SOURCE_DIR}/src/connectors

--- a/src/apps/workbench/backtester/core/backtester_engine.cpp
+++ b/src/apps/workbench/backtester/core/backtester_engine.cpp
@@ -37,10 +37,10 @@ sep::workbench::backtester::BacktestResult BacktesterEngine::run(
     }
     sep::quantum::PatternMetricEngine& engine_ref = *engine;
     std::vector<uint8_t> byte_stream;
-    byte_stream.reserve(candles.size() * sizeof(sep::workbench::CandleData));
+    byte_stream.reserve(candles.size() * sizeof(sep::common::CandleData));
     for (const auto& candle : candles) {
         const uint8_t* bytes = reinterpret_cast<const uint8_t*>(&candle);
-        byte_stream.insert(byte_stream.end(), bytes, bytes + sizeof(sep::workbench::CandleData));
+        byte_stream.insert(byte_stream.end(), bytes, bytes + sizeof(sep::common::CandleData));
     }
 
     engine_ref.ingestData(byte_stream.data(), byte_stream.size());

--- a/src/apps/workbench/backtester/data/json_data_parser.cpp
+++ b/src/apps/workbench/backtester/data/json_data_parser.cpp
@@ -4,8 +4,8 @@
 #include <nlohmann/json.hpp>
 #include <iostream>
 
-std::vector<sep::workbench::CandleData> JsonDataParser::parse(const std::string& filepath) {
-    std::vector<sep::workbench::CandleData> candles;
+std::vector<sep::common::CandleData> JsonDataParser::parse(const std::string& filepath) {
+    std::vector<sep::common::CandleData> candles;
     std::ifstream file(filepath);
     if (!file.is_open()) {
         std::cerr << "Failed to open file: " << filepath << std::endl;

--- a/src/connectors/oanda_connector.cpp
+++ b/src/connectors/oanda_connector.cpp
@@ -9,9 +9,6 @@
 #include <thread>
 #include "engine/data_parser.h"
 #include "common/financial_data_types.h"
-#ifdef SEP_ENABLE_WORKBENCH
-#include "apps/workbench/core/ui_layout_manager.h"
-#endif
 #include <mutex>
 
 namespace sep {


### PR DESCRIPTION
## Summary
- remove unused ui_layout_manager include
- include backtester headers in workbench library
- use sep::common::CandleData everywhere

## Testing
- `./build.sh` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_688488160758832aacbc06e99ab5dc90