### PR TITLE
Enhance backend tab with dataset processing and results

### DIFF
--- a/src/apps/workbench/core/workbench_core.cpp
+++ b/src/apps/workbench/core/workbench_core.cpp
@@ -145,7 +145,8 @@ bool WorkbenchEngine::initialize()
 
         signals_tab_ = std::make_unique<workbench::SignalsTabController>();
         engine_tab_ = std::make_unique<workbench::EngineTabController>();
-        backend_tab_ = std::make_unique<workbench::BackendTabController>();
+        backend_tab_ = std::make_unique<workbench::BackendTabController>(metrics_monitor_,
+                                                                         multi_timeframe_analyzer_.get());
         backtester_tab_ = std::make_unique<BacktesterTabController>();
 
         signals_tab_->initialize();

--- a/src/apps/workbench/tabs/backend_tab_controller.cpp
+++ b/src/apps/workbench/tabs/backend_tab_controller.cpp
@@ -7,13 +7,17 @@
 
 #include "imgui.h"
 #include "implot.h"
+#include "apps/workbench/core/multi_timeframe_analyzer.h"
 
 namespace sep::workbench {
 
-BackendTabController::BackendTabController()
-    : backtester_(std::make_unique<backtester::Backtester>()),
+BackendTabController::BackendTabController(std::shared_ptr<MetricsMonitor> monitor,
+                                           MultiTimeframeAnalyzer* analyzer)
+    : monitor_(std::move(monitor)),
+      backtester_(std::make_unique<backtester::Backtester>()),
       data_loader_(std::make_unique<backtester::DataLoader>()),
-      pattern_engine_(std::make_unique<quantum::PatternMetricEngine>()) {}
+      pattern_engine_(std::make_unique<quantum::PatternMetricEngine>()),
+      mtf_analyzer_(analyzer) {}
 
 BackendTabController::~BackendTabController() { shutdown(); }
 bool BackendTabController::initialize() {
@@ -192,6 +196,11 @@ void BackendTabController::renderBacktesterPanel() {
     if (ImGui::Button("Load Dataset")) {
         data_loader_->load_data(backtest_file_buffer_);
         dataset_loaded_ = !data_loader_->get_data().empty();
+        if (dataset_loaded_) {
+            strncpy(file_path_buffer_, backtest_file_buffer_, sizeof(file_path_buffer_) - 1);
+            file_path_buffer_[sizeof(file_path_buffer_) - 1] = '\0';
+            handleDataLoad();
+        }
     }
     if (ImGui::Button("Run Backtest")) {
         backtester_->run(pattern_engine_.get(), backtest_file_buffer_);
@@ -246,6 +255,9 @@ void BackendTabController::renderBacktesterPanel() {
 }
 
 void BackendTabController::renderBacktestingSuite() {
+    if (!dataset_loaded_ || (monitor_ && monitor_->isProcessing()))
+        return;
+
     ImGui::Begin("Backtest Results");
     ImGui::PushID("BacktestResults");
 
@@ -296,8 +308,56 @@ void BackendTabController::renderBacktestingSuite() {
 }
 
 void BackendTabController::handleDataLoad() {
-    if (monitor_ && strlen(file_path_buffer_) > 0) {
-        monitor_->ingestFile(file_path_buffer_);
+    if (!monitor_ || strlen(file_path_buffer_) == 0)
+        return;
+
+    data_loader_->load_data(file_path_buffer_);
+    const auto& candles = data_loader_->get_data();
+    if (candles.empty())
+        return;
+
+    std::vector<uint8_t> bytes;
+    bytes.reserve(candles.size() * sizeof(common::CandleData));
+    for (const auto& c : candles) {
+        const uint8_t* b = reinterpret_cast<const uint8_t*>(&c);
+        bytes.insert(bytes.end(), b, b + sizeof(common::CandleData));
+    }
+
+    monitor_->startProcessing();
+    monitor_->ingestData(bytes.data(), bytes.size());
+    monitor_->stopProcessing();
+
+    pattern_engine_->ingestData(bytes.data(), bytes.size());
+    pattern_engine_->evolvePatterns();
+    const auto& metrics = pattern_engine_->computeMetrics();
+    monitor_->ingestSignals(pattern_engine_->getSignals());
+
+    sep_signals_.clear();
+    for (size_t i = 0; i < std::min(metrics.size(), candles.size()); ++i) {
+        const auto& m = metrics[i];
+        const auto& candle = candles[candles.size() - metrics.size() + i];
+        common::SEPSignalData sig;
+        sig.timestamp = candle.timestamp;
+        sig.coherence = m.coherence;
+        sig.stability = m.stability;
+        sig.entropy = m.entropy;
+        sig.alpha_signal = (m.coherence + m.stability - m.entropy) / 2.0f;
+        sig.trend_strength = (m.coherence * m.stability) - m.entropy;
+        if (m.coherence > 0.8f && m.stability > 0.7f && m.entropy < 0.2f)
+            sig.signal_type = common::MultiTimeframeSignal::STRONG_BUY;
+        else if (m.coherence > 0.7f && m.stability > 0.6f && m.entropy < 0.3f)
+            sig.signal_type = common::MultiTimeframeSignal::BUY;
+        else if (m.coherence < 0.2f && m.stability < 0.3f && m.entropy > 0.8f)
+            sig.signal_type = common::MultiTimeframeSignal::STRONG_SELL;
+        else if (m.coherence < 0.3f && m.stability < 0.4f && m.entropy > 0.7f)
+            sig.signal_type = common::MultiTimeframeSignal::SELL;
+        else
+            sig.signal_type = common::MultiTimeframeSignal::NEUTRAL;
+        sep_signals_.push_back(sig);
+    }
+
+    if (mtf_analyzer_) {
+        mtf_analyzer_->ingestHistoricalData("EUR_USD", candles);
     }
 }
 

--- a/src/apps/workbench/tabs/backend_tab_controller.h
+++ b/src/apps/workbench/tabs/backend_tab_controller.h
@@ -17,9 +17,12 @@
 
 namespace sep::workbench {
 
+class MultiTimeframeAnalyzer;
+
 class BackendTabController {
 public:
-    BackendTabController();
+    BackendTabController(std::shared_ptr<MetricsMonitor> monitor = nullptr,
+                         MultiTimeframeAnalyzer* analyzer = nullptr);
     ~BackendTabController();
 
     bool initialize();
@@ -29,6 +32,9 @@ public:
     void setMetricsMonitor(std::shared_ptr<MetricsMonitor> monitor);
     void setServiceConnector(ServiceConnector* connector);
     void setTradeManager(TradeManager* manager) { trade_manager_ = manager; }
+    void setMultiTimeframeAnalyzer(MultiTimeframeAnalyzer* analyzer) {
+        mtf_analyzer_ = analyzer;
+    }
 
 private:
     ServiceConnector* service_connector_ = nullptr;
@@ -78,7 +84,10 @@ private:
     std::vector<float> pnl_history_;
     std::vector<float> win_rate_history_;
     std::vector<float> sharpe_history_;
+    std::deque<sep::common::SEPSignalData> sep_signals_;
     bool dataset_loaded_{false};
+
+    MultiTimeframeAnalyzer* mtf_analyzer_{nullptr};
 };
 
 } // namespace sep::workbench


### PR DESCRIPTION
## Summary
- extend `BackendTabController` to take a `MetricsMonitor` and `MultiTimeframeAnalyzer`
- push dataset candles through `PatternMetricEngine` and store generated `SEPSignalData`
- hook new constructor in `WorkbenchCore`
- show backtest results only when processing is finished

## Testing
- `./build.sh` *(fails: docker not available)*

------
https://chatgpt.com/codex/tasks/task_e_68858ecc5524832a8504e65e899b339c