### PR TITLE
Address lint warnings and document SPA parser check

### DIFF
--- a/docs/spa_parser_null_deref.md
+++ b/docs/spa_parser_null_deref.md
@@ -1,0 +1,14 @@
+# PipeWire spa_pod_parser Null Dereference Review
+
+Static analysis flagged a potential null pointer dereference in
+`/usr/include/spa-0.2/spa/pod/parser.h`. The function
+`spa_pod_parser_deref` may return `NULL` when presented with an
+invalid offset. Subsequent helpers such as `spa_pod_parser_get_*`
+check for `NULL` before dereferencing the returned pointer.
+
+SEP includes this header via `src/audio/spa_includes.h`, which wraps
+the include and documents the safety of these helpers. Because the
+library performs its own null checks and SEP does not bypass those
+helpers, the reported issue does not surface in SEP's code paths.
+
+No changes are required in the project at this time.

--- a/src/apps/sep_demo/sep_demo_app.cpp
+++ b/src/apps/sep_demo/sep_demo_app.cpp
@@ -258,7 +258,7 @@ void SystemMetricsPanel::updateMetrics() {
     
     // Update processing rate (simplified)
     static size_t last_pattern_count = 0;
-    float time_delta = elapsed / 1000.0f;
+    float time_delta = static_cast<float>(elapsed) / 1000.0f;
     float processed = static_cast<float>(patterns.size() - last_pattern_count);
     metrics_.processing_rate = processed / time_delta;
     last_pattern_count = patterns.size();
@@ -397,7 +397,7 @@ void PatternGeneratorPanel::generateClusterPattern() {
     std::vector<quantum::Pattern> patterns;
     patterns.reserve(pattern_count_);
 
-    int clusters = 3;
+    size_t clusters = 3;
     std::vector<glm::vec3> cluster_centers = {
         glm::vec3(-5.0f, 0.0f, 0.0f),
         glm::vec3(5.0f, 0.0f, 0.0f),
@@ -405,7 +405,7 @@ void PatternGeneratorPanel::generateClusterPattern() {
     };
 
     for (int i = 0; i < pattern_count_; ++i) {
-        int cluster_idx = i % clusters;
+        size_t cluster_idx = static_cast<size_t>(i) % clusters;
         glm::vec3 center = cluster_centers[cluster_idx];
 
         quantum::Pattern pattern;

--- a/src/connectors/oanda_connector.cpp
+++ b/src/connectors/oanda_connector.cpp
@@ -348,11 +348,11 @@ OandaConnector::CurlResponse OandaConnector::makeRequest(const std::string& endp
 }
 
 double OandaConnector::calculateATR(const std::string& instrument, const std::string& granularity,
-                                    int periods)
+                                    size_t periods)
 {
     auto candles = getHistoricalData(instrument, granularity, "", "", periods + 1);
-    
-    if (candles.size() < static_cast<size_t>(periods)) {
+
+    if (candles.size() < periods) {
         last_error_ = "Insufficient candle data for ATR calculation";
         return 0.0;
     }
@@ -880,7 +880,7 @@ DataValidationResult OandaConnector::validateCandleSequence(const std::vector<Oa
 
     // Check for timestamp continuity
     // This is a simplified check. A robust implementation would parse the granularity string.
-    int64_t expected_diff = 60;  // Default to M1
+    int64_t expected_diff = 60LL;  // Default to M1
     if (granularity == "H1")
         expected_diff = 3600;
     else if (granularity == "D")

--- a/src/connectors/oanda_connector.h
+++ b/src/connectors/oanda_connector.h
@@ -88,7 +88,7 @@ public:
 
     // Technical analysis
     double calculateATR(const std::string& instrument, const std::string& granularity = "H1",
-                        int periods = 14);
+                        size_t periods = 14);
     MarketData getMarketData(const std::string& instrument);
     int getVolatilityLevel(double current_atr, const std::string& instrument);
 

--- a/src/engine/data_parser.cpp
+++ b/src/engine/data_parser.cpp
@@ -164,7 +164,7 @@ std::vector<quantum::Pattern> DataParser::parseCSV(const std::string& path)
     }
 
     std::string line;
-    int line_num = 0;
+    size_t line_num = 0;
 
     while (std::getline(file, line))
     {


### PR DESCRIPTION
## Summary
- fix line number parsing variable type
- update ATR calculation signature to use `size_t`
- clean up cluster pattern generation code
- avoid float promotion in metrics update
- record investigation on PipeWire spa_pod parser null dereference

## Testing
- `./build.sh` *(fails: command not found or environment issue)*

------
https://chatgpt.com/codex/tasks/task_e_68859d25bf18832aa9922e1b6a497258