### PR TITLE
Enhance backtester flow

### DIFF
--- a/src/apps/workbench/backtester/core/backtester_engine.cpp
+++ b/src/apps/workbench/backtester/core/backtester_engine.cpp
@@ -74,45 +74,9 @@ sep::workbench::backtester::BacktestResult BacktesterEngine::run(
             }
         }
     }
-    std::vector<float> prices;
-    prices.reserve(candles.size());
-    for (const auto& candle : candles) {
-        prices.push_back(static_cast<float>(candle.close));
-    }
-
-    std::vector<float> pnl;
-    std::vector<sep::workbench::backtester::Trade> trades;
-    int wins = 0;
-    int losses = 0;
-    size_t count = std::min(signals.size(), prices.size() - 1);
-    for (size_t i = 0; i < count; ++i) {
-        if (signals[i].type == sep::quantum::SignalType::BUY) {
-            float entry = prices[i];
-            float exit = prices[i + 1];
-            pnl.push_back(exit - entry);
-            trades.push_back({sep::quantum::SignalType::BUY, entry, exit, 1});
-            wins += exit > entry;
-            losses += exit <= entry;
-        } else if (signals[i].type == sep::quantum::SignalType::SELL) {
-            float entry = prices[i];
-            float exit = prices[i + 1];
-            pnl.push_back(entry - exit);
-            trades.push_back({sep::quantum::SignalType::SELL, entry, exit, 1});
-            wins += entry > exit;
-            losses += entry <= exit;
-        }
-    }
-
-    result.total_trades = static_cast<int>(pnl.size());
-    result.trades = std::move(trades);
-    if (result.total_trades > 0) {
-        result.win_rate = static_cast<float>(wins) / result.total_trades;
-        result.total_pnl = std::accumulate(pnl.begin(), pnl.end(), 0.0f);
-        result.sharpe_ratio = PerformanceMetrics::computeSharpeRatio(pnl);
-        result.max_drawdown = PerformanceMetrics::computeMaxDrawdown(pnl);
-    }
-
-    return result;
+    sep::workbench::backtester::Backtester backtester;
+    backtester.run(signals, candles);
+    return backtester.getResult();
 }
 
 sep::workbench::backtester::BacktestResult BacktesterEngine::run(

--- a/src/apps/workbench/backtester/strategies/sep_signal_strategy.cpp
+++ b/src/apps/workbench/backtester/strategies/sep_signal_strategy.cpp
@@ -13,31 +13,42 @@ SEPSignalStrategy::~SEPSignalStrategy() = default;
 std::vector<sep::quantum::Signal>
 SEPSignalStrategy::execute(const std::vector<sep::common::CandleData>& candles,
                            const std::vector<sep::quantum::Signal>& engine_signals) {
-    std::vector<sep::quantum::Signal> signals;
+    std::vector<sep::quantum::Signal> base_signals;
     if (!engine_signals.empty()) {
-        signals = engine_signals;
-        for (auto& s : signals) {
-            if (s.confidence < 0.5f) {
+        base_signals = engine_signals;
+    } else if (!candles.empty()) {
+        std::vector<uint8_t> byte_stream;
+        byte_stream.reserve(candles.size() * sizeof(sep::common::CandleData));
+        for (const auto& c : candles) {
+            const uint8_t* ptr = reinterpret_cast<const uint8_t*>(&c);
+            byte_stream.insert(byte_stream.end(), ptr,
+                               ptr + sizeof(sep::common::CandleData));
+        }
+        engine_.ingestData(byte_stream.data(), byte_stream.size());
+        engine_.evolvePatterns();
+        engine_.computeMetrics();
+        base_signals = engine_.getSignals();
+    }
+
+    std::vector<sep::quantum::Signal> signals;
+    signals.reserve(base_signals.size());
+    for (size_t i = 0; i < base_signals.size(); ++i) {
+        auto s = base_signals[i];
+        if (s.confidence < 0.6f) {
+            s.type = sep::quantum::SignalType::HOLD;
+        } else if (i >= 3 && i < candles.size()) {
+            float avg = (static_cast<float>(candles[i - 1].close) +
+                         static_cast<float>(candles[i - 2].close) +
+                         static_cast<float>(candles[i - 3].close)) /
+                        3.0f;
+            float price = static_cast<float>(candles[i].close);
+            if (s.type == sep::quantum::SignalType::BUY && price < avg) {
+                s.type = sep::quantum::SignalType::HOLD;
+            } else if (s.type == sep::quantum::SignalType::SELL && price > avg) {
                 s.type = sep::quantum::SignalType::HOLD;
             }
         }
-        return signals;
+        signals.push_back(s);
     }
-    if (candles.empty()) {
-        return signals;
-    }
-
-    std::vector<uint8_t> byte_stream;
-    byte_stream.reserve(candles.size() * sizeof(sep::common::CandleData));
-    for (const auto& c : candles) {
-        const uint8_t* ptr = reinterpret_cast<const uint8_t*>(&c);
-        byte_stream.insert(byte_stream.end(), ptr,
-                           ptr + sizeof(sep::common::CandleData));
-    }
-
-    engine_.ingestData(byte_stream.data(), byte_stream.size());
-    engine_.evolvePatterns();
-    engine_.computeMetrics();
-    signals = engine_.getSignals();
     return signals;
 }

--- a/src/apps/workbench/backtester/ui/backtester_tab_controller.cpp
+++ b/src/apps/workbench/backtester/ui/backtester_tab_controller.cpp
@@ -80,7 +80,18 @@ void BacktesterTabController::render() {
     ImGui::Text("Sharpe Ratio: %.2f", result_.sharpe_ratio);
     ImGui::Text("Max Drawdown: %.2f", result_.max_drawdown);
 
-    if (!result_.trades.empty()) {
+    if (!result_.equity_curve.empty()) {
+        std::vector<double> xs(result_.equity_curve.size());
+        std::vector<double> curve(result_.equity_curve.size());
+        for (size_t i = 0; i < result_.equity_curve.size(); ++i) {
+            xs[i] = static_cast<double>(i);
+            curve[i] = static_cast<double>(result_.equity_curve[i]);
+        }
+        if (ImPlot::BeginPlot("Profit Curve", ImVec2(-1,150))) {
+            ImPlot::PlotLine("PnL", xs.data(), curve.data(), static_cast<int>(curve.size()));
+            ImPlot::EndPlot();
+        }
+    } else if (!result_.trades.empty()) {
         std::vector<double> xs(result_.trades.size());
         std::vector<double> curve(result_.trades.size());
         double cumulative = 0.0;
@@ -93,7 +104,6 @@ void BacktesterTabController::render() {
             xs[i] = static_cast<double>(i);
             curve[i] = cumulative;
         }
-
         if (ImPlot::BeginPlot("Profit Curve", ImVec2(-1,150))) {
             ImPlot::PlotLine("PnL", xs.data(), curve.data(), static_cast<int>(curve.size()));
             ImPlot::EndPlot();


### PR DESCRIPTION
## Summary
- refactor `BacktesterEngine` to reuse `Backtester` for trade computation
- improve `SEPSignalStrategy` signal filtering logic
- use equity curve in `BacktesterTabController`

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DSEP_USE_CUDA=OFF` *(fails: Findbenchmark.cmake not found)*

------
https://chatgpt.com/codex/tasks/task_e_688599c63530832aa25ae05a3ba168df