### PR TITLE
Connect backtester tab to workbench engine

### DIFF
--- a/src/apps/workbench/backtester/core/backtester_engine.cpp
+++ b/src/apps/workbench/backtester/core/backtester_engine.cpp
@@ -121,3 +121,18 @@ sep::workbench::backtester::BacktestResult BacktesterEngine::run(
     SEPSignalStrategy default_strategy;
     return run(dataset_path, engine, &default_strategy);
 }
+
+sep::workbench::backtester::BacktestResult BacktesterEngine::run(
+    const std::vector<sep::quantum::Signal>& signals,
+    const std::string& dataset_path) {
+    sep::workbench::backtester::DataLoader loader;
+    if (dataset_path == "EURUSD_48H") {
+        loader.load_48h_sample();
+    } else {
+        loader.load_data(dataset_path);
+    }
+
+    sep::workbench::backtester::Backtester backtester;
+    backtester.run(signals, loader.get_data());
+    return backtester.getResult();
+}

--- a/src/apps/workbench/backtester/core/backtester_engine.h
+++ b/src/apps/workbench/backtester/core/backtester_engine.h
@@ -15,8 +15,11 @@ public:
 
     sep::workbench::backtester::BacktestResult run(const std::string& dataset_path);
     sep::workbench::backtester::BacktestResult run(const std::string& dataset_path,
-    sep::quantum::PatternMetricEngine* engine,
-    BaseStrategy* strategy);
+                                                   sep::quantum::PatternMetricEngine* engine,
+                                                   BaseStrategy* strategy);
     sep::workbench::backtester::BacktestResult run(const std::string& dataset_path,
                                                    sep::quantum::PatternMetricEngine* engine);
+    sep::workbench::backtester::BacktestResult run(
+        const std::vector<sep::quantum::Signal>& signals,
+        const std::string& dataset_path);
 };

--- a/src/apps/workbench/backtester/strategies/sep_signal_strategy.cpp
+++ b/src/apps/workbench/backtester/strategies/sep_signal_strategy.cpp
@@ -13,8 +13,14 @@ SEPSignalStrategy::~SEPSignalStrategy() = default;
 std::vector<sep::quantum::Signal>
 SEPSignalStrategy::execute(const std::vector<sep::common::CandleData>& candles,
                            const std::vector<sep::quantum::Signal>& engine_signals) {
-    std::vector<sep::quantum::Signal> signals = engine_signals;
-    if (!signals.empty()) {
+    std::vector<sep::quantum::Signal> signals;
+    if (!engine_signals.empty()) {
+        signals = engine_signals;
+        for (auto& s : signals) {
+            if (s.confidence < 0.5f) {
+                s.type = sep::quantum::SignalType::HOLD;
+            }
+        }
         return signals;
     }
     if (candles.empty()) {

--- a/src/apps/workbench/backtester/ui/backtester_tab_controller.cpp
+++ b/src/apps/workbench/backtester/ui/backtester_tab_controller.cpp
@@ -15,6 +15,16 @@ BacktesterTabController::BacktesterTabController()
 BacktesterTabController::~BacktesterTabController() {
 }
 
+void BacktesterTabController::setPatternMetricEngine(
+    sep::quantum::PatternMetricEngine* engine) {
+    pattern_engine_ptr_ = engine;
+}
+
+void BacktesterTabController::setOandaConnector(
+    sep::connectors::OandaConnector* connector) {
+    oanda_connector_ = connector;
+}
+
 void BacktesterTabController::render() {
     ImGui::Begin("Backtester");
     ImGui::InputText("Dataset", dataset_path_, sizeof(dataset_path_));
@@ -48,8 +58,12 @@ void BacktesterTabController::render() {
             if (strategy_index_ == 0) {
                 strat_ptr = &strategy;
             }
-            pattern_engine_.init(use_gpu_ ? &gpu_context_ : nullptr);
-            result_ = engine_->run(dataset_path_, &pattern_engine_, strat_ptr);
+            sep::quantum::PatternMetricEngine* engine_to_use = pattern_engine_ptr_;
+            if (!engine_to_use) {
+                engine_to_use = &pattern_engine_;
+                engine_to_use->init(use_gpu_ ? &gpu_context_ : nullptr);
+            }
+            result_ = engine_->run(dataset_path_, engine_to_use, strat_ptr);
             globalEventBus().publish(BacktestResultEvent{result_});
             running_ = false;
         }

--- a/src/apps/workbench/backtester/ui/backtester_tab_controller.h
+++ b/src/apps/workbench/backtester/ui/backtester_tab_controller.h
@@ -4,6 +4,7 @@
 #include "apps/workbench/backtester/strategies/base_strategy.h"
 #include "apps/workbench/core/file_dialog.hpp"
 #include "apps/workbench/core/ui_layout_manager.h"
+#include "connectors/oanda_connector.h"
 #include <memory>
 #include <vector>
 
@@ -14,9 +15,14 @@ public:
 
     void render();
 
+    void setPatternMetricEngine(sep::quantum::PatternMetricEngine* engine);
+    void setOandaConnector(sep::connectors::OandaConnector* connector);
+
 private:
     std::unique_ptr<BacktesterEngine> engine_;
     sep::quantum::PatternMetricEngine pattern_engine_;
+    sep::quantum::PatternMetricEngine* pattern_engine_ptr_ = nullptr;
+    sep::connectors::OandaConnector* oanda_connector_ = nullptr;
     sep::quantum::GPUContext gpu_context_{};
     bool use_gpu_ = false;
     std::vector<std::string> strategy_names_{"SEP Signal"};

--- a/src/apps/workbench/core/workbench_core.cpp
+++ b/src/apps/workbench/core/workbench_core.cpp
@@ -174,6 +174,13 @@ bool WorkbenchEngine::initialize()
         config::CudaConfig config;
         offline_engine_->init(config);
         active_engine_ = offline_engine_.get();
+
+        if (backtester_tab_) {
+            backtester_tab_->setPatternMetricEngine(getPatternMetricEngine());
+            if (service_connector_) {
+                backtester_tab_->setOandaConnector(service_connector_->getOandaConnector());
+            }
+        }
         
         // Skip service check - use offline engine as primary engine
         ::std::cout << "[WorkbenchEngine] Using offline engine as primary engine - no service needed" << ::std::endl;


### PR DESCRIPTION
## Summary
- allow passing external signals to BacktesterEngine
- interpret SEP engine signals with a simple confidence filter
- enable BacktesterTabController to reuse shared engine/connector
- connect tab to WorkbenchEngine initialization

## Testing
- `./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_6885965f4034832ab515f2bb291188c5