### PR TITLE
Fix missing includes

### DIFF
--- a/src/engine/cuda.h
+++ b/src/engine/cuda.h
@@ -5,6 +5,7 @@
 #include "engine/cuda_helpers.h"
 #include "engine/cuda_sep.h"
 #endif
+#include "engine/core.h"
 
 namespace sep::cuda {
 

--- a/src/engine/cuda_sep.h
+++ b/src/engine/cuda_sep.h
@@ -16,6 +16,7 @@ struct cudaDeviceProp;
 #endif
 
 #include "engine/standard_includes.h"
+#include "engine/stream.h"
 
 #ifndef SEP_cudaMemAttachGlobal
 #define SEP_cudaMemAttachGlobal cudaMemAttachGlobal
@@ -26,9 +27,6 @@ struct cudaDeviceProp;
 
 namespace sep {
 namespace cuda {
-
-    // Stream class forward declaration
-    class Stream;
 
 #ifdef __CUDACC__
 // When compiling CUDA files, use the real CUDA functions directly

--- a/src/engine/event.h
+++ b/src/engine/event.h
@@ -2,11 +2,10 @@
 #define SEP_CUDA_EVENT_H
 
 #include <cuda_runtime.h>
+#include "engine/stream.h"
 
 namespace sep {
 namespace cuda {
-
-class Stream;
 
 class Event {
  public:


### PR DESCRIPTION
## Summary
- include `engine/stream.h` anywhere Stream is referenced
- add `engine/core.h` for CudaCore definition

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68866c693e00832aaeb4df9b74e25f58