### PR TITLE
Live metrics update

### DIFF
--- a/src/apps/workbench/core/multi_timeframe_analyzer.cpp
+++ b/src/apps/workbench/core/multi_timeframe_analyzer.cpp
@@ -77,9 +77,10 @@ void MultiTimeframeAnalyzer::shutdown() {
     SEP_LOG_INFO("MultiTimeframeAnalyzer shutdown complete");
 }
 
-void MultiTimeframeAnalyzer::ingestMarketData(const std::string& instrument, const sep::common::CandleData& candle) {
+void MultiTimeframeAnalyzer::ingestMarketData(const std::string& instrument,
+                                              const sep::common::CandleData& candle) {
     std::lock_guard<std::mutex> lock(analysis_mutex_);
-    
+
     // Add to 1-minute base timeframe first
     if (timeframe_data_.count("1m")) {
         auto& tf_data = timeframe_data_["1m"];
@@ -93,12 +94,6 @@ void MultiTimeframeAnalyzer::ingestMarketData(const std::string& instrument, con
 
     if (metrics_monitor_) {
         metrics_monitor_->ingestCandle(candle);
-    }
-    
-    // Update higher timeframes by resampling from 1m data
-    updateAllTimeframes(instrument);
-    if (metrics_callback_) {
-        metrics_callback_(latest_metrics_);
     }
 }
 
@@ -168,6 +163,10 @@ void MultiTimeframeAnalyzer::updateAllTimeframes(const std::string& instrument) 
         if (correlation_history_[tf].size() > max_correlation_history_) {
             correlation_history_[tf].pop_front();
         }
+    }
+
+    if (metrics_callback_) {
+        metrics_callback_(latest_metrics_);
     }
 }
 

--- a/src/apps/workbench/core/service_connector.cpp
+++ b/src/apps/workbench/core/service_connector.cpp
@@ -275,10 +275,16 @@ void ServiceConnector::setMultiTimeframeAnalyzer(MultiTimeframeAnalyzer* analyze
     if (oanda_connector_ && mtf_analyzer_)
     {
         oanda_connector_->setCandleCallback([this](const common::CandleData& c) {
-            if (mtf_analyzer_)
+            if (!mtf_analyzer_)
+                return;
+
+            mtf_analyzer_->ingestMarketData("EUR_USD", c);
+            mtf_analyzer_->updateAllTimeframes("EUR_USD");
+
+            if (signals_tab_)
             {
-                mtf_analyzer_->ingestMarketData("EUR_USD", c);
-                mtf_analyzer_->updateAllTimeframes("EUR_USD");
+                auto metrics = mtf_analyzer_->getLatestMetrics("EUR_USD");
+                signals_tab_->setLatestMetrics(metrics);
             }
         });
     }

--- a/src/apps/workbench/core/workbench_core.cpp
+++ b/src/apps/workbench/core/workbench_core.cpp
@@ -111,27 +111,27 @@ bool WorkbenchEngine::initialize()
         multi_timeframe_analyzer_ = ::std::make_unique<MultiTimeframeAnalyzer>();
         multi_timeframe_analyzer_->setMetricsMonitor(metrics_monitor_.get());
         multi_timeframe_analyzer_->setMetricsCallback([this](const std::map<std::string, workbench::TimeframeMetrics>& m) {
-            if (!metrics_monitor_) return;
-            auto rolling = metrics_monitor_->getRollingMetrics();
-            auto it1 = m.find("1h");
-            if (it1 != m.end()) {
-                rolling.coherence_1h_avg = it1->second.dominant_coherence;
-                rolling.stability_1h_avg = it1->second.stability_index;
-                rolling.entropy_1h_avg = it1->second.entropy_level;
+            if (metrics_monitor_) {
+                auto rolling = metrics_monitor_->getRollingMetrics();
+                auto it1 = m.find("1h");
+                if (it1 != m.end()) {
+                    rolling.coherence_1h_avg = it1->second.dominant_coherence;
+                    rolling.stability_1h_avg = it1->second.stability_index;
+                    rolling.entropy_1h_avg = it1->second.entropy_level;
+                }
+                auto it4 = m.find("4h");
+                if (it4 != m.end()) {
+                    rolling.coherence_4h_avg = it4->second.dominant_coherence;
+                    rolling.stability_4h_avg = it4->second.stability_index;
+                    rolling.entropy_4h_avg = it4->second.entropy_level;
+                }
+                metrics_monitor_->setRollingMetrics(rolling);
             }
-            auto it4 = m.find("4h");
-            if (it4 != m.end()) {
-                rolling.coherence_4h_avg = it4->second.dominant_coherence;
-                rolling.stability_4h_avg = it4->second.stability_index;
-                rolling.entropy_4h_avg = it4->second.entropy_level;
-            }
-            metrics_monitor_->setRollingMetrics(rolling);
-            if (signals_tab_) {
-                signals_tab_->setMetricsMonitor(metrics_monitor_);
-                signals_tab_->setLatestMetrics(m);
-            }
-            if (engine_tab_) {
-                engine_tab_->setMetricsMonitor(metrics_monitor_);
+
+            {
+                std::lock_guard<std::mutex> lock(pending_metrics_mutex_);
+                pending_metrics_ = m;
+                metrics_ready_ = true;
             }
         });
 
@@ -371,9 +371,26 @@ void WorkbenchEngine::updateFrame(float delta_time)
 {
     // Handle state-specific updates
     handleStateTransition();
-    
+
     // No demo updates needed for trading mode
     updateData();
+
+    {
+        std::lock_guard<std::mutex> lock(pending_metrics_mutex_);
+        if (metrics_ready_)
+        {
+            if (signals_tab_)
+            {
+                signals_tab_->setMetricsMonitor(metrics_monitor_);
+                signals_tab_->setLatestMetrics(pending_metrics_);
+            }
+            if (engine_tab_)
+            {
+                engine_tab_->setMetricsMonitor(metrics_monitor_);
+            }
+            metrics_ready_ = false;
+        }
+    }
 }
 
 void WorkbenchEngine::renderFrame()

--- a/src/apps/workbench/core/workbench_core.hpp
+++ b/src/apps/workbench/core/workbench_core.hpp
@@ -7,6 +7,8 @@
 #include "backtester/ui/backtester_tab_controller.h"
 #include "ui_layout_manager.h"
 #include "multi_timeframe_analyzer.h"
+#include <map>
+#include <mutex>
 
 // Forward declaration for GLFW
 struct GLFWwindow;
@@ -157,7 +159,12 @@ private:
     void handleDemoSelection();
     void handleDemoRunning();
     void handleErrorRecovery();
-    
+
+    // Cross-thread metric delivery
+    std::map<std::string, TimeframeMetrics> pending_metrics_;
+    std::mutex pending_metrics_mutex_;
+    bool metrics_ready_{false};
+
     // Singleton instance for static callbacks
     static WorkbenchEngine* instance_;
 };


### PR DESCRIPTION
## Summary
- propagate candles to MultiTimeframeAnalyzer in ServiceConnector
- compute metrics on updates and expose latest via callback
- forward metrics to UI in WorkbenchCore without blocking

## Testing
- `./build.sh` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_688582f7814c832a93adca7ae9d8d3a1