### PR TITLE
Improve metric calculations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,7 @@ FetchContent_Declare(
   GIT_REPOSITORY https://github.com/oneapi-src/oneTBB.git
   GIT_TAG v2021.10.0
 )
+set(CMAKE_BUILD_WITH_INSTALL_RPATH ON)
 FetchContent_MakeAvailable(tbb)
 
 # Create imgui library manually since imgui doesn't provide CMakeLists.txt

--- a/src/quantum/pattern_metric_engine.cpp
+++ b/src/quantum/pattern_metric_engine.cpp
@@ -207,13 +207,8 @@ const std::vector<Signal>& PatternMetricEngine::getSignals() const {
 const std::vector<PatternMetrics>& PatternMetricEngine::computeMetrics()
 {
     std::lock_guard<std::mutex> lock(engine_mutex_);
-    
-
-    
     current_metrics_.clear();
     current_metrics_.reserve(current_patterns_.size());
-
-    scratch_diffs_.clear();
 
     for (const auto& p : current_patterns_) {
         PatternMetrics m;
@@ -221,24 +216,19 @@ const std::vector<PatternMetrics>& PatternMetricEngine::computeMetrics()
         m.pattern_id[sizeof(m.pattern_id) - 1] = '\0';
 
         if (!p.data.empty()) {
-            // Calculate coherence based on pattern self-similarity and consistency
-            float sum_squares = 0.0f;
+            // Single-pass mean and variance using Welford's algorithm
             float mean = 0.0f;
-            
-            // Calculate mean
+            float m2 = 0.0f;
+            float sum_squares = 0.0f;
+            size_t count = 0;
             for (float val : p.data) {
-                mean += val;
-            }
-            mean /= p.data.size();
-            
-            // Calculate variance and coherence
-            float variance = 0.0f;
-            for (float val : p.data) {
-                float diff = val - mean;
-                variance += diff * diff;
+                count++;
+                float delta = val - mean;
+                mean += delta / static_cast<float>(count);
+                m2 += delta * (val - mean);
                 sum_squares += val * val;
             }
-            variance /= p.data.size();
+            float variance = count > 1 ? m2 / static_cast<float>(count) : 0.0f;
             
             // Coherence is high when variance is low relative to signal strength
             // Use coefficient of variation (inverse) as coherence measure

--- a/src/quantum/pattern_metric_engine.h
+++ b/src/quantum/pattern_metric_engine.h
@@ -236,7 +236,6 @@ private:
 
     // Preallocated scratch space to avoid frequent allocations
     std::vector<uint32_t> scratch_pattern_bits_;
-    std::vector<float> scratch_diffs_;
 
     // Thread safety and streaming
     std::mutex engine_mutex_;


### PR DESCRIPTION
## Summary
- enable install RPATH to fix TBB build
- remove unused scratch space for diffs
- use Welford algorithm for mean/variance in `computeMetrics`

## Testing
- `python3 -m pytest -q tests/test_portfolio_signal_aggregator.py`
- `python3 -m unittest tests.test_portfolio_signal_aggregator`
- `cmake ..` *(fails: fatal error: 'hiredis/hiredis.h' file not found)*
- `ninja pattern_metrics_test` *(fails: fatal error: 'hiredis/hiredis.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_688814074650832ab2e97ce017294e18