### PR TITLE
Fix aggregator test imports

### DIFF
--- a/tests/test_portfolio_signal_aggregator.py
+++ b/tests/test_portfolio_signal_aggregator.py
@@ -1,4 +1,13 @@
+import os
+import sys
 import unittest
+
+# Ensure the project root is on the path so _sep can be imported when running
+# tests directly via `pytest` without manually setting PYTHONPATH.
+ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+
 from _sep.testbed.portfolio_signal_aggregator import aggregate_signals
 
 


### PR DESCRIPTION
## Summary
- ensure project root is added to `sys.path` for aggregator tests

## Testing
- `pytest -q tests/test_portfolio_signal_aggregator.py`

------
https://chatgpt.com/codex/tasks/task_e_688814074650832ab2e97ce017294e18