### PR TITLE
Integrate pattern engine signals in backtester

### DIFF
--- a/src/apps/workbench/backtester/core/backtester_engine.cpp
+++ b/src/apps/workbench/backtester/core/backtester_engine.cpp
@@ -55,9 +55,10 @@ sep::workbench::backtester::BacktestResult BacktesterEngine::run(
     engine_ref.evolvePatterns();
     engine_ref.computeMetrics();
 
-    std::vector<sep::quantum::Signal> signals;
+    std::vector<sep::quantum::Signal> engine_signals = engine_ref.getSignals();
+    std::vector<sep::quantum::Signal> signals = engine_signals;
     if (strategy) {
-        signals = strategy->execute(candles);
+        signals = strategy->execute(candles, engine_signals);
     }
     std::vector<float> prices;
     prices.reserve(candles.size());

--- a/src/apps/workbench/backtester/strategies/base_strategy.h
+++ b/src/apps/workbench/backtester/strategies/base_strategy.h
@@ -16,5 +16,6 @@ public:
      * @return Generated buy/sell/hold signals for each candle.
      */
     virtual std::vector<sep::quantum::Signal>
-    execute(const std::vector<sep::common::CandleData>& candles) = 0;
+    execute(const std::vector<sep::common::CandleData>& candles,
+            const std::vector<sep::quantum::Signal>& engine_signals) = 0;
 };

--- a/src/apps/workbench/backtester/strategies/sep_signal_strategy.cpp
+++ b/src/apps/workbench/backtester/strategies/sep_signal_strategy.cpp
@@ -11,8 +11,12 @@ SEPSignalStrategy::SEPSignalStrategy() {
 SEPSignalStrategy::~SEPSignalStrategy() = default;
 
 std::vector<sep::quantum::Signal>
-SEPSignalStrategy::execute(const std::vector<sep::common::CandleData>& candles) {
-    std::vector<sep::quantum::Signal> signals;
+SEPSignalStrategy::execute(const std::vector<sep::common::CandleData>& candles,
+                           const std::vector<sep::quantum::Signal>& engine_signals) {
+    std::vector<sep::quantum::Signal> signals = engine_signals;
+    if (!signals.empty()) {
+        return signals;
+    }
     if (candles.empty()) {
         return signals;
     }

--- a/src/apps/workbench/backtester/strategies/sep_signal_strategy.h
+++ b/src/apps/workbench/backtester/strategies/sep_signal_strategy.h
@@ -10,7 +10,8 @@ public:
     ~SEPSignalStrategy();
 
     std::vector<sep::quantum::Signal>
-    execute(const std::vector<sep::common::CandleData>& candles) override;
+    execute(const std::vector<sep::common::CandleData>& candles,
+            const std::vector<sep::quantum::Signal>& engine_signals) override;
 
 private:
     sep::quantum::PatternMetricEngine engine_;

--- a/src/apps/workbench/backtester/ui/backtester_tab_controller.cpp
+++ b/src/apps/workbench/backtester/ui/backtester_tab_controller.cpp
@@ -10,7 +10,6 @@ using sep::workbench::BacktestResultEvent;
 
 BacktesterTabController::BacktesterTabController()
     : engine_(std::make_unique<BacktesterEngine>()) {
-    pattern_engine_.init(nullptr);
 }
 
 BacktesterTabController::~BacktesterTabController() {
@@ -36,6 +35,7 @@ void BacktesterTabController::render() {
                     return true;
                 },
                 &strategy_names_, strategy_names_.size());
+    ImGui::Checkbox("Use GPU", &use_gpu_);
 
     if (!running_) {
         if (ImGui::Button("Start")) {
@@ -45,6 +45,7 @@ void BacktesterTabController::render() {
             if (strategy_index_ == 0) {
                 strat_ptr = &strategy;
             }
+            pattern_engine_.init(use_gpu_ ? &gpu_context_ : nullptr);
             result_ = engine_->run(dataset_path_, &pattern_engine_, strat_ptr);
             globalEventBus().publish(BacktestResultEvent{result_});
             running_ = false;

--- a/src/apps/workbench/backtester/ui/backtester_tab_controller.h
+++ b/src/apps/workbench/backtester/ui/backtester_tab_controller.h
@@ -17,6 +17,8 @@ public:
 private:
     std::unique_ptr<BacktesterEngine> engine_;
     sep::quantum::PatternMetricEngine pattern_engine_;
+    sep::quantum::GPUContext gpu_context_{};
+    bool use_gpu_ = false;
     std::vector<std::string> strategy_names_{"SEP Signal"};
     int strategy_index_ = 0;
     sep::workbench::FileDialog file_dialog_;


### PR DESCRIPTION
## Summary
- wire PatternMetricEngine output into strategy execution
- allow strategies to accept engine-generated signals
- enable GPU/CPU toggle in Backtester tab
- display backtest metrics and trades

## Testing
- `cmake -S tests -B build/tests`
- `cmake --build build/tests`
- `ctest --test-dir build/tests`
- `./run_clang_tidy.sh` *(fails: compile_commands.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_688540c4f180832ab4cb64bfd803e906