### PR TITLE
Integrate engine signals with strategy

### DIFF
--- a/src/apps/workbench/backtester/core/backtester_engine.cpp
+++ b/src/apps/workbench/backtester/core/backtester_engine.cpp
@@ -58,7 +58,21 @@ sep::workbench::backtester::BacktestResult BacktesterEngine::run(
     std::vector<sep::quantum::Signal> engine_signals = engine_ref.getSignals();
     std::vector<sep::quantum::Signal> signals = engine_signals;
     if (strategy) {
-        signals = strategy->execute(candles, engine_signals);
+        std::vector<sep::quantum::Signal> strat_signals =
+            strategy->execute(candles, engine_signals);
+        if (!strat_signals.empty()) {
+            size_t merge_size =
+                std::min(strat_signals.size(), engine_signals.size());
+            for (size_t i = 0; i < merge_size; ++i) {
+                if (strat_signals[i].type != sep::quantum::SignalType::HOLD) {
+                    signals[i] = strat_signals[i];
+                }
+            }
+            if (strat_signals.size() > engine_signals.size()) {
+                signals.insert(signals.end(), strat_signals.begin() + merge_size,
+                               strat_signals.end());
+            }
+        }
     }
     std::vector<float> prices;
     prices.reserve(candles.size());

--- a/src/apps/workbench/backtester/ui/backtester_tab_controller.cpp
+++ b/src/apps/workbench/backtester/ui/backtester_tab_controller.cpp
@@ -35,7 +35,10 @@ void BacktesterTabController::render() {
                     return true;
                 },
                 &strategy_names_, strategy_names_.size());
-    ImGui::Checkbox("Use GPU", &use_gpu_);
+    int device_index = use_gpu_ ? 1 : 0;
+    const char* device_items[] = {"CPU", "GPU"};
+    ImGui::Combo("Device", &device_index, device_items, 2);
+    use_gpu_ = device_index == 1;
 
     if (!running_) {
         if (ImGui::Button("Start")) {


### PR DESCRIPTION
## Summary
- merge PatternMetricEngine signals with BaseStrategy output
- select compute device in the backtester tab

## Testing
- `apt-get update`
- `apt-get install -y libglm-dev`
- `g++ -std=c++17 -I./src -I./extern -c src/apps/workbench/backtester/core/backtester_engine.cpp -o /tmp/backtester_engine.o` *(fails: fatal error: data_loader.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68854393b2d8832aa7c4d1cc1c610154