### PR TITLE
Improve signal validation logic

### DIFF
--- a/src/apps/workbench/core/signal_validator.h
+++ b/src/apps/workbench/core/signal_validator.h
@@ -15,51 +15,39 @@ public:
 
     ValidationResult validate_signal(const std::vector<sep::quantum::Signal>& signals, const std::vector<float>& prices) {
         // Real signal validation implementation (TODO.md Phase 2.2)
-        if (signals.empty() || prices.empty() || signals.size() != prices.size()) {
-            return {0.0, 1.0}; // No data or mismatched sizes
+        if (signals.empty() || prices.size() < signals.size() + 1) {
+            return {0.0, 1.0};
         }
-        
+
         int correct_predictions = 0;
         int total_predictions = 0;
         int false_positives = 0;
-        int total_signals = 0;
-        
-        for (size_t i = 0; i < signals.size() - 1; i++) {
+
+        for (size_t i = 0; i < signals.size() && i < prices.size() - 1; ++i) {
             const auto& current_signal = signals[i];
             float current_price = prices[i];
             float next_price = prices[i + 1];
-            
-            // Calculate actual price movement
-            float price_change = (next_price - current_price) / current_price;
-            bool actual_bullish = price_change > 0.0001f; // 1 pip threshold
-            bool actual_bearish = price_change < -0.0001f;
-            
-            // Check signal predictions based on confidence
-            if (current_signal.confidence > 0.7f) { // Strong signal threshold
-                total_signals++;
-                
-                bool predicted_bullish = current_signal.type == sep::quantum::SignalType::BUY;
-                bool predicted_bearish = current_signal.type == sep::quantum::SignalType::SELL;
-                
-                if (predicted_bullish || predicted_bearish) {
-                    total_predictions++;
-                    
-                    // Check if prediction was correct
-                    if ((predicted_bullish && actual_bullish) || 
-                        (predicted_bearish && actual_bearish)) {
-                        correct_predictions++;
-                    } else if ((predicted_bullish && actual_bearish) || 
-                               (predicted_bearish && actual_bullish)) {
-                        false_positives++;
-                    }
+
+            bool price_up = next_price > current_price;
+            bool price_down = next_price < current_price;
+
+            bool predicted_buy = current_signal.type == sep::quantum::SignalType::BUY;
+            bool predicted_sell = current_signal.type == sep::quantum::SignalType::SELL;
+
+            if (predicted_buy || predicted_sell) {
+                ++total_predictions;
+                if ((predicted_buy && price_up) || (predicted_sell && price_down)) {
+                    ++correct_predictions;
+                } else if ((predicted_buy && price_down) || (predicted_sell && price_up)) {
+                    ++false_positives;
                 }
             }
         }
-        
-        double predictive_accuracy = total_predictions > 0 ? 
+
+        double predictive_accuracy = total_predictions > 0 ?
             static_cast<double>(correct_predictions) / total_predictions : 0.0;
-        double false_positive_rate = total_signals > 0 ? 
-            static_cast<double>(false_positives) / total_signals : 0.0;
+        double false_positive_rate = total_predictions > 0 ?
+            static_cast<double>(false_positives) / total_predictions : 0.0;
             
         return {predictive_accuracy, false_positive_rate};
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,7 +3,8 @@ project(pattern_metrics_tests)
 
 find_package(GTest REQUIRED)
 add_executable(pattern_metrics_test
-    pattern_metrics_test.cpp)
+    pattern_metrics_test.cpp
+    signal_validator_test.cpp)
 target_include_directories(pattern_metrics_test PRIVATE ../src)
 target_link_libraries(pattern_metrics_test GTest::gtest GTest::gtest_main)
 

--- a/tests/signal_validator_test.cpp
+++ b/tests/signal_validator_test.cpp
@@ -1,0 +1,29 @@
+#include <gtest/gtest.h>
+#include "apps/workbench/core/signal_validator.h"
+#include "quantum/pattern_metric_engine.h"
+
+using namespace sep::workbench;
+
+TEST(SignalValidator, BuySignalCorrect) {
+    std::vector<sep::quantum::Signal> signals(1);
+    signals[0].type = sep::quantum::SignalType::BUY;
+    signals[0].confidence = 1.0f;
+    std::vector<float> prices = {1.0f, 1.1f};
+
+    SignalValidator validator;
+    auto result = validator.validate_signal(signals, prices);
+    EXPECT_DOUBLE_EQ(result.predictive_accuracy, 1.0);
+    EXPECT_DOUBLE_EQ(result.false_positive_rate, 0.0);
+}
+
+TEST(SignalValidator, SellSignalIncorrect) {
+    std::vector<sep::quantum::Signal> signals(1);
+    signals[0].type = sep::quantum::SignalType::SELL;
+    signals[0].confidence = 1.0f;
+    std::vector<float> prices = {1.0f, 1.1f};
+
+    SignalValidator validator;
+    auto result = validator.validate_signal(signals, prices);
+    EXPECT_DOUBLE_EQ(result.predictive_accuracy, 0.0);
+    EXPECT_DOUBLE_EQ(result.false_positive_rate, 1.0);
+}


### PR DESCRIPTION
## Summary
- refine the signal comparison algorithm to classify outcomes against price change
- compute metrics over all directional predictions
- compile new unit tests for signal validation

## Testing
- `cmake -S tests -B build/tests -G Ninja`
- `cmake --build build/tests`
- `CTEST_OUTPUT_ON_FAILURE=1 ctest --test-dir build/tests`


------
https://chatgpt.com/codex/tasks/task_e_68858ecfd7f4832aa90dcd69d1c47252