### PR TITLE
Add missing engine core include

### DIFF
--- a/src/quantum/quantum_manifold_optimizer.h
+++ b/src/quantum/quantum_manifold_optimizer.h
@@ -7,6 +7,7 @@
 #include "engine/cufft.h"
 #endif
 #include "engine/types.h"
+#include "engine/core.h"
 #include "memory/types.h"
 #include "quantum/config.h"
 #include "quantum/pattern_evolution_bridge.h"


### PR DESCRIPTION
## Summary
- include `engine/core.h` in `quantum_manifold_optimizer.h`

`processor.h` already included `engine/system_hooks.h`.

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68866c7173a0832a80da41e04f4ee618