### PR TITLE
Fix sign comparison and type cast warnings

### DIFF
--- a/src/apps/sep_demo/sep_demo_app.cpp
+++ b/src/apps/sep_demo/sep_demo_app.cpp
@@ -169,7 +169,8 @@ void PatternProcessingPanel::renderProcessingMetrics() {
     // Simple text-based history display instead of plot
     if (ImGui::CollapsingHeader("Metrics History")) {
         ImGui::Text("Recent Coherence Values:");
-        size_t start = coherence_history_.size() > 10 ? coherence_history_.size() - 10 : 0;
+        size_t start = coherence_history_.size() > 10u ?
+            coherence_history_.size() - 10u : 0u;
         for (size_t i = start; i < coherence_history_.size(); ++i) {
             ImGui::Text("  [%zu]: %.3f", i, coherence_history_[i]);
         }

--- a/src/connectors/oanda_connector.cpp
+++ b/src/connectors/oanda_connector.cpp
@@ -350,7 +350,8 @@ OandaConnector::CurlResponse OandaConnector::makeRequest(const std::string& endp
 double OandaConnector::calculateATR(const std::string& instrument, const std::string& granularity,
                                     size_t periods)
 {
-    auto candles = getHistoricalData(instrument, granularity, "", "", periods + 1);
+    auto candles = getHistoricalData(instrument, granularity, "", "",
+                                     static_cast<int>(periods + 1));
 
     if (candles.size() < periods) {
         last_error_ = "Insufficient candle data for ATR calculation";


### PR DESCRIPTION
## Summary
- address sign comparison in `sep_demo_app.cpp`
- cast to int when calling `getHistoricalData`

## Testing
- `./run_clang_tidy.sh` *(fails: compile_commands.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885a45c4050832a82f6cfe1a10725b2