### PR TITLE
Improve engine metrics utilities

### DIFF
--- a/_sep/testbed/engine_metrics_parser.py
+++ b/_sep/testbed/engine_metrics_parser.py
@@ -23,15 +23,35 @@ def parse_metrics_files(files: List[Path]) -> List[Dict[str, float]]:
 
 
 def average_metrics(metrics: List[Dict[str, float]]) -> Dict[str, float]:
+    """Return the average metrics across all parsed files."""
     if not metrics:
-        return {"coherence": 0.0, "stability": 0.0, "entropy": 0.0}
-    total = {"coherence": 0.0, "stability": 0.0, "entropy": 0.0}
+        return {
+            "coherence": 0.0,
+            "stability": 0.0,
+            "entropy": 0.0,
+            "pattern_count": 0.0,
+        }
+
+    total = {
+        "coherence": 0.0,
+        "stability": 0.0,
+        "entropy": 0.0,
+        "pattern_count": 0.0,
+    }
+
     for m in metrics:
-        total["coherence"] += m["coherence"]
-        total["stability"] += m["stability"]
-        total["entropy"] += m["entropy"]
+        total["coherence"] += m.get("coherence", 0.0)
+        total["stability"] += m.get("stability", 0.0)
+        total["entropy"] += m.get("entropy", 0.0)
+        total["pattern_count"] += m.get("pattern_count", 0)
+
     n = len(metrics)
-    return {k: v / n for k, v in total.items()}
+    return {
+        "coherence": total["coherence"] / n,
+        "stability": total["stability"] / n,
+        "entropy": total["entropy"] / n,
+        "pattern_count": total["pattern_count"] / n,
+    }
 
 
 if __name__ == "__main__":

--- a/tests/test_engine_metrics_parser.py
+++ b/tests/test_engine_metrics_parser.py
@@ -1,0 +1,24 @@
+import json
+from pathlib import Path
+from _sep.testbed.engine_metrics_parser import parse_metrics_files, average_metrics
+
+
+def test_parser_and_average(tmp_path):
+    file1 = tmp_path / "m1.json"
+    file2 = tmp_path / "m2.json"
+    file1.write_text(json.dumps({
+        "metrics": {"coherence": 0.5, "stability": 0.6, "entropy": 0.3},
+        "pattern_count": 4
+    }))
+    file2.write_text(json.dumps({
+        "metrics": {"coherence": 0.7, "stability": 0.8, "entropy": 0.2},
+        "pattern_count": 6
+    }))
+
+    rows = parse_metrics_files([file1, file2])
+    assert len(rows) == 2
+    avg = average_metrics(rows)
+    assert avg["coherence"] == (0.5 + 0.7) / 2
+    assert avg["stability"] == (0.6 + 0.8) / 2
+    assert avg["entropy"] == (0.3 + 0.2) / 2
+    assert avg["pattern_count"] == (4 + 6) / 2


### PR DESCRIPTION
## Summary
- extend `average_metrics` to also aggregate `pattern_count`
- add unit test for metrics parsing and averaging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888333d8788832a8c20788719f12435