### PR TITLE
Integrate backtesting results across tabs

### DIFF
--- a/src/apps/workbench/backtester/core/backtester_engine.cpp
+++ b/src/apps/workbench/backtester/core/backtester_engine.cpp
@@ -19,12 +19,14 @@ sep::workbench::backtester::BacktestResult BacktesterEngine::run(const std::stri
         std::cerr << "Failed to initialize PatternMetricEngine" << std::endl;
         return {};
     }
-    return run(dataset_path, &engine);
+    SEPSignalStrategy strategy;
+    return run(dataset_path, &engine, &strategy);
 }
 
 sep::workbench::backtester::BacktestResult BacktesterEngine::run(
     const std::string& dataset_path,
-    sep::quantum::PatternMetricEngine* engine) {
+    sep::quantum::PatternMetricEngine* engine,
+    sep::workbench::backtester::BaseStrategy* strategy) {
     sep::workbench::backtester::DataLoader loader;
     if (dataset_path == "EURUSD_48H") {
         loader.load_48h_sample();
@@ -53,8 +55,10 @@ sep::workbench::backtester::BacktestResult BacktesterEngine::run(
     engine_ref.evolvePatterns();
     engine_ref.computeMetrics();
 
-    SEPSignalStrategy strategy;
-    auto signals = strategy.execute(candles);
+    std::vector<sep::quantum::Signal> signals;
+    if (strategy) {
+        signals = strategy->execute(candles);
+    }
     std::vector<float> prices;
     prices.reserve(candles.size());
     for (const auto& candle : candles) {

--- a/src/apps/workbench/backtester/core/backtester_engine.h
+++ b/src/apps/workbench/backtester/core/backtester_engine.h
@@ -3,6 +3,7 @@
 #include "apps/workbench/backtester/data/data_loader.h"
 #include "apps/workbench/backtester/backtester.h"
 #include "apps/workbench/backtester/core/performance_metrics.h"
+#include "apps/workbench/backtester/strategies/base_strategy.h"
 #include "quantum/pattern_metric_engine.h"
 #include <string>
 #include <vector>
@@ -13,6 +14,9 @@ public:
     ~BacktesterEngine();
 
     sep::workbench::backtester::BacktestResult run(const std::string& dataset_path);
+    sep::workbench::backtester::BacktestResult run(const std::string& dataset_path,
+                                                   sep::quantum::PatternMetricEngine* engine,
+                                                   sep::workbench::backtester::BaseStrategy* strategy);
     sep::workbench::backtester::BacktestResult run(const std::string& dataset_path,
                                                    sep::quantum::PatternMetricEngine* engine);
 };

--- a/src/apps/workbench/backtester/ui/backtester_tab_controller.cpp
+++ b/src/apps/workbench/backtester/ui/backtester_tab_controller.cpp
@@ -3,9 +3,12 @@
 #include "imgui.h"
 #include "implot.h"
 #include <iostream>
+#include "apps/workbench/backtester/strategies/sep_signal_strategy.h"
 
 BacktesterTabController::BacktesterTabController()
-    : engine_(std::make_unique<BacktesterEngine>()) {}
+    : engine_(std::make_unique<BacktesterEngine>()) {
+    pattern_engine_.init(nullptr);
+}
 
 BacktesterTabController::~BacktesterTabController() {
 }
@@ -13,11 +16,34 @@ BacktesterTabController::~BacktesterTabController() {
 void BacktesterTabController::render() {
     ImGui::Begin("Backtester");
     ImGui::InputText("Dataset", dataset_path_, sizeof(dataset_path_));
+    ImGui::SameLine();
+    if (ImGui::Button("Browse")) {
+        file_dialog_.open();
+    }
+    std::string selected;
+    if (file_dialog_.render(selected)) {
+        strncpy(dataset_path_, selected.c_str(), sizeof(dataset_path_) - 1);
+        dataset_path_[sizeof(dataset_path_) - 1] = '\0';
+    }
+    ImGui::Combo("Strategy", &strategy_index_,
+                [](void* data, int idx, const char** out_text) {
+                    auto* vec = static_cast<std::vector<std::string>*>(data);
+                    if (idx < 0 || idx >= static_cast<int>(vec->size())) return false;
+                    *out_text = (*vec)[idx].c_str();
+                    return true;
+                },
+                &strategy_names_, strategy_names_.size());
 
     if (!running_) {
         if (ImGui::Button("Start")) {
             running_ = true;
-            result_ = engine_->run(dataset_path_);
+            SEPSignalStrategy strategy;
+            backtester::BaseStrategy* strat_ptr = nullptr;
+            if (strategy_index_ == 0) {
+                strat_ptr = &strategy;
+            }
+            result_ = engine_->run(dataset_path_, &pattern_engine_, strat_ptr);
+            globalEventBus().publish(BacktestResultEvent{result_});
             running_ = false;
         }
     } else {

--- a/src/apps/workbench/backtester/ui/backtester_tab_controller.h
+++ b/src/apps/workbench/backtester/ui/backtester_tab_controller.h
@@ -1,7 +1,11 @@
 #pragma once
 
 #include "apps/workbench/backtester/core/backtester_engine.h"
+#include "apps/workbench/backtester/strategies/base_strategy.h"
+#include "apps/workbench/core/file_dialog.hpp"
+#include "apps/workbench/core/ui_layout_manager.h"
 #include <memory>
+#include <vector>
 
 class BacktesterTabController {
 public:
@@ -12,6 +16,10 @@ public:
 
 private:
     std::unique_ptr<BacktesterEngine> engine_;
+    sep::quantum::PatternMetricEngine pattern_engine_;
+    std::vector<std::string> strategy_names_{"SEP Signal"};
+    int strategy_index_ = 0;
+    FileDialog file_dialog_;
     sep::workbench::backtester::BacktestResult result_{};
     bool running_ = false;
     char dataset_path_[512] = "eur_usd_m1_48h.json";

--- a/src/apps/workbench/core/ui_layout_manager.h
+++ b/src/apps/workbench/core/ui_layout_manager.h
@@ -7,6 +7,7 @@
 #include <vector>
 #include <unordered_map>
 #include <typeindex>
+#include "apps/workbench/backtester/backtester.h"
 
 #include "imgui.h"
 #include "common/financial_data_types.h"
@@ -90,6 +91,10 @@ struct ConnectionStateEvent {
 
 struct OrderUpdateEvent {
     sep::common::OrderInfo info;
+};
+
+struct BacktestResultEvent {
+    sep::workbench::backtester::BacktestResult result;
 };
 
 class EventBus {

--- a/src/apps/workbench/tabs/backend_tab_controller.cpp
+++ b/src/apps/workbench/tabs/backend_tab_controller.cpp
@@ -5,6 +5,7 @@
 #include <cstring>
 
 #include "imgui.h"
+#include "implot.h"
 
 namespace sep::workbench {
 
@@ -23,6 +24,9 @@ bool BackendTabController::initialize() {
         } else {
             *it = e.info;
         }
+    });
+    globalEventBus().subscribe<BacktestResultEvent>([this](const BacktestResultEvent& e) {
+        onBacktestResult(e);
     });
     return true;
 }
@@ -205,50 +209,19 @@ void BackendTabController::renderBacktesterPanel() {
 void BackendTabController::renderBacktestingSuite() {
     ImGui::Begin("BacktestingSuite");
     ImGui::PushID("BacktestingSuite");
-    ImGui::InputText("Dataset", backtest_file_buffer_, sizeof(backtest_file_buffer_));
-    if (ImGui::Button("Run Backtest")) {
-        data_loader_->load_data(backtest_file_buffer_);
-        backtester_->run(pattern_engine_.get(), data_loader_.get());
-        equity_curve_.clear();
-        const auto& trades = backtester_->getResult().trades;
-        float equity = 0.0f;
-        equity_curve_.push_back(equity);
-        for (const auto& t : trades) {
-            float diff = (t.type == quantum::SignalType::BUY)
-                             ? t.exit_price - t.entry_price
-                             : t.entry_price - t.exit_price;
-            equity += diff;
-            equity_curve_.push_back(equity);
-        }
-    }
-    ImGui::SameLine();
-    if (ImGui::Button("Run 48h Sample")) {
-        strncpy(backtest_file_buffer_, "eur_usd_m1_48h.json", sizeof(backtest_file_buffer_) - 1);
-        backtest_file_buffer_[sizeof(backtest_file_buffer_) - 1] = '\0';
-        data_loader_->load_data(backtest_file_buffer_);
-        backtester_->run(pattern_engine_.get(), data_loader_.get());
-        equity_curve_.clear();
-        const auto& trades = backtester_->getResult().trades;
-        float equity = 0.0f;
-        equity_curve_.push_back(equity);
-        for (const auto& t : trades) {
-            float diff = (t.type == sep::quantum::SignalType::BUY)
-                             ? t.exit_price - t.entry_price
-                             : t.entry_price - t.exit_price;
-            equity += diff;
-            equity_curve_.push_back(equity);
-        }
-    }
 
-    const auto& result = backtester_->getResult();
-    ImGui::Text("Total Trades: %d", result.total_trades);
-    ImGui::Text("Win Rate: %.2f", result.win_rate);
-    ImGui::Text("Total PnL: %.2f", result.total_pnl);
-    ImGui::Text("Sharpe Ratio: %.2f", result.sharpe_ratio);
-    ImGui::Text("Max Drawdown: %.2f", result.max_drawdown);
+    ImGui::Text("Total Trades: %d", last_result_.total_trades);
+    ImGui::Text("Win Rate: %.2f", last_result_.win_rate);
+    ImGui::Text("Total PnL: %.2f", last_result_.total_pnl);
+    ImGui::Text("Sharpe Ratio: %.2f", last_result_.sharpe_ratio);
+    ImGui::Text("Max Drawdown: %.2f", last_result_.max_drawdown);
     if (!equity_curve_.empty()) {
-        ImGui::PlotLines("Equity Curve", (const float*)equity_curve_.data(),
-                         static_cast<int>(equity_curve_.size()));
+        if (ImPlot::BeginPlot("Equity Curve", ImVec2(-1,150))) {
+            std::vector<double> xs(equity_curve_.size());
+            for (size_t i = 0; i < xs.size(); ++i) xs[i] = static_cast<double>(i);
+            ImPlot::PlotLine("Equity", xs.data(), equity_curve_.data(), static_cast<int>(equity_curve_.size()));
+            ImPlot::EndPlot();
+        }
     }
 
     ImGui::PopID();
@@ -283,6 +256,20 @@ void BackendTabController::updateTradeHistory() {
     std::string line;
     while (std::getline(file, line)) {
         trade_history_.push_back(line);
+    }
+}
+
+void BackendTabController::onBacktestResult(const BacktestResultEvent& e) {
+    last_result_ = e.result;
+    equity_curve_.clear();
+    float equity = 0.0f;
+    equity_curve_.push_back(equity);
+    for (const auto& t : last_result_.trades) {
+        float diff = (t.type == sep::quantum::SignalType::BUY)
+                         ? t.exit_price - t.entry_price
+                         : t.entry_price - t.exit_price;
+        equity += diff;
+        equity_curve_.push_back(equity);
     }
 }
 

--- a/src/apps/workbench/tabs/backend_tab_controller.h
+++ b/src/apps/workbench/tabs/backend_tab_controller.h
@@ -39,6 +39,7 @@ private:
     void renderTradeHistoryPanel();
     void renderBacktestingSuite();
     void updateTradeHistory();
+    void onBacktestResult(const BacktestResultEvent& e);
 
     void handleDataLoad();
     void handleClearData();
@@ -51,6 +52,8 @@ private:
     std::unique_ptr<sep::workbench::backtester::DataLoader> data_loader_;
     std::unique_ptr<sep::quantum::PatternMetricEngine> pattern_engine_;
     FileDialog file_dialog_;
+
+    backtester::BacktestResult last_result_{};
 
     // UI State
     char file_path_buffer_[512] = "eur_usd_m1_48h.json";


### PR DESCRIPTION
## Summary
- route backtesting results via new `BacktestResultEvent`
- extend `BacktesterEngine` API for custom strategies
- allow dataset browsing and strategy selection in Backtester tab
- show received metrics and equity curve in Backend tab

## Testing
- `cmake -S tests -B build/tests`
- `cmake --build build/tests`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6884cb19f5b4832a9659c03d8bfa20c0