### PR TITLE
Fix PatternData include in memory tier manager

### DIFF
--- a/src/memory/memory_tier_manager.hpp
+++ b/src/memory/memory_tier_manager.hpp
@@ -10,6 +10,7 @@
 // Project includes
 #include "engine/common.h"
 #include "engine/dag_graph.h"
+#include "engine/pattern_types.h"
 #include "engine/standard_includes.h"
 #include "engine/types.h"
 #include "memory/memory_tier.hpp"
@@ -32,9 +33,6 @@
 #include <glm/vec3.hpp>
 
 namespace sep {
-namespace compat {
-struct PatternData;
-}
 namespace core {
 class SystemHooks;
 }


### PR DESCRIPTION
## Summary
- include `engine/pattern_types.h` in `memory_tier_manager.hpp`
- drop unused forward declaration

## Testing
- `git show --stat`


------
https://chatgpt.com/codex/tasks/task_e_688668d1fc6c832aa07e4421396c103f