### PR TITLE
Include Redis manager header in types

### DIFF
--- a/src/memory/types.h
+++ b/src/memory/types.h
@@ -5,11 +5,9 @@
 #include <string>
 #include <stdexcept>
 #include <vector>
+#include "memory/redis_manager.h"
 
 namespace sep {
-namespace persistence {
-class IRedisManager;
-} // namespace persistence
 
 namespace memory {
 


### PR DESCRIPTION
## Summary
- remove forward declaration of `IRedisManager`
- include `memory/redis_manager.h` directly in `types.h`

## Testing
- `None`

------
https://chatgpt.com/codex/tasks/task_e_68866c598bb0832aa52b2e9e0566e46c