### PR TITLE
Include crow headers in API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,6 +147,7 @@ target_link_libraries(imgui PUBLIC glfw OpenGL::GL)
 # Add subdirectories
 set(FMT_INSTALL OFF CACHE BOOL "" FORCE)
 add_subdirectory(third_party/fmt)
+add_subdirectory(extern/crow)
 # Trigger rebuild again
 add_subdirectory(src)
 add_subdirectory(examples)

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -13,6 +13,7 @@ target_link_libraries(sep_api PRIVATE ${CURL_LIBRARIES})
 if(HIREDIS_FOUND)
     target_link_libraries(sep_api PRIVATE ${HIREDIS_LIBRARIES})
 endif()
+target_link_libraries(sep_api PUBLIC crow)
 
 if(MSVC)
     target_compile_options(sep_api PRIVATE /FI"${CMAKE_SOURCE_DIR}/src/engine/glm_config.h")

--- a/src/api/crow_adapter.h
+++ b/src/api/crow_adapter.h
@@ -8,13 +8,7 @@
 
 #pragma once
 
-// Forward declarations - use class instead of struct to match crow's definitions
-namespace crow {
-    template <typename... Middlewares>
-    class Crow;
-    class request;
-    class response;
-}
+#include "crow.h"
 
 #include <memory>
 #include <string>

--- a/src/api/server.h
+++ b/src/api/server.h
@@ -20,13 +20,7 @@
 #include <spdlog/spdlog.h>
 
 
-// Forward declarations for Crow request/response and application
-namespace crow {
-struct request;
-struct response;
-template <typename... Middlewares>
-class Crow;
-}  // namespace crow
+#include "crow.h"
 
 namespace sep::ollama {
 class OllamaClient;


### PR DESCRIPTION
## Summary
- add Crow subdirectory in root CMake
- link sep_api target with Crow
- include crow.h directly and drop forward declarations

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68866b16bbd4832aba5b8551e3533149