### PR TITLE
Add portfolio signal aggregator with tests

### DIFF
--- a/_sep/testbed/portfolio_signal_aggregator.py
+++ b/_sep/testbed/portfolio_signal_aggregator.py
@@ -1,0 +1,33 @@
+"""Utility to aggregate quantum trading signals across multiple instruments."""
+from typing import List, Dict
+
+
+def aggregate_signals(signals: List[Dict[str, float]], threshold: float = 0.2) -> str:
+    """Return portfolio-level action ('BUY', 'SELL', or 'HOLD').
+
+    Each signal dict must contain ``action`` ('BUY', 'SELL', or 'HOLD') and
+    ``confidence`` in the range [0, 1]. The actions are combined into a net
+    confidence score which is compared against ``threshold``.
+    """
+    net = 0.0
+    for s in signals:
+        action = s.get("action")
+        conf = float(s.get("confidence", 0.0))
+        if action == "BUY":
+            net += conf
+        elif action == "SELL":
+            net -= conf
+    if net > threshold:
+        return "BUY"
+    if net < -threshold:
+        return "SELL"
+    return "HOLD"
+
+
+if __name__ == "__main__":  # pragma: no cover - manual demonstration
+    demo_signals = [
+        {"instrument": "EUR_USD", "action": "BUY", "confidence": 0.8},
+        {"instrument": "GBP_USD", "action": "SELL", "confidence": 0.6},
+        {"instrument": "USD_JPY", "action": "BUY", "confidence": 0.55},
+    ]
+    print("Portfolio Action:", aggregate_signals(demo_signals))

--- a/tests/test_portfolio_signal_aggregator.py
+++ b/tests/test_portfolio_signal_aggregator.py
@@ -1,0 +1,29 @@
+import unittest
+from _sep.testbed.portfolio_signal_aggregator import aggregate_signals
+
+
+class PortfolioSignalAggregatorTest(unittest.TestCase):
+    def test_buy_result(self):
+        signals = [
+            {"instrument": "EUR_USD", "action": "BUY", "confidence": 0.8},
+            {"instrument": "GBP_USD", "action": "SELL", "confidence": 0.3},
+        ]
+        self.assertEqual(aggregate_signals(signals, threshold=0.2), "BUY")
+
+    def test_hold_result(self):
+        signals = [
+            {"instrument": "EUR_USD", "action": "BUY", "confidence": 0.1},
+            {"instrument": "USD_JPY", "action": "SELL", "confidence": 0.1},
+        ]
+        self.assertEqual(aggregate_signals(signals, threshold=0.5), "HOLD")
+
+    def test_sell_result(self):
+        signals = [
+            {"instrument": "EUR_USD", "action": "SELL", "confidence": 0.7},
+            {"instrument": "USD_JPY", "action": "SELL", "confidence": 0.6},
+        ]
+        self.assertEqual(aggregate_signals(signals, threshold=0.5), "SELL")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `portfolio_signal_aggregator.py` in `_sep/testbed`
- add unit tests for signal aggregation

## Testing
- `python3 -m unittest tests/test_portfolio_signal_aggregator.py -v`
- `./build.sh` *(fails: clang++-15 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68880d040b0c832aa237a4964d4570d6