### PR TITLE
Improve install.sh to build docker image automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,10 +208,11 @@ dependencies and `--minimal` for a lightweight install.
 
 ```bash
 ./install.sh --minimal
+```
 
 The script installs Python packages system-wide using `--break-system-packages`
-to satisfy Ubuntu 24.04's managed environment restrictions.
-```
+to satisfy Ubuntu 24.04's managed environment restrictions. It also builds the
+`sep-engine-builder` Docker image so `./build.sh` can run immediately.
 
 ### Build & Test
 

--- a/install.sh
+++ b/install.sh
@@ -144,3 +144,13 @@ for pkg in "${PACKAGES[@]}" docker.io docker-compose-v2; do
   fi
 done
 
+# Build Docker image used by build.sh if Docker is available
+if $SUDO docker info >/dev/null 2>&1; then
+  if ! $SUDO docker image inspect sep-engine-builder >/dev/null 2>&1; then
+    echo "Building sep-engine-builder Docker image..."
+    $SUDO docker build -t sep-engine-builder .
+  fi
+else
+  echo "Warning: Docker is not running, skipping image build" >&2
+fi
+


### PR DESCRIPTION
## Summary
- update install script to build sep-engine-builder Docker image if Docker is available
- mention this behavior in README

## Testing
- `shellcheck install.sh`
- `sudo bash install.sh --no-cuda --minimal`

------
https://chatgpt.com/codex/tasks/task_e_688c6584266c832aa7dd9fd5bd3b9901