### PR TITLE
Add streaming candle updates and connection status

### DIFF
--- a/src/apps/workbench/core/metrics_monitor.cpp
+++ b/src/apps/workbench/core/metrics_monitor.cpp
@@ -169,6 +169,11 @@ void MetricsMonitor::setLatestMarketData(const sep::connectors::MarketData& data
     latest_market_data_ = data;
 }
 
+void MetricsMonitor::setRollingMetrics(const RollingMetrics& metrics) {
+    std::lock_guard<std::mutex> lock(metrics_mutex_);
+    rolling_metrics_ = metrics;
+}
+
 void MetricsMonitor::setMinPatternLength(size_t min_length) {
     min_pattern_length_ = min_length;
 }

--- a/src/apps/workbench/core/metrics_monitor.h
+++ b/src/apps/workbench/core/metrics_monitor.h
@@ -112,6 +112,7 @@ public:
     sep::quantum::SignalThresholds calculateSignalThresholds() const;
     sep::connectors::MarketData getLatestMarketData() const;
     void setLatestMarketData(const sep::connectors::MarketData& data);
+    void setRollingMetrics(const RollingMetrics& metrics);
     
     std::unordered_map<std::string, double> getMetrics() const;
     void set(const std::string& key, double value);

--- a/src/apps/workbench/core/multi_timeframe_analyzer.cpp
+++ b/src/apps/workbench/core/multi_timeframe_analyzer.cpp
@@ -33,6 +33,10 @@ MultiTimeframeAnalyzer::~MultiTimeframeAnalyzer() {
     shutdown();
 }
 
