### PR TITLE
Update vendor dependencies and GLM setup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,14 +84,14 @@ set_target_properties(yaml-cpp PROPERTIES CXX_STANDARD 17)
 FetchContent_Declare(
   imgui
   GIT_REPOSITORY https://github.com/ocornut/imgui.git
-  GIT_TAG v1.89.9
+  GIT_TAG v1.92.2
 )
 FetchContent_MakeAvailable(imgui)
 
 FetchContent_Declare(
   implot
   GIT_REPOSITORY https://github.com/epezent/implot.git
-  GIT_TAG v0.16
+  GIT_TAG v0.17
 )
 FetchContent_MakeAvailable(implot)
 

--- a/cmake/template.cmake
+++ b/cmake/template.cmake
@@ -36,4 +36,12 @@ function(add_sep_library target_name)
             target_include_directories(${target_name} PUBLIC ${CUDAToolkit_INCLUDE_DIRS})
         endif()
     endif()
+
+    # Ensure GLM configuration is injected for every target so that
+    # GLM_ENABLE_EXPERIMENTAL and other settings in glm_config.h are honored.
+    if(MSVC)
+        target_compile_options(${target_name} PUBLIC /FI"${CMAKE_SOURCE_DIR}/src/engine/glm_config.h")
+    else()
+        target_compile_options(${target_name} PUBLIC -include "${CMAKE_SOURCE_DIR}/src/engine/glm_config.h")
+    endif()
 endfunction()

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -56,7 +56,7 @@ This phase runs in parallel with feature development and focuses on improving co
 -   **Status**: **NOT STARTED**
 -   **Priority**: Medium
 -   **Tasks**:
-    -   [ ] **`imgui` / `implot` Issues**: The majority of `HIGH` severity issues (`bugprone-incorrect-roundings`, `bugprone-sizeof-expression`, `core.NullDereference`) are within third-party libraries. Latest upstream versions are ImGui `1.92.2` and ImPlot `0.17` (checked 2025‑07). For now the project remains on `1.89.9` and `0.16`; warnings from these libraries are suppressed in the static analysis report.
+    -   [ ] **`imgui` / `implot` Issues**: The majority of `HIGH` severity issues (`bugprone-incorrect-roundings`, `bugprone-sizeof-expression`, `core.NullDereference`) stem from these third-party libraries. The project has been upgraded to ImGui `1.92.2` and ImPlot `0.17` so the latest upstream fixes are applied. Any remaining warnings from these libraries are acknowledged and accepted in the static analysis report.
     -   [ ] **`sep` Source Code**:
         -   Address `clang-diagnostic-double-promotion` warnings across the codebase (e.g., in `data_parser.cpp`, `oanda_connector.cpp`, `sep_demo_app.cpp`) to ensure floating-point precision is handled correctly.
         -   Fix `deadcode.DeadStores` and `unused-parameter` warnings to improve code clarity and remove unnecessary variables.


### PR DESCRIPTION
## Summary
- update FetchContent versions of imgui and implot
- inject `glm_config.h` compile option in `add_sep_library`
- document accepted vendor warnings

## Testing
- `cmake -S . -B build` *(fails: CUDA_HOME not set)*

------
https://chatgpt.com/codex/tasks/task_e_6884cdecaa18832aa95d1127161956b8