### PR TITLE
Add standalone API server target

### DIFF
--- a/run_api_server.sh
+++ b/run_api_server.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Launch the standalone SEP API server
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+cd "$SCRIPT_DIR"
+
+if [ ! -d "build" ]; then
+    echo "Build directory not found. Running build.sh first..."
+    ./build.sh || exit 1
+fi
+
+# Wait for the executable to be created
+echo "Waiting for sep_api_server executable..."
+while [ ! -f "build/src/sep_api_server" ]; do
+    sleep 1
+done
+
+echo "Starting SEP API Server..."
+./build/src/sep_api_server "$@"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,5 +8,23 @@ add_subdirectory(connectors)
 add_subdirectory(audio)
 add_subdirectory(apps)
 
+# Standalone API server for headless engine operation
+add_executable(sep_api_server
+    api_main.cpp
+)
+
+target_include_directories(sep_api_server PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_SOURCE_DIR}/src
+)
+
+target_link_libraries(sep_api_server PRIVATE
+    sep_api
+    sep_engine
+    sep_quantum
+    sep_memory
+    Threads::Threads
+)
+
 
 


### PR DESCRIPTION
## Summary
- build new `sep_api_server` executable for headless engine mode
- add helper script to start the API server

## Testing
- `./build.sh` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6886c8dd90e4832a998a5dae16ee53bd