+void MultiTimeframeAnalyzer::setMetricsCallback(MetricsCallback cb) {
+    metrics_callback_ = std::move(cb);
+}
+
 bool MultiTimeframeAnalyzer::initialize() {
     try {
         // Initialize coherence manager with constructor
@@ -88,6 +92,9 @@ void MultiTimeframeAnalyzer::ingestMarketData(const std::string& instrument, con
     
     // Update higher timeframes by resampling from 1m data
     updateAllTimeframes(instrument);
+    if (metrics_callback_) {
+        metrics_callback_(latest_metrics_);
+    }
 }
 
 void MultiTimeframeAnalyzer::ingestHistoricalData(const std::string& instrument, 

--- a/src/apps/workbench/core/multi_timeframe_analyzer.h
+++ b/src/apps/workbench/core/multi_timeframe_analyzer.h
@@ -3,6 +3,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <functional>
 #include <vector>
 #include "common/financial_data_types.h"
 
@@ -114,6 +115,7 @@ public:
 private:
     Config config_;
     std::mutex analysis_mutex_;
+    MetricsCallback metrics_callback_;
     
     // SEP Engine components - one per timeframe for parallel processing
     std::map<std::string, std::unique_ptr<sep::quantum::PatternMetricEngine>> pattern_engines_;
@@ -165,8 +167,11 @@ public:
     
     // Data ingestion
     void ingestMarketData(const std::string& instrument, const sep::common::CandleData& candle);
-    void ingestHistoricalData(const std::string& instrument, 
+    void ingestHistoricalData(const std::string& instrument,
                             const std::vector<sep::common::CandleData>& historical_candles);
+
+    using MetricsCallback = std::function<void(const std::map<std::string, TimeframeMetrics>&)>;
+    void setMetricsCallback(MetricsCallback cb);
     
     // Analysis methods
     MultiTimeframeSignal generateSignal(const std::string& instrument);

--- a/src/apps/workbench/core/workbench_core.cpp
+++ b/src/apps/workbench/core/workbench_core.cpp
@@ -110,6 +110,23 @@ bool WorkbenchEngine::initialize()
         signal_generator_->setMemoryManager(&::sep::memory::MemoryTierManager::getInstance());
         metrics_monitor_ = ::std::make_shared<MetricsMonitor>();
         multi_timeframe_analyzer_ = ::std::make_unique<MultiTimeframeAnalyzer>();
+        multi_timeframe_analyzer_->setMetricsCallback([this](const std::map<std::string, workbench::TimeframeMetrics>& m) {
+            if (!metrics_monitor_) return;
+            auto rolling = metrics_monitor_->getRollingMetrics();
+            auto it1 = m.find("1h");
+            if (it1 != m.end()) {
+                rolling.coherence_1h_avg = it1->second.dominant_coherence;
+                rolling.stability_1h_avg = it1->second.stability_index;
+                rolling.entropy_1h_avg = it1->second.entropy_level;
+            }
+            auto it4 = m.find("4h");
+            if (it4 != m.end()) {
+                rolling.coherence_4h_avg = it4->second.dominant_coherence;
+                rolling.stability_4h_avg = it4->second.stability_index;
+                rolling.entropy_4h_avg = it4->second.entropy_level;
+            }
+            metrics_monitor_->setRollingMetrics(rolling);
+        });
         
         // Initialize renderer and metrics dashboard
         int width, height;
@@ -154,6 +171,15 @@ bool WorkbenchEngine::initialize()
         if (service_connector_ && service_connector_->getOandaConnector()) {
             auto oanda_ptr = service_connector_->getOandaConnector();
             std::cout << "[WorkbenchEngine] OANDA connector available: " << (oanda_ptr ? "Yes" : "No") << std::endl;
+            oanda_ptr->setPriceCallback([this](const connectors::MarketData& md) {
+                if (metrics_monitor_) metrics_monitor_->setLatestMarketData(md);
+            });
+            oanda_ptr->setCandleCallback([this](const common::CandleData& c) {
+                if (multi_timeframe_analyzer_) {
+                    multi_timeframe_analyzer_->ingestMarketData("EUR_USD", c);
+                }
+            });
+            oanda_ptr->startPriceStream({"EUR_USD"});
         }
 
         const char* skip_env = std::getenv("SEP_SKIP_FETCH");
@@ -524,36 +550,37 @@ void WorkbenchEngine::handleErrorRecovery()
 
 void WorkbenchEngine::attemptServiceConnection()
 {
+    ConnectionState state = ConnectionState::DISCONNECTED;
     if (service_connector_) {
         metrics_.service_connected = service_connector_->connect();
-        
+
         if (metrics_.service_connected) {
             std::cout << "[WorkbenchEngine] Successfully connected to SEP service" << std::endl;
-            // Switch to service engine
             active_engine_ = service_connector_->getEngine();
-
-            // If service engine is null, fall back to offline
-            if (!active_engine_)
-            {
+            if (!active_engine_) {
                 std::cout
                     << "[WorkbenchEngine] Service engine is null, falling back to offline mode"
                     << std::endl;
                 active_engine_ = offline_engine_.get();
                 metrics_.service_connected = false;
+                state = ConnectionState::DISCONNECTED;
+            } else {
+                state = ConnectionState::CONNECTED;
             }
         } else {
             std::cout << "[WorkbenchEngine] Failed to connect to SEP service, using offline mode"
                       << std::endl;
             active_engine_ = offline_engine_.get();
+            state = ConnectionState::CONNECTION_FAILED;
         }
-    }
-    else
-    {
-        // No service connector, use offline mode
+    } else {
         std::cout << "[WorkbenchEngine] No service connector available, using offline mode"
                   << std::endl;
         active_engine_ = offline_engine_.get();
+        state = ConnectionState::DISCONNECTED;
     }
+
+    globalEventBus().publish(ConnectionStateEvent{state});
 
     // Ensure we always have a valid engine
     if (!active_engine_)

--- a/src/connectors/oanda_connector.cpp
+++ b/src/connectors/oanda_connector.cpp
@@ -211,6 +211,14 @@ bool OandaConnector::stopPriceStream() {
 
     streaming_active_ = false;
 
+    // flush any partially built candles
+    for (auto& [instrument, builder] : candle_builders_) {
+        if (builder.active && candle_callback_) {
+            candle_callback_(builder.candle);
+            builder.active = false;
+        }
+    }
+
     if (stream_thread_.joinable())
     {
         stream_thread_.join();
@@ -221,6 +229,10 @@ bool OandaConnector::stopPriceStream() {
 
 void OandaConnector::setPriceCallback(std::function<void(const MarketData&)> callback) {
     price_callback_ = callback;
+}
+
+void OandaConnector::setCandleCallback(std::function<void(const common::CandleData&)> cb) {
+    candle_callback_ = std::move(cb);
 }
 
 nlohmann::json OandaConnector::getAccountInfo() {
@@ -444,9 +456,11 @@ void OandaConnector::processStreamData(const std::string& data) {
             if (json_data.contains("type")) {
                 std::string type = json_data["type"];
                 if (type == "PRICE") {
+                    auto md = parseMarketData(json_data);
                     if (price_callback_) {
-                        price_callback_(parseMarketData(json_data));
+                        price_callback_(md);
                     }
+                    updateCandleBuilder(md);
                 } else if (type == "HEARTBEAT") {
                     // Connection is alive
                 }
@@ -477,8 +491,28 @@ MarketData OandaConnector::parseMarketData(const nlohmann::json& price_data) {
     }
     
     market_data.mid = (market_data.bid + market_data.ask) / 2.0;
-    
+
     return market_data;
+}
+
+void OandaConnector::updateCandleBuilder(const MarketData& md) {
+    auto tp = std::chrono::time_point<std::chrono::system_clock>(
+        std::chrono::nanoseconds(md.timestamp));
+    auto start = std::chrono::time_point_cast<std::chrono::minutes>(tp);
+    auto& builder = candle_builders_[md.instrument];
+    if (!builder.active || builder.start != start) {
+        if (builder.active && candle_callback_) {
+            candle_callback_(builder.candle);
+        }
+        builder.candle = common::CandleData(md.mid, md.mid, md.mid, md.mid, md.volume, start);
+        builder.start = start;
+        builder.active = true;
+    } else {
+        builder.candle.high = std::max(builder.candle.high, md.mid);
+        builder.candle.low = std::min(builder.candle.low, md.mid);
+        builder.candle.close = md.mid;
+        builder.candle.volume += md.volume;
+    }
 }
 
 OandaCandle OandaConnector::parseCandle(const nlohmann::json& candle_data) {

--- a/src/connectors/oanda_connector.h
+++ b/src/connectors/oanda_connector.h
@@ -77,6 +77,7 @@ public:
     bool startPriceStream(const std::vector<std::string>& instruments);
     bool stopPriceStream();
     void setPriceCallback(std::function<void(const MarketData&)> callback);
+    void setCandleCallback(std::function<void(const common::CandleData&)> cb);
 
     // Account information
     nlohmann::json getAccountInfo();
@@ -117,6 +118,14 @@ private:
     CURL* curl_handle_;
     std::string last_error_;
     std::function<void(const MarketData&)> price_callback_;
+    std::function<void(const common::CandleData&)> candle_callback_;
+
+    struct CandleBuilder {
+        common::CandleData candle;
+        std::chrono::system_clock::time_point start;
+        bool active{false};
+    };
+    std::unordered_map<std::string, CandleBuilder> candle_builders_;
     
     // HTTP helpers
     struct CurlResponse {
@@ -129,6 +138,7 @@ private:
 
     CurlResponse makeRequest(const std::string& endpoint, const std::string& method = "GET", const std::string& data = "");
     void processStreamData(const std::string& data);
+    void updateCandleBuilder(const MarketData& md);
 
     // Data conversion and validation
     MarketData parseMarketData(const nlohmann::json& price_data);


### PR DESCRIPTION
## Summary
- emit candle callbacks from `OandaConnector`
- continuously update `MultiTimeframeAnalyzer` and forward metrics
- push metrics to `MetricsMonitor` for live charts
- publish connection events from workbench engine

## Testing
- `cmake -S . -B build && cmake --build build -j4` *(fails: CUDA_HOME environment variable not set)*
- `./run_clang_tidy.sh` *(fails: compile_commands.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884cb12852c832a90af077a811bc26c