### PR TITLE
Add equity curve plotting in workbench

### DIFF
--- a/src/apps/workbench/backtester/backtester.cpp
+++ b/src/apps/workbench/backtester/backtester.cpp
@@ -118,5 +118,9 @@ void Backtester::run(sep::quantum::PatternMetricEngine* engine,
 const BacktestResult& Backtester::getResult() const {
     return result_;
 }
+const std::vector<float>& Backtester::getEquityCurve() const {
+    return result_.equity_curve;
+}
+
 
 }

--- a/src/apps/workbench/backtester/backtester.h
+++ b/src/apps/workbench/backtester/backtester.h
@@ -33,6 +33,7 @@ public:
     void run(sep::quantum::PatternMetricEngine* engine,
              const std::vector<sep::common::CandleData>& data);
     const BacktestResult& getResult() const;
+    const std::vector<float>& getEquityCurve() const { return result_.equity_curve; }
 
 private:
     BacktestResult result_;

--- a/src/apps/workbench/core_old/metrics_dashboard.cpp
+++ b/src/apps/workbench/core_old/metrics_dashboard.cpp
@@ -7,6 +7,7 @@
 #include "quantum/pattern_metric_engine.h"
 #include "imgui.h"
 #include <implot.h>
+#include <vector>
 #include <iostream>
 #include <algorithm>
 #include <cstdlib>
@@ -378,8 +379,7 @@ void MetricsDashboard::handleStopProcessing() {
 void MetricsDashboard::renderBacktesterPanel()
 {
     ImGui::Begin("Backtester", &show_backtester_panel_);
-    if (ImGui::Button("Run Backtest"))
-    {
+    if (ImGui::Button("Run Backtest")) {
         backtester::DataLoader loader;
         if (std::strlen(file_path_buffer_) > 0)
             loader.load_data(file_path_buffer_);
@@ -388,7 +388,8 @@ void MetricsDashboard::renderBacktesterPanel()
 
         sep::quantum::PatternMetricEngine engine;
         engine.init(nullptr);
-        backtester_->run(&engine, &loader);
+        backtester_->run(&engine, loader.get_data());
+        equity_curve_ = backtester_->getEquityCurve();
     }
 
     const auto& result = backtester_->getResult();
@@ -397,6 +398,14 @@ void MetricsDashboard::renderBacktesterPanel()
     ImGui::Text("Total PnL: %.2f", result.total_pnl);
     ImGui::Text("Sharpe Ratio: %.2f", result.sharpe_ratio);
     ImGui::Text("Max Drawdown: %.2f", result.max_drawdown);
+    if (!equity_curve_.empty()) {
+        if (ImPlot::BeginPlot("Equity Curve", ImVec2(-1,120))) {
+            std::vector<float> xs(equity_curve_.size());
+            for (size_t i = 0; i < xs.size(); ++i) xs[i] = static_cast<float>(i);
+            ImPlot::PlotLine("Equity", xs.data(), equity_curve_.data(), static_cast<int>(xs.size()));
+            ImPlot::EndPlot();
+        }
+    }
 
     ImGui::End();
 }

--- a/src/apps/workbench/core_old/metrics_dashboard.h
+++ b/src/apps/workbench/core_old/metrics_dashboard.h
@@ -156,6 +156,7 @@ private:
     // Memory monitoring
     std::vector<float> memory_history_;
     std::vector<float> memory_growth_history_;
+    std::vector<float> equity_curve_;
     bool auto_monitor_memory_{true};
     
     // OANDA integration

--- a/src/apps/workbench/tabs/backend_tab_controller.cpp
+++ b/src/apps/workbench/tabs/backend_tab_controller.cpp
@@ -192,6 +192,7 @@ void BackendTabController::renderBacktesterPanel() {
     if (ImGui::Button("Run Backtest")) {
         data_loader_->load_data(backtest_file_buffer_);
         backtester_->run(pattern_engine_.get(), data_loader_->get_data());
+        equity_curve_ = backtester_->getEquityCurve();
         if (monitor_) {
             const auto& candles = data_loader_->get_data();
             std::vector<uint8_t> bytes;


### PR DESCRIPTION
## Summary
- expose equity curve from `Backtester`
- display equity curve in metrics dashboard backtester panel
- track equity curve when running a backtest from the backend tab

## Testing
- `cmake -S . -B build` *(fails: CUDA_HOME environment variable not set)*

------
https://chatgpt.com/codex/tasks/task_e_688582fca380832aa3d575baf84e74b3