### PR TITLE
Improve metric JSON parsing

### DIFF
--- a/_sep/testbed/json_utils.py
+++ b/_sep/testbed/json_utils.py
@@ -1,0 +1,10 @@
+import json
+import re
+from typing import Any
+
+def parse_first_json(text: str) -> Any:
+    """Extract and parse the first JSON object found in text."""
+    match = re.search(r"\{.*\}", text, re.DOTALL)
+    if not match:
+        raise ValueError("No JSON object found")
+    return json.loads(match.group(0))

--- a/scripts/direct_metrics_analysis.py
+++ b/scripts/direct_metrics_analysis.py
@@ -105,8 +105,8 @@ def simulate_sep_metrics(df):
                         ], capture_output=True, text=True, timeout=5)
                         
                         if result.returncode == 0 and result.stdout:
-                            import json
-                            sep_output = json.loads(result.stdout)
+                            from _sep.testbed.json_utils import parse_first_json
+                            sep_output = parse_first_json(result.stdout)
                             coherence = sep_output.get('coherence', 0.5)
                             stability = sep_output.get('stability', 0.5)
                             entropy = sep_output.get('entropy', 0.5)

--- a/scripts/quick_alpha_test.py
+++ b/scripts/quick_alpha_test.py
@@ -8,6 +8,12 @@ import sys
 from pathlib import Path
 import pytest
 
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from _sep.testbed.json_utils import parse_first_json
+
 BIN_PATH = Path("./examples/pattern_metric_example")
 if not BIN_PATH.exists():
     pytest.skip("pattern_metric_example binary not built", allow_module_level=True)
@@ -20,7 +26,7 @@ def test_single_file_processing():
     
     try:
         result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=30)
-        metrics = json.loads(result.stdout)
+        metrics = parse_first_json(result.stdout)
         
         print(f"Successfully processed file with {len(metrics)} pattern results")
         if metrics:

--- a/scripts/run_alpha_experiment.py
+++ b/scripts/run_alpha_experiment.py
@@ -9,6 +9,7 @@ from performance_metrics import sharpe_ratio
 from pathlib import Path
 import shutil
 import tempfile
+from _sep.testbed.json_utils import parse_first_json
 
 # Removed parse_metrics_from_stream function - now using direct JSON parsing
 
@@ -57,7 +58,7 @@ def analyze_chunks_statefully(chunk_list, temp_dir):
     cmd = [str(executable_path), str(combined_file), "--json"]
     
     result = subprocess.run(cmd, capture_output=True, text=True, check=True)
-    return json.loads(result.stdout)
+    return parse_first_json(result.stdout)
 
 def run_backtest(metrics_data):
     """Runs the financial_backtest.py script on a list of metrics."""

--- a/tests/test_json_utils.py
+++ b/tests/test_json_utils.py
@@ -1,0 +1,18 @@
+import pytest
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from _sep.testbed.json_utils import parse_first_json
+
+def test_parse_first_json_simple():
+    text = "prefix {\"a\": 1} suffix"
+    assert parse_first_json(text) == {"a": 1}
+
+
+def test_parse_first_json_missing():
+    with pytest.raises(ValueError):
+        parse_first_json("no json here")


### PR DESCRIPTION
## Summary
- add `_sep.testbed.json_utils.parse_first_json` helper
- make experiment scripts use the helper for robust JSON parsing
- add tests for `parse_first_json`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888171de02c832ab41f067f627579cd