### PR TITLE
Enable OANDA dataset loader

### DIFF
--- a/run_workbench.sh
+++ b/run_workbench.sh
@@ -51,6 +51,13 @@ while [ ! -f "build/src/apps/workbench/sep_workbench" ]; do
     sleep 1
 done
 
+# Ensure sample data is available
+SAMPLE_FILE="eur_usd_m1_48h.json"
+if [ ! -f "$SAMPLE_FILE" ]; then
+    echo "Sample dataset not found. Downloading..."
+    ./build/src/apps/data_downloader
+fi
+
 # Run the sep_workbench with OANDA credentials
 echo "Starting SEP Workbench..."
 echo "Press Ctrl+C to exit"

--- a/src/apps/workbench/backtester/data/data_loader.cpp
+++ b/src/apps/workbench/backtester/data/data_loader.cpp
@@ -21,9 +21,10 @@ std::string DataLoader::load_48h_sample()
     return fallback;
 }
 
-void DataLoader::load_data(const std::string& file_path)
+std::vector<common::CandleData> DataLoader::load_data(const std::string& file_path)
 {
     data_ = JsonDataParser::parse(file_path);
+    return data_;
 }
 
 } // namespace backtester

--- a/src/apps/workbench/backtester/data/data_loader.h
+++ b/src/apps/workbench/backtester/data/data_loader.h
@@ -24,7 +24,7 @@ namespace sep
                  */
                 std::string load_48h_sample();
 
-                void load_data(const std::string& file_path);
+                std::vector<common::CandleData> load_data(const std::string& file_path);
                 const std::vector<common::CandleData>& get_data() const { return data_; }
 
             private:

--- a/src/apps/workbench/core/workbench_core.cpp
+++ b/src/apps/workbench/core/workbench_core.cpp
@@ -13,6 +13,7 @@
 #include "apps/workbench/tabs/signals_tab_controller.h"
 #include "apps/workbench/tabs/engine_tab_controller.h"
 #include "apps/workbench/tabs/backend_tab_controller.h"
+#include "apps/workbench/backtester/data/data_loader.h"
 
 #include "apps/workbench/signal_generator/quantum_signal_generator.h"
 #include "apps/workbench/core/metrics_monitor.h"
@@ -150,7 +151,17 @@ bool WorkbenchEngine::initialize()
             auto oanda_ptr = service_connector_->getOandaConnector();
             std::cout << "[WorkbenchEngine] OANDA connector available: " << (oanda_ptr ? "Yes" : "No") << std::endl;
         }
-        
+
+        const char* skip_env = std::getenv("SEP_SKIP_FETCH");
+        if (!skip_env && signals_tab_) {
+            backtester::DataLoader loader;
+            auto candles = loader.load_data("eur_usd_m1_48h.json");
+            if (!candles.empty()) {
+                std::deque<sep::common::CandleData> dq(candles.begin(), candles.end());
+                signals_tab_->setCandleData(dq);
+            }
+        }
+
         transitionTo(ApplicationState::LANDING_PAGE);
 
         std::cout << "[WorkbenchEngine] Initialization complete!" << std::endl;

--- a/src/connectors/oanda_connector.cpp
+++ b/src/connectors/oanda_connector.cpp
@@ -151,6 +151,24 @@ std::vector<OandaCandle> OandaConnector::getHistoricalData(
                 if (candles.size() != static_cast<size_t>(48 * 60)) {
                     last_error_ += " - expected 2880 got " + std::to_string(candles.size());
                 }
+            } else if (instrument == "EUR_USD") {
+                std::vector<sep::common::CandleData> out;
+                out.reserve(candles.size());
+                for (const auto& c : candles) {
+                    sep::common::CandleData cd;
+                    std::tm tm{};
+                    std::istringstream ss(c.time);
+                    ss >> std::get_time(&tm, "%Y-%m-%dT%H:%M:%S");
+                    cd.time = std::chrono::system_clock::from_time_t(std::mktime(&tm));
+                    cd.open = c.open;
+                    cd.high = c.high;
+                    cd.low = c.low;
+                    cd.close = c.close;
+                    cd.volume = c.volume;
+                    out.push_back(cd);
+                }
+                DataParser parser;
+                parser.saveValidatedCandlesJSON(out, "eur_usd_m1_48h.json");
             }
         }
         


### PR DESCRIPTION
## Summary
- add simple JSON loader for backtester
- persist fetched EUR/USD candles in `getHistoricalData`
- pre-load candles when starting the workbench
- download sample data automatically from run script

## Testing
- `./build.sh` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68848823030c832abe79ec391ecfc944