### PR TITLE
Fix candlestick rendering with PlotCandles

### DIFF
--- a/src/apps/workbench/tabs/signals_tab_controller.cpp
+++ b/src/apps/workbench/tabs/signals_tab_controller.cpp
@@ -359,8 +359,10 @@ void SignalsTabController::renderCandlesticks() {
         high[i] = c.high;
     }
 
-    ImPlot::SetNextAxisLimits(ImAxis_Y1, local_min - range * 0.05, local_max + range * 0.05, ImPlotCond_Always);
-    ImPlot::PlotCandlestick("OHLC", xs.data(), open.data(), close.data(), low.data(), high.data(), static_cast<int>(count));
+    ImPlot::SetNextAxisLimits(ImAxis_Y1, local_min - range * 0.05,
+                              local_max + range * 0.05, ImPlotCond_Always);
+    ImPlot::PlotCandles("OHLC", xs.data(), open.data(), close.data(),
+                        low.data(), high.data(), static_cast<int>(count));
 }
 
 void SignalsTabController::renderTechnicalIndicators() {


### PR DESCRIPTION
## Summary
- use `PlotCandles` instead of deprecated `PlotCandlestick`
- keep real‑time metric plots and zoom/pan logic

## Testing
- `cmake .. -GNinja` *(fails: CUDA_HOME environment variable not set)*

------
https://chatgpt.com/codex/tasks/task_e_68859d0ea218832aa2218f20d6c23d49