### PR TITLE
Add module READMEs and improve install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM nvidia/cuda:12.9.0-devel-ubuntu22.04
+# Use fully qualified image reference for better compatibility with Docker
+# alternatives like Podman which require explicit registry prefixes.
+FROM docker.io/nvidia/cuda:12.9.0-devel-ubuntu22.04
 
 # Set CUDA environment variables
 ENV CUDA_HOME=/usr/local/cuda

--- a/install.sh
+++ b/install.sh
@@ -33,6 +33,15 @@ else
   export SEP_HAS_CUDA=1
 fi
 
+# Build the sep-engine-builder image if a container runtime is available
+if command -v "${DOCKER_BIN:-docker}" >/dev/null 2>&1; then
+  RUNTIME="${DOCKER_BIN:-docker}"
+  if ! "$RUNTIME" image inspect sep-engine-builder >/dev/null 2>&1; then
+    echo "Building sep-engine-builder container image..."
+    "$RUNTIME" build -t sep-engine-builder . || echo "Container build failed"
+  fi
+fi
+
 WS_DIR="$(cd "$(dirname "$0")" && pwd)"
 LOG_DIR="$WS_DIR/logs"
 BUILD_DIR="$WS_DIR/build/deps"
@@ -70,7 +79,10 @@ sudo apt-get install -y "${PACKAGES[@]}" | tee "$LOG_DIR/apt.log"
 # Install Docker and Docker Compose
 echo "Installing Docker..."
 sudo apt-get install -y docker.io docker-compose-v2 | sudo tee -a "$LOG_DIR/apt.log" >/dev/null
-sudo systemctl enable --now docker >/dev/null 2>&1 || true
+# Attempt to start Docker if systemd is available
+if command -v systemctl >/dev/null 2>&1; then
+  sudo systemctl enable --now docker >/dev/null 2>&1 || true
+fi
 if [ "$EUID" -ne 0 ]; then
   sudo usermod -aG docker "$USER" || true
 fi

--- a/src/api/README.md
+++ b/src/api/README.md
@@ -1,0 +1,2 @@
+This directory contains the HTTP API and server infrastructure for the SEP Engine.
+It exposes REST endpoints and middleware used by external applications.

--- a/src/apps/README.md
+++ b/src/apps/README.md
@@ -1,0 +1,1 @@
+Executable applications built on the SEP engine, including trading clients and experimental tools.

--- a/src/common/README.md
+++ b/src/common/README.md
@@ -1,0 +1,1 @@
+Shared utility code and definitions used across multiple modules of the project.

--- a/src/connectors/README.md
+++ b/src/connectors/README.md
@@ -1,0 +1,1 @@
+Implementations of market data and trading connectors, such as the OANDA adapter.

--- a/src/engine/README.md
+++ b/src/engine/README.md
@@ -1,0 +1,1 @@
+Core computational engine and CUDA accelerated modules powering pattern analysis.

--- a/src/glad/README.md
+++ b/src/glad/README.md
@@ -1,0 +1,1 @@
+OpenGL loader library (generated via glad) used by visualization components.

--- a/src/memory/README.md
+++ b/src/memory/README.md
@@ -1,0 +1,1 @@
+Implements tiered memory management, persistence layers, and related utilities.

--- a/src/quantum/README.md
+++ b/src/quantum/README.md
@@ -1,0 +1,1 @@
+Algorithms and kernels responsible for the SEP engine's quantum pattern analysis.

--- a/src/ui/README.md
+++ b/src/ui/README.md
@@ -1,0 +1,1 @@
+ImGui-based user interface helpers and rendering utilities.

--- a/src/util/README.md
+++ b/src/util/README.md
@@ -1,0 +1,1 @@
+Miscellaneous utilities and helper classes shared throughout the engine.


### PR DESCRIPTION
## Summary
- provide READMEs for each source subdirectory
- use fully qualified image reference in Dockerfile
- make install.sh more robust and attempt to build the sep-engine-builder image

## Testing
- `DOCKER_BIN=podman ./build.sh` *(fails: short-name "sep-engine-builder" did not resolve)*

------
https://chatgpt.com/codex/tasks/task_e_6887fe86977c832a81707e10ebdb8ce8