### PR TITLE
Address parser precision and document SPA header

### DIFF
--- a/src/audio/spa_includes.h
+++ b/src/audio/spa_includes.h
@@ -7,7 +7,9 @@
 #include <spa/pod/parser.h>
 
 // `spa_pod_parser_get` performs internal null checks before dereferencing
-// its arguments. Warnings are suppressed because the analyzer cannot
-// detect these checks across the header boundary.
+// its arguments. This wrapper documents that safety guarantee so that
+// static analyzers do not flag a potential null dereference when
+// including <spa/pod/parser.h>.
+
 
 #pragma clang diagnostic pop

--- a/src/engine/data_parser.cpp
+++ b/src/engine/data_parser.cpp
@@ -402,7 +402,7 @@ std::vector<sep::common::CandleData> DataParser::parseQuantJSON(const std::strin
         file >> j;
         
         if (j.is_array()) {
-            int index = 0;
+            size_t index = 0;
             for (const auto& candle_json : j) {
                 sep::common::CandleData candle;
 
@@ -422,19 +422,19 @@ std::vector<sep::common::CandleData> DataParser::parseQuantJSON(const std::strin
                 }
 
                 if (candle_json.contains("open") && candle_json["open"].is_number())
-                    candle.open = candle_json["open"].get<float>();
+                    candle.open = candle_json["open"].get<double>();
                 else
                     valid = false;
                 if (candle_json.contains("high") && candle_json["high"].is_number())
-                    candle.high = candle_json["high"].get<float>();
+                    candle.high = candle_json["high"].get<double>();
                 else
                     valid = false;
                 if (candle_json.contains("low") && candle_json["low"].is_number())
-                    candle.low = candle_json["low"].get<float>();
+                    candle.low = candle_json["low"].get<double>();
                 else
                     valid = false;
                 if (candle_json.contains("close") && candle_json["close"].is_number())
-                    candle.close = candle_json["close"].get<float>();
+                    candle.close = candle_json["close"].get<double>();
                 else
                     valid = false;
 
@@ -460,7 +460,7 @@ std::vector<sep::common::CandleData> DataParser::parseQuantJSON(const std::strin
                 return candles;
             }
 
-            int index = 0;
+            size_t index = 0;
             for (const auto& candle_json : j["candles"]) {
             sep::common::CandleData candle;
             


### PR DESCRIPTION
## Summary
- fix JSON candle parsing precision in `DataParser`
- change index counters to `size_t`
- clarify PipeWire SPA parser null-check comment

## Testing
- `./build.sh` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_688599d837dc832a8daf33b9bd202912