### PR TITLE
Implement timestamp helper

### DIFF
--- a/src/common/financial_data_types.h
+++ b/src/common/financial_data_types.h
@@ -30,4 +30,30 @@ struct SEPSignalData {
     };
 };
 
+inline std::chrono::system_clock::time_point parseTimestamp(const std::string& ts) {
+    std::tm tm = {};
+    std::istringstream ss(ts);
+    ss >> std::get_time(&tm, "%Y-%m-%dT%H:%M:%S");
+    if (ss.fail()) {
+        return std::chrono::system_clock::now();
+    }
+
+    auto tp = std::chrono::system_clock::from_time_t(std::mktime(&tm));
+
+    if (ss.peek() == '.') {
+        ss.get();
+        std::string fractional;
+        std::getline(ss, fractional, 'Z');
+        while (fractional.size() < 9) fractional.push_back('0');
+        int nanoseconds = 0;
+        try {
+            nanoseconds = std::stoi(fractional.substr(0, 9));
+        } catch (...) {
+            nanoseconds = 0;
+        }
+        tp += std::chrono::nanoseconds(nanoseconds);
+    }
+
+    return tp;
+}
 }  // namespace sep::common

--- a/src/connectors/oanda_connector.cpp
+++ b/src/connectors/oanda_connector.cpp
@@ -763,7 +763,7 @@ bool OandaConnector::fetchHistoricalData(const std::string& instrument, const st
     for (const auto& c : candles)
     {
         sep::common::CandleData cd;
-        cd.time = c.time;
+        cd.time = sep::common::parseTimestamp(c.time);
         cd.open = static_cast<float>(c.open);
         cd.high = static_cast<float>(c.high);
         cd.low = static_cast<float>(c.low);
@@ -786,11 +786,8 @@ bool OandaConnector::saveEURUSDM1_48h(const std::string& output_file)
 
 int64_t OandaConnector::parseTimestamp(const std::string& time_str)
 {
-    std::tm tm = {};
-    std::stringstream ss(time_str);
-    ss >> std::get_time(&tm, "%Y-%m-%dT%H:%M:%S");
-    auto time_point = std::chrono::system_clock::from_time_t(std::mktime(&tm));
-    return std::chrono::duration_cast<std::chrono::seconds>(time_point.time_since_epoch()).count();
+    auto tp = sep::common::parseTimestamp(time_str);
+    return std::chrono::duration_cast<std::chrono::seconds>(tp.time_since_epoch()).count();
 }
 
 DataValidationResult OandaConnector::validateCandle(const OandaCandle& candle)

--- a/src/engine/data_parser.cpp
+++ b/src/engine/data_parser.cpp
@@ -71,7 +71,7 @@ std::vector<quantum::Pattern> DataParser::parseBuffer(const uint8_t* data, size_
                         sep::common::CandleData candle;
                         
                         if (candle_json.contains("time") && candle_json["time"].is_string()) {
-                            candle.time = candle_json["time"].get<std::string>().c_str();
+                            candle.time = sep::common::parseTimestamp(candle_json["time"].get<std::string>());
                         }
                         
                         if (candle_json.contains("volume") && candle_json["volume"].is_number()) {
@@ -411,7 +411,7 @@ std::vector<sep::common::CandleData> DataParser::parseQuantJSON(const std::strin
                 bool valid = true;
 
                 if (candle_json.contains("time") && candle_json["time"].is_string()) {
-                    candle.time = candle_json["time"].get<std::string>();
+                    candle.time = sep::common::parseTimestamp(candle_json["time"].get<std::string>());
                 } else {
                     std::cerr << "[DataParser] Missing time at index " << index << "\n";
                     valid = false;
@@ -441,14 +441,14 @@ std::vector<sep::common::CandleData> DataParser::parseQuantJSON(const std::strin
                     valid = false;
 
                 if (!candles.empty()) {
-                    auto prev_ts = parseTimestamp(candles.back().time);
-                    auto cur_ts = parseTimestamp(candle.time);
+                    auto prev_ts = candles.back().time;
+                    auto cur_ts = candle.time;
                     if (cur_ts <= prev_ts) {
                         std::cerr << "[DataParser] Non-increasing timestamp at index " << index << "\n";
                         valid = false;
-                    } else if (cur_ts - prev_ts != 60000) {
-                        std::cerr << "[DataParser] Missing candle between " << candles.back().time
-                                  << " and " << candle.time << "\n";
+                    } else if (std::chrono::duration_cast<std::chrono::milliseconds>(cur_ts - prev_ts).count() != 60000) {
+                        std::cerr << "[DataParser] Missing candle between " << candles.size()-1
+                                  << " and current" << "\n";
                     }
                 }
 
@@ -468,7 +468,7 @@ std::vector<sep::common::CandleData> DataParser::parseQuantJSON(const std::strin
             
             // Parse time
             if (candle_json.contains("time") && candle_json["time"].is_string()) {
-                candle.time = candle_json["time"].get<std::string>().c_str();
+                candle.time = sep::common::parseTimestamp(candle_json["time"].get<std::string>());
             }
             
             // Parse volume
@@ -504,11 +504,10 @@ std::vector<sep::common::CandleData> DataParser::parseQuantJSON(const std::strin
             }
 
             if (!candles.empty()) {
-                auto prev_ts = parseTimestamp(candles.back().time);
-                auto cur_ts = parseTimestamp(candle.time);
-                if (cur_ts - prev_ts != 60000) {
-                    std::cerr << "[DataParser] Missing candle between " << candles.back().time
-                              << " and " << candle.time << "\n";
+                auto prev_ts = candles.back().time;
+                auto cur_ts = candle.time;
+                if (std::chrono::duration_cast<std::chrono::milliseconds>(cur_ts - prev_ts).count() != 60000) {
+                    std::cerr << "[DataParser] Missing candle between previous and current\n";
                 }
             }
 
@@ -535,7 +534,7 @@ std::vector<quantum::Pattern> DataParser::candlesToPatterns(
         quantum::Pattern pattern;
 
         // Use timestamp as unique ID
-        pattern.id = std::to_string(parseTimestamp(candle.time));
+        pattern.id = std::to_string(std::chrono::duration_cast<std::chrono::milliseconds>(candle.time.time_since_epoch()).count());
 
         // Map OHLC to position vector (raw data, no normalization)
         pattern.position.x = candle.open;
@@ -547,9 +546,9 @@ std::vector<quantum::Pattern> DataParser::candlesToPatterns(
         pattern.data.push_back(static_cast<float>(candle.volume));
         
         // Set timestamp
-        pattern.timestamp = parseTimestamp(candle.time);
-        pattern.last_accessed = pattern.timestamp;
-        pattern.last_modified = pattern.timestamp;
+        pattern.timestamp = candle.time;
+        pattern.last_accessed = candle.time;
+        pattern.last_modified = candle.time;
         
         // Initialize quantum state with defaults - let the quantum algorithms determine these
         pattern.generation = 0;
@@ -617,8 +616,8 @@ bool DataParser::saveValidatedCandlesJSON(const std::vector<sep::common::CandleD
             return false;
         }
         if (i > 0) {
-            auto prev_ts = parseTimestamp(candles[i - 1].time);
-            auto cur_ts = parseTimestamp(c.time);
+            auto prev_ts = candles[i - 1].time;
+            auto cur_ts = c.time;
             if (cur_ts <= prev_ts) {
                 std::cerr << "[DataParser] Non-increasing timestamp at index " << i << "\n";
                 return false;
@@ -632,27 +631,8 @@ bool DataParser::saveValidatedCandlesJSON(const std::vector<sep::common::CandleD
 
 uint64_t DataParser::parseTimestamp(const std::string& timestamp) const
 {
-    // Parse ISO 8601 format with nanoseconds: "2021-04-07T00:00:00.000000000Z"
-    std::tm tm = {};
-    std::istringstream ss(timestamp.c_str());
-
-    // Parse up to seconds
-    ss >> std::get_time(&tm, "%Y-%m-%dT%H:%M:%S");
-    
-    if (!ss.fail()) {
-        // Skip the fractional seconds part
-        std::string fractional;
-        std::getline(ss, fractional, 'Z');
-
-        auto tp = std::chrono::system_clock::from_time_t(std::mktime(&tm));
-        return std::chrono::duration_cast<std::chrono::milliseconds>(
-            tp.time_since_epoch()).count();
-    }
-    
-    // If parsing fails, return current time
-    auto now = std::chrono::system_clock::now();
-    return std::chrono::duration_cast<std::chrono::milliseconds>(
-        now.time_since_epoch()).count();
+    auto tp = sep::common::parseTimestamp(timestamp);
+    return std::chrono::duration_cast<std::chrono::milliseconds>(tp.time_since_epoch()).count();
 }
 
 bool DataParser::exportCorrelationCSV(const std::string& path,


### PR DESCRIPTION
## Summary
- add `parseTimestamp` helper for candle timestamps
- use it in DataParser and OandaConnector

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` *(fails: CUDA_HOME environment variable not set)*

------
https://chatgpt.com/codex/tasks/task_e_6884881b94a0832aa893cd4c10fec554