### PR TITLE
Remove forward declarations and include necessary headers

### DIFF
--- a/src/api/sep_engine.h
+++ b/src/api/sep_engine.h
@@ -11,6 +11,9 @@
 #include "api/types.h"
 #include "engine/types.h"
 #include "quantum/types.h"
+#include "quantum/processor.h"
+#include "quantum/relationship.h"
+#include "quantum/pattern_processor.hpp"
 
 
 
@@ -19,13 +22,7 @@
 #include <nlohmann/json.hpp>
 #include <string>
 
-namespace sep::context {
-class Processor;
-class RelationshipManager;
-}  // namespace sep::context
-namespace sep::pattern {
-class PatternProcessor;
-}  // namespace pattern
+
 
 namespace sep::api {
 


### PR DESCRIPTION
## Summary
- ensure SepEngine directly includes processor, relationship manager, and pattern processor headers
- remove unused forward declarations in sep_engine.h

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68866b8ff018832a8e3464bfb031d8fe