### PR TITLE
Connect PatternMetricEngine to demos

### DIFF
--- a/docs/GUI.md
+++ b/docs/GUI.md
@@ -62,3 +62,7 @@ This phase involves building out the UI and logic for each of the three main tab
 -   **Interactivity**: Users can zoom, pan, and inspect data points on the charts.
 -   **Tab Separation**: UI components are logically separated into their respective controllers with clear responsibilities.
 -   **Maintainability**: The core engine can be modified and built independently of the GUI.
+
+## Demo Engine Integration
+
+`DemoOrchestrator` now forwards the active `PatternMetricEngine` to the current demo via `DemoManager`. Demos can query pattern metrics to influence simulations or visualizations. The reference is cleared when a demo is unloaded to avoid dangling pointers.

--- a/src/apps/workbench/core/demo_orchestrator.cpp
+++ b/src/apps/workbench/core/demo_orchestrator.cpp
@@ -70,6 +70,10 @@ bool DemoOrchestrator::loadDemo(const std::string& demo_id, sep::core::Engine* e
         if (!manager.switchToDemo(demo_id)) {
             throw std::runtime_error("Failed to create demo: " + demo_id);
         }
+
+        // Provide PatternMetricEngine to the active demo
+        pattern_engine_ = engine ? engine->getPatternMetricEngine() : nullptr;
+        manager.setPatternMetricEngine(pattern_engine_);
         
         // Store demo info
         current_demo_id_ = demo_id;
@@ -105,10 +109,12 @@ void DemoOrchestrator::unloadCurrentDemo() {
         // Use DemoManager to unload
         auto& manager = DemoManager::getInstance();
         manager.on_unload();
-        
+        manager.setPatternMetricEngine(nullptr);
+
         current_demo_id_.clear();
         engine_ = nullptr;
         renderer_ = nullptr;
+        pattern_engine_ = nullptr;
         
         setState(DemoState::UNLOADED);
         

--- a/src/apps/workbench/core/demo_orchestrator.hpp
+++ b/src/apps/workbench/core/demo_orchestrator.hpp
@@ -16,6 +16,9 @@ namespace sep {
         class Engine;
     }
     class SimpleRenderer;
+    namespace quantum {
+        class PatternMetricEngine;
+    }
 }
 
 namespace sep::workbench {
@@ -111,6 +114,7 @@ private:
     // Engine references
     sep::core::Engine* engine_{nullptr};
     sep::SimpleRenderer* renderer_{nullptr};
+    sep::quantum::PatternMetricEngine* pattern_engine_{nullptr};
     
     // Metrics
     DemoMetrics metrics_;

--- a/src/apps/workbench/demos/cosmo_demo.cpp
+++ b/src/apps/workbench/demos/cosmo_demo.cpp
@@ -17,6 +17,11 @@ namespace workbench {
         initParticles();
     }
 
+void CosmoDemo::setPatternMetricEngine(sep::quantum::PatternMetricEngine* engine)
+{
+    pattern_engine_ = engine;
+}
+
 void CosmoDemo::initParticles() {
     particles_.clear();
     std::size_t count = 100;
@@ -59,7 +64,11 @@ void CosmoDemo::integrate(float dt) {
 }
 
 void CosmoDemo::on_update(float) {
-    integrate(time_step_);
+    float scale = 1.0f;
+    if (pattern_engine_) {
+        scale += 0.001f * static_cast<float>(pattern_engine_->getPatterns().size());
+    }
+    integrate(time_step_ * scale);
 }
 
 void CosmoDemo::on_render() {

--- a/src/apps/workbench/demos/cosmo_demo.hpp
+++ b/src/apps/workbench/demos/cosmo_demo.hpp
@@ -5,6 +5,7 @@
 
 #include "demo_base.hpp"
 #include "demo_manager.hpp"
+#include "quantum/pattern_metric_engine.h"
 #include "imgui.h"
 
 // Forward declarations
@@ -20,6 +21,7 @@ namespace workbench {
 class CosmoDemo : public Demo {
 public:
     void on_load(sep::core::Engine* engine, sep::SimpleRenderer* renderer) override;
+    void setPatternMetricEngine(sep::quantum::PatternMetricEngine* engine) override;
     void on_update(float dt) override;
     void on_render() override;
     void on_ui_render() override;
@@ -41,6 +43,7 @@ private:
 
     sep::core::Engine* engine_{nullptr};
     sep::SimpleRenderer* renderer_{nullptr};
+    sep::quantum::PatternMetricEngine* pattern_engine_{nullptr};
 
     void initParticles();
     void integrate(float dt);

--- a/src/apps/workbench/demos/demo_base.hpp
+++ b/src/apps/workbench/demos/demo_base.hpp
@@ -6,6 +6,9 @@ namespace sep {
         class Engine;
     }
     class SimpleRenderer;
+    namespace quantum {
+        class PatternMetricEngine;
+    }
 }
 
 namespace sep::workbench {
@@ -18,5 +21,6 @@ namespace sep::workbench {
         virtual void on_render() = 0;
         virtual void on_ui_render() = 0; // For ImGui controls
         virtual void on_key_press(int key) = 0;
+        virtual void setPatternMetricEngine(sep::quantum::PatternMetricEngine* engine) {}
     };
 }

--- a/src/apps/workbench/demos/demo_manager.cpp
+++ b/src/apps/workbench/demos/demo_manager.cpp
@@ -17,6 +17,13 @@ namespace workbench {
         renderer_ = renderer;
     }
 
+    void DemoManager::setPatternMetricEngine(sep::quantum::PatternMetricEngine* engine)
+    {
+        pattern_engine_ = engine;
+        if (current_demo_)
+            current_demo_->setPatternMetricEngine(engine);
+    }
+
 void DemoManager::registerDemo(const std::string& name, std::function<std::unique_ptr<Demo>()> factory) {
     demo_factories_[name] = std::move(factory);
 }
@@ -31,6 +38,8 @@ bool DemoManager::switchToDemo(const std::string& name) {
 
     current_demo_ = it->second();
     current_demo_->on_load(engine_, renderer_);
+    if (pattern_engine_)
+        current_demo_->setPatternMetricEngine(pattern_engine_);
     current_demo_name_ = name;
     return true;
 }

--- a/src/apps/workbench/demos/demo_manager.hpp
+++ b/src/apps/workbench/demos/demo_manager.hpp
@@ -14,6 +14,9 @@ namespace sep
         class Engine;
     }
     class SimpleRenderer;
+    namespace quantum {
+        class PatternMetricEngine;
+    }
 
     namespace workbench
     {
@@ -26,6 +29,7 @@ namespace sep
             void registerDemo(const std::string& name,
                               std::function<std::unique_ptr<Demo>()> factory);
             bool switchToDemo(const std::string& name);
+            void setPatternMetricEngine(sep::quantum::PatternMetricEngine* engine);
             void on_update(float dt);
             void on_render();
             void on_ui_render();
@@ -40,6 +44,7 @@ namespace sep
 
             sep::core::Engine* engine_{nullptr};
             sep::SimpleRenderer* renderer_{nullptr};
+            sep::quantum::PatternMetricEngine* pattern_engine_{nullptr};
             std::map<std::string, std::function<std::unique_ptr<Demo>()>> demo_factories_;
             std::unique_ptr<Demo> current_demo_;
             std::string current_demo_name_;


### PR DESCRIPTION
## Summary
- pass PatternMetricEngine from DemoOrchestrator to DemoManager
- allow demos to receive pattern engine reference
- use the pattern engine in `CosmoDemo`
- document the new interaction in `docs/GUI.md`

## Testing
- `cmake -B build -S .` *(fails: CUDA_HOME environment variable not set)*
- `./build.sh` *(fails to run due to missing Docker/CUDA runtime)*

------
https://chatgpt.com/codex/tasks/task_e_6885a2172080832a80b32335e50f49bc