### PR TITLE
Fix initialization order for multi-timeframe analyzer

### DIFF
--- a/src/apps/workbench/core/service_connector.cpp
+++ b/src/apps/workbench/core/service_connector.cpp
@@ -235,6 +235,20 @@ void ServiceConnector::setSignalsTab(SignalsTabController* tab)
     }
 }
 
+void ServiceConnector::setMultiTimeframeAnalyzer(MultiTimeframeAnalyzer* analyzer)
+{
+    mtf_analyzer_ = analyzer;
+    if (oanda_connector_ && mtf_analyzer_)
+    {
+        oanda_connector_->setCandleCallback([this](const common::CandleData& c) {
+            if (mtf_analyzer_)
+            {
+                mtf_analyzer_->ingestMarketData("EUR_USD", c);
+            }
+        });
+    }
+}
+
 ServiceHealth ServiceConnector::getServiceHealth() const {
     return health_metrics_;
 }

--- a/src/apps/workbench/core/service_connector.hpp
+++ b/src/apps/workbench/core/service_connector.hpp
@@ -90,7 +90,7 @@ public:
     const ConnectionConfig& getConfig() const { return config_; }
 
     void setSignalsTab(SignalsTabController* tab);
-    void setMultiTimeframeAnalyzer(MultiTimeframeAnalyzer* analyzer) { mtf_analyzer_ = analyzer; }
+    void setMultiTimeframeAnalyzer(MultiTimeframeAnalyzer* analyzer);
     const std::deque<common::CandleData>& getInitialData() const { return initial_data_; }
 
 private:

--- a/src/apps/workbench/core/workbench_core.cpp
+++ b/src/apps/workbench/core/workbench_core.cpp
@@ -89,8 +89,6 @@ bool WorkbenchEngine::initialize()
         // Initialize core components
         ::std::cout << "[WorkbenchEngine] Initializing core components..." << ::std::endl;
 
-        service_connector_ = ::std::make_unique<ServiceConnector>();
-        
         // Removed demo components for real trading
         // sep::workbench::registerDemos();
         // demo_orchestrator_ = std::make_unique<DemoOrchestrator>();
@@ -130,7 +128,13 @@ bool WorkbenchEngine::initialize()
             if (signals_tab_) {
                 signals_tab_->setMetricsMonitor(metrics_monitor_);
             }
+            if (engine_tab_) {
+                engine_tab_->setMetricsMonitor(metrics_monitor_);
+            }
         });
+
+        service_connector_ = ::std::make_unique<ServiceConnector>();
+        service_connector_->setMultiTimeframeAnalyzer(multi_timeframe_analyzer_.get());
         
         // Initialize renderer and metrics dashboard
         int width, height;
@@ -153,7 +157,6 @@ bool WorkbenchEngine::initialize()
         signals_tab_->setMetricsMonitor(metrics_monitor_);
         signals_tab_->setWorkbenchEngine(this);
         service_connector_->setSignalsTab(signals_tab_.get());
-        service_connector_->setMultiTimeframeAnalyzer(multi_timeframe_analyzer_.get());
         engine_tab_->setSEPEngine(active_engine_);
         engine_tab_->setMetricsMonitor(metrics_monitor_);
         engine_tab_->setMultiTimeframeAnalyzer(multi_timeframe_analyzer_.get());


### PR DESCRIPTION
## Summary
- construct `MultiTimeframeAnalyzer` before `ServiceConnector`
- wire analyzer into `ServiceConnector` when created
- forward candle callbacks to the analyzer
- send metrics updates to both Engine and Signals tabs

## Testing
- `./build.sh` *(fails: cd /sep: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688540bfd6d8832a8fad54cf16bb258c