### PR TITLE
Integrate live candle callbacks

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -44,7 +44,7 @@ The project now compiles successfully. Use the provided scripts to build and run
 # Build the project
 ./build.sh
 
-# Run the workbench application
+# Run the workbench application (live mode)
 ./run_workbench.sh
 ```
 

--- a/docs/archive_old/archive/OANDA_INTEGRATION_GUIDE.md
+++ b/docs/archive_old/archive/OANDA_INTEGRATION_GUIDE.md
@@ -61,7 +61,7 @@ export OANDA_ACCOUNT_ID="001-001-13487160-001"
 This script will:
 - Load OANDA credentials from `keys.txt`
 - Verify the credentials are set
-- Launch the SEP workbench with OANDA integration enabled
+- Launch the SEP workbench with OANDA integration enabled in live mode
 
 ## How It Works
 

--- a/run_workbench.sh
+++ b/run_workbench.sh
@@ -4,8 +4,8 @@
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 cd "$SCRIPT_DIR"
 
-# SEP Workbench Runner with OANDA Credentials
-# This script sets up the environment and runs the SEP workbench
+# SEP Workbench Live Trading Runner with OANDA
+# This script sets up the environment and launches the workbench in live mode
 
 echo "==================================="
 echo "SEP Workbench with OANDA Trading"
@@ -31,7 +31,7 @@ fi
 
 echo "OANDA Account: $OANDA_ACCOUNT_ID"
 echo "Using PRACTICE server: api-fxpractice.oanda.com"
-echo "This is REAL money trading - be careful!"
+echo "Live mode enabled - real-time data will be streamed." 
 echo ""
 
 # Check if build directory exists

--- a/src/apps/workbench/core/service_connector.cpp
+++ b/src/apps/workbench/core/service_connector.cpp
@@ -14,6 +14,7 @@
 #include <iostream>
 #include <thread>
 #include <cstring>
+#include <deque>
 #include "engine/data_parser.h"
 
 // Platform-specific includes
@@ -148,7 +149,31 @@ bool ServiceConnector::connect() {
         
         connection_state_ = sep::workbench::ConnectionState::CONNECTED;
         health_metrics_.last_heartbeat = std::chrono::steady_clock::now();
-        
+
+        if (oanda_connector_) {
+            oanda_connector_->setCandleCallback([this](const common::CandleData& c) {
+                if (mtf_analyzer_) {
+                    mtf_analyzer_->ingestMarketData("EUR_USD", c);
+                }
+                if (signals_tab_) {
+                    std::deque<common::CandleData> tmp{c};
+                    signals_tab_->setCandleData(tmp);
+                }
+                if (service_engine_) {
+                    auto* pme = service_engine_->getPatternMetricEngine();
+                    if (pme) {
+                        float ohlc[4] = {
+                            static_cast<float>(c.open),
+                            static_cast<float>(c.high),
+                            static_cast<float>(c.low),
+                            static_cast<float>(c.close)};
+                        const uint8_t* bytes = reinterpret_cast<const uint8_t*>(ohlc);
+                        pme->ingestData(bytes, sizeof(ohlc));
+                    }
+                }
+            });
+        }
+
         // Start health monitoring
         startHealthMonitoring();
         


### PR DESCRIPTION
## Summary
- forward OANDA candle data through ServiceConnector
- stream OHLC bytes into PatternMetricEngine
- clarify that run_workbench.sh launches in live mode

## Testing
- `cmake -B build -S .` *(fails: CUDA_HOME environment variable not set)*
- `./run_clang_tidy.sh` *(fails: compile_commands.json not found)*


------
https://chatgpt.com/codex/tasks/task_e_68857cfe256c832aad537175080cbae9