### PR TITLE
Enable energy metric outputs

### DIFF
--- a/_sep/testbed/engine_metrics_parser.py
+++ b/_sep/testbed/engine_metrics_parser.py
@@ -21,6 +21,7 @@ def parse_metrics_files(files: List[Path]) -> List[Dict[str, float]]:
                 "coherence": float(metrics.get("coherence", 0.0)),
                 "stability": float(metrics.get("stability", 0.0)),
                 "entropy": float(metrics.get("entropy", 0.0)),
+                "energy": float(metrics.get("energy", 0.0)),
                 "pattern_count": int(data.get("pattern_count", 0)),
             })
         except Exception as exc:
@@ -35,6 +36,7 @@ def average_metrics(metrics: List[Dict[str, float]]) -> Dict[str, float]:
             "coherence": 0.0,
             "stability": 0.0,
             "entropy": 0.0,
+            "energy": 0.0,
             "pattern_count": 0.0,
         }
 
@@ -42,6 +44,7 @@ def average_metrics(metrics: List[Dict[str, float]]) -> Dict[str, float]:
         "coherence": 0.0,
         "stability": 0.0,
         "entropy": 0.0,
+        "energy": 0.0,
         "pattern_count": 0.0,
     }
 
@@ -49,6 +52,7 @@ def average_metrics(metrics: List[Dict[str, float]]) -> Dict[str, float]:
         total["coherence"] += m.get("coherence", 0.0)
         total["stability"] += m.get("stability", 0.0)
         total["entropy"] += m.get("entropy", 0.0)
+        total["energy"] += m.get("energy", 0.0)
         total["pattern_count"] += m.get("pattern_count", 0)
 
     n = len(metrics)
@@ -56,6 +60,7 @@ def average_metrics(metrics: List[Dict[str, float]]) -> Dict[str, float]:
         "coherence": total["coherence"] / n,
         "stability": total["stability"] / n,
         "entropy": total["entropy"] / n,
+        "energy": total["energy"] / n,
         "pattern_count": total["pattern_count"] / n,
     }
 
@@ -75,5 +80,6 @@ if __name__ == "__main__":
     avg = average_metrics(rows)
     print(
         f"Average coherence={avg['coherence']:.4f} "
-        f"stability={avg['stability']:.4f} entropy={avg['entropy']:.4f}"
+        f"stability={avg['stability']:.4f} entropy={avg['entropy']:.4f} "
+        f"energy={avg['energy']:.4f}"
     )

--- a/examples/pattern_metric_example.cpp
+++ b/examples/pattern_metric_example.cpp
@@ -22,8 +22,9 @@ namespace fs = std::filesystem;
 
 struct AnalysisResult {
     double coherence = 0.0;
-    double stability = 0.0; 
+    double stability = 0.0;
     double entropy = 0.0;
+    double energy = 0.0;
     size_t pattern_count = 0;
     std::string timestamp;
 };
@@ -64,15 +65,17 @@ public:
         
         // Calculate aggregate metrics from all patterns
         if (!metrics.empty()) {
-            double total_coherence = 0.0, total_stability = 0.0, total_entropy = 0.0;
+            double total_coherence = 0.0, total_stability = 0.0, total_entropy = 0.0, total_energy = 0.0;
             for (const auto& metric : metrics) {
                 total_coherence += metric.coherence;
                 total_stability += metric.stability;
                 total_entropy += metric.entropy;
+                total_energy += metric.energy;
             }
             result.coherence = total_coherence / metrics.size();
             result.stability = total_stability / metrics.size();
             result.entropy = total_entropy / metrics.size();
+            result.energy = total_energy / metrics.size();
         }
         result.pattern_count = metrics.size();
         
@@ -122,6 +125,7 @@ public:
             output["metrics"]["coherence"] = result.coherence;
             output["metrics"]["stability"] = result.stability;
             output["metrics"]["entropy"] = result.entropy;
+            output["metrics"]["energy"] = result.energy;
             output["pattern_count"] = result.pattern_count;
             
             std::cout << output.dump(2) << std::endl;
@@ -131,6 +135,7 @@ public:
             std::cout << "Coherence: " << std::fixed << std::setprecision(6) << result.coherence << std::endl;
             std::cout << "Stability: " << std::fixed << std::setprecision(6) << result.stability << std::endl;
             std::cout << "Entropy: " << std::fixed << std::setprecision(6) << result.entropy << std::endl;
+            std::cout << "Energy: " << std::fixed << std::setprecision(6) << result.energy << std::endl;
             std::cout << "Pattern Count: " << result.pattern_count << std::endl;
         }
     }

--- a/src/engine/engine.cu
+++ b/src/engine/engine.cu
@@ -581,6 +581,7 @@ std::map<std::string, double> Engine::getMetrics() const {
         metrics["pattern_" + std::string(pm.pattern_id) + "_coherence"] = pm.coherence;
         metrics["pattern_" + std::string(pm.pattern_id) + "_stability"] = pm.stability;
         metrics["pattern_" + std::string(pm.pattern_id) + "_entropy"] = pm.entropy;
+        metrics["pattern_" + std::string(pm.pattern_id) + "_energy"] = pm.energy;
     }
     
     return metrics;

--- a/tests/test_engine_metrics_parser.py
+++ b/tests/test_engine_metrics_parser.py
@@ -13,11 +13,11 @@ def test_parser_and_average(tmp_path):
     file1 = tmp_path / "m1.json"
     file2 = tmp_path / "m2.json"
     file1.write_text(json.dumps({
-        "metrics": {"coherence": 0.5, "stability": 0.6, "entropy": 0.3},
+        "metrics": {"coherence": 0.5, "stability": 0.6, "entropy": 0.3, "energy": 1.2},
         "pattern_count": 4
     }))
     file2.write_text(json.dumps({
-        "metrics": {"coherence": 0.7, "stability": 0.8, "entropy": 0.2},
+        "metrics": {"coherence": 0.7, "stability": 0.8, "entropy": 0.2, "energy": 2.8},
         "pattern_count": 6
     }))
 
@@ -27,4 +27,5 @@ def test_parser_and_average(tmp_path):
     assert avg["coherence"] == (0.5 + 0.7) / 2
     assert avg["stability"] == (0.6 + 0.8) / 2
     assert avg["entropy"] == (0.3 + 0.2) / 2
+    assert avg["energy"] == (1.2 + 2.8) / 2
     assert avg["pattern_count"] == (4 + 6) / 2


### PR DESCRIPTION
## Summary
- update pattern_metric_example with energy metric tracking
- expose energy metric via Engine::getMetrics
- parse and average energy metric in testbed tooling
- test energy metric handling in engine_metrics_parser

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688839cdf8b0832a8bae5ed485a530a0