### PR TITLE
Implement realtime candle flow into analyzer

### DIFF
--- a/src/apps/workbench/core/multi_timeframe_analyzer.cpp
+++ b/src/apps/workbench/core/multi_timeframe_analyzer.cpp
@@ -95,6 +95,9 @@ void MultiTimeframeAnalyzer::ingestMarketData(const std::string& instrument,
     if (metrics_monitor_) {
         metrics_monitor_->ingestCandle(candle);
     }
+
+    // Trigger analysis across configured timeframes
+    updateAllTimeframes(instrument);
 }
 
 void MultiTimeframeAnalyzer::ingestHistoricalData(const std::string& instrument, 
@@ -735,6 +738,15 @@ std::deque<CorrelationMetrics> MultiTimeframeAnalyzer::getCorrelationHistory(con
         return correlation_history_.at(timeframe);
     }
     return {};
+}
+
+const std::deque<common::CandleData>& MultiTimeframeAnalyzer::getCandles(const std::string& timeframe) const {
+    static const std::deque<common::CandleData> empty;
+    auto it = timeframe_data_.find(timeframe);
+    if (it != timeframe_data_.end()) {
+        return it->second.candles;
+    }
+    return empty;
 }
 
 // TimeframeUtils implementation

--- a/src/apps/workbench/core/multi_timeframe_analyzer.h
+++ b/src/apps/workbench/core/multi_timeframe_analyzer.h
@@ -185,6 +185,9 @@ public:
     
     // Real-time updates
     void updateAllTimeframes(const std::string& instrument);
+
+    // Access stored candles for a given timeframe (e.g. "1m")
+    const std::deque<sep::common::CandleData>& getCandles(const std::string& timeframe) const;
     
     // Configuration and tuning
     void updateConfig(const Config& new_config);

--- a/src/apps/workbench/core/service_connector.cpp
+++ b/src/apps/workbench/core/service_connector.cpp
@@ -71,12 +71,14 @@ ServiceConnector::ServiceConnector(const ConnectionConfig& config)
 
         if (oanda_connector_->initialize()) {
             oanda_connector_->setCandleCallback([this](const common::CandleData& c) {
-                if (mtf_analyzer_) {
-                    mtf_analyzer_->ingestMarketData("EUR_USD", c);
-                }
+                if (!mtf_analyzer_) return;
+
+                mtf_analyzer_->ingestMarketData("EUR_USD", c);
+
                 if (signals_tab_) {
-                    std::deque<common::CandleData> tmp{c};
-                    signals_tab_->setCandleData(tmp);
+                    signals_tab_->setCandleData(mtf_analyzer_->getCandles("1m"));
+                    auto metrics = mtf_analyzer_->getLatestMetrics("EUR_USD");
+                    signals_tab_->setLatestMetrics(metrics);
                 }
             });
 
@@ -154,17 +156,17 @@ bool ServiceConnector::connect() {
         health_metrics_.last_heartbeat = std::chrono::steady_clock::now();
 
         if (oanda_connector_) {
-            // Forward live candle data from the connector into the active analysis
-            // components. PatternMetricEngine::ingestData already protects its
-            // internal state with a mutex, so we simply push the OHLC bytes.
+            // Forward live candle data from the connector into the analysis components
             oanda_connector_->setCandleCallback([this](const common::CandleData& c) {
-                if (mtf_analyzer_) {
-                    mtf_analyzer_->ingestMarketData("EUR_USD", c);
-                }
+                if (!mtf_analyzer_)
+                    return;
+
+                mtf_analyzer_->ingestMarketData("EUR_USD", c);
 
                 if (signals_tab_) {
-                    std::deque<common::CandleData> buf{c};
-                    signals_tab_->setCandleData(buf);
+                    signals_tab_->setCandleData(mtf_analyzer_->getCandles("1m"));
+                    auto metrics = mtf_analyzer_->getLatestMetrics("EUR_USD");
+                    signals_tab_->setLatestMetrics(metrics);
                 }
 
                 if (service_engine_) {
@@ -283,10 +285,10 @@ void ServiceConnector::setMultiTimeframeAnalyzer(MultiTimeframeAnalyzer* analyze
                 return;
 
             mtf_analyzer_->ingestMarketData("EUR_USD", c);
-            mtf_analyzer_->updateAllTimeframes("EUR_USD");
 
             if (signals_tab_)
             {
+                signals_tab_->setCandleData(mtf_analyzer_->getCandles("1m"));
                 auto metrics = mtf_analyzer_->getLatestMetrics("EUR_USD");
                 signals_tab_->setLatestMetrics(metrics);
             }


### PR DESCRIPTION
## Summary
- connect live OANDA candles directly into `MultiTimeframeAnalyzer`
- trigger analysis and store timeframe data when ingesting new candles
- expose candles to the UI and update `SignalsTabController` with latest metrics

## Testing
- `cmake /workspace/sep/tests -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DCMAKE_EXPORT_COMPILE_COMMANDS=ON`
- `make -j$(nproc)`
- `ctest --output-on-failure`
- `clang-tidy /workspace/sep/src/apps/workbench/core/multi_timeframe_analyzer.cpp -p /tmp/build` *(fails: Found compiler error(s).)*
- `cpplint /workspace/sep/src/apps/workbench/core/multi_timeframe_analyzer.cpp`
- `cpplint /workspace/sep/src/apps/workbench/core/service_connector.cpp`


------
https://chatgpt.com/codex/tasks/task_e_688589a80754832ab81ea96cbc1d0f65