### PR TITLE
Fix include paths for connectors

### DIFF
--- a/docs/strategy/Coherence_and_Duality_in_Computational_Systems.md
+++ b/docs/strategy/Coherence_and_Duality_in_Computational_Systems.md
@@ -91,11 +91,11 @@ struct CandleData {
 };
 
 // oanda_connector.cpp (isolated state)
-#include "oanda_connector.h"
+#include "connectors/oanda_connector.h"
 CandleData fetchCandle() { ... }
 
 // signals_tab_controller.cpp (isolated state)
-#include "oanda_connector.h"
+#include "connectors/oanda_connector.h"
 void renderChart(const CandleData& candle) { ... }
 ```
 Here, `oanda_connector.h` is the register enabling coherence between `oanda_connector.cpp` and `signals_tab_controller.cpp`.

--- a/src/apps/data_downloader.cpp
+++ b/src/apps/data_downloader.cpp
@@ -1,5 +1,5 @@
 #include <iostream>
-#include "../connectors/oanda_connector.h"
+#include "connectors/oanda_connector.h"
 
 int main() {
     // Replace with your actual API key and account ID for testing

--- a/src/apps/workbench/core_old/metrics_dashboard.h
+++ b/src/apps/workbench/core_old/metrics_dashboard.h
@@ -3,8 +3,8 @@
 #include "metrics_monitor.h"
 #include "memory_monitor.hpp"
 #include "file_dialog.hpp"
-#include "oanda_connector.h"
-#include "market_data_converter.h"
+#include "connectors/oanda_connector.h"
+#include "connectors/market_data_converter.h"
 #include "backtester/backtester.h"
 #include <memory>
 #include <vector>

--- a/src/apps/workbench/demos/oanda_trading_demo.hpp
+++ b/src/apps/workbench/demos/oanda_trading_demo.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "../core/demo_interface.hpp"
-#include "../../connectors/oanda_connector.h"
+#include "connectors/oanda_connector.h"
 #include <memory>
 #include <string>
 #include <vector>

--- a/src/connectors/market_data_converter.cpp
+++ b/src/connectors/market_data_converter.cpp
@@ -1,4 +1,4 @@
-#include "market_data_converter.h"
+#include "connectors/market_data_converter.h"
 #include <cstring>
 #include <cmath>
 #include <numeric>

--- a/src/connectors/market_data_converter.h
+++ b/src/connectors/market_data_converter.h
@@ -3,7 +3,7 @@
 #include <vector>
 #include <cstdint>
 #include <string>
-#include "oanda_connector.h"
+#include "connectors/oanda_connector.h"
 
 namespace sep {
 namespace connectors {

--- a/src/connectors/oanda_connector.cpp
+++ b/src/connectors/oanda_connector.cpp
@@ -1,4 +1,4 @@
-#include "oanda_connector.h"
+#include "connectors/oanda_connector.h"
 
 #include <chrono>
 #include <cstring>


### PR DESCRIPTION
## Summary
- use `connectors/` path when including OANDA connector headers
- update example docs
- keep `sep_workbench_lib` include directories exposing `src`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688668f43df8832a889966134c709444