### PR TITLE
Fix test imports and metrics parsing

### DIFF
--- a/_sep/testbed/engine_metrics_parser.py
+++ b/_sep/testbed/engine_metrics_parser.py
@@ -8,7 +8,13 @@ def parse_metrics_files(files: List[Path]) -> List[Dict[str, float]]:
     results = []
     for fp in files:
         try:
-            data = json.loads(fp.read_text())
+            text = fp.read_text()
+            try:
+                data = json.loads(text)
+            except json.JSONDecodeError:
+                # Handle files that contain extra text before/after JSON
+                from .json_utils import parse_first_json
+                data = parse_first_json(text)
             metrics = data.get("metrics", {})
             results.append({
                 "file": fp.name,

--- a/tests/test_engine_metrics_parser.py
+++ b/tests/test_engine_metrics_parser.py
@@ -1,5 +1,11 @@
 import json
 from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
 from _sep.testbed.engine_metrics_parser import parse_metrics_files, average_metrics
 
 


### PR DESCRIPTION
## Summary
- handle non-JSON text in `engine_metrics_parser`
- ensure tests import `_sep` package properly
- confirm tests all pass

## Testing
- `pytest -q tests/test_engine_metrics_parser.py tests/test_json_utils.py tests/test_portfolio_signal_aggregator.py`

------
https://chatgpt.com/codex/tasks/task_e_688837a06d40832aad2e7fd048a14cef