### PR TITLE
Implement additional backtesting metrics

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -290,7 +290,7 @@ python3 prepare_experiment_data.py            # Expand dataset
 
 **Sprint 2: Strategy Optimization**
 - Implement parameter grid search in `run_alpha_experiment.py`
-- Add Sharpe ratio calculation to `financial_backtest.py`
+- ~~Add Sharpe ratio calculation to `financial_backtest.py`~~ ✅ Done
 - Create strategy comparison framework
 
 **Sprint 3: Risk Management**

--- a/scripts/financial_backtest.py
+++ b/scripts/financial_backtest.py
@@ -71,7 +71,7 @@ def run_analysis_a(df):
     strat_returns = df['strategy_returns'].dropna()
     bench_returns = df['benchmark_returns'].dropna()
 
-    metrics = calculate_advanced_metrics(strat_returns)
+    metrics = calculate_advanced_metrics(strat_returns, bench_returns)
     strategy_drawdown = max_drawdown(df['strategy_cumulative_returns'])
     benchmark_drawdown = max_drawdown(df['benchmark_cumulative_returns'])
 
@@ -86,6 +86,8 @@ def run_analysis_a(df):
     print(f"Max Drawdown: {strategy_drawdown:.2%} (Benchmark: {benchmark_drawdown:.2%})")
     print(f"Calmar Ratio: {metrics['calmar']:.2f}")
     print(f"95% VaR: {metrics['var_95']:.4f}")
+    print(f"Information Ratio: {metrics['info_ratio']:.2f}")
+    print(f"Profit Factor: {metrics['profit_factor']:.2f}")
     print(f"Annualized Alpha: {alpha_annualized:.2%}")
     print("\n")
 

--- a/scripts/performance_metrics.py
+++ b/scripts/performance_metrics.py
@@ -24,7 +24,33 @@ def max_drawdown(equity_curve):
     return drawdowns.min()
 
 
-def calculate_advanced_metrics(returns):
+def information_ratio(strategy_returns, benchmark_returns, periods_per_year=252):
+    """Return the annualized information ratio."""
+    sr = np.asarray(strategy_returns)
+    br = np.asarray(benchmark_returns)
+    if sr.size == 0 or br.size == 0 or sr.size != br.size:
+        return 0.0
+    active = sr - br
+    mean = active.mean()
+    std = active.std(ddof=1)
+    if std == 0:
+        return 0.0
+    return mean / std * np.sqrt(periods_per_year)
+
+
+def profit_factor(returns):
+    """Return the profit factor for a series of returns."""
+    r = np.asarray(returns)
+    if r.size == 0:
+        return 0.0
+    gains = r[r > 0].sum()
+    losses = -r[r < 0].sum()
+    if losses == 0:
+        return float("inf") if gains > 0 else 0.0
+    return gains / losses
+
+
+def calculate_advanced_metrics(returns, benchmark_returns=None):
     """Return common risk-adjusted performance metrics."""
     r = np.asarray(returns)
     if r.size == 0:
@@ -33,6 +59,8 @@ def calculate_advanced_metrics(returns):
             "calmar": 0.0,
             "max_dd": 0.0,
             "var_95": 0.0,
+            "info_ratio": 0.0,
+            "profit_factor": 0.0,
         }
 
     sr = sharpe_ratio(r)
@@ -41,10 +69,14 @@ def calculate_advanced_metrics(returns):
     annual_return = equity[-1] ** (252.0 / len(r)) - 1.0
     calmar = annual_return / abs(max_dd) if max_dd != 0 else 0.0
     var_95 = np.quantile(r, 0.05)
+    info = information_ratio(r, benchmark_returns) if benchmark_returns is not None else 0.0
+    pf = profit_factor(r)
 
     return {
         "sharpe": sr,
         "calmar": calmar,
         "max_dd": max_dd,
         "var_95": var_95,
+        "info_ratio": info,
+        "profit_factor": pf,
     }


### PR DESCRIPTION
## Summary
- mark Sharpe ratio task complete in TODO
- add information ratio and profit factor helpers
- extend backtest script to report new metrics

## Testing
- `python3 -m py_compile scripts/performance_metrics.py scripts/financial_backtest.py`
- `python3 scripts/financial_backtest.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68880d040b0c832aa237a4964d4570d6