### PR TITLE
Address warnings and document spa parser

### DIFF
--- a/src/apps/sep_demo/sep_demo_app.cpp
+++ b/src/apps/sep_demo/sep_demo_app.cpp
@@ -364,18 +364,19 @@ void PatternGeneratorPanel::generateWavePattern() {
         pattern.id = "wave_" + std::to_string(i) + "_" + std::to_string(gen());
         pattern.position = glm::vec4(
             t * wave_length - wave_length / 2.0f,
-            std::sin(angle * 3.0f) * wave_amplitude,
-            std::cos(angle * 2.0f) * wave_amplitude,
+            std::sinf(angle * 3.0f) * wave_amplitude,
+            std::cosf(angle * 2.0f) * wave_amplitude,
             1.0f
         );
         pattern.velocity = glm::vec4(0.0f);
         pattern.coherence = coherence_dist(gen);
-        pattern.amplitude = std::complex<float>(std::cos(angle), std::sin(angle));
+        pattern.amplitude =
+            std::complex<float>(std::cosf(angle), std::sinf(angle));
         pattern.generation = 0;
         
         pattern.quantum_state.coherence = pattern.coherence;
         pattern.quantum_state.stability = stability_dist(gen);
-        pattern.quantum_state.energy = 1.0f + std::sin(angle);
+        pattern.quantum_state.energy = 1.0f + std::sinf(angle);
         pattern.quantum_state.phase = angle;
         
         patterns.push_back(pattern);

--- a/src/audio/spa_includes.h
+++ b/src/audio/spa_includes.h
@@ -6,4 +6,8 @@
 
 #include <spa/pod/parser.h>
 
+// `spa_pod_parser_get` performs internal null checks before dereferencing
+// its arguments. Warnings are suppressed because the analyzer cannot
+// detect these checks across the header boundary.
+
 #pragma clang diagnostic pop


### PR DESCRIPTION
## Summary
- use sinf/cosf to avoid double promotion in sep_demo_app
- explain null checks when including `spa/pod/parser.h`

## Testing
- `./build.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68859675c748832a88d6dae139f20dea