### PR TITLE
Fix install script to handle CUDA gracefully

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -64,8 +64,23 @@ fi
 echo "Updating package lists..."
 sudo apt-get update -y
 
+# Some Java-based packages require this directory to exist to avoid dpkg errors
+sudo mkdir -p /etc/ssl/certs/java
+
+sudo apt-get install -y ca-certificates-java >/dev/null 2>&1 || true
+
 echo "Installing base packages..."
 sudo apt-get install -y "${PACKAGES[@]}" | tee "$LOG_DIR/apt.log"
+
+if [ "$SEP_HAS_CUDA" -eq 1 ]; then
+  echo "Installing CUDA toolkit..."
+  if ! sudo apt-get install -y --no-install-recommends \
+      cuda-toolkit-12-5 cuda-cudart-dev-12-5 \
+      | tee -a "$LOG_DIR/apt.log"; then
+    echo "CUDA toolkit installation failed; continuing without CUDA support" | tee -a "$LOG_DIR/apt.log"
+    export SEP_HAS_CUDA=0
+  fi
+fi
 
 # Install Docker and Docker Compose
 echo "Installing Docker..."


### PR DESCRIPTION
## Summary
- refine install.sh to handle Java keystore path
- install `ca-certificates-java` silently
- make CUDA toolkit install optional and non-fatal

## Testing
- `./install.sh --minimal` *(fails: Sub-process /usr/bin/dpkg returned an error code (1))*

------
https://chatgpt.com/codex/tasks/task_e_6887fe86977c832a81707e10ebdb8ce8