### PR TITLE
Add candlestick plotting and metric graphs

### DIFF
--- a/src/apps/workbench/tabs/signals_tab_controller.cpp
+++ b/src/apps/workbench/tabs/signals_tab_controller.cpp
@@ -307,7 +307,6 @@ void SignalsTabController::setSEPSignals(const std::deque<sep::common::SEPSignal
 
 void SignalsTabController::renderMainChart() {
     if (candle_data_.empty()) {
-        ImGui::Text("No data available.");
         return;
     }
 
@@ -372,9 +371,7 @@ void SignalsTabController::renderCandlesticks() {
         high[i] = c.high;
     }
 
-    ImPlot::PushPlotClipRect();
-    ImPlot::PlotCandles("Price", xs.data(), open.data(), close.data(), low.data(), high.data(), static_cast<int>(count));
-    ImPlot::PopPlotClipRect();
+    ImPlot::PlotCandlestick("OHLC", xs.data(), open.data(), close.data(), low.data(), high.data(), static_cast<int>(count));
 }
 
 void SignalsTabController::renderTechnicalIndicators() {
@@ -864,8 +861,15 @@ void SignalsTabController::handleMouseInput() {
         crosshair_pos_ = ImGui::GetMousePos();
         hover_info_.position = crosshair_pos_;
         updateHoverInfo();
+
+        if (ImGui::IsMouseDragging(ImPlot::GetInputMap().Pan)) {
+            is_panning_ = true;
+        } else {
+            is_panning_ = false;
+        }
     } else {
         hover_info_.active = false;
+        is_panning_ = false;
     }
 }
 


### PR DESCRIPTION
## Summary
- display OHLC candles using `ImPlot::PlotCandlestick`
- drop placeholder text when no data exists
- keep metric graphs for coherence, stability and entropy
- track panning state during mouse input

## Testing
- `./run_clang_tidy.sh` *(fails: compile_commands.json not found)*
- `ctest` *(fails: build directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_68857fac313c832a94e6f4dd5f3c5671