### PR TITLE
Forward candle updates to analyzer

### DIFF
--- a/src/apps/workbench/core/workbench_core.cpp
+++ b/src/apps/workbench/core/workbench_core.cpp
@@ -184,8 +184,30 @@ bool WorkbenchEngine::initialize()
             auto oanda_ptr = service_connector_->getOandaConnector();
             std::cout << "[WorkbenchEngine] OANDA connector available: " << (oanda_ptr ? "Yes" : "No") << std::endl;
             oanda_ptr->setPriceCallback([this](const connectors::MarketData& md) {
-                if (metrics_monitor_) metrics_monitor_->setLatestMarketData(md);
+                if (metrics_monitor_) {
+                    metrics_monitor_->setLatestMarketData(md);
+                }
+
+                if (active_engine_) {
+                    auto* pme = active_engine_->getPatternMetricEngine();
+                    if (pme) {
+                        float price = static_cast<float>(md.mid);
+                        pme->ingestData(reinterpret_cast<const uint8_t*>(&price), sizeof(price));
+                        pme->evolvePatterns();
+                        pme->computeMetrics();
+                    }
+                }
             });
+
+            oanda_ptr->setCandleCallback([this](const common::CandleData& c) {
+                if (signals_tab_) {
+                    signals_tab_->addCandle(c);
+                }
+                if (multi_timeframe_analyzer_) {
+                    multi_timeframe_analyzer_->ingestMarketData("EUR_USD", c);
+                }
+            });
+
             oanda_ptr->startPriceStream({"EUR_USD"});
         }
 

--- a/src/apps/workbench/tabs/signals_tab_controller.cpp
+++ b/src/apps/workbench/tabs/signals_tab_controller.cpp
@@ -219,6 +219,20 @@ void SignalsTabController::setCandleData(const std::vector<sep::common::CandleDa
     }
 }
 
+void SignalsTabController::addCandle(const sep::common::CandleData& candle) {
+    candle_data_.push_back(candle);
+    if (candle_data_.size() > 1440) {
+        candle_data_.pop_front();
+    }
+    volume_max_ = std::max(volume_max_, static_cast<float>(candle.volume));
+    updatePriceRange();
+    chart_zoom_.index_end = candle_data_.size();
+    candle_data_updated_ = true;
+    if (auto_detect_trends_) {
+        detectTrendLines();
+    }
+}
+
 void SignalsTabController::setSEPSignals(const std::deque<sep::common::SEPSignalData>& signals) {
     sep_signals_ = signals;
     if (sep_signals_.size() > 1440) {

--- a/src/apps/workbench/tabs/signals_tab_controller.h
+++ b/src/apps/workbench/tabs/signals_tab_controller.h
@@ -41,6 +41,7 @@ public:
 
         void setCandleData(const std::deque<sep::common::CandleData>& data);
         void setCandleData(const std::vector<sep::common::CandleData>& data);
+        void addCandle(const sep::common::CandleData& candle);
         const std::deque<sep::common::CandleData>& getCandleData() const { return candle_data_; }
         void setSEPSignals(const std::deque<sep::common::SEPSignalData>& signals);
 


### PR DESCRIPTION
## Summary
- forward candles to `SignalsTabController` via new `addCandle` helper
- on every price tick send raw bytes to `PatternMetricEngine`
- pipe candle callbacks to `MultiTimeframeAnalyzer`

## Testing
- `./build.sh` *(fails: Docker not available)*

------
https://chatgpt.com/codex/tasks/task_e_6885965a185c832ab8ea443236c8b915