### PR TITLE
Connect backtester engine to pattern engine

### DIFF
--- a/src/apps/workbench/backtester/core/backtester_engine.cpp
+++ b/src/apps/workbench/backtester/core/backtester_engine.cpp
@@ -99,3 +99,10 @@ sep::workbench::backtester::BacktestResult BacktesterEngine::run(
 
     return result;
 }
+
+sep::workbench::backtester::BacktestResult BacktesterEngine::run(
+    const std::string& dataset_path,
+    sep::quantum::PatternMetricEngine* engine) {
+    SEPSignalStrategy default_strategy;
+    return run(dataset_path, engine, &default_strategy);
+}

--- a/src/apps/workbench/core/workbench_core.cpp
+++ b/src/apps/workbench/core/workbench_core.cpp
@@ -141,6 +141,7 @@ bool WorkbenchEngine::initialize()
         signals_tab_->initialize();
         engine_tab_->initialize();
         backend_tab_->initialize();
+        backend_tab_->setMetricsMonitor(metrics_monitor_);
 
         // Set up data flow
         signals_tab_->setOandaConnector(service_connector_->getOandaConnector());


### PR DESCRIPTION
## Summary
- link `BacktesterEngine` with the reusable `PatternMetricEngine`
- surface resulting metrics through the backend tab

## Testing
- `./build.sh` *(fails: cd /sep: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6884cddf6da0832aa72e54691dbaacea