### PR TITLE
Improve CUDA setup scripts

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -52,6 +52,7 @@ fi
     -e CUDA_TOOLKIT_ROOT_DIR=$CUDA_PREFIX \
     -e CUDA_BIN_PATH=$CUDA_PREFIX/bin \
     -e CMAKE_CUDA_COMPILER=$CUDA_PREFIX/bin/nvcc \
+    -e CUDAToolkit_ROOT=$CUDA_PREFIX \
     -e PATH=$CUDA_PREFIX/bin:${PATH} \
     -e LD_LIBRARY_PATH=$CUDA_PREFIX/lib64:/usr/lib/x86_64-linux-gnu:${LD_LIBRARY_PATH-} \
     sep-engine-builder bash -c '
@@ -76,6 +77,7 @@ fi
         -DCMAKE_CXX_COMPILER=clang++-15 \
         -DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} ${EXTRA_CXX_FLAGS:-}" \
         -DCMAKE_CUDA_FLAGS="${CMAKE_CUDA_FLAGS} ${EXTRA_CUDA_FLAGS:-}" \
+        -DCUDAToolkit_ROOT=$CUDA_PREFIX \
         -DSEP_USE_CUDA=ON
     
     # Build with logging

--- a/install.sh
+++ b/install.sh
@@ -134,10 +134,10 @@ if [ "$USE_CUDA" -eq 1 ] && [ "$USE_LOCAL_CUDA" -eq 0 ]; then
     fi
   fi
   # Create CUDA compatibility symlink when using distro toolkit
-  if [ ! -d /usr/local/cuda ] && [ -d /usr/lib/nvidia-cuda-toolkit ]; then
+  if [ -d /usr/lib/nvidia-cuda-toolkit ]; then
     echo "Creating /usr/local/cuda symlink for distro toolkit"
-    $SUDO ln -s /usr/lib/nvidia-cuda-toolkit /usr/local/cuda
-    $SUDO ln -s /usr/lib/x86_64-linux-gnu /usr/local/cuda/lib64
+    $SUDO ln -sf /usr/lib/nvidia-cuda-toolkit /usr/local/cuda
+    $SUDO ln -sf /usr/lib/x86_64-linux-gnu /usr/local/cuda/lib64
   fi
 fi
 


### PR DESCRIPTION
## Summary
- ensure CUDA builder container receives `CUDAToolkit_ROOT`
- update CUDA toolkit symlink logic for distro installs

## Testing
- `./build.sh --rebuild` *(fails: `_CMAKE_CUDA_WHOLE_FLAG` missing)*

------
https://chatgpt.com/codex/tasks/task_e_688c859df654832abe7dd7588b9a3d40