### PR TITLE
Add ServiceProxy handling and engine UI updates

### DIFF
--- a/src/apps/workbench/core/service_connector.cpp
+++ b/src/apps/workbench/core/service_connector.cpp
@@ -209,6 +209,7 @@ void ServiceConnector::disconnect() {
     }
     
     service_engine_ = nullptr;
+    service_proxy_engine_ = nullptr;
     connection_state_ = sep::workbench::ConnectionState::DISCONNECTED;
     
     // Notify via EventBus
@@ -856,7 +857,9 @@ core::Engine* ServiceConnector::createLocalEngine()
         std::cout << "[ServiceConnector] Local SEP engine initialized successfully" << std::endl;
         health_metrics_.is_responsive = true;
         health_metrics_.version_info = "SEP Local Engine v1.0";
-        
+
+        service_proxy_engine_ = nullptr;
+
         return local_engine_.get();
         
     } catch (const std::exception& e) {
@@ -865,11 +868,11 @@ core::Engine* ServiceConnector::createLocalEngine()
     }
 }
 
-core::Engine* ServiceConnector::createHttpEngineProxy(int socket_fd)
+core::ServiceProxyEngine* ServiceConnector::createHttpEngineProxy(int socket_fd)
 {
     try {
         std::cout << "[ServiceConnector] Creating HTTP proxy engine for remote service..." << std::endl;
-        
+
     // Create a proxy engine that forwards commands to the remote service via HTTP
     http_proxy_engine_ = std::make_unique<core::ServiceProxyEngine>(config_.service_address, config_.service_port);
 
@@ -879,22 +882,23 @@ core::Engine* ServiceConnector::createHttpEngineProxy(int socket_fd)
         std::cerr << "[ServiceConnector] " << err << std::endl;
         health_metrics_.last_error = err;
         health_metrics_.is_responsive = false;
-        // Fallback to local engine
-        return createLocalEngine();
+        service_proxy_engine_ = nullptr;
+        return nullptr;
     }
 
     health_metrics_.last_error.clear();
-        
+
         std::cout << "[ServiceConnector] HTTP proxy engine created successfully" << std::endl;
         health_metrics_.is_responsive = true;
         health_metrics_.version_info = "SEP Remote Service Proxy v1.0";
-        
-        return http_proxy_engine_.get();
-        
+
+        service_proxy_engine_ = http_proxy_engine_.get();
+        return service_proxy_engine_;
+
     } catch (const std::exception& e) {
         std::cerr << "[ServiceConnector] Exception creating HTTP proxy engine: " << e.what() << std::endl;
-        // Fallback to local engine
-        return createLocalEngine();
+        service_proxy_engine_ = nullptr;
+        return nullptr;
     }
 }
 

--- a/src/apps/workbench/core/service_connector.hpp
+++ b/src/apps/workbench/core/service_connector.hpp
@@ -73,7 +73,7 @@ public:
     sep::core::Engine* getEngine() const { return service_engine_; }
     sep::connectors::OandaConnector* getOandaConnector() const { return oanda_connector_.get(); }
     workbench::TradeManager* getTradeManager() const { return trade_manager_.get(); }
-    sep::core::ServiceProxyEngine* getServiceProxyEngine() const { return http_proxy_engine_.get(); }
+    sep::core::ServiceProxyEngine* getServiceProxyEngine() const { return service_proxy_engine_; }
     ServiceHealth getServiceHealth() const;
     
     // Health monitoring
@@ -126,11 +126,12 @@ private:
     // Service engine creation
     sep::core::Engine* createServiceEngineProxy(int socket_fd);
     sep::core::Engine* createLocalEngine();
-    sep::core::Engine* createHttpEngineProxy(int socket_fd);
+    sep::core::ServiceProxyEngine* createHttpEngineProxy(int socket_fd);
     
     // Engine instances
     std::unique_ptr<sep::core::Engine> local_engine_;
     std::unique_ptr<sep::core::ServiceProxyEngine> http_proxy_engine_;
