### PR TITLE
Fix install CUDA symlink fallback

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -42,14 +42,18 @@ if ! "$DOCKER_BIN" info >/dev/null 2>&1; then
 fi
 
 # Build and setup development environment
+CUDA_PREFIX=/usr/local/cuda
+if [ ! -d "$CUDA_PREFIX" ]; then
+    CUDA_PREFIX=/usr
+fi
 "${DOCKER_BIN}" run --gpus all --rm \
     -v $(pwd):/sep \
-    -e CUDA_HOME=/usr/local/cuda \
-    -e CUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda \
-    -e CUDA_BIN_PATH=/usr/local/cuda/bin \
-    -e CMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc \
-    -e PATH=/usr/local/cuda/bin:${PATH} \
-    -e LD_LIBRARY_PATH=/usr/local/cuda/lib64:${LD_LIBRARY_PATH-} \
+    -e CUDA_HOME=$CUDA_PREFIX \
+    -e CUDA_TOOLKIT_ROOT_DIR=$CUDA_PREFIX \
+    -e CUDA_BIN_PATH=$CUDA_PREFIX/bin \
+    -e CMAKE_CUDA_COMPILER=$CUDA_PREFIX/bin/nvcc \
+    -e PATH=$CUDA_PREFIX/bin:${PATH} \
+    -e LD_LIBRARY_PATH=$CUDA_PREFIX/lib64:/usr/lib/x86_64-linux-gnu:${LD_LIBRARY_PATH-} \
     sep-engine-builder bash -c '
     # Verify CUDA environment
     echo "Verifying CUDA environment..."

--- a/install.sh
+++ b/install.sh
@@ -133,6 +133,12 @@ if [ "$USE_CUDA" -eq 1 ] && [ "$USE_LOCAL_CUDA" -eq 0 ]; then
       echo "Warning: nvcc still missing and no local installer found" >&2
     fi
   fi
+  # Create CUDA compatibility symlink when using distro toolkit
+  if [ ! -d /usr/local/cuda ] && [ -d /usr/lib/nvidia-cuda-toolkit ]; then
+    echo "Creating /usr/local/cuda symlink for distro toolkit"
+    $SUDO ln -s /usr/lib/nvidia-cuda-toolkit /usr/local/cuda
+    $SUDO ln -s /usr/lib/x86_64-linux-gnu /usr/local/cuda/lib64
+  fi
 fi
 
 # Install Docker and Docker Compose


### PR DESCRIPTION
## Summary
- add fallback NVCC symlink logic in `install.sh`
- adjust `build.sh` to use fallback CUDA path when `/usr/local/cuda` missing

## Testing
- `docker --version`
- `docker compose version`
- `nvcc --version`
- `./build.sh --rebuild` *(fails: _CMAKE_CUDA_WHOLE_FLAG missing)*

------
https://chatgpt.com/codex/tasks/task_e_688c7f2f09f8832a90d3d16950435e55