### PR TITLE
Use real backtest data in workbench

### DIFF
--- a/src/apps/workbench/backtester/backtester.cpp
+++ b/src/apps/workbench/backtester/backtester.cpp
@@ -16,6 +16,8 @@ void Backtester::run(sep::quantum::PatternMetricEngine* engine, DataLoader* data
         return;
     }
 
+    result_ = {};
+
     const auto& candles = data_loader->get_data();
     if (candles.empty()) {
         return;
@@ -101,8 +103,11 @@ void Backtester::run(sep::quantum::PatternMetricEngine* engine, DataLoader* data
     float peak = 0.0f;
     float max_drawdown = 0.0f;
     float current_pnl = 0.0f;
+    result_.equity_curve.clear();
+    result_.equity_curve.push_back(current_pnl);
     for (float p : pnl) {
         current_pnl += p;
+        result_.equity_curve.push_back(current_pnl);
         if (current_pnl > peak) {
             peak = current_pnl;
         }

--- a/src/apps/workbench/backtester/backtester.h
+++ b/src/apps/workbench/backtester/backtester.h
@@ -20,6 +20,7 @@ struct BacktestResult {
     float total_pnl;
     float sharpe_ratio;
     float max_drawdown;
+    std::vector<float> equity_curve;
     std::vector<Trade> trades;
 };
 

--- a/src/apps/workbench/core_old/metrics_dashboard.cpp
+++ b/src/apps/workbench/core_old/metrics_dashboard.cpp
@@ -3,6 +3,8 @@
 #include <filesystem>
 
 #include "backtester/backtester.h"
+#include "backtester/data/data_loader.h"
+#include "quantum/pattern_metric_engine.h"
 #include "imgui.h"
 #include <implot.h>
 #include <iostream>
@@ -378,10 +380,15 @@ void MetricsDashboard::renderBacktesterPanel()
     ImGui::Begin("Backtester", &show_backtester_panel_);
     if (ImGui::Button("Run Backtest"))
     {
-        // TODO: Get actual prices and signals
-        std::vector<float> prices = {1.0, 1.1, 1.2, 1.1, 1.0};
-        std::vector<MetricsMonitor::ThresholdSignal> signals;
-        backtester_->run(prices, signals);
+        backtester::DataLoader loader;
+        if (std::strlen(file_path_buffer_) > 0)
+            loader.load_data(file_path_buffer_);
+        else
+            loader.load_48h_sample();
+
+        sep::quantum::PatternMetricEngine engine;
+        engine.init(nullptr);
+        backtester_->run(&engine, &loader);
     }
 
     const auto& result = backtester_->getResult();

--- a/src/apps/workbench/tabs/backend_tab_controller.cpp
+++ b/src/apps/workbench/tabs/backend_tab_controller.cpp
@@ -215,6 +215,16 @@ void BackendTabController::renderBacktestingSuite() {
     ImGui::Text("Total PnL: %.2f", last_result_.total_pnl);
     ImGui::Text("Sharpe Ratio: %.2f", last_result_.sharpe_ratio);
     ImGui::Text("Max Drawdown: %.2f", last_result_.max_drawdown);
+    if (!pnl_history_.empty()) {
+        if (ImPlot::BeginPlot("Backtest Metrics", ImVec2(-1,150))) {
+            std::vector<float> xs(pnl_history_.size());
+            for (size_t i = 0; i < xs.size(); ++i) xs[i] = static_cast<float>(i);
+            ImPlot::PlotLine("PnL", xs.data(), pnl_history_.data(), static_cast<int>(pnl_history_.size()));
+            ImPlot::PlotLine("WinRate", xs.data(), win_rate_history_.data(), static_cast<int>(win_rate_history_.size()));
+            ImPlot::PlotLine("Sharpe", xs.data(), sharpe_history_.data(), static_cast<int>(sharpe_history_.size()));
+            ImPlot::EndPlot();
+        }
+    }
     if (!equity_curve_.empty()) {
         if (ImPlot::BeginPlot("Equity Curve", ImVec2(-1,150))) {
             std::vector<float> xs(equity_curve_.size());
@@ -261,16 +271,10 @@ void BackendTabController::updateTradeHistory() {
 
 void BackendTabController::onBacktestResult(const BacktestResultEvent& e) {
     last_result_ = e.result;
-    equity_curve_.clear();
-    float equity = 0.0f;
-    equity_curve_.push_back(equity);
-    for (const auto& t : last_result_.trades) {
-        float diff = (t.type == sep::quantum::SignalType::BUY)
-                         ? t.exit_price - t.entry_price
-                         : t.entry_price - t.exit_price;
-        equity += diff;
-        equity_curve_.push_back(equity);
-    }
+    equity_curve_ = e.result.equity_curve;
+    pnl_history_.push_back(last_result_.total_pnl);
+    win_rate_history_.push_back(last_result_.win_rate);
+    sharpe_history_.push_back(last_result_.sharpe_ratio);
 }
 
 void BackendTabController::renderTradeHistoryPanel() {

--- a/src/apps/workbench/tabs/backend_tab_controller.h
+++ b/src/apps/workbench/tabs/backend_tab_controller.h
@@ -73,6 +73,9 @@ private:
 
     std::vector<std::string> trade_history_;
     std::vector<float> equity_curve_;
+    std::vector<float> pnl_history_;
+    std::vector<float> win_rate_history_;
+    std::vector<float> sharpe_history_;
 };
 
 } // namespace sep::workbench


### PR DESCRIPTION
## Summary
- hook up Backtester to load candle history and return an equity curve
- integrate Backtester with Metrics Dashboard using DataLoader
- track backtest metrics in BackendTabController
- plot P&L, win rate, sharpe ratio and equity curve

## Testing
- `./build.sh` *(fails: missing Docker image)*

------
https://chatgpt.com/codex/tasks/task_e_688576de4034832a9adf52ef3f048b4c