### PR TITLE
Enable dataset-driven backtesting workflow

### DIFF
--- a/src/apps/workbench/backtester/core/backtester_engine.cpp
+++ b/src/apps/workbench/backtester/core/backtester_engine.cpp
@@ -44,6 +44,7 @@ sep::workbench::backtester::BacktestResult BacktesterEngine::run(
         return result;
     }
     sep::quantum::PatternMetricEngine& engine_ref = *engine;
+    engine_ref.clear();
     std::vector<uint8_t> byte_stream;
     byte_stream.reserve(candles.size() * sizeof(sep::common::CandleData));
     for (const auto& candle : candles) {

--- a/src/apps/workbench/backtester/ui/backtester_tab_controller.cpp
+++ b/src/apps/workbench/backtester/ui/backtester_tab_controller.cpp
@@ -25,6 +25,23 @@ void BacktesterTabController::setOandaConnector(
     oanda_connector_ = connector;
 }
 
+void BacktesterTabController::runBacktest(const std::string& path) {
+    running_ = true;
+    SEPSignalStrategy strategy;
+    BaseStrategy* strat_ptr = nullptr;
+    if (strategy_index_ == 0) {
+        strat_ptr = &strategy;
+    }
+    sep::quantum::PatternMetricEngine* engine_to_use = pattern_engine_ptr_;
+    if (!engine_to_use) {
+        engine_to_use = &pattern_engine_;
+        engine_to_use->init(use_gpu_ ? &gpu_context_ : nullptr);
+    }
+    result_ = engine_->run(path, engine_to_use, strat_ptr);
+    globalEventBus().publish(BacktestResultEvent{result_});
+    running_ = false;
+}
+
 void BacktesterTabController::render() {
     ImGui::Begin("Backtester");
     ImGui::InputText("Dataset", dataset_path_, sizeof(dataset_path_));
@@ -36,6 +53,7 @@ void BacktesterTabController::render() {
     if (file_dialog_.render(selected)) {
         strncpy(dataset_path_, selected.c_str(), sizeof(dataset_path_) - 1);
         dataset_path_[sizeof(dataset_path_) - 1] = '\0';
+        runBacktest(dataset_path_);
     }
     ImGui::Combo("Strategy", &strategy_index_,
                 [](void* data, int idx, const char** out_text) {
@@ -52,20 +70,7 @@ void BacktesterTabController::render() {
 
     if (!running_) {
         if (ImGui::Button("Start")) {
-            running_ = true;
-            SEPSignalStrategy strategy;
-            BaseStrategy* strat_ptr = nullptr;
-            if (strategy_index_ == 0) {
-                strat_ptr = &strategy;
-            }
-            sep::quantum::PatternMetricEngine* engine_to_use = pattern_engine_ptr_;
-            if (!engine_to_use) {
-                engine_to_use = &pattern_engine_;
-                engine_to_use->init(use_gpu_ ? &gpu_context_ : nullptr);
-            }
-            result_ = engine_->run(dataset_path_, engine_to_use, strat_ptr);
-            globalEventBus().publish(BacktestResultEvent{result_});
-            running_ = false;
+            runBacktest(dataset_path_);
         }
     } else {
         if (ImGui::Button("Stop")) {

--- a/src/apps/workbench/backtester/ui/backtester_tab_controller.h
+++ b/src/apps/workbench/backtester/ui/backtester_tab_controller.h
@@ -18,6 +18,8 @@ public:
     void setPatternMetricEngine(sep::quantum::PatternMetricEngine* engine);
     void setOandaConnector(sep::connectors::OandaConnector* connector);
 
+    void runBacktest(const std::string& path);
+
 private:
     std::unique_ptr<BacktesterEngine> engine_;
     sep::quantum::PatternMetricEngine pattern_engine_;

--- a/src/apps/workbench/tabs/backend_tab_controller.cpp
+++ b/src/apps/workbench/tabs/backend_tab_controller.cpp
@@ -193,6 +193,10 @@ void BackendTabController::renderBacktesterPanel() {
         dialog_target_ = DialogTarget::Backtest;
         file_dialog_.open(std::filesystem::path(backtest_file_buffer_).empty() ? "." : std::filesystem::path(backtest_file_buffer_).parent_path().string());
     }
+    ImGui::SameLine();
+    if (ImGui::Button("Open Backtester Tab")) {
+        globalEventBus().publish(PanelVisibilityEvent{"Backtester", true});
+    }
     if (ImGui::Button("Load Dataset")) {
         data_loader_->load_data(backtest_file_buffer_);
         dataset_loaded_ = !data_loader_->get_data().empty();


### PR DESCRIPTION
## Summary
- ensure the passed `PatternMetricEngine` resets state for each run
- trigger backtests when selecting a dataset in the UI
- expose a helper to run backtests programmatically
- allow Backend tab to open the backtester tab directly

## Testing
- `cmake ../tests` *(passed)*
- `cmake --build .` *(failed: glm/glm.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68859d1c43ac832a9f5b6b84b5b8ceb2