### PR TITLE
Improve build portability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,8 +145,12 @@ find_package(OpenGL REQUIRED)
 target_link_libraries(imgui PUBLIC glfw OpenGL::GL)
 
 # Add subdirectories
-set(FMT_INSTALL OFF CACHE BOOL "" FORCE)
-add_subdirectory(third_party/fmt)
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/third_party/fmt")
+    set(FMT_INSTALL OFF CACHE BOOL "" FORCE)
+    add_subdirectory(third_party/fmt)
+else()
+    find_package(fmt REQUIRED)
+endif()
 add_subdirectory(extern/crow)
 # Trigger rebuild again
 add_subdirectory(src)

--- a/build.sh
+++ b/build.sh
@@ -30,6 +30,17 @@ mkdir -p build
 USER_ID=$(id -u)
 GROUP_ID=$(id -g)
 
+# Fallback to native build if container runtime is unavailable
+if ! "$DOCKER_BIN" info >/dev/null 2>&1; then
+    echo "Container runtime $DOCKER_BIN not available. Building natively..."
+    cd build
+    cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release -DSEP_USE_CUDA=OFF \
+        -DCMAKE_CXX_COMPILER=clang++-15 -DCMAKE_C_COMPILER=clang-15
+    ninja -k 0 2>&1 | tee ../output/build_log.txt
+    cd ..
+    exit 0
+fi
+
 # Build and setup development environment
 "${DOCKER_BIN}" run --gpus all --rm \
     -v $(pwd):/sep \

--- a/cmake/template.cmake
+++ b/cmake/template.cmake
@@ -12,6 +12,9 @@ function(add_sep_library target_name)
             ${CMAKE_SOURCE_DIR}/src
     )
 
+    if(NOT SEP_USE_CUDA)
+        list(FILTER SEP_LIB_DEPENDENCIES EXCLUDE REGEX "^CUDA::")
+    endif()
     if(SEP_LIB_DEPENDENCIES)
         target_link_libraries(${target_name}
             PUBLIC

--- a/install.sh
+++ b/install.sh
@@ -106,7 +106,7 @@ if ! command -v python3.13 >/dev/null; then
 fi
 
 # Install Python packages for analysis
-pip3 install pandas numpy matplotlib codechecker
+pip3 install --break-system-packages pandas numpy matplotlib codechecker
 
 # Set up clang tool symlinks
 sudo ln -sf /usr/bin/clang-tidy-15 /usr/bin/clang-tidy

--- a/src/apps/oanda_trader/CMakeLists.txt
+++ b/src/apps/oanda_trader/CMakeLists.txt
@@ -59,8 +59,8 @@ target_link_libraries(quantum_tracker PUBLIC
     glfw
     Threads::Threads
     ${CMAKE_DL_LIBS}
-    CUDA::cudart
-    CUDA::cuda_driver
+    $<$<BOOL:${SEP_USE_CUDA}>:CUDA::cudart>
+    $<$<BOOL:${SEP_USE_CUDA}>:CUDA::cuda_driver>
 )
 
 set_target_properties(quantum_tracker PROPERTIES


### PR DESCRIPTION
## Summary
- allow fallback to native build when Docker isn't available
- keep CUDA dependencies optional for libraries
- search for fmt locally when third_party dependency is missing
- install Python packages even in PEP 668 environments
- link CUDA conditionally in quantum_tracker

## Testing
- `./build.sh` *(fails: CUDA::cudart target not found, build incomplete)*

------
https://chatgpt.com/codex/tasks/task_e_6887f41733c0832a9c181837e0d2bfce