### PR TITLE
Implement instrument selection and order features

### DIFF
--- a/src/apps/workbench/core/unified_dashboard.cpp
+++ b/src/apps/workbench/core/unified_dashboard.cpp
@@ -419,9 +419,11 @@ bool UnifiedDashboard::loadSampleData() {
         
         for (const auto& candle_json : candles_json) {
             sep::connectors::OandaCandle candle;
-            
+
             // Parse timestamp
-            candle.time = candle_json["time"];
+            std::string ts = candle_json["time"];
+            auto tp = sep::common::parseTimestamp(ts);
+            candle.time = std::to_string(sep::common::time_point_to_nanoseconds(tp));
             
             // Parse OHLC from mid prices
             const auto& mid = candle_json["mid"];

--- a/src/apps/workbench/core_old/metrics_dashboard.cpp
+++ b/src/apps/workbench/core_old/metrics_dashboard.cpp
@@ -410,17 +410,22 @@ void MetricsDashboard::renderBacktesterPanel()
     if (!result.trades.empty()) {
         ImGui::Separator();
         ImGui::Text("Trades");
-        ImGui::Columns(4, "trades");
+        ImGui::Columns(5, "trades");
         ImGui::Text("Type"); ImGui::NextColumn();
         ImGui::Text("Entry"); ImGui::NextColumn();
         ImGui::Text("Exit"); ImGui::NextColumn();
         ImGui::Text("Hold"); ImGui::NextColumn();
+        ImGui::Text("P/L"); ImGui::NextColumn();
         ImGui::Separator();
         for (const auto& t : result.trades) {
             ImGui::Text("%s", t.type == sep::quantum::SignalType::BUY ? "BUY" : "SELL"); ImGui::NextColumn();
             ImGui::Text("%.5f", t.entry_price); ImGui::NextColumn();
             ImGui::Text("%.5f", t.exit_price); ImGui::NextColumn();
             ImGui::Text("%d", t.holding_period); ImGui::NextColumn();
+            float pl = (t.type == sep::quantum::SignalType::BUY)
+                         ? (t.exit_price - t.entry_price)
+                         : (t.entry_price - t.exit_price);
+            ImGui::Text("%.5f", pl); ImGui::NextColumn();
         }
         ImGui::Columns(1);
     }

--- a/src/apps/workbench/core_old/trading_hud.cpp
+++ b/src/apps/workbench/core_old/trading_hud.cpp
@@ -158,6 +158,10 @@ void TradingHUD::renderTopBar() {
             auto candles = oanda_connector_->getHistoricalData(selected_instrument_, "M1", "", "", 500);
             updateCandleData(candles);
             instrument_history_[selected_instrument_] = std::deque<CandleData>(candle_data_.begin(), candle_data_.end());
+            if (live_mode_) {
+                oanda_connector_->stopPriceStream();
+                oanda_connector_->startPriceStream({selected_instrument_});
+            }
         }
     }
     
@@ -672,16 +676,19 @@ void TradingHUD::renderTradingControls() {
     if (ImGui::Button("BUY", ImVec2(-1, 30))) {
         if (oanda_connector_) {
             auto md = oanda_connector_->getMarketData(selected_instrument_);
+            double risk_amount = account_info_.balance * 0.02; // 2% risk
+            double pip_value = 0.0001;
+            int order_units = static_cast<int>(std::floor(risk_amount / (stop_loss_pips * pip_value)));
             nlohmann::json order;
             order["order"]["instrument"] = selected_instrument_;
-            order["order"]["units"] = std::to_string(static_cast<int>(std::abs(position_size)));
+            order["order"]["units"] = std::to_string(order_units);
             order["order"]["type"] = "MARKET";
             order["order"]["timeInForce"] = "FOK";
             order["order"]["positionFill"] = "DEFAULT";
-            double sl_price = md.ask - stop_loss_pips * 0.0001;
+            double sl_price = md.ask - stop_loss_pips * pip_value;
             order["order"]["stopLossOnFill"]["price"] = std::to_string(sl_price);
             if (take_profit_pips > 0.0f) {
-                double tp_price = md.ask + take_profit_pips * 0.0001;
+                double tp_price = md.ask + take_profit_pips * pip_value;
                 order["order"]["takeProfitOnFill"]["price"] = std::to_string(tp_price);
             }
             oanda_connector_->placeOrder(order);
@@ -691,16 +698,19 @@ void TradingHUD::renderTradingControls() {
     if (ImGui::Button("SELL", ImVec2(-1, 30))) {
         if (oanda_connector_) {
             auto md = oanda_connector_->getMarketData(selected_instrument_);
+            double risk_amount = account_info_.balance * 0.02; // 2% risk
+            double pip_value = 0.0001;
+            int order_units = -static_cast<int>(std::floor(risk_amount / (stop_loss_pips * pip_value)));
             nlohmann::json order;
             order["order"]["instrument"] = selected_instrument_;
-            order["order"]["units"] = std::to_string(-static_cast<int>(std::abs(position_size)));
+            order["order"]["units"] = std::to_string(order_units);
             order["order"]["type"] = "MARKET";
             order["order"]["timeInForce"] = "FOK";
             order["order"]["positionFill"] = "DEFAULT";
-            double sl_price = md.bid + stop_loss_pips * 0.0001;
+            double sl_price = md.bid + stop_loss_pips * pip_value;
             order["order"]["stopLossOnFill"]["price"] = std::to_string(sl_price);
             if (take_profit_pips > 0.0f) {
-                double tp_price = md.bid - take_profit_pips * 0.0001;
+                double tp_price = md.bid - take_profit_pips * pip_value;
                 order["order"]["takeProfitOnFill"]["price"] = std::to_string(tp_price);
             }
             oanda_connector_->placeOrder(order);


### PR DESCRIPTION
## Summary
- parse candle timestamps when loading dashboard data
- show trade P/L in metrics dashboard
- restart streaming on instrument switch and compute risk-based order sizes for BUY/SELL

## Testing
- `./build.sh` *(failed: no output)*
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_688599cd06cc832a95252381d11e777f