+    sep::core::ServiceProxyEngine* service_proxy_engine_{nullptr};
 
     SignalsTabController* signals_tab_{nullptr};
     MultiTimeframeAnalyzer* mtf_analyzer_{nullptr};

--- a/src/apps/workbench/core/workbench_core.cpp
+++ b/src/apps/workbench/core/workbench_core.cpp
@@ -554,6 +554,9 @@ void WorkbenchEngine::attemptServiceConnection()
     ConnectionState state = ConnectionState::DISCONNECTED;
     if (service_connector_) {
         metrics_.service_connected = service_connector_->connect();
+        if (engine_tab_) {
+            engine_tab_->setServiceProxyEngine(service_connector_->getServiceProxyEngine());
+        }
 
         if (metrics_.service_connected) {
             std::cout << "[WorkbenchEngine] Successfully connected to SEP service" << std::endl;

--- a/src/apps/workbench/tabs/engine_tab_controller.cpp
+++ b/src/apps/workbench/tabs/engine_tab_controller.cpp
@@ -73,6 +73,9 @@ void EngineTabController::setMetricsMonitor(std::shared_ptr<MetricsMonitor> moni
 
 void EngineTabController::setSEPEngine(core::Engine* engine) {
     sep_engine_ = engine;
+    if (engine && engine != reinterpret_cast<core::Engine*>(service_proxy_engine_)) {
+        local_engine_ = engine;
+    }
 }
 
 void EngineTabController::setPatternMetricEngine(quantum::PatternMetricEngine* pattern_engine) {
@@ -89,6 +92,9 @@ void EngineTabController::setMultiTimeframeAnalyzer(MultiTimeframeAnalyzer* anal
 
 void EngineTabController::setServiceProxyEngine(core::ServiceProxyEngine* engine) {
     service_proxy_engine_ = engine;
+    if (use_remote_engine_ && service_proxy_engine_) {
+        sep_engine_ = service_proxy_engine_;
+    }
 }
 
 void EngineTabController::renderSEPMetricsPanel() {
@@ -263,6 +269,21 @@ void EngineTabController::renderSEPMetricsPanel() {
 
 void EngineTabController::renderEngineControls() {
     ImGui::Text("Engine Controls:");
+
+    if (service_proxy_engine_) {
+        bool connected = service_proxy_engine_->isConnected();
+        ImGui::Text("Service Status: %s", connected ? "Connected" : "Disconnected");
+        ImGui::SameLine();
+        if (ImGui::Checkbox("Use Remote Engine", &use_remote_engine_)) {
+            if (use_remote_engine_ && connected) {
+                sep_engine_ = service_proxy_engine_;
+            } else if (local_engine_) {
+                sep_engine_ = local_engine_;
+            }
+        }
+    } else {
+        ImGui::Text("Service Status: Offline");
+    }
 
     if (ImGui::Button("Reset Engine State")) {
         resetEngineState();

--- a/src/apps/workbench/tabs/engine_tab_controller.h
+++ b/src/apps/workbench/tabs/engine_tab_controller.h
@@ -37,10 +37,12 @@ public:
 private:
     std::shared_ptr<MetricsMonitor> metrics_monitor_;
     sep::core::Engine* sep_engine_ = nullptr;
+    sep::core::Engine* local_engine_ = nullptr;
     sep::quantum::PatternMetricEngine* pattern_engine_ = nullptr;
     sep::quantum::CoherenceManager* coherence_manager_ = nullptr;
     MultiTimeframeAnalyzer* multi_timeframe_analyzer_ = nullptr;
     sep::core::ServiceProxyEngine* service_proxy_engine_ = nullptr;
+    bool use_remote_engine_ = false;
 
     // Rendering functions
     void renderSEPMetricsPanel();


### PR DESCRIPTION
## Summary
- return pointer to HTTP proxy engine from ServiceConnector
- expose and track ServiceProxyEngine pointer
- refresh EngineTab connection after connecting
- show connection status and remote toggle in EngineTab

## Testing
- `./build.sh` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688540d3e3a0832a8827832286a0614c