### PR TITLE
Add testbed script to launch engine

### DIFF
--- a/_sep/testbed/README.md
+++ b/_sep/testbed/README.md
@@ -1,3 +1,11 @@
 # Testbed
 
 This directory hosts early-stage algorithms and memory-layout experiments. Components here are considered experimental until they are validated and promoted into `src/`.
+
+## Engine Service Helper
+
+- `run_engine_service.sh` launches the `sep_engine` binary in foreground mode. Use this to run the backend separately from the GUI.
+
+```bash
+./run_engine_service.sh
+```

--- a/_sep/testbed/run_engine_service.sh
+++ b/_sep/testbed/run_engine_service.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Simple helper to start the SEP API server in foreground for testing
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+cd "$SCRIPT_DIR/../.." || exit 1
+
+if [ ! -d "build" ]; then
+    echo "Build directory not found. Run ./build.sh first."
+    exit 1
+fi
+
+ENGINE_BIN="build/sep_engine"
+if [ ! -f "$ENGINE_BIN" ]; then
+    echo "Engine binary not found at $ENGINE_BIN"
+    exit 1
+fi
+
+# Launch the engine with default config
+"$ENGINE_BIN" --foreground &
+ENGINE_PID=$!
+
+echo "SEP engine started with PID $ENGINE_PID"
+
+echo "Press Ctrl+C to stop"
+trap 'kill $ENGINE_PID' INT TERM
+wait $ENGINE_PID


### PR DESCRIPTION
## Summary
- add `run_engine_service.sh` helper for running the engine without the GUI
- document the new script in testbed README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886c223d9d4832ab77495d75f0a3ff3