### PR TITLE
Add aggregate metrics helper

### DIFF
--- a/src/quantum/pattern_metric_engine.cpp
+++ b/src/quantum/pattern_metric_engine.cpp
@@ -335,6 +335,32 @@ namespace sep::quantum
         return current_metrics_;
     }
 
+    PatternMetricEngine::AggregateMetrics PatternMetricEngine::computeAggregateMetrics() const
+    {
+        AggregateMetrics agg;
+        const auto& metrics = computeMetrics();
+        if (metrics.empty())
+        {
+            return agg;
+        }
+
+        for (const auto& m : metrics)
+        {
+            agg.average_coherence += m.coherence;
+            agg.average_stability += m.stability;
+            agg.average_entropy += m.entropy;
+            agg.average_energy += m.energy;
+        }
+
+        float n = static_cast<float>(metrics.size());
+        agg.average_coherence /= n;
+        agg.average_stability /= n;
+        agg.average_entropy /= n;
+        agg.average_energy /= n;
+
+        return agg;
+    }
+
     const std::vector<sep::compat::PatternData>& PatternMetricEngine::getPatterns() const
     {
         if (cache_dirty_)

--- a/src/quantum/pattern_metric_engine.h
+++ b/src/quantum/pattern_metric_engine.h
@@ -49,6 +49,15 @@ namespace sep::quantum
         PatternMetrics() { pattern_id[0] = '\0'; }
     };
 
+    /// @brief Aggregated metrics across all current patterns.
+    struct AggregateMetrics
+    {
+        float average_coherence{0.0f};
+        float average_stability{0.0f};
+        float average_entropy{0.0f};
+        float average_energy{0.0f};
+    };
+
     /// @brief Calculate Shannon entropy of a sequence of values.
     /// @param values Input data sequence.
     /// @return Normalized entropy in the range [0,1].
@@ -186,6 +195,9 @@ namespace sep::quantum
         /// @brief Computes metrics for the currently identified patterns.
         /// @return A vector of PatternMetrics structs.
         const std::vector<PatternMetrics>& computeMetrics() const;
+
+        /// @brief Compute aggregate metrics across all current patterns.
+        AggregateMetrics computeAggregateMetrics() const;
 
         /// @brief Sets the thresholds for signal generation.
         void setSignalThresholds(const SignalThresholds& thresholds);

--- a/tests/pattern_metrics_test.cpp
+++ b/tests/pattern_metrics_test.cpp
@@ -68,3 +68,31 @@ TEST(PatternMetrics, EmptyPatternMetrics)
     EXPECT_EQ(metrics[0].stability, 0.0f);
     EXPECT_NEAR(metrics[0].entropy, 0.5f, 1e-5f);
 }
+
+TEST(PatternMetrics, AggregateMetrics)
+{
+    PatternMetricEngine engine;
+    engine.clear();
+
+    sep::compat::PatternData p1;
+    std::strncpy(p1.id, "p1", sizeof(p1.id) - 1);
+    p1.data = {1.0f, 1.0f};
+
+    sep::compat::PatternData p2;
+    std::strncpy(p2.id, "p2", sizeof(p2.id) - 1);
+    p2.data = {2.0f, 2.0f};
+
+    engine.addPattern(p1);
+    engine.addPattern(p2);
+
+    const auto& metrics = engine.computeMetrics();
+    auto agg = engine.computeAggregateMetrics();
+
+    float avg_coh = (metrics[0].coherence + metrics[1].coherence) / 2.0f;
+    float avg_stab = (metrics[0].stability + metrics[1].stability) / 2.0f;
+    float avg_ent = (metrics[0].entropy + metrics[1].entropy) / 2.0f;
+
+    EXPECT_NEAR(agg.average_coherence, avg_coh, 1e-5f);
+    EXPECT_NEAR(agg.average_stability, avg_stab, 1e-5f);
+    EXPECT_NEAR(agg.average_entropy, avg_ent, 1e-5f);
+}


### PR DESCRIPTION
## Summary
- add `AggregateMetrics` struct and computeAggregateMetrics to PatternMetricEngine
- test aggregate metrics

## Testing
- `pytest -q`
- `cmake -S . -B build-test -G Ninja` *(fails: CUDA_HOME not set)*

------
https://chatgpt.com/codex/tasks/task_e_688837a06d40832aad2e7fd048a14cef