### PR TITLE
Enable live metrics in Signals tab

### DIFF
--- a/src/apps/workbench/core/multi_timeframe_analyzer.cpp
+++ b/src/apps/workbench/core/multi_timeframe_analyzer.cpp
@@ -217,10 +217,13 @@ std::vector<sep::common::CandleData> MultiTimeframeAnalyzer::resampleCandles(
 }
 
 TimeframeMetrics MultiTimeframeAnalyzer::analyzeTimeframe(
-    const std::string& timeframe, 
+    const std::string& timeframe,
     const std::vector<sep::common::CandleData>& candles) {
-    
+
     TimeframeMetrics metrics(timeframe);
+    if (!candles.empty()) {
+        metrics.timestamp = candles.back().timestamp;
+    }
     
     if (candles.empty() || !pattern_engines_.count(timeframe)) {
         return metrics;

--- a/src/apps/workbench/core/service_connector.cpp
+++ b/src/apps/workbench/core/service_connector.cpp
@@ -245,6 +245,7 @@ void ServiceConnector::setMultiTimeframeAnalyzer(MultiTimeframeAnalyzer* analyze
             if (mtf_analyzer_)
             {
                 mtf_analyzer_->ingestMarketData("EUR_USD", c);
+                mtf_analyzer_->updateAllTimeframes("EUR_USD");
             }
         });
     }

--- a/src/apps/workbench/core/workbench_core.cpp
+++ b/src/apps/workbench/core/workbench_core.cpp
@@ -127,6 +127,7 @@ bool WorkbenchEngine::initialize()
             metrics_monitor_->setRollingMetrics(rolling);
             if (signals_tab_) {
                 signals_tab_->setMetricsMonitor(metrics_monitor_);
+                signals_tab_->setLatestMetrics(m);
             }
             if (engine_tab_) {
                 engine_tab_->setMetricsMonitor(metrics_monitor_);

--- a/src/apps/workbench/tabs/signals_tab_controller.cpp
+++ b/src/apps/workbench/tabs/signals_tab_controller.cpp
@@ -3,6 +3,7 @@
 #include "quantum/pattern_metric_engine.h"
 #include "apps/workbench/config.hpp"
 #include "core/metrics_monitor.h"
+#include "apps/workbench/core/multi_timeframe_analyzer.h"
 
 #include <implot.h>
 #include "imgui_internal.h"
@@ -264,6 +265,12 @@ void SignalsTabController::setMetricsMonitor(std::shared_ptr<MetricsMonitor> mon
 
 void SignalsTabController::setWorkbenchEngine(WorkbenchEngine* engine) {
     workbench_engine_ = engine;
+}
+
+void SignalsTabController::setLatestMetrics(const std::map<std::string, TimeframeMetrics>& metrics) {
+    std::lock_guard<std::mutex> lock(metrics_mutex_);
+    latest_tf_metrics_ = metrics;
+    metrics_updated_ = true;
 }
 
 void SignalsTabController::setCandleData(const std::deque<sep::common::CandleData>& data) {
@@ -908,10 +915,12 @@ void SignalsTabController::calculateEnhancedHoverMetrics() {
         }
     }
     
-    hover_info_.mtf_coherence["1m"] = hover_info_.nearest_sep_signal->coherence;
-    hover_info_.mtf_coherence["5m"] = hover_info_.nearest_sep_signal->coherence;
-    hover_info_.mtf_coherence["15m"] = hover_info_.nearest_sep_signal->coherence;
-    hover_info_.mtf_coherence["1h"] = hover_info_.nearest_sep_signal->coherence;
+    {
+        std::lock_guard<std::mutex> lock(metrics_mutex_);
+        for (const auto& [tf, m] : latest_tf_metrics_) {
+            hover_info_.mtf_coherence[tf] = m.dominant_coherence;
+        }
+    }
     
     float coherence = hover_info_.nearest_sep_signal->coherence;
     float stability = hover_info_.nearest_sep_signal->stability;

--- a/src/apps/workbench/tabs/signals_tab_controller.h
+++ b/src/apps/workbench/tabs/signals_tab_controller.h
@@ -5,6 +5,8 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include <map>
+#include <mutex>
 
 #include "common/financial_data_types.h"
 #include "imgui.h"
@@ -13,6 +15,7 @@
 #include "signal_generator/quantum_signal_generator.h"
 #include "apps/workbench/config.hpp"
 #include "apps/workbench/core/common_structs.h"
+#include "apps/workbench/core/multi_timeframe_analyzer.h"
 
 namespace sep::workbench {
 
@@ -34,6 +37,7 @@ public:
     void setQuantumSignalGenerator(QuantumSignalGenerator* generator);
     void setMetricsMonitor(std::shared_ptr<MetricsMonitor> monitor);
     void setWorkbenchEngine(WorkbenchEngine* engine);
+    void setLatestMetrics(const std::map<std::string, TimeframeMetrics>& metrics);
 
         void setCandleData(const std::deque<sep::common::CandleData>& data);
         void setCandleData(const std::vector<sep::common::CandleData>& data);
@@ -51,6 +55,9 @@ private:
     std::unordered_map<std::string, TechnicalIndicator> indicators_;
     std::vector<TrendLine> trend_lines_;
     EnhancedHoverInfo hover_info_;
+    std::map<std::string, TimeframeMetrics> latest_tf_metrics_;
+    std::mutex metrics_mutex_;
+    bool metrics_updated_{false};
 
     // Chart interaction
     ChartZoom chart_zoom_;


### PR DESCRIPTION
## Summary
- stream new candles to `MultiTimeframeAnalyzer`
- timestamp timeframe metrics on analysis
- deliver latest metrics to the UI
- expose metrics in `SignalsTabController`

## Testing
- `./build.sh` *(fails: Docker not available)*

------
https://chatgpt.com/codex/tasks/task_e_688576da7488832aad42aa0a50196d0d