### PR TITLE
Add dataset backtest API and UI controls

### DIFF
--- a/src/apps/workbench/backtester/backtester.cpp
+++ b/src/apps/workbench/backtester/backtester.cpp
@@ -11,22 +11,25 @@ Backtester::Backtester() {
     result_ = {};
 }
 
-void Backtester::run(sep::quantum::PatternMetricEngine* engine, DataLoader* data_loader) {
-    if (!engine || !data_loader) {
+void Backtester::run(sep::quantum::PatternMetricEngine* engine,
+                     const std::vector<sep::common::CandleData>& candles) {
+    if (!engine) {
         return;
     }
 
     result_ = {};
-
-    const auto& candles = data_loader->get_data();
     if (candles.empty()) {
         return;
     }
 
     std::vector<uint8_t> byte_stream;
+    byte_stream.reserve(candles.size() * sizeof(sep::common::CandleData));
     for (const auto& candle : candles) {
-        const uint8_t* candle_bytes = reinterpret_cast<const uint8_t*>(&candle);
-        byte_stream.insert(byte_stream.end(), candle_bytes, candle_bytes + sizeof(sep::common::CandleData));
+        const uint8_t* candle_bytes =
+            reinterpret_cast<const uint8_t*>(&candle);
+        byte_stream.insert(byte_stream.end(),
+                           candle_bytes,
+                           candle_bytes + sizeof(sep::common::CandleData));
     }
 
     engine->ingestData(byte_stream.data(), byte_stream.size());
@@ -35,8 +38,9 @@ void Backtester::run(sep::quantum::PatternMetricEngine* engine, DataLoader* data
     const auto& signals = engine->getSignals();
 
     std::vector<float> prices;
+    prices.reserve(candles.size());
     for (const auto& candle : candles) {
-        prices.push_back(candle.close);
+        prices.push_back(static_cast<float>(candle.close));
     }
 
     if (prices.empty() || signals.empty()) {
@@ -46,42 +50,24 @@ void Backtester::run(sep::quantum::PatternMetricEngine* engine, DataLoader* data
     std::vector<float> pnl;
     int wins = 0;
     int losses = 0;
-
-    for (size_t i = 0; i < signals.size(); ++i) {
+    size_t count = std::min(signals.size(), prices.size() - 1);
+    for (size_t i = 0; i < count; ++i) {
         if (signals[i].type == sep::quantum::SignalType::BUY) {
-            if (i + 1 < prices.size()) {
-                Trade trade;
-                trade.type = sep::quantum::SignalType::BUY;
-                trade.entry_price = prices[i];
-                trade.exit_price = prices[i + 1];
-                trade.holding_period = 1;
-                result_.trades.push_back(trade);
-                pnl.push_back(trade.exit_price - trade.entry_price);
-                if (trade.exit_price > trade.entry_price) {
-                    wins++;
-                } else {
-                    losses++;
-                }
-            }
+            Trade trade{sep::quantum::SignalType::BUY, prices[i], prices[i + 1], 1};
+            result_.trades.push_back(trade);
+            pnl.push_back(trade.exit_price - trade.entry_price);
+            wins += trade.exit_price > trade.entry_price;
+            losses += trade.exit_price <= trade.entry_price;
         } else if (signals[i].type == sep::quantum::SignalType::SELL) {
-            if (i + 1 < prices.size()) {
-                Trade trade;
-                trade.type = sep::quantum::SignalType::SELL;
-                trade.entry_price = prices[i];
-                trade.exit_price = prices[i + 1];
-                trade.holding_period = 1;
-                result_.trades.push_back(trade);
-                pnl.push_back(trade.entry_price - trade.exit_price);
-                if (trade.entry_price > trade.exit_price) {
-                    wins++;
-                } else {
-                    losses++;
-                }
-            }
+            Trade trade{sep::quantum::SignalType::SELL, prices[i], prices[i + 1], 1};
+            result_.trades.push_back(trade);
+            pnl.push_back(trade.entry_price - trade.exit_price);
+            wins += trade.entry_price > trade.exit_price;
+            losses += trade.entry_price <= trade.exit_price;
         }
     }
 
-    result_.total_trades = result_.trades.size();
+    result_.total_trades = static_cast<int>(pnl.size());
     if (result_.total_trades > 0) {
         result_.win_rate = static_cast<float>(wins) / result_.total_trades;
     }
@@ -117,6 +103,16 @@ void Backtester::run(sep::quantum::PatternMetricEngine* engine, DataLoader* data
         }
     }
     result_.max_drawdown = max_drawdown;
+}
+
+void Backtester::run(sep::quantum::PatternMetricEngine* engine,
+                     DataLoader* data_loader) {
+    if (!engine || !data_loader) {
+        return;
+    }
+
+    const auto& candles = data_loader->get_data();
+    run(engine, candles);
 }
 
 const BacktestResult& Backtester::getResult() const {

--- a/src/apps/workbench/backtester/backtester.h
+++ b/src/apps/workbench/backtester/backtester.h
@@ -2,6 +2,7 @@
 
 #include "quantum/pattern_metric_engine.h"
 #include "data_loader.h"
+#include "common/financial_data_types.h"
 #include <vector>
 #include <string>
 
@@ -29,6 +30,8 @@ public:
     Backtester();
 
     void run(sep::quantum::PatternMetricEngine* engine, DataLoader* data_loader);
+    void run(sep::quantum::PatternMetricEngine* engine,
+             const std::vector<sep::common::CandleData>& data);
     const BacktestResult& getResult() const;
 
 private:

--- a/src/apps/workbench/core/metrics_monitor.cpp
+++ b/src/apps/workbench/core/metrics_monitor.cpp
@@ -159,6 +159,11 @@ const MetricsMonitor::ThresholdSignal& MetricsMonitor::getLatestSignal() const {
     return latest_signal_;
 }
 
+void MetricsMonitor::ingestSignals(const std::vector<sep::quantum::Signal>& signals) {
+    std::lock_guard<std::mutex> lock(metrics_mutex_);
+    latest_signals_ = signals;
+}
+
 sep::connectors::MarketData MetricsMonitor::getLatestMarketData() const {
     std::lock_guard<std::mutex> lock(metrics_mutex_);
     return latest_market_data_;

--- a/src/apps/workbench/core/metrics_monitor.h
+++ b/src/apps/workbench/core/metrics_monitor.h
@@ -109,6 +109,7 @@ public:
     const SystemMetrics& getSystemMetrics() const;
     const RollingMetrics& getRollingMetrics() const;
     const ThresholdSignal& getLatestSignal() const;
+    void ingestSignals(const std::vector<sep::quantum::Signal>& signals);
     sep::quantum::SignalThresholds calculateSignalThresholds() const;
     sep::connectors::MarketData getLatestMarketData() const;
     void setLatestMarketData(const sep::connectors::MarketData& data);
@@ -151,6 +152,7 @@ private:
     SystemMetrics system_metrics_;
     RollingMetrics rolling_metrics_;
     ThresholdSignal latest_signal_;
+    std::vector<sep::quantum::Signal> latest_signals_;
     sep::connectors::MarketData latest_market_data_;
     
     // Historical data for rolling calculations

--- a/src/apps/workbench/tabs/backend_tab_controller.cpp
+++ b/src/apps/workbench/tabs/backend_tab_controller.cpp
@@ -3,6 +3,7 @@
 #include <filesystem>
 #include <iostream>
 #include <cstring>
+#include "common/financial_data_types.h"
 
 #include "imgui.h"
 #include "implot.h"
@@ -44,8 +45,14 @@ void BackendTabController::render() {
 
     std::string selected;
     if (file_dialog_.render(selected)) {
-        strncpy(file_path_buffer_, selected.c_str(), sizeof(file_path_buffer_) - 1);
-        file_path_buffer_[sizeof(file_path_buffer_) - 1] = '\0';
+        if (dialog_target_ == DialogTarget::DataSource) {
+            strncpy(file_path_buffer_, selected.c_str(), sizeof(file_path_buffer_) - 1);
+            file_path_buffer_[sizeof(file_path_buffer_) - 1] = '\0';
+        } else if (dialog_target_ == DialogTarget::Backtest) {
+            strncpy(backtest_file_buffer_, selected.c_str(), sizeof(backtest_file_buffer_) - 1);
+            backtest_file_buffer_[sizeof(backtest_file_buffer_) - 1] = '\0';
+        }
+        dialog_target_ = DialogTarget::None;
     }
 
     ImGui::Columns(1);
@@ -74,6 +81,7 @@ void BackendTabController::renderDataSourceSelector() {
             ImGui::InputText("File Path", file_path_buffer_, sizeof(file_path_buffer_));
             ImGui::SameLine();
             if (ImGui::Button("Browse")) {
+                dialog_target_ = DialogTarget::DataSource;
                 file_dialog_.open(std::filesystem::path(file_path_buffer_).empty() ? "." : std::filesystem::path(file_path_buffer_).parent_path().string());
             }
             if (ImGui::Button("Load File", ImVec2(-1, 0))) {
@@ -176,9 +184,25 @@ void BackendTabController::renderBacktesterPanel() {
 
     ImGui::Begin("Backtest Runner");
     ImGui::InputText("Dataset", backtest_file_buffer_, sizeof(backtest_file_buffer_));
+    ImGui::SameLine();
+    if (ImGui::Button("Browse##bt")) {
+        dialog_target_ = DialogTarget::Backtest;
+        file_dialog_.open(std::filesystem::path(backtest_file_buffer_).empty() ? "." : std::filesystem::path(backtest_file_buffer_).parent_path().string());
+    }
     if (ImGui::Button("Run Backtest")) {
         data_loader_->load_data(backtest_file_buffer_);
-        backtester_->run(pattern_engine_.get(), data_loader_.get());
+        backtester_->run(pattern_engine_.get(), data_loader_->get_data());
+        if (monitor_) {
+            const auto& candles = data_loader_->get_data();
+            std::vector<uint8_t> bytes;
+            bytes.reserve(candles.size() * sizeof(common::CandleData));
+            for (const auto& c : candles) {
+                const uint8_t* b = reinterpret_cast<const uint8_t*>(&c);
+                bytes.insert(bytes.end(), b, b + sizeof(common::CandleData));
+            }
+            monitor_->ingestData(bytes.data(), bytes.size());
+            monitor_->ingestSignals(pattern_engine_->getSignals());
+        }
         globalEventBus().publish(BacktestResultEvent{backtester_->getResult()});
     }
     ImGui::End();

--- a/src/apps/workbench/tabs/backend_tab_controller.h
+++ b/src/apps/workbench/tabs/backend_tab_controller.h
@@ -52,6 +52,8 @@ private:
     std::unique_ptr<sep::workbench::backtester::DataLoader> data_loader_;
     std::unique_ptr<sep::quantum::PatternMetricEngine> pattern_engine_;
     FileDialog file_dialog_;
+    enum class DialogTarget { None, DataSource, Backtest };
+    DialogTarget dialog_target_{DialogTarget::None};
 
     backtester::BacktestResult last_result_{};
 


### PR DESCRIPTION
## Summary
- add run overload to Backtester for direct dataset input
- allow Backend tab to browse dataset files and run backtests
- forward generated signals and data to MetricsMonitor
- store latest signals in MetricsMonitor for inspection

## Testing
- `./run_clang_tidy.sh` *(fails: compile_commands.json not found)*
- `./build.sh` *(fails: no build output)*

------
https://chatgpt.com/codex/tasks/task_e_68857fb84800832ab73905b8017ae7c1