### PR TITLE
Improve JSON parsing utility

### DIFF
--- a/_sep/testbed/json_utils.py
+++ b/_sep/testbed/json_utils.py
@@ -4,7 +4,8 @@ from typing import Any
 
 def parse_first_json(text: str) -> Any:
     """Extract and parse the first JSON object found in text."""
-    match = re.search(r"\{.*\}", text, re.DOTALL)
+    match = re.search(r"\{.*?\}", text, re.DOTALL)
     if not match:
         raise ValueError("No JSON object found")
-    return json.loads(match.group(0))
+    candidate = match.group(0)
+    return json.loads(candidate)

--- a/tests/test_json_utils.py
+++ b/tests/test_json_utils.py
@@ -13,6 +13,11 @@ def test_parse_first_json_simple():
     assert parse_first_json(text) == {"a": 1}
 
 
+def test_parse_first_json_extra_data():
+    text = "noise {\"a\": 1} trailing {\"b\":2}"
+    assert parse_first_json(text) == {"a": 1}
+
+
 def test_parse_first_json_missing():
     with pytest.raises(ValueError):
         parse_first_json("no json here")


### PR DESCRIPTION
## Summary
- fix `parse_first_json` to stop on the first JSON blob
- add regression test covering trailing text

## Testing
- `pytest tests/test_json_utils.py -q`
- `pytest -q`
- `./build.sh` *(fails: cannot find `cuda_runtime.h`)*

------
https://chatgpt.com/codex/tasks/task_e_6888333d8788832a8c20788719f12435