### PR TITLE
Add dataset path backtester

### DIFF
--- a/src/apps/workbench/backtester/backtester.cpp
+++ b/src/apps/workbench/backtester/backtester.cpp
@@ -105,6 +105,17 @@ void Backtester::run(sep::quantum::PatternMetricEngine* engine,
     result_.max_drawdown = max_drawdown;
 }
 
+void Backtester::run(sep::quantum::PatternMetricEngine* engine,
+                     const std::string& dataset_path) {
+    if (!engine) {
+        return;
+    }
+
+    DataLoader loader;
+    const auto candles = loader.load_data(dataset_path);
+    run(engine, candles);
+}
+
 void Backtester::run(const std::vector<sep::quantum::Signal>& signals,
                      const std::vector<sep::common::CandleData>& candles) {
     result_ = {};

--- a/src/apps/workbench/backtester/backtester.h
+++ b/src/apps/workbench/backtester/backtester.h
@@ -32,6 +32,8 @@ public:
     void run(sep::quantum::PatternMetricEngine* engine, DataLoader* data_loader);
     void run(sep::quantum::PatternMetricEngine* engine,
              const std::vector<sep::common::CandleData>& data);
+    void run(sep::quantum::PatternMetricEngine* engine,
+             const std::string& dataset_path);
     void run(const std::vector<sep::quantum::Signal>& signals,
              const std::vector<sep::common::CandleData>& data);
     const BacktestResult& getResult() const;

--- a/src/apps/workbench/tabs/backend_tab_controller.cpp
+++ b/src/apps/workbench/tabs/backend_tab_controller.cpp
@@ -194,11 +194,9 @@ void BackendTabController::renderBacktesterPanel() {
         dataset_loaded_ = !data_loader_->get_data().empty();
     }
     if (ImGui::Button("Run Backtest")) {
-        if (!dataset_loaded_) {
-            data_loader_->load_data(backtest_file_buffer_);
-        }
-        backtester_->run(pattern_engine_.get(), data_loader_->get_data());
+        backtester_->run(pattern_engine_.get(), backtest_file_buffer_);
         equity_curve_ = backtester_->getEquityCurve();
+        dataset_loaded_ = true;
         if (monitor_) {
             const auto& candles = data_loader_->get_data();
             std::vector<uint8_t> bytes;


### PR DESCRIPTION
## Summary
- allow Backtester to run directly on a dataset path
- wire backend tab controller to new method

## Testing
- `./build.sh` *(fails: docker unavailable)*
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_688589ae34b4832a99133077f18caa34