### PR TITLE
Stream OANDA candles into multi-timeframe analyzer

### DIFF
--- a/src/apps/workbench/core/service_connector.cpp
+++ b/src/apps/workbench/core/service_connector.cpp
@@ -60,6 +60,13 @@ ServiceConnector::ServiceConnector(const ConnectionConfig& config)
         trade_manager_ = std::make_unique<workbench::TradeManager>(oanda_connector_.get());
         trade_manager_->setRiskPercentage(0.02);
         trade_manager_->setPaperTrading(cfg.oanda().paper_trading);
+        if (mtf_analyzer_) {
+            oanda_connector_->setCandleCallback([this](const common::CandleData& c) {
+                if (mtf_analyzer_) {
+                    mtf_analyzer_->ingestMarketData("EUR_USD", c);
+                }
+            });
+        }
         std::cout << "[ServiceConnector] OANDA connector configured for PRACTICE server" << std::endl;
         std::cout << "[ServiceConnector] API Key length: " << api_key.length() << std::endl;
         std::cout << "[ServiceConnector] Account ID: " << account_id << std::endl;

--- a/src/apps/workbench/core/service_connector.hpp
+++ b/src/apps/workbench/core/service_connector.hpp
@@ -10,6 +10,7 @@
 #include "connectors/oanda_connector.h"
 #include "service_proxy_engine.h"
 #include "trade_manager.h"
+#include "multi_timeframe_analyzer.h"
 #include "tabs/signals_tab_controller.h"
 #include "common/financial_data_types.h"
 
@@ -89,6 +90,7 @@ public:
     const ConnectionConfig& getConfig() const { return config_; }
 
     void setSignalsTab(SignalsTabController* tab);
+    void setMultiTimeframeAnalyzer(MultiTimeframeAnalyzer* analyzer) { mtf_analyzer_ = analyzer; }
     const std::deque<common::CandleData>& getInitialData() const { return initial_data_; }
 
 private:
@@ -131,6 +133,7 @@ private:
     std::unique_ptr<sep::core::ServiceProxyEngine> http_proxy_engine_;
 
     SignalsTabController* signals_tab_{nullptr};
+    MultiTimeframeAnalyzer* mtf_analyzer_{nullptr};
     std::deque<common::CandleData> initial_data_;
     std::deque<common::SEPSignalData> initial_signals_;
 

--- a/src/apps/workbench/core/workbench_core.cpp
+++ b/src/apps/workbench/core/workbench_core.cpp
@@ -25,6 +25,7 @@
 // Include ImGui headers
 #include "imgui.h"
 #include "imgui_internal.h"
+#include "imgui_helpers.hpp"
 #include <implot.h>
 
 // Use correct paths for ImGui implementation files
@@ -126,6 +127,9 @@ bool WorkbenchEngine::initialize()
                 rolling.entropy_4h_avg = it4->second.entropy_level;
             }
             metrics_monitor_->setRollingMetrics(rolling);
+            if (signals_tab_) {
+                signals_tab_->setMetricsMonitor(metrics_monitor_);
+            }
         });
         
         // Initialize renderer and metrics dashboard
@@ -148,6 +152,7 @@ bool WorkbenchEngine::initialize()
         signals_tab_->setMetricsMonitor(metrics_monitor_);
         signals_tab_->setWorkbenchEngine(this);
         service_connector_->setSignalsTab(signals_tab_.get());
+        service_connector_->setMultiTimeframeAnalyzer(multi_timeframe_analyzer_.get());
         engine_tab_->setSEPEngine(active_engine_);
         engine_tab_->setMetricsMonitor(metrics_monitor_);
         engine_tab_->setMultiTimeframeAnalyzer(multi_timeframe_analyzer_.get());
@@ -173,11 +178,6 @@ bool WorkbenchEngine::initialize()
             std::cout << "[WorkbenchEngine] OANDA connector available: " << (oanda_ptr ? "Yes" : "No") << std::endl;
             oanda_ptr->setPriceCallback([this](const connectors::MarketData& md) {
                 if (metrics_monitor_) metrics_monitor_->setLatestMarketData(md);
-            });
-            oanda_ptr->setCandleCallback([this](const common::CandleData& c) {
-                if (multi_timeframe_analyzer_) {
-                    multi_timeframe_analyzer_->ingestMarketData("EUR_USD", c);
-                }
             });
             oanda_ptr->startPriceStream({"EUR_USD"});
         }
@@ -581,6 +581,11 @@ void WorkbenchEngine::attemptServiceConnection()
     }
 
     globalEventBus().publish(ConnectionStateEvent{state});
+    if (state == ConnectionState::CONNECTED) {
+        Toast("Service Connected", "Successfully connected to SEP service");
+    } else if (state == ConnectionState::CONNECTION_FAILED) {
+        Toast("Connection Failed", "Could not connect to SEP service");
+    }
 
     // Ensure we always have a valid engine
     if (!active_engine_)

--- a/src/connectors/oanda_connector.cpp
+++ b/src/connectors/oanda_connector.cpp
@@ -498,8 +498,20 @@ void OandaConnector::updateCandleBuilder(const MarketData& md) {
     auto start = std::chrono::time_point_cast<std::chrono::minutes>(tp);
     auto& builder = candle_builders_[md.instrument];
     if (!builder.active || builder.start != start) {
-        if (builder.active && candle_callback_) {
-            candle_callback_(builder.candle);
+        if (builder.active) {
+            if (candle_callback_) {
+                candle_callback_(builder.candle);
+            }
+            if (price_callback_) {
+                MarketData candle_md;
+                candle_md.instrument = md.instrument;
+                candle_md.bid = builder.candle.close;
+                candle_md.ask = builder.candle.close;
+                candle_md.mid = builder.candle.close;
+                candle_md.timestamp = sep::common::time_point_to_nanoseconds(builder.start);
+                candle_md.volume = builder.candle.volume;
+                price_callback_(candle_md);
+            }
         }
         builder.candle = common::CandleData(md.mid, md.mid, md.mid, md.mid, md.volume, start);
         builder.start = start;


### PR DESCRIPTION
## Summary
- forward completed streaming candles through `setPriceCallback`
- allow `ServiceConnector` to register a `MultiTimeframeAnalyzer`
- connect analyzer in `WorkbenchEngine` init and display connection toast

## Testing
- `cmake ..` *(fails: CUDA_HOME environment variable not set)*

------
https://chatgpt.com/codex/tasks/task_e_6884cdd88cb0832abab983251ca6a564