### PR TITLE
Fix install script dependencies

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -66,6 +66,7 @@ MIN_PACKAGES=(
   libcurl4-openssl-dev curl python3 python3-pip gdb
   libpipewire-0.3-dev libspa-0.2-dev libtbb-dev
   valgrind nodejs npm
+  wget
 )
 
 FULL_PACKAGES=(


### PR DESCRIPTION
## Summary
- ensure wget is installed in installer for CUDA keyring download

## Testing
- `bash -n install.sh`
- `sudo /bin/bash -c './install.sh --minimal --no-cuda'`

------
https://chatgpt.com/codex/tasks/task_e_688c61312984832a8959d455768d7e49