### PR TITLE
Generate condensed static analysis summary

### DIFF
--- a/docs/ARCH/condensed_report.md
+++ b/docs/ARCH/condensed_report.md
@@ -1,0 +1,41 @@
+# Condensed Static Analysis Report
+
+Original reports processed: 10229
+
+Unique issues identified: 2758
+
+
+## Issues by Severity
+
+| Severity | Count |
+|---|---|
+| CRITICAL | 4 |
+| HIGH | 6541 |
+| LOW | 234 |
+| MEDIUM | 3437 |
+| STYLE | 13 |
+
+## Top Files by Issue Count
+
+| File | Count |
+|---|---|
+| build/_deps/tbb-src/test/common/doctest.h | 4377 |
+| build/_deps/tbb-src/src/tbb/tools_api/ittnotify.h | 921 |
+| build/_deps/tbb-src/src/tbb/tools_api/ittnotify_static.h | 596 |
+| build/_deps/tbb-src/test/common/concurrent_associative_common.h | 310 |
+| build/_deps/tbb-src/src/tbb/tools_api/legacy/ittnotify.h | 132 |
+| build/_deps/tbb-src/test/common/container_move_support.h | 126 |
+| build/_deps/tbb-src/test/common/test_comparisons.h | 100 |
+| build/_deps/tbb-src/test/conformance/conformance_concurrent_hash_map.cpp | 99 |
+| build/_deps/tbb-src/test/conformance/conformance_concurrent_queue.cpp | 82 |
+| build/_deps/implot-src/implot_items.cpp | 81 |
+| build/_deps/implot-src/implot_demo.cpp | 79 |
+| build/_deps/tbb-src/include/oneapi/tbb/detail/_config.h | 76 |
+| build/_deps/imgui-src/imgui_demo.cpp | 60 |
+| build/_deps/tbb-src/test/conformance/conformance_concurrent_vector.cpp | 60 |
+| src/apps/workbench/tabs/signals_tab_controller.cpp | 60 |
+| build/_deps/implot-src/implot.cpp | 58 |
+| build/_deps/tbb-src/test/common/graph_utils.h | 57 |
+| build/_deps/tbb-src/include/oneapi/tbb/flow_graph.h | 56 |
+| build/_deps/tbb-src/test/conformance/conformance_flowgraph.h | 55 |
+| build/_deps/tbb-src/test/common/containers_common.h | 53 |

--- a/docs/ARCH/diagnostic.md
+++ b/docs/ARCH/diagnostic.md
@@ -1,0 +1,18 @@
+# Diagnostic Issue Map
+
+```mermaid
+graph TD
+    subgraph Static_Analysis_Issues
+        A["build/_deps\n9828 issues"]
+        B["src/apps\n240"]
+        C["/usr\n80"]
+        D["third_party/fmt\n40"]
+        E["src/engine\n16"]
+        F["src/glad\n8"]
+        G["src/connectors\n7"]
+        H["src/audio\n5"]
+        I["examples/pattern_metric_example.cpp\n3"]
+        J["src/quantum\n1"]
+        K["src/memory\n1"]
+    end
+```

--- a/docs/ARCH/issue_breakdown.md
+++ b/docs/ARCH/issue_breakdown.md
@@ -1,0 +1,15 @@
+# Issue Breakdown by Folder
+
+| Folder | Count |
+|---|---|
+| build/_deps | 9828 |
+| src/apps | 240 |
+| /usr | 80 |
+| third_party/fmt | 40 |
+| src/engine | 16 |
+| src/glad | 8 |
+| src/connectors | 7 |
+| src/audio | 5 |
+| examples/pattern_metric_example.cpp | 3 |
+| src/quantum | 1 |
+| src/memory | 1 |

--- a/docs/ARCH/pipeline.md
+++ b/docs/ARCH/pipeline.md
@@ -1,0 +1,11 @@
+# SEP Engine Data Pipeline
+
+```mermaid
+graph TD
+    MD[Market Data Sources] --> OC[OandaConnector]
+    OC --> DP[DataParser]
+    DP --> PME[PatternMetricEngine]
+    PME --> MC[Metrics Computation]
+    MC --> SG[Signal Generation]
+    SG --> GUI[Workbench GUI]
+```

--- a/scripts/condense_report.py
+++ b/scripts/condense_report.py
@@ -1,0 +1,63 @@
+import re
+from collections import defaultdict
+import pathlib
+
+report_path = pathlib.Path('docs/report.md')
+summary_path = pathlib.Path('docs/ARCH/condensed_report.md')
+breakdown_path = pathlib.Path('docs/ARCH/issue_breakdown.md')
+
+pattern = re.compile(r'^\[(?P<severity>[^\]]+)\]\s+(?P<file>[^:]+):(?P<line>\d+):(?P<col>\d+):\s+(?P<message>.*)\s\[(?P<rule>[^\]]+)\]')
+
+severity_counts = defaultdict(int)
+file_counts = defaultdict(int)
+folder_counts = defaultdict(int)
+unique_entries = defaultdict(int)
+
+total = 0
+with report_path.open('r', errors='ignore') as f:
+    for line in f:
+        m = pattern.match(line)
+        if m:
+            total += 1
+            sev = m.group('severity')
+            file = m.group('file')
+            msg = m.group('message')
+            rule = m.group('rule')
+            severity_counts[sev] += 1
+            file_counts[file] += 1
+            parts = file.replace('/sep/', '').split('/')
+            folder = '/'.join(parts[:2]) if len(parts) > 1 else parts[0]
+            folder_counts[folder] += 1
+            unique_entries[(file, msg, rule)] += 1
+
+unique_issue_count = len(unique_entries)
+
+# Compose markdown
+lines = []
+lines.append('# Condensed Static Analysis Report\n')
+lines.append(f'Original reports processed: {total}\n')
+lines.append(f'Unique issues identified: {unique_issue_count}\n')
+lines.append('\n## Issues by Severity\n')
+lines.append('| Severity | Count |\n|---|---|')
+for sev, count in sorted(severity_counts.items(), key=lambda x: x[0]):
+    lines.append(f'| {sev} | {count} |')
+
+lines.append('\n## Top Files by Issue Count\n')
+lines.append('| File | Count |\n|---|---|')
+for file, count in sorted(file_counts.items(), key=lambda x: x[1], reverse=True)[:20]:
+    short = file.replace('/sep/', '')
+    lines.append(f'| {short} | {count} |')
+
+summary_path.write_text('\n'.join(lines))
+
+# Issue breakdown by top-level folders for diagnostics
+b_lines = []
+b_lines.append('# Issue Breakdown by Folder\n')
+b_lines.append('| Folder | Count |\n|---|---|')
+for folder, count in sorted(folder_counts.items(), key=lambda x: x[1], reverse=True):
+    b_lines.append(f'| {folder} | {count} |')
+
+breakdown_path.write_text('\n'.join(b_lines))
+
+print(f'Wrote summary to {summary_path}')
+print(f'Wrote folder breakdown to {breakdown_path}')


### PR DESCRIPTION
## Summary
- add script to parse docs/report.md
- produce condensed report and folder breakdown
- document main data pipeline via mermaid
- add diagram of issue counts by folder

## Testing
- `python3 scripts/condense_report.py`

------
https://chatgpt.com/codex/tasks/task_e_688568e7dddc832abdcaea88866bf8ed