### PR TITLE
Enable real‑time candle ingestion

### DIFF
--- a/src/apps/workbench/core/metrics_monitor.cpp
+++ b/src/apps/workbench/core/metrics_monitor.cpp
@@ -90,6 +90,16 @@ void MetricsMonitor::ingestData(const uint8_t* data, size_t size) {
     }
 }
 
+void MetricsMonitor::ingestCandle(const sep::common::CandleData& candle) {
+    float ohlc[4] = {
+        static_cast<float>(candle.open),
+        static_cast<float>(candle.high),
+        static_cast<float>(candle.low),
+        static_cast<float>(candle.close)};
+    const uint8_t* bytes = reinterpret_cast<const uint8_t*>(ohlc);
+    ingestData(bytes, sizeof(ohlc));
+}
+
 void MetricsMonitor::ingestFile(const std::string& filepath) {
     if (!engine_)
     {

--- a/src/apps/workbench/core/metrics_monitor.h
+++ b/src/apps/workbench/core/metrics_monitor.h
@@ -96,6 +96,7 @@ public:
 
     // Data ingestion
     void ingestData(const uint8_t* data, size_t size);
+    void ingestCandle(const sep::common::CandleData& candle);
     void ingestFile(const std::string& filepath);
     void ingestStream(std::istream& stream);
 

--- a/src/apps/workbench/core/multi_timeframe_analyzer.cpp
+++ b/src/apps/workbench/core/multi_timeframe_analyzer.cpp
@@ -2,6 +2,7 @@
 #include "engine/data_parser.h"
 #include "common/financial_data_types.h"
 #include "connectors/market_data_converter.h"
+#include "metrics_monitor.h"
 
 #include <algorithm>
 #include <cmath>
@@ -83,11 +84,15 @@ void MultiTimeframeAnalyzer::ingestMarketData(const std::string& instrument, con
     if (timeframe_data_.count("1m")) {
         auto& tf_data = timeframe_data_["1m"];
         tf_data.candles.push_back(candle);
-        
+
         // Maintain rolling window
         if (tf_data.candles.size() > tf_data.max_candles) {
             tf_data.candles.pop_front();
         }
+    }
+
+    if (metrics_monitor_) {
+        metrics_monitor_->ingestCandle(candle);
     }
     
     // Update higher timeframes by resampling from 1m data

--- a/src/apps/workbench/core/multi_timeframe_analyzer.h
+++ b/src/apps/workbench/core/multi_timeframe_analyzer.h
@@ -20,6 +20,8 @@
 
 namespace sep::workbench {
 
+class MetricsMonitor;
+
 
 
 struct TimeframeData {
@@ -119,6 +121,7 @@ private:
     Config config_;
     std::mutex analysis_mutex_;
     MetricsCallback metrics_callback_;
+    MetricsMonitor* metrics_monitor_{nullptr};
     
     // SEP Engine components - one per timeframe for parallel processing
     std::map<std::string, std::unique_ptr<sep::quantum::PatternMetricEngine>> pattern_engines_;
@@ -174,6 +177,7 @@ public:
                             const std::vector<sep::common::CandleData>& historical_candles);
 
     void setMetricsCallback(MetricsCallback cb);
+    void setMetricsMonitor(MetricsMonitor* monitor) { metrics_monitor_ = monitor; }
     
     // Analysis methods
     MultiTimeframeSignal generateSignal(const std::string& instrument);

--- a/src/apps/workbench/core/service_connector.cpp
+++ b/src/apps/workbench/core/service_connector.cpp
@@ -61,13 +61,6 @@ ServiceConnector::ServiceConnector(const ConnectionConfig& config)
         trade_manager_ = std::make_unique<workbench::TradeManager>(oanda_connector_.get());
         trade_manager_->setRiskPercentage(0.02);
         trade_manager_->setPaperTrading(cfg.oanda().paper_trading);
-        if (mtf_analyzer_) {
-            oanda_connector_->setCandleCallback([this](const common::CandleData& c) {
-                if (mtf_analyzer_) {
-                    mtf_analyzer_->ingestMarketData("EUR_USD", c);
-                }
-            });
-        }
         std::cout << "[ServiceConnector] OANDA connector configured for PRACTICE server" << std::endl;
         std::cout << "[ServiceConnector] API Key length: " << api_key.length() << std::endl;
         std::cout << "[ServiceConnector] Account ID: " << account_id << std::endl;
@@ -77,6 +70,16 @@ ServiceConnector::ServiceConnector(const ConnectionConfig& config)
         bool skip_fetch = skip_env && dataset_exists;
 
         if (oanda_connector_->initialize()) {
+            oanda_connector_->setCandleCallback([this](const common::CandleData& c) {
+                if (mtf_analyzer_) {
+                    mtf_analyzer_->ingestMarketData("EUR_USD", c);
+                }
+                if (signals_tab_) {
+                    std::deque<common::CandleData> tmp{c};
+                    signals_tab_->setCandleData(tmp);
+                }
+            });
+
             if (!skip_fetch) {
                 std::filesystem::create_directories("Testing/OANDA");
                 if (oanda_connector_->saveEURUSDM1_48h(dataset)) {

--- a/src/apps/workbench/core/workbench_core.cpp
+++ b/src/apps/workbench/core/workbench_core.cpp
@@ -109,6 +109,7 @@ bool WorkbenchEngine::initialize()
         signal_generator_->setMemoryManager(&::sep::memory::MemoryTierManager::getInstance());
         metrics_monitor_ = ::std::make_shared<MetricsMonitor>();
         multi_timeframe_analyzer_ = ::std::make_unique<MultiTimeframeAnalyzer>();
+        multi_timeframe_analyzer_->setMetricsMonitor(metrics_monitor_.get());
         multi_timeframe_analyzer_->setMetricsCallback([this](const std::map<std::string, workbench::TimeframeMetrics>& m) {
             if (!metrics_monitor_) return;
             auto rolling = metrics_monitor_->getRollingMetrics();


### PR DESCRIPTION
## Summary
- wire OANDA candles to MultiTimeframeAnalyzer after connector init
- keep MetricsMonitor synced via new ingestCandle API
- push live candles to chart from ServiceConnector
- allow MultiTimeframeAnalyzer to forward candles to MetricsMonitor

## Testing
- `./build.sh` *(failed: docker not available)*

------
https://chatgpt.com/codex/tasks/task_e_68857fb1acc0832ab2cd2bc66bb615c6