### PR TITLE
Add advanced performance metrics

### DIFF
--- a/scripts/financial_backtest.py
+++ b/scripts/financial_backtest.py
@@ -2,7 +2,11 @@ import argparse
 import json
 import pandas as pd
 import numpy as np
-from performance_metrics import sharpe_ratio, max_drawdown
+from performance_metrics import (
+    sharpe_ratio,
+    max_drawdown,
+    calculate_advanced_metrics,
+)
 
 def calculate_gauge(metrics_df):
     """
@@ -67,10 +71,10 @@ def run_analysis_a(df):
     strat_returns = df['strategy_returns'].dropna()
     bench_returns = df['benchmark_returns'].dropna()
 
-    sr = sharpe_ratio(strat_returns)
+    metrics = calculate_advanced_metrics(strat_returns)
     strategy_drawdown = max_drawdown(df['strategy_cumulative_returns'])
     benchmark_drawdown = max_drawdown(df['benchmark_cumulative_returns'])
-    
+
     # Alpha (simplified version)
     alpha = df['strategy_returns'].mean() - df['benchmark_returns'].mean()
     alpha_annualized = alpha * 252
@@ -78,8 +82,10 @@ def run_analysis_a(df):
     print("--- Performance Metrics ---")
     print(f"Strategy Total Return: {df['strategy_cumulative_returns'].iloc[-1]:.2%}")
     print(f"Benchmark Total Return: {df['benchmark_cumulative_returns'].iloc[-1]:.2%}")
-    print(f"Sharpe Ratio: {sr:.2f}")
+    print(f"Sharpe Ratio: {metrics['sharpe']:.2f}")
     print(f"Max Drawdown: {strategy_drawdown:.2%} (Benchmark: {benchmark_drawdown:.2%})")
+    print(f"Calmar Ratio: {metrics['calmar']:.2f}")
+    print(f"95% VaR: {metrics['var_95']:.4f}")
     print(f"Annualized Alpha: {alpha_annualized:.2%}")
     print("\n")
 

--- a/scripts/performance_metrics.py
+++ b/scripts/performance_metrics.py
@@ -22,3 +22,29 @@ def max_drawdown(equity_curve):
     running_max = np.maximum.accumulate(eq)
     drawdowns = (eq - running_max) / running_max
     return drawdowns.min()
+
+
+def calculate_advanced_metrics(returns):
+    """Return common risk-adjusted performance metrics."""
+    r = np.asarray(returns)
+    if r.size == 0:
+        return {
+            "sharpe": 0.0,
+            "calmar": 0.0,
+            "max_dd": 0.0,
+            "var_95": 0.0,
+        }
+
+    sr = sharpe_ratio(r)
+    equity = (1 + r).cumprod()
+    max_dd = max_drawdown(equity)
+    annual_return = equity[-1] ** (252.0 / len(r)) - 1.0
+    calmar = annual_return / abs(max_dd) if max_dd != 0 else 0.0
+    var_95 = np.quantile(r, 0.05)
+
+    return {
+        "sharpe": sr,
+        "calmar": calmar,
+        "max_dd": max_dd,
+        "var_95": var_95,
+    }


### PR DESCRIPTION
## Summary
- extend `performance_metrics.py` with `calculate_advanced_metrics`
- use `calculate_advanced_metrics` in `financial_backtest.py` to display Calmar ratio and VaR

## Testing
- `python3 -m py_compile scripts/performance_metrics.py scripts/financial_backtest.py`

------
https://chatgpt.com/codex/tasks/task_e_68880779f170832a921827a687ad42b4