### PR TITLE
Fix engine header includes

### DIFF
--- a/src/apps/workbench/core/service_connector.cpp
+++ b/src/apps/workbench/core/service_connector.cpp
@@ -1,7 +1,7 @@
 #include "service_connector.hpp"
 
 // Include engine headers - they should be found via CMake include paths
-#include "engine.h"
+#include "engine/engine.h"
 #include "engine/manager.h"
 #include "service_proxy_engine.h"
 #include "config.h"

--- a/src/apps/workbench/core/unified_dashboard.cpp
+++ b/src/apps/workbench/core/unified_dashboard.cpp
@@ -1,4 +1,5 @@
 #include "unified_dashboard.h"
+#include "engine/engine.h"
 
 #include <fstream>
 #include <iomanip>

--- a/src/apps/workbench/core/workbench_core.hpp
+++ b/src/apps/workbench/core/workbench_core.hpp
@@ -8,6 +8,7 @@
 #include "backtester/ui/backtester_tab_controller.h"
 #include "ui_layout_manager.h"
 #include "multi_timeframe_analyzer.h"
+#include "engine/engine.h"
 #include <map>
 #include <mutex>
 

--- a/src/apps/workbench/core_old/trading_hud.cpp
+++ b/src/apps/workbench/core_old/trading_hud.cpp
@@ -1,4 +1,5 @@
 #include "trading_hud.h"
+#include "engine/engine.h"
 #include <algorithm>
 #include <numeric>
 #include <cmath>


### PR DESCRIPTION
## Summary
- include `engine/engine.h` inside Workbench core header
- switch `service_connector.cpp` to the engine header path
- ensure unified dashboard and legacy trading HUD cpp files include engine header

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688668c6b28c832ab14f8e18567f4281