### PR TITLE
Connect signal generator to memory manager

### DIFF
--- a/src/apps/workbench/core/workbench_core.cpp
+++ b/src/apps/workbench/core/workbench_core.cpp
@@ -17,6 +17,7 @@
 #include "apps/workbench/signal_generator/quantum_signal_generator.h"
 #include "apps/workbench/core/metrics_monitor.h"
 #include "apps/workbench/core/multi_timeframe_analyzer.h"
+#include "memory/memory_tier_manager.hpp"
 #include "engine/data_parser.h"
 
 // Include ImGui headers
@@ -104,6 +105,7 @@ bool WorkbenchEngine::initialize()
             metrics_.service_connected = (e.state == ConnectionState::CONNECTED);
         });
         signal_generator_ = ::std::make_unique<QuantumSignalGenerator>();
+        signal_generator_->setMemoryManager(&::sep::memory::MemoryTierManager::getInstance());
         metrics_monitor_ = ::std::make_shared<MetricsMonitor>();
         multi_timeframe_analyzer_ = ::std::make_unique<MultiTimeframeAnalyzer>();
         

--- a/src/apps/workbench/signal_generator/quantum_signal_generator.cpp
+++ b/src/apps/workbench/signal_generator/quantum_signal_generator.cpp
@@ -7,6 +7,10 @@ QuantumSignalGenerator::QuantumSignalGenerator() {
     strategy_ = nullptr;
 }
 
+void QuantumSignalGenerator::setMemoryManager(sep::memory::MemoryTierManager* manager) {
+    memory_manager_ = manager;
+}
+
 void QuantumSignalGenerator::setStrategy(std::unique_ptr<SignalStrategy> strategy) {
     strategy_ = std::move(strategy);
 }
@@ -19,10 +23,14 @@ SignalResult QuantumSignalGenerator::generateSignal(const dag::DagNode& pattern)
 }
 
 void QuantumSignalGenerator::tick() {
-    if (strategy_) {
-        // Use empty DAG node since engine connection not available yet
-        dag::DagNode empty_node;
-        last_signal_ = strategy_->generateSignal(empty_node);
+    if (strategy_ && memory_manager_) {
+        auto& dag = memory_manager_->getDagGraph();
+        const dag::DagNode* node = dag.getMostRecentNode();
+        if (node) {
+            last_signal_ = strategy_->generateSignal(*node);
+        } else {
+            last_signal_ = {SignalType::HOLD, 0.0f, "No data"};
+        }
     } else {
         last_signal_ = {SignalType::HOLD, 0.0f, "No strategy set"};
     }

--- a/src/apps/workbench/signal_generator/quantum_signal_generator.h
+++ b/src/apps/workbench/signal_generator/quantum_signal_generator.h
@@ -3,6 +3,7 @@
 #include "engine/dag_graph.h"
 #include "apps/workbench/signal_generator/signal_strategy.h"
 #include "apps/workbench/signal_generator/signal_types.h"
+#include "memory/memory_tier_manager.hpp"
 
 #include <memory>
 
@@ -11,6 +12,9 @@ namespace sep::workbench {
 class QuantumSignalGenerator {
 public:
     QuantumSignalGenerator();
+
+    // Supply MemoryTierManager for DAG access
+    void setMemoryManager(sep::memory::MemoryTierManager* manager);
 
     // Set the active signal generation strategy
     void setStrategy(std::unique_ptr<SignalStrategy> strategy);
@@ -30,6 +34,7 @@ public:
 private:
     std::unique_ptr<SignalStrategy> strategy_;
     SignalResult last_signal_;
+    sep::memory::MemoryTierManager* memory_manager_{nullptr};
 };
 
 } // namespace sep::workbench

--- a/src/engine/dag_graph.h
+++ b/src/engine/dag_graph.h
@@ -72,6 +72,9 @@ public:
     float getAlpha(uint64_t id) const;
     float getCorrelation(uint64_t id) const;
     uint32_t getGeneration(uint64_t id) const;
+
+    // Get most recently added node, or nullptr if empty
+    const DagNode* getMostRecentNode() const;
     
     // JSON serialization for metrics output
     std::string exportAsJson() const;

--- a/src/engine/dag_graph_quant.cpp
+++ b/src/engine/dag_graph_quant.cpp
@@ -159,6 +159,13 @@ uint32_t DagGraph::getGeneration(uint64_t id) const {
     return (it != nodes_.end()) ? it->second.generation : 0;
 }
 
+const DagNode* DagGraph::getMostRecentNode() const {
+    if (nodes_.empty()) return nullptr;
+    auto it = nodes_.find(next_id_ - 1);
+    if (it != nodes_.end()) return &it->second;
+    return nullptr;
+}
+
 std::string DagGraph::exportAsJson() const
 {
     std::stringstream json;


### PR DESCRIPTION
## Summary
- connect QuantumSignalGenerator to MemoryTierManager and use latest DagNode
- give DagGraph ability to return the most recent node
- pass MemoryTierManager instance when creating QuantumSignalGenerator

## Testing
- `./build.sh` *(fails: `/sep` missing)*

------
https://chatgpt.com/codex/tasks/task_e_6884881f3280832aaf8d228d7cb8ba3c