### PR TITLE
Integrate Oanda callbacks for live updates

### DIFF
--- a/src/apps/workbench/core/workbench_core.cpp
+++ b/src/apps/workbench/core/workbench_core.cpp
@@ -190,31 +190,7 @@ bool WorkbenchEngine::initialize()
         if (service_connector_ && service_connector_->getOandaConnector()) {
             auto oanda_ptr = service_connector_->getOandaConnector();
             std::cout << "[WorkbenchEngine] OANDA connector available: " << (oanda_ptr ? "Yes" : "No") << std::endl;
-            oanda_ptr->setPriceCallback([this](const connectors::MarketData& md) {
-                if (metrics_monitor_) {
-                    metrics_monitor_->setLatestMarketData(md);
-                }
-
-                if (active_engine_) {
-                    auto* pme = active_engine_->getPatternMetricEngine();
-                    if (pme) {
-                        float price = static_cast<float>(md.mid);
-                        pme->ingestData(reinterpret_cast<const uint8_t*>(&price), sizeof(price));
-                        pme->evolvePatterns();
-                        pme->computeMetrics();
-                    }
-                }
-            });
-
-            oanda_ptr->setCandleCallback([this](const common::CandleData& c) {
-                if (signals_tab_) {
-                    signals_tab_->addCandle(c);
-                }
-                if (multi_timeframe_analyzer_) {
-                    multi_timeframe_analyzer_->ingestMarketData("EUR_USD", c);
-                }
-            });
-
+            setupOandaCallbacks(oanda_ptr);
             oanda_ptr->startPriceStream({"EUR_USD"});
         }
 
@@ -933,6 +909,37 @@ void WorkbenchEngine::updateData()
             std::cerr << "[WorkbenchEngine] SEP signal processing error: " << e.what() << std::endl;
         }
     }
+}
+
+void WorkbenchEngine::setupOandaCallbacks(connectors::OandaConnector* oanda_ptr)
+{
+    if (!oanda_ptr)
+        return;
+
+    oanda_ptr->setPriceCallback([this](const connectors::MarketData& md) {
+        if (metrics_monitor_) {
+            metrics_monitor_->setLatestMarketData(md);
+        }
+
+        if (active_engine_) {
+            auto* pme = active_engine_->getPatternMetricEngine();
+            if (pme) {
+                float price = static_cast<float>(md.mid);
+                pme->ingestData(reinterpret_cast<const uint8_t*>(&price), sizeof(price));
+                pme->evolvePatterns();
+                pme->computeMetrics();
+            }
+        }
+    });
+
+    oanda_ptr->setCandleCallback([this](const common::CandleData& c) {
+        if (signals_tab_) {
+            signals_tab_->addCandle(c);
+        }
+        if (multi_timeframe_analyzer_) {
+            multi_timeframe_analyzer_->ingestMarketData("EUR_USD", c);
+        }
+    });
 }
 
 } // namespace sep::workbench

--- a/src/apps/workbench/core/workbench_core.hpp
+++ b/src/apps/workbench/core/workbench_core.hpp
@@ -19,6 +19,7 @@ namespace sep {
     {
         class Engine;
     }
+    namespace connectors { class OandaConnector; }
 }  // namespace sep
 
 namespace sep::workbench {
@@ -159,6 +160,9 @@ private:
     void handleDemoSelection();
     void handleDemoRunning();
     void handleErrorRecovery();
+
+    // Connector integration
+    void setupOandaCallbacks(sep::connectors::OandaConnector* oanda_ptr);
 
     // Cross-thread metric delivery
     std::map<std::string, TimeframeMetrics> pending_metrics_;


### PR DESCRIPTION
## Summary
- centralize Oanda callback registration in WorkbenchCore
- forward candle updates to MultiTimeframeAnalyzer and SignalsTabController
- process price updates with PatternMetricEngine

## Testing
- `cmake -B build -DSEP_USE_CUDA=OFF ..` *(fails: Could NOT find OpenGL)*
- `./simple_test/build/simple_test_runner`


------
https://chatgpt.com/codex/tasks/task_e_688599c0b090832ab1951edecf355ee1