### PR TITLE
Refine pattern metric API

### DIFF
--- a/src/engine/engine.cu
+++ b/src/engine/engine.cu
@@ -575,7 +575,7 @@ std::map<std::string, double> Engine::getMetrics() const {
     }
     
     // Add pattern metric engine metrics if available
-    const auto& pattern_metrics = const_cast<sep::quantum::PatternMetricEngine&>(pattern_metric_engine_).computeMetrics();
+    const auto& pattern_metrics = pattern_metric_engine_.computeMetrics();
     for (size_t i = 0; i < pattern_metrics.size(); ++i) {
         const auto& pm = pattern_metrics[i];
         metrics["pattern_" + std::string(pm.pattern_id) + "_coherence"] = pm.coherence;

--- a/src/quantum/pattern_metric_engine.cpp
+++ b/src/quantum/pattern_metric_engine.cpp
@@ -234,7 +234,7 @@ namespace sep::quantum
 
     const std::vector<Signal>& PatternMetricEngine::getSignals() const { return current_signals_; }
 
-    const std::vector<PatternMetrics>& PatternMetricEngine::computeMetrics()
+    const std::vector<PatternMetrics>& PatternMetricEngine::computeMetrics() const
     {
         std::lock_guard<std::mutex> lock(engine_mutex_);
 

--- a/src/quantum/pattern_metric_engine.h
+++ b/src/quantum/pattern_metric_engine.h
@@ -185,7 +185,7 @@ namespace sep::quantum
 
         /// @brief Computes metrics for the currently identified patterns.
         /// @return A vector of PatternMetrics structs.
-        const std::vector<PatternMetrics>& computeMetrics();
+        const std::vector<PatternMetrics>& computeMetrics() const;
 
         /// @brief Sets the thresholds for signal generation.
         void setSignalThresholds(const SignalThresholds& thresholds);
@@ -235,16 +235,16 @@ namespace sep::quantum
         std::deque<compat::PatternData> current_patterns_;
         mutable std::vector<compat::PatternData> pattern_cache_;
         mutable bool cache_dirty_{false};
-        std::vector<PatternMetrics> current_metrics_;
+        mutable std::vector<PatternMetrics> current_metrics_;
         SignalThresholds signal_thresholds_;
         std::vector<Signal> current_signals_;
 
         // Preallocated scratch space to avoid frequent allocations
         std::vector<uint32_t> scratch_pattern_bits_;
-        std::vector<float> scratch_diffs_;
+        mutable std::vector<float> scratch_diffs_;
 
         // Thread safety and streaming
-        std::mutex engine_mutex_;
+        mutable std::mutex engine_mutex_;
         std::vector<uint8_t> stream_buffer_;
     };
 


### PR DESCRIPTION
## Summary
- expose pattern metric computation as a `const` method
- adjust fields for const-correctness
- simplify engine metric retrieval

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888333d8788832a8c20788719f12435