### PR TITLE
Implement keyboard shortcuts in SignalsTab

### DIFF
--- a/src/apps/workbench/tabs/signals_tab_controller.cpp
+++ b/src/apps/workbench/tabs/signals_tab_controller.cpp
@@ -895,6 +895,17 @@ void SignalsTabController::handleMouseInput() {
         show_crosshair_ = !show_crosshair_;
     }
 
+    ImGuiIO& io = ImGui::GetIO();
+    if (ImGui::IsKeyPressed(ImGuiKey_G)) {
+        show_grid_ = !show_grid_;
+    }
+    if (io.KeyCtrl && ImGui::IsKeyPressed(ImGuiKey_R)) {
+        chart_zoom_.is_zoomed = false;
+    }
+    if (io.KeyCtrl && ImGui::IsKeyPressed(ImGuiKey_Z)) {
+        chart_zoom_.is_zoomed = false;
+    }
+
     if (ImPlot::IsPlotHovered()) {
         hover_info_.active = true;
         crosshair_pos_ = ImGui::GetMousePos();


### PR DESCRIPTION
## Summary
- add grid toggle and zoom reset shortcuts to SignalsTabController
- support Ctrl+R and Ctrl+Z to reset zoom and toggle crosshair with space

## Testing
- `cmake ..` *(fails: CUDA_HOME not set)*

------
https://chatgpt.com/codex/tasks/task_e_68858c4f32c4832aaae4bef9cac1fc83