### PR TITLE
Integrate quantum bridge with OANDA trader

### DIFF
--- a/src/apps/oanda_trader/oanda_trader_app.cpp
+++ b/src/apps/oanda_trader/oanda_trader_app.cpp
@@ -36,7 +36,19 @@ bool OandaTraderApp::initialize() {
     
     // Initialize SEP engine
     sep_engine_ = std::make_unique<sep::core::Engine>();
-    
+
+    // Initialize quantum bridge for signal processing
+    quantum_bridge_ = std::make_unique<sep::trading::QuantumSignalBridge>();
+    if (!quantum_bridge_->initialize()) {
+        last_error_ = "Failed to initialize quantum signal bridge";
+        return false;
+    }
+
+    // Set default thresholds based on tracker configuration
+    quantum_bridge_->setConfidenceThreshold(0.6f);
+    quantum_bridge_->setCoherenceThreshold(0.4f);
+    quantum_bridge_->setStabilityThreshold(0.0f);
+
     return true;
 }
 
@@ -220,7 +232,7 @@ void OandaTraderApp::renderAccountInfo() {
 
 void OandaTraderApp::renderMarketData() {
     ImGui::Begin("Market Data");
-    
+
     ImGui::Text("Real-time market data:");
     ImGui::Separator();
     
@@ -229,7 +241,19 @@ void OandaTraderApp::renderMarketData() {
         ImGui::Text("%s - Bid: %.5f, Ask: %.5f, Time: %llu",
                     instrument.c_str(), data.bid, data.ask, (unsigned long long)data.timestamp);
     }
-    
+
+    {
+        std::lock_guard<std::mutex> lock(signal_mutex_);
+        if (last_signal_.timestamp != 0) {
+            const char* action_str = last_signal_.action == sep::trading::QuantumTradingSignal::BUY ? "BUY" :
+                                      last_signal_.action == sep::trading::QuantumTradingSignal::SELL ? "SELL" : "HOLD";
+            ImGui::Separator();
+            ImGui::Text("Quantum Signal: %s", action_str);
+            ImGui::Text("Conf: %.2f Coh: %.2f Stab: %.2f", last_signal_.confidence,
+                        last_signal_.coherence, last_signal_.stability);
+        }
+    }
+
     ImGui::End();
 }
 
@@ -415,27 +439,47 @@ void OandaTraderApp::connectToOanda() {
     
     // Set the price callback
     oanda_connector_->setPriceCallback([this](const sep::connectors::MarketData& data) {
-        std::lock_guard<std::mutex> lock(market_data_mutex_);
-        market_data_map_[data.instrument] = data;
-        
-        // Log real market data
-        std::cout << "[Market Data] " << data.instrument
-                  << " - Bid: " << data.bid
-                  << ", Ask: " << data.ask
-                  << ", Mid: " << data.mid
-                  << ", Time: " << data.timestamp << std::endl;
+        {
+            std::lock_guard<std::mutex> lock(market_data_mutex_);
+            market_data_map_[data.instrument] = data;
+        }
+
+        {
+            std::lock_guard<std::mutex> lock(market_history_mutex_);
+            market_history_.push_back(data);
+            if (market_history_.size() > 256) {
+                market_history_.pop_front();
+            }
+        }
+
+        if (quantum_bridge_) {
+            std::vector<sep::connectors::MarketData> history_copy;
+            {
+                std::lock_guard<std::mutex> lock(market_history_mutex_);
+                history_copy.assign(market_history_.begin(), market_history_.end());
+            }
+
+            auto signal = quantum_bridge_->analyzeMarketData(data, history_copy);
+            {
+                std::lock_guard<std::mutex> lock(signal_mutex_);
+                last_signal_ = signal;
+            }
+            if (signal.should_execute) {
+                std::cout << "[Signal] " << (signal.action == sep::trading::QuantumTradingSignal::BUY ? "BUY" : "SELL")
+                          << " confidence:" << signal.confidence << " size:" << signal.suggested_position_size << std::endl;
+            }
+        }
     });
 
-    // Start the price stream in a new thread with error handling
+    // Start the price stream using managed thread
     try {
-        data_stream_thread_ = std::thread([this]() {
+        data_stream_thread_.start([this]() {
             std::cout << "[OANDA] Starting price stream for EUR_USD..." << std::endl;
             if (!oanda_connector_->startPriceStream({"EUR_USD"})) {
                 std::cerr << "[OANDA] Failed to start price stream: "
                           << oanda_connector_->getLastError() << std::endl;
             }
         });
-        data_stream_thread_.detach();
     } catch (const std::exception& e) {
         std::cerr << "[OANDA] Exception starting price stream: " << e.what() << std::endl;
     }
@@ -471,8 +515,9 @@ void OandaTraderApp::shutdown() {
     if (oanda_connector_) {
         oanda_connector_->stopPriceStream();
     }
-    if (data_stream_thread_.joinable()) {
-        data_stream_thread_.join();
+    data_stream_thread_.join();
+    if (quantum_bridge_) {
+        quantum_bridge_->shutdown();
     }
     cleanupGraphics();
 }

--- a/src/apps/oanda_trader/oanda_trader_app.hpp
+++ b/src/apps/oanda_trader/oanda_trader_app.hpp
@@ -7,11 +7,14 @@
 #include <mutex>
 #include <string>
 #include <thread>
+#include <deque>
 #include <vector>
 
 #include "connectors/oanda_connector.h"
 #include "engine/engine.h"
 #include "imgui.h"
+#include "util/managed_thread.hpp"
+#include "quantum_signal_bridge.hpp"
 
 namespace sep::apps {
 
@@ -61,9 +64,14 @@ private:
     std::string account_currency_ = "USD";
     
     // Real-time data handling
-    std::thread data_stream_thread_;
+    sep::util::ManagedThread data_stream_thread_;
     std::mutex market_data_mutex_;
     std::map<std::string, sep::connectors::MarketData> market_data_map_;
+    std::deque<sep::connectors::MarketData> market_history_;
+    std::mutex market_history_mutex_;
+    std::unique_ptr<sep::trading::QuantumSignalBridge> quantum_bridge_;
+    sep::trading::QuantumTradingSignal last_signal_;
+    std::mutex signal_mutex_;
     std::vector<nlohmann::json> open_positions_;
     std::mutex positions_mutex_;
     std::vector<nlohmann::json> order_history_;

--- a/src/util/managed_thread.hpp
+++ b/src/util/managed_thread.hpp
@@ -1,0 +1,60 @@
+#ifndef SEP_UTIL_MANAGED_THREAD_HPP
+#define SEP_UTIL_MANAGED_THREAD_HPP
+
+#include <thread>
+#include <utility>
+
+namespace sep::util {
+
+class ManagedThread {
+public:
+    ManagedThread() = default;
+
+    template <typename Callable, typename... Args>
+    explicit ManagedThread(Callable&& func, Args&&... args) {
+        start(std::forward<Callable>(func), std::forward<Args>(args)...);
+    }
+
+    ~ManagedThread() {
+        join();
+    }
+
+    ManagedThread(const ManagedThread&) = delete;
+    ManagedThread& operator=(const ManagedThread&) = delete;
+
+    ManagedThread(ManagedThread&& other) noexcept
+        : thread_(std::move(other.thread_)) {}
+
+    ManagedThread& operator=(ManagedThread&& other) noexcept {
+        if (this != &other) {
+            join();
+            thread_ = std::move(other.thread_);
+        }
+        return *this;
+    }
+
+    template <typename Callable, typename... Args>
+    void start(Callable&& func, Args&&... args) {
+        if (thread_.joinable()) {
+            thread_.join();
+        }
+        thread_ = std::thread(std::forward<Callable>(func), std::forward<Args>(args)...);
+    }
+
+    bool joinable() const noexcept { return thread_.joinable(); }
+
+    void join() {
+        if (thread_.joinable()) {
+            thread_.join();
+        }
+    }
+
+    std::thread::id get_id() const noexcept { return thread_.get_id(); }
+
+private:
+    std::thread thread_;
+};
+
+} // namespace sep::util
+
+#endif // SEP_UTIL_MANAGED_THREAD_HPP


### PR DESCRIPTION
## Summary
- add ManagedThread RAII helper for safe thread cleanup
- wire QuantumSignalBridge into `OandaTraderApp`
- process streaming data safely and display last quantum signal
- replace detached thread with managed thread logic

## Testing
- `./build.sh` *(fails: `docker: command not found`)*
- `cmake .. -DCMAKE_BUILD_TYPE=Release` *(fails: `CUDA_HOME environment variable not set`)*

------
https://chatgpt.com/codex/tasks/task_e_6887152c7d44832a956cbab107176171