### PR TITLE
Improve crosshair toggling and metrics monitor

### DIFF
--- a/src/apps/workbench/tabs/signals_tab_controller.cpp
+++ b/src/apps/workbench/tabs/signals_tab_controller.cpp
@@ -260,6 +260,15 @@ void SignalsTabController::setQuantumSignalGenerator(QuantumSignalGenerator* gen
 
 void SignalsTabController::setMetricsMonitor(std::shared_ptr<MetricsMonitor> monitor) {
     metrics_monitor_ = std::move(monitor);
+    coherence_history_1h_.clear();
+    stability_history_1h_.clear();
+    entropy_history_1h_.clear();
+    coherence_history_4h_.clear();
+    stability_history_4h_.clear();
+    entropy_history_4h_.clear();
+    if (metrics_monitor_) {
+        metrics_monitor_->startProcessing();
+    }
 }
 
 void SignalsTabController::setWorkbenchEngine(WorkbenchEngine* engine) {
@@ -828,6 +837,10 @@ void SignalsTabController::setupChartArea() {
 }
 
 void SignalsTabController::handleMouseInput() {
+    if (ImGui::IsKeyPressed(ImGuiKey_Space)) {
+        show_crosshair_ = !show_crosshair_;
+    }
+
     if (ImPlot::IsPlotHovered()) {
         hover_info_.active = true;
         crosshair_pos_ = ImGui::GetMousePos();

--- a/src/apps/workbench/tabs/signals_tab_controller.h
+++ b/src/apps/workbench/tabs/signals_tab_controller.h
@@ -55,7 +55,7 @@ private:
     // Chart interaction
     ChartZoom chart_zoom_;
     ImVec2 crosshair_pos_;
-    bool show_crosshair_ = true;
+    bool show_crosshair_ = true; // toggled with Space key
     bool is_panning_ = false;
     ImVec2 pan_start_pos_;
 


### PR DESCRIPTION
## Summary
- add keyboard toggle for crosshair overlay using Space key
- clear history and start processing when setting metrics monitor

## Testing
- `cmake -S . -B build -GNinja -DSEP_USE_CUDA=OFF -DBUILD_TESTING=OFF` *(fails: benchmarkConfig.cmake missing)*

------
https://chatgpt.com/codex/tasks/task_e_688576d63798832ab42da4fe9b5a8b72