### PR TITLE
Fix remote engine proxy wiring

### DIFF
--- a/src/apps/workbench/core/service_connector.cpp
+++ b/src/apps/workbench/core/service_connector.cpp
@@ -889,14 +889,16 @@ core::ServiceProxyEngine* ServiceConnector::createHttpEngineProxy(int socket_fd)
 
     // Create a proxy engine that forwards commands to the remote service via HTTP
     http_proxy_engine_ = std::make_unique<core::ServiceProxyEngine>(config_.service_address, config_.service_port);
+    service_proxy_engine_ = http_proxy_engine_.get();
 
     config::CudaConfig cfg{};
-    if (!http_proxy_engine_->init(cfg) || !http_proxy_engine_->isConnected()) {
-        std::string err = "HTTP proxy engine connection failed: " + http_proxy_engine_->getLastError();
+    if (!service_proxy_engine_->init(cfg) || !service_proxy_engine_->isConnected()) {
+        std::string err = "HTTP proxy engine connection failed: " + service_proxy_engine_->getLastError();
         std::cerr << "[ServiceConnector] " << err << std::endl;
         health_metrics_.last_error = err;
         health_metrics_.is_responsive = false;
         service_proxy_engine_ = nullptr;
+        http_proxy_engine_.reset();
         return nullptr;
     }
 

--- a/src/apps/workbench/tabs/engine_tab_controller.cpp
+++ b/src/apps/workbench/tabs/engine_tab_controller.cpp
@@ -270,9 +270,14 @@ void EngineTabController::renderSEPMetricsPanel() {
 void EngineTabController::renderEngineControls() {
     ImGui::Text("Engine Controls:");
 
+    bool connected = service_proxy_engine_ && service_proxy_engine_->isConnected();
+    ImVec4 status_color = connected ? ImVec4(0.0f, 1.0f, 0.0f, 1.0f)
+                                    : ImVec4(1.0f, 0.0f, 0.0f, 1.0f);
+    ImGui::TextColored(status_color, "Service Status: %s",
+                       service_proxy_engine_ ? (connected ? "Connected" : "Disconnected")
+                                             : "Offline");
+
     if (service_proxy_engine_) {
-        bool connected = service_proxy_engine_->isConnected();
-        ImGui::Text("Service Status: %s", connected ? "Connected" : "Disconnected");
         ImGui::SameLine();
         if (ImGui::Checkbox("Use Remote Engine", &use_remote_engine_)) {
             if (use_remote_engine_ && connected) {
@@ -281,9 +286,11 @@ void EngineTabController::renderEngineControls() {
                 sep_engine_ = local_engine_;
             }
         }
-    } else {
-        ImGui::Text("Service Status: Offline");
     }
+
+    ImGui::Text("Current Engine: %s", (sep_engine_ == service_proxy_engine_ && connected)
+                                          ? "Remote"
+                                          : "Local");
 
     if (ImGui::Button("Reset Engine State")) {
         resetEngineState();


### PR DESCRIPTION
## Summary
- ensure the HTTP engine proxy is assigned before initialization
- colorize connection status and show current engine in UI

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` *(fails: CUDA_HOME environment variable not set)*

------
https://chatgpt.com/codex/tasks/task_e_688543a407bc832aa4ca9e8b6998988e