### PR TITLE
Fix service connection failure handling

### DIFF
--- a/docs/archive_old/archive/WORKBENCH_CONNECTION_FIX.md
+++ b/docs/archive_old/archive/WORKBENCH_CONNECTION_FIX.md
@@ -102,3 +102,4 @@ The workbench will display connection status:
 - CUDA is NOT optional
 - The engine connection is MANDATORY
 - The workbench will **not** start a local engine if the service is missing. Ensure the SEP engine service is running before launching the workbench.
+- Connection failures now propagate an error state in the UI; no fallback engine is launched.

--- a/src/apps/workbench/core/service_connector.cpp
+++ b/src/apps/workbench/core/service_connector.cpp
@@ -445,11 +445,21 @@ bool ServiceConnector::sendHeartbeat() {
             }
         } else if (recv_result == 0) {
             // Connection closed
-            std::cerr << "[ServiceConnector] Connection closed by service" << std::endl;
+        std::cerr << "[ServiceConnector] Connection closed by service" << std::endl;
+        connection_state_ = sep::workbench::ConnectionState::CONNECTION_FAILED;
+        globalEventBus().publish(ConnectionStateEvent{connection_state_});
+        if (connection_callback_) {
+            connection_callback_(connection_state_);
+        }
         }
     }
-    
+
     health_metrics_.is_responsive = false;
+    connection_state_ = sep::workbench::ConnectionState::CONNECTION_FAILED;
+    globalEventBus().publish(ConnectionStateEvent{connection_state_});
+    if (connection_callback_) {
+        connection_callback_(connection_state_);
+    }
     return false;
 }
 
@@ -897,37 +907,6 @@ sep::core::Engine* ServiceConnector::createServiceEngineProxy(int socket_fd)
     return nullptr;
 }
 
-core::Engine* ServiceConnector::createLocalEngine()
-{
-    try {
-        std::cout << "[ServiceConnector] Initializing local SEP engine..." << std::endl;
-        
-        // Create a real local engine instance
-        local_engine_ = std::make_unique<core::Engine>();
-        
-        // Initialize the engine with default configuration
-        config::CudaConfig cuda_config;
-        cuda_config.use_gpu = true;
-        cuda_config.max_memory_mb = 1024;
-        
-        if (!local_engine_->init(cuda_config)) {
-            std::cerr << "[ServiceConnector] Failed to initialize local engine" << std::endl;
-            return nullptr;
-        }
-        
-        std::cout << "[ServiceConnector] Local SEP engine initialized successfully" << std::endl;
-        health_metrics_.is_responsive = true;
-        health_metrics_.version_info = "SEP Local Engine v1.0";
-
-        service_proxy_engine_ = nullptr;
-
-        return local_engine_.get();
-        
-    } catch (const std::exception& e) {
-        std::cerr << "[ServiceConnector] Exception creating local engine: " << e.what() << std::endl;
-        return nullptr;
-    }
-}
 
 core::ServiceProxyEngine* ServiceConnector::createHttpEngineProxy(int socket_fd)
 {

--- a/src/apps/workbench/core/service_connector.hpp
+++ b/src/apps/workbench/core/service_connector.hpp
@@ -126,11 +126,9 @@ private:
     
     // Service engine creation
     sep::core::Engine* createServiceEngineProxy(int socket_fd);
-    sep::core::Engine* createLocalEngine();
     sep::core::ServiceProxyEngine* createHttpEngineProxy(int socket_fd);
     
     // Engine instances
-    std::unique_ptr<sep::core::Engine> local_engine_;
     std::unique_ptr<sep::core::ServiceProxyEngine> http_proxy_engine_;
     sep::core::ServiceProxyEngine* service_proxy_engine_{nullptr};
 


### PR DESCRIPTION
## Summary
- remove unused `createLocalEngine` code path
- mark heartbeat failures as `CONNECTION_FAILED`
- document that the workbench no longer spawns a local engine

## Testing
- `cmake .. -DSEP_USE_CUDA=OFF` *(fails: missing fmt and libpipewire packages)*

------
https://chatgpt.com/codex/tasks/task_e_688589badb50832ab633a72502d7dbdf