### PR TITLE
Update analyzer callbacks and streaming controls

### DIFF
--- a/src/apps/workbench/core/service_connector.cpp
+++ b/src/apps/workbench/core/service_connector.cpp
@@ -265,8 +265,9 @@ void ServiceConnector::disconnect() {
     }
     
     std::cout << "[ServiceConnector] Disconnecting from SEP service..." << std::endl;
-    
+
     stopHealthMonitoring();
+    stopStreaming();
     
     // Clean up connection based on connection type
     if (service_handle_) {
@@ -659,6 +660,19 @@ bool ServiceConnector::validateServiceVersion() {
     std::cout << "[ServiceConnector] Version validation failed, assuming compatibility" << std::endl;
     health_metrics_.version_info = "SEP Service v0.1.0 (assumed)";
     return true;
+}
+
+bool ServiceConnector::startStreaming(const std::vector<std::string>& instruments) {
+    if (!oanda_connector_) {
+        return false;
+    }
+    return oanda_connector_->startPriceStream(instruments);
+}
+
+void ServiceConnector::stopStreaming() {
+    if (oanda_connector_) {
+        oanda_connector_->stopPriceStream();
+    }
 }
 
 bool ServiceConnector::connectSharedMemory() {

--- a/src/apps/workbench/core/service_connector.hpp
+++ b/src/apps/workbench/core/service_connector.hpp
@@ -80,6 +80,9 @@ public:
     void startHealthMonitoring();
     void stopHealthMonitoring();
     bool sendHeartbeat();
+
+    bool startStreaming(const std::vector<std::string>& instruments);
+    void stopStreaming();
     
     // Callbacks
     using ConnectionCallback = std::function<void(ConnectionState)>;

--- a/src/apps/workbench/core/workbench_core.cpp
+++ b/src/apps/workbench/core/workbench_core.cpp
@@ -159,6 +159,7 @@ bool WorkbenchEngine::initialize()
         signals_tab_->setQuantumSignalGenerator(signal_generator_.get());
         signals_tab_->setMetricsMonitor(metrics_monitor_);
         signals_tab_->setWorkbenchEngine(this);
+        signals_tab_->setMultiTimeframeAnalyzer(multi_timeframe_analyzer_.get());
         service_connector_->setSignalsTab(signals_tab_.get());
         engine_tab_->setSEPEngine(active_engine_);
         engine_tab_->setMetricsMonitor(metrics_monitor_);
@@ -191,7 +192,7 @@ bool WorkbenchEngine::initialize()
             auto oanda_ptr = service_connector_->getOandaConnector();
             std::cout << "[WorkbenchEngine] OANDA connector available: " << (oanda_ptr ? "Yes" : "No") << std::endl;
             setupOandaCallbacks(oanda_ptr);
-            oanda_ptr->startPriceStream({"EUR_USD"});
+            service_connector_->startStreaming({"EUR_USD"});
         }
 
         const char* skip_env = std::getenv("SEP_SKIP_FETCH");
@@ -690,6 +691,11 @@ void WorkbenchEngine::shutdown()
     // Stop the main loop
     should_exit_ = true;
 
+    if (service_connector_) {
+        service_connector_->stopStreaming();
+        service_connector_->disconnect();
+    }
+
     // Clean up components (demo system removed)
     
     // Clean up ImGui
@@ -929,6 +935,14 @@ void WorkbenchEngine::setupOandaCallbacks(connectors::OandaConnector* oanda_ptr)
                 pme->evolvePatterns();
                 pme->computeMetrics();
             }
+        }
+
+        if (multi_timeframe_analyzer_) {
+            common::CandleData tick_candle{
+                md.mid, md.mid, md.mid, md.mid, md.volume,
+                std::chrono::time_point<std::chrono::system_clock>(
+                    std::chrono::nanoseconds(md.timestamp))};
+            multi_timeframe_analyzer_->ingestMarketData(md.instrument, tick_candle);
         }
     });
 

--- a/src/apps/workbench/core/workbench_core.hpp
+++ b/src/apps/workbench/core/workbench_core.hpp
@@ -90,6 +90,7 @@ public:
     // Signal generator
     QuantumSignalGenerator* getSignalGenerator() const { return signal_generator_.get(); }
     sep::quantum::PatternMetricEngine* getPatternMetricEngine() const { return active_engine_ ? active_engine_->getPatternMetricEngine() : nullptr; }
+    MultiTimeframeAnalyzer* getMultiTimeframeAnalyzer() const { return multi_timeframe_analyzer_.get(); }
 
     // Static callbacks for GLFW
     static void errorCallback(int error, const char* description);

--- a/src/apps/workbench/tabs/signals_tab_controller.cpp
+++ b/src/apps/workbench/tabs/signals_tab_controller.cpp
@@ -103,6 +103,10 @@ void SignalsTabController::renderThresholdControlPanel() {
 }
 
 void SignalsTabController::render() {
+    if (mtf_analyzer_) {
+        setLatestMetrics(mtf_analyzer_->getLatestMetrics(selected_instrument_));
+        setCandleData(mtf_analyzer_->getCandles("1m"));
+    }
     ImGui::Columns(2, "SignalsColumns", true);
     renderThresholdControlPanel();
     ImGui::NextColumn();

--- a/src/apps/workbench/tabs/signals_tab_controller.h
+++ b/src/apps/workbench/tabs/signals_tab_controller.h
@@ -38,6 +38,7 @@ public:
     void setMetricsMonitor(std::shared_ptr<MetricsMonitor> monitor);
     void setWorkbenchEngine(WorkbenchEngine* engine);
     void setLatestMetrics(const std::map<std::string, TimeframeMetrics>& metrics);
+    void setMultiTimeframeAnalyzer(MultiTimeframeAnalyzer* analyzer) { mtf_analyzer_ = analyzer; }
 
         void setCandleData(const std::deque<sep::common::CandleData>& data);
         void setCandleData(const std::vector<sep::common::CandleData>& data);
@@ -50,6 +51,7 @@ private:
     QuantumSignalGenerator* signal_generator_ = nullptr;
     std::shared_ptr<MetricsMonitor> metrics_monitor_;
     WorkbenchEngine* workbench_engine_ = nullptr;
+    MultiTimeframeAnalyzer* mtf_analyzer_ = nullptr;
     // Chart data
         std::deque<sep::common::CandleData> candle_data_;
         std::deque<sep::common::SEPSignalData> sep_signals_;


### PR DESCRIPTION
## Summary
- feed tick data into the multi timeframe analyzer
- expose streaming control helpers in `ServiceConnector`
- refresh metrics and candles in `SignalsTabController`
- propagate analyzer references through workbench

## Testing
- `g++ -std=c++17 -I./src -I./extern -c src/apps/workbench/core/workbench_core.cpp -o /tmp/workbench_core.o` *(fails: tabs/signals_tab_controller.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68859d13f9b8832aa4f88814c6